### PR TITLE
fix: use utf8-lossy encoding for all CSV reads

### DIFF
--- a/goldenmatch/a2a/skills.py
+++ b/goldenmatch/a2a/skills.py
@@ -83,7 +83,7 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
         analysis = session.analyze(params["file_path"])
         decision = select_strategy(
             profile_for_agent(
-                pl.read_csv(params["file_path"], encoding="utf8", ignore_errors=True)
+                pl.read_csv(params["file_path"], encoding="utf8-lossy", ignore_errors=True)
             )
         )
         cfg = _decision_to_config(decision)

--- a/goldenmatch/core/agent.py
+++ b/goldenmatch/core/agent.py
@@ -329,7 +329,7 @@ class AgentSession:
 
     def analyze(self, file_path: str) -> dict[str, Any]:
         """Load a CSV and return profiling + strategy analysis."""
-        df = pl.read_csv(file_path, encoding="utf8", ignore_errors=True)
+        df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
         self.data = df
 
         profile = profile_for_agent(df)
@@ -373,7 +373,7 @@ class AgentSession:
         """Full deduplication with profiling, strategy, gating, and review queue."""
         from goldenmatch._api import dedupe_df
 
-        df = pl.read_csv(file_path, encoding="utf8", ignore_errors=True)
+        df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
         self.data = df
 
         profile = profile_for_agent(df)
@@ -438,8 +438,8 @@ class AgentSession:
         """Match two CSV sources with profiling, strategy, and gating."""
         from goldenmatch._api import match_df
 
-        df_a = pl.read_csv(file_a, encoding="utf8", ignore_errors=True)
-        df_b = pl.read_csv(file_b, encoding="utf8", ignore_errors=True)
+        df_a = pl.read_csv(file_a, encoding="utf8-lossy", ignore_errors=True)
+        df_b = pl.read_csv(file_b, encoding="utf8-lossy", ignore_errors=True)
 
         # Profile the target (first file)
         profile = profile_for_agent(df_a)
@@ -481,7 +481,7 @@ class AgentSession:
         """
         from goldenmatch._api import dedupe_df
 
-        df = pl.read_csv(file_path, encoding="utf8", ignore_errors=True)
+        df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
         self.data = df
 
         profile = profile_for_agent(df)

--- a/goldenmatch/core/chunked.py
+++ b/goldenmatch/core/chunked.py
@@ -167,7 +167,7 @@ class ChunkedMatcher:
         """Read CSV in chunks."""
         # Read full file lazily and collect in chunks
         try:
-            full_df = pl.read_csv(path, encoding="utf8", ignore_errors=True)
+            full_df = pl.read_csv(path, encoding="utf8-lossy", ignore_errors=True)
         except Exception:
             full_df = pl.read_csv(str(path), ignore_errors=True)
 

--- a/goldenmatch/core/ingest.py
+++ b/goldenmatch/core/ingest.py
@@ -66,7 +66,7 @@ def load_file(
         # fast Polars scan_csv path (comma-delimited by default).
         if parse_mode == "auto" and (delimiter is not None or suffix == ".csv"):
             sep = delimiter or ","
-            enc = encoding or "utf8"
+            enc = encoding or "utf8-lossy"
             return pl.scan_csv(path, separator=sep, encoding=enc)
 
         # Otherwise route through smart_load

--- a/goldenmatch/core/smart_ingest.py
+++ b/goldenmatch/core/smart_ingest.py
@@ -515,7 +515,7 @@ def smart_load(
     try:
         text = path.read_text(encoding=enc, errors="replace")
     except Exception:
-        text = path.read_text(encoding="utf8", errors="replace")
+        text = path.read_text(encoding="utf8-lossy", errors="replace")
         enc = "utf8"
         log.append("encoding fallback to utf8")
 


### PR DESCRIPTION
## Summary

All CSV read paths now use `encoding=\"utf8-lossy\"` instead of strict `utf8`. This prevents crashes on files with Latin-1 characters (accented names, special characters in government/international data).

## Problem

`goldenmatch dedupe nc_voters.txt` crashes with `ComputeError: invalid utf-8 sequence` on NC voter registration data because names contain Latin-1 characters.

## Changes

| File | Before | After |
|------|--------|-------|
| `core/ingest.py` (main pipeline) | `utf8` | `utf8-lossy` |
| `core/agent.py` (5 places) | `utf8` | `utf8-lossy` |
| `core/chunked.py` | `utf8` | `utf8-lossy` |
| `core/smart_ingest.py` | `utf8` | `utf8-lossy` |
| `a2a/skills.py` | `utf8` | `utf8-lossy` |

`_api.py` and `core/autoconfig.py` already used `utf8-lossy` — this makes all paths consistent.

## Test plan

- [x] 1,181 tests pass
- [x] NC voter data (208K rows with Latin-1 chars) loads without error