### PR TITLE
fix: dedupe_df() now supports zero-config auto-detection

### DIFF
--- a/goldenmatch/__init__.py
+++ b/goldenmatch/__init__.py
@@ -147,7 +147,7 @@ from goldenmatch.core.lineage import build_lineage, save_lineage
 from goldenmatch.core.boost import boost_accuracy
 
 # ── Auto-configuration ──────────────────────────────────────────────────
-from goldenmatch.core.autoconfig import auto_configure
+from goldenmatch.core.autoconfig import auto_configure, auto_configure_df
 from goldenmatch.core.threshold import suggest_threshold
 
 # ── Data quality ─────────────────────────────────────────────────────────
@@ -243,7 +243,7 @@ __all__ = [
     # Active learning / boost
     "boost_accuracy",
     # Auto-configuration
-    "auto_configure", "suggest_threshold",
+    "auto_configure", "auto_configure_df", "suggest_threshold",
     # Data quality
     "auto_fix_dataframe", "validate_dataframe", "detect_anomalies",
     # Schema matching

--- a/goldenmatch/_api.py
+++ b/goldenmatch/_api.py
@@ -286,10 +286,19 @@ def dedupe_df(
     if isinstance(config, str):
         config = load_config(config)
     elif config is None:
-        config = _build_config(exact, fuzzy, blocking, threshold, llm_scorer, backend)
+        if exact or fuzzy:
+            config = _build_config(exact, fuzzy, blocking, threshold, llm_scorer, backend)
+        else:
+            # Zero-config: auto-detect column types and build matchkeys
+            from goldenmatch.core.autoconfig import auto_configure_df
+            config = auto_configure_df(df)
 
+    # Apply overrides uniformly regardless of config source
     if backend and hasattr(config, "backend"):
         config.backend = backend
+    if llm_scorer and hasattr(config, "llm_scorer"):
+        from goldenmatch.config.schemas import LLMScorerConfig
+        config.llm_scorer = LLMScorerConfig(enabled=True)
 
     result = run_dedupe_df(df, config, source_name=source_name)
 

--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -349,34 +349,24 @@ def select_model(row_count: int, has_embedding_columns: bool, threshold: int = 5
 
 # ── Main entry point ──────────────────────────────────────────────────────
 
-def auto_configure(files: list[tuple[str, str]]) -> GoldenMatchConfig:
-    """Auto-generate a GoldenMatchConfig from input files.
+def auto_configure_df(df: pl.DataFrame) -> GoldenMatchConfig:
+    """Auto-generate a GoldenMatchConfig from a DataFrame.
+
+    Profiles columns by name heuristics and data sampling, then builds
+    matchkeys, blocking, and golden rules automatically.
 
     Args:
-        files: List of (path, source_name) tuples.
+        df: Polars DataFrame to auto-configure for.
 
     Returns:
         A fully populated GoldenMatchConfig ready for pipeline execution.
     """
-    # Load and combine files
-    dfs = []
-    for path, source_name in files:
-        p = Path(path)
-        if p.suffix.lower() in (".xlsx", ".xls"):
-            df = pl.read_excel(p, engine="openpyxl")
-        elif p.suffix.lower() == ".parquet":
-            df = pl.read_parquet(p)
-        else:
-            df = pl.read_csv(p, encoding="utf8-lossy", infer_schema_length=10000, ignore_errors=True)
-        dfs.append(df)
+    total_rows = df.height
 
-    combined = pl.concat(dfs, how="diagonal") if len(dfs) > 1 else dfs[0]
-    total_rows = combined.height
-
-    logger.info("Auto-configuring %d rows, %d columns", total_rows, len(combined.columns))
+    logger.info("Auto-configuring %d rows, %d columns", total_rows, len(df.columns))
 
     # Profile columns
-    profiles = profile_columns(combined)
+    profiles = profile_columns(df)
 
     logger.info(
         "Detected column types: %s",
@@ -403,7 +393,7 @@ def auto_configure(files: list[tuple[str, str]]) -> GoldenMatchConfig:
 
     # Build blocking (required for weighted/probabilistic matchkeys)
     has_fuzzy = any(mk.type in ("weighted", "probabilistic") for mk in matchkeys)
-    blocking = build_blocking(profiles, combined) if has_fuzzy else None
+    blocking = build_blocking(profiles, df) if has_fuzzy else None
 
     # Build config
     config = GoldenMatchConfig(
@@ -414,6 +404,31 @@ def auto_configure(files: list[tuple[str, str]]) -> GoldenMatchConfig:
     )
 
     return config
+
+
+def auto_configure(files: list[tuple[str, str]]) -> GoldenMatchConfig:
+    """Auto-generate a GoldenMatchConfig from input files.
+
+    Args:
+        files: List of (path, source_name) tuples.
+
+    Returns:
+        A fully populated GoldenMatchConfig ready for pipeline execution.
+    """
+    # Load and combine files
+    dfs = []
+    for path, source_name in files:
+        p = Path(path)
+        if p.suffix.lower() in (".xlsx", ".xls"):
+            df = pl.read_excel(p, engine="openpyxl")
+        elif p.suffix.lower() == ".parquet":
+            df = pl.read_parquet(p)
+        else:
+            df = pl.read_csv(p, encoding="utf8-lossy", infer_schema_length=10000, ignore_errors=True)
+        dfs.append(df)
+
+    combined = pl.concat(dfs, how="diagonal") if len(dfs) > 1 else dfs[0]
+    return auto_configure_df(combined)
 
 
 def build_probabilistic_matchkeys(profiles: list[ColumnProfile]) -> list[MatchkeyConfig]:


### PR DESCRIPTION
## Summary

- `dedupe_df(df)` with no `exact`/`fuzzy` kwargs now auto-detects column types and builds matchkeys automatically
- Previously crashed with `ValueError: Missing required columns: ['__placeholder__']`
- The CLI's zero-config mode already worked (calls `auto_configure`), but the Python API didn't

## Changes

- Added `auto_configure_df(df)` in `core/autoconfig.py` — takes a DataFrame directly
- Refactored `auto_configure(files)` to delegate to `auto_configure_df` after loading files
- `dedupe_df()` now calls `auto_configure_df` when no config/exact/fuzzy provided
- Exported `auto_configure_df` from package

## Test plan

- [x] 1,181 existing tests pass
- [x] Manual test: `dedupe_df(df)` with `first_name`, `last_name`, `email`, `phone` columns — finds 2 clusters correctly
- [x] NC voter data (208K rows): auto-config detects name/email/phone/zip/address types