### PR TITLE
fix: prevent OOM/segfault on wide datasets and mixed-type golden records

### DIFF
--- a/goldenmatch/config/schemas.py
+++ b/goldenmatch/config/schemas.py
@@ -204,11 +204,13 @@ class BlockingConfig(BaseModel):
         """Ensure at least keys or passes is provided for strategies that need them."""
         if self.auto_suggest:
             return self  # auto_suggest discovers keys at runtime
+        # Strategies that don't need keys: ann, ann_pairs, canopy, learned,
+        # sorted_neighborhood (uses sort_key instead)
         needs_keys = self.strategy in ("static", "adaptive")
         needs_passes = self.strategy == "multi_pass"
         if needs_keys and not self.keys and not self.sub_block_keys:
             raise ValueError(
-                "BlockingConfig with strategy='static' or 'adaptive' requires 'keys'."
+                f"BlockingConfig with strategy='{self.strategy}' requires 'keys'."
             )
         if needs_passes and not self.keys and not self.passes:
             raise ValueError(

--- a/goldenmatch/config/schemas.py
+++ b/goldenmatch/config/schemas.py
@@ -177,7 +177,7 @@ class CanopyConfig(BaseModel):
 
 
 class BlockingConfig(BaseModel):
-    keys: list[BlockingKeyConfig]
+    keys: list[BlockingKeyConfig] = []
     max_block_size: int = 5000
     skip_oversized: bool = False
     strategy: Literal["static", "adaptive", "sorted_neighborhood", "multi_pass", "ann", "canopy", "ann_pairs", "learned"] = "static"
@@ -198,6 +198,23 @@ class BlockingConfig(BaseModel):
     ann_model: str = "all-MiniLM-L6-v2"
     ann_top_k: int = 20
     canopy: CanopyConfig | None = None
+
+    @model_validator(mode="after")
+    def _validate_keys_or_passes(self) -> "BlockingConfig":
+        """Ensure at least keys or passes is provided for strategies that need them."""
+        if self.auto_suggest:
+            return self  # auto_suggest discovers keys at runtime
+        needs_keys = self.strategy in ("static", "adaptive")
+        needs_passes = self.strategy == "multi_pass"
+        if needs_keys and not self.keys and not self.sub_block_keys:
+            raise ValueError(
+                "BlockingConfig with strategy='static' or 'adaptive' requires 'keys'."
+            )
+        if needs_passes and not self.keys and not self.passes:
+            raise ValueError(
+                "BlockingConfig with strategy='multi_pass' requires 'keys' or 'passes'."
+            )
+        return self
 
 
 # ── GoldenFieldRule / GoldenRulesConfig ─────────────────────────────────────

--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -32,7 +32,7 @@ _EMAIL_PATTERNS = re.compile(r"(email|e.?mail|email.?addr)", re.IGNORECASE)
 _PHONE_PATTERNS = re.compile(r"(phone|tel|mobile|fax|cell)", re.IGNORECASE)
 _ZIP_PATTERNS = re.compile(r"(zip|postal|postcode|zip.?code)", re.IGNORECASE)
 _ADDRESS_PATTERNS = re.compile(r"(address|street|addr|line.?1|line.?2)", re.IGNORECASE)
-_GEO_PATTERNS = re.compile(r"(city|^state$|state.?cd|^country$|province|region|county)", re.IGNORECASE)
+_GEO_PATTERNS = re.compile(r"(\bcity\b|^state$|state.?cd|^country$|province|region|\bcounty\b)", re.IGNORECASE)
 _DATE_PATTERNS = re.compile(r"(date|_dt$|_date$|registr|created|updated|birth.?d|dob)", re.IGNORECASE)
 _ID_PATTERNS = re.compile(r"(^id$|^key$|^code$|^sku$|_id$|_key$)", re.IGNORECASE)
 
@@ -107,10 +107,15 @@ def _classify_by_data(values: list[str]) -> tuple[str, float]:
     return col_type, confidence
 
 
-def profile_columns(df: pl.DataFrame, sample_size: int = 1000) -> list[ColumnProfile]:
+def profile_columns(
+    df: pl.DataFrame, sample_size: int = 1000, max_columns: int = 40,
+) -> list[ColumnProfile]:
     """Classify columns by type using name heuristics + data profiling.
 
     Samples randomly to avoid bias from header-adjacent rows.
+    Wide datasets (>max_columns) are trimmed: columns matching known patterns
+    (name, email, phone, zip, address) are prioritized, then remaining columns
+    fill up to the cap.
     """
     # Sample randomly
     if df.height > sample_size:
@@ -118,8 +123,28 @@ def profile_columns(df: pl.DataFrame, sample_size: int = 1000) -> list[ColumnPro
     else:
         sample = df
 
+    # For wide datasets, prioritize columns likely useful for matching
+    columns = [c for c in df.columns if not c.startswith("__")]
+    if len(columns) > max_columns:
+        # Phase 1: keep columns matching known patterns
+        priority = []
+        rest = []
+        for col_name in columns:
+            if _classify_by_name(col_name) is not None:
+                priority.append(col_name)
+            else:
+                rest.append(col_name)
+        # Fill remaining slots from unmatched columns
+        remaining_slots = max(0, max_columns - len(priority))
+        columns = priority + rest[:remaining_slots]
+        logger.info(
+            "Wide dataset (%d columns), auto-configure limited to %d columns "
+            "(%d pattern-matched, %d additional)",
+            len(df.columns), len(columns), len(priority), remaining_slots,
+        )
+
     profiles = []
-    for col_name in df.columns:
+    for col_name in columns:
         # Skip internal columns
         if col_name.startswith("__"):
             continue
@@ -204,7 +229,9 @@ def _adaptive_threshold(fields: list[MatchkeyField]) -> float:
     return 0.80
 
 
-def build_matchkeys(profiles: list[ColumnProfile]) -> list[MatchkeyConfig]:
+def build_matchkeys(
+    profiles: list[ColumnProfile], df: pl.DataFrame | None = None,
+) -> list[MatchkeyConfig]:
     """Generate matchkeys from column profiles."""
     # Separate exact and fuzzy columns
     exact_fields = []
@@ -224,6 +251,13 @@ def build_matchkeys(profiles: list[ColumnProfile]) -> list[MatchkeyConfig]:
             continue
 
         scorer, weight, transforms = scorer_info
+
+        # Skip exact matchkeys for large datasets — exact matchkeys do a full
+        # self-join which is O(N^2) without blocking. For auto-configure, use
+        # exact columns only in blocking (handled by build_blocking).
+        if scorer == "exact" and df is not None and df.height > 10000:
+            continue
+
         mf = MatchkeyField(
             field=p.name,
             scorer=scorer,
@@ -261,6 +295,13 @@ def build_matchkeys(profiles: list[ColumnProfile]) -> list[MatchkeyConfig]:
             weight=1.0,
             model=None,  # auto-selected later
         ))
+
+    # Limit fuzzy fields to prevent OOM on wide datasets
+    max_fuzzy_fields = 5
+    if len(all_weighted) > max_fuzzy_fields:
+        # Sort by weight descending, keep top N
+        all_weighted.sort(key=lambda f: f.weight or 0.0, reverse=True)
+        all_weighted = all_weighted[:max_fuzzy_fields]
 
     if all_weighted:
         threshold = _adaptive_threshold(all_weighted)
@@ -321,8 +362,11 @@ def build_blocking(profiles: list[ColumnProfile], df: pl.DataFrame) -> BlockingC
 
     # Best case: block on highest-cardinality exact column (with low null rate + safe block size)
     if exact_cols:
+        # Pre-filter: only evaluate top 5 by cardinality to avoid expensive group_by on all columns
+        exact_cols_sorted = sorted(exact_cols, key=lambda p: df[p.name].n_unique(), reverse=True)
+        candidates = exact_cols_sorted[:5]
         # Filter out columns that create oversized blocks
-        safe_exact = [p for p in exact_cols if _max_block_size(p.name) <= max_safe_block]
+        safe_exact = [p for p in candidates if _max_block_size(p.name) <= max_safe_block]
         if safe_exact:
             best = max(safe_exact, key=lambda p: df[p.name].n_unique())
             transforms = ["lowercase", "strip"] if best.col_type == "email" else ["strip"]
@@ -337,8 +381,10 @@ def build_blocking(profiles: list[ColumnProfile], df: pl.DataFrame) -> BlockingC
         )
 
     # Name columns: use multi-pass with soundex + substring
+    # Prefer columns matched by name pattern (person names) over data-profiled names
     if name_cols:
-        best_name = name_cols[0].name
+        pattern_names = [p for p in name_cols if _classify_by_name(p.name) == "name"]
+        best_name = (pattern_names[0] if pattern_names else name_cols[0]).name
         return BlockingConfig(
             keys=[BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "soundex"])],
             strategy="multi_pass",
@@ -415,7 +461,7 @@ def auto_configure_df(df: pl.DataFrame) -> GoldenMatchConfig:
     )
 
     # Build matchkeys
-    matchkeys = build_matchkeys(profiles)
+    matchkeys = build_matchkeys(profiles, df=df)
 
     # Check if embeddings are needed
     has_embeddings = any(

--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -32,7 +32,7 @@ _EMAIL_PATTERNS = re.compile(r"(email|e.?mail|email.?addr)", re.IGNORECASE)
 _PHONE_PATTERNS = re.compile(r"(phone|tel|mobile|fax|cell)", re.IGNORECASE)
 _ZIP_PATTERNS = re.compile(r"(zip|postal|postcode|zip.?code)", re.IGNORECASE)
 _ADDRESS_PATTERNS = re.compile(r"(address|street|addr|line.?1|line.?2)", re.IGNORECASE)
-_GEO_PATTERNS = re.compile(r"(\bcity\b|^state$|state.?cd|^country$|province|region|\bcounty\b)", re.IGNORECASE)
+_GEO_PATTERNS = re.compile(r"((?<![a-z])city|^state$|state.?cd|^country$|province|region|(?<![a-z])county)", re.IGNORECASE)
 _DATE_PATTERNS = re.compile(r"(date|_dt$|_date$|registr|created|updated|birth.?d|dob)", re.IGNORECASE)
 _ID_PATTERNS = re.compile(r"(^id$|^key$|^code$|^sku$|_id$|_key$)", re.IGNORECASE)
 
@@ -256,6 +256,11 @@ def build_matchkeys(
         # self-join which is O(N^2) without blocking. For auto-configure, use
         # exact columns only in blocking (handled by build_blocking).
         if scorer == "exact" and df is not None and df.height > 10000:
+            logger.info(
+                "Skipping exact matchkey for '%s' (dataset has %d rows; "
+                "exact self-joins are O(N^2) — use blocking instead)",
+                p.name, df.height,
+            )
             continue
 
         mf = MatchkeyField(
@@ -299,9 +304,13 @@ def build_matchkeys(
     # Limit fuzzy fields to prevent OOM on wide datasets
     max_fuzzy_fields = 5
     if len(all_weighted) > max_fuzzy_fields:
-        # Sort by weight descending, keep top N
         all_weighted.sort(key=lambda f: f.weight or 0.0, reverse=True)
+        dropped = [f.field for f in all_weighted[max_fuzzy_fields:] if f.field]
         all_weighted = all_weighted[:max_fuzzy_fields]
+        logger.info(
+            "Truncated fuzzy fields from %d to %d. Dropped: %s",
+            len(all_weighted) + len(dropped), max_fuzzy_fields, dropped,
+        )
 
     if all_weighted:
         threshold = _adaptive_threshold(all_weighted)

--- a/goldenmatch/core/blocker.py
+++ b/goldenmatch/core/blocker.py
@@ -611,7 +611,7 @@ def build_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
         List of BlockResult, one per valid block.
     """
     # Auto-select: pick best key based on histogram analysis
-    if config.auto_select and len(config.keys) > 1:
+    if config.auto_select and config.keys and len(config.keys) > 1:
         best_key = select_best_blocking_key(lf, config.keys, config.max_block_size)
         config = config.model_copy(update={"keys": [best_key], "auto_select": False})
 

--- a/goldenmatch/core/pipeline.py
+++ b/goldenmatch/core/pipeline.py
@@ -419,7 +419,17 @@ def _run_dedupe_pipeline(
                 if isinstance(val_info, dict) and "value" in val_info:
                     row[col] = val_info["value"]
             golden_rows.append(row)
-        golden_df = pl.DataFrame(golden_rows)
+        # Build explicit schema to prevent mixed-type inference errors.
+        # Golden records from different clusters may have different value types
+        # for the same column (e.g. "0" str vs 0 int).
+        all_keys: set[str] = set()
+        for row in golden_rows:
+            all_keys.update(row.keys())
+        schema_overrides = {
+            k: pl.Utf8 for k in all_keys
+            if k not in ("__cluster_id__", "__golden_confidence__")
+        }
+        golden_df = pl.DataFrame(golden_rows, schema_overrides=schema_overrides)
 
     # Classify records
     multi_cluster_ids = [
@@ -507,6 +517,10 @@ def run_dedupe_df(
     output_report: bool = False,
 ) -> dict:
     """Run dedupe pipeline on a DataFrame directly (no file I/O)."""
+    # Cast all columns to string to prevent schema mismatch errors when
+    # mixed-type columns (e.g. birth_year inferred as i64 in some rows,
+    # str in others) reach blocking/scoring operations.
+    df = df.cast({col: pl.Utf8 for col in df.columns if not col.startswith("__")})
     matchkeys = config.get_matchkeys()
     lf = df.lazy()
     required = _get_required_columns(config)


### PR DESCRIPTION
## Summary
- **BlockingConfig.keys** now defaults to `[]` — no longer required when using `multi_pass` with `passes`
- **Auto-configure safe for wide datasets** — caps columns at 40, fuzzy fields at 5, skips exact matchkeys on >10K rows
- **Fix `_GEO_PATTERNS` regex** — `city` matched inside "Capa**city**", now uses `\bcity\b`
- **Fix golden record DataFrame construction** — `schema_overrides` prevents mixed-type inference across cluster rows
- **Cast to Utf8 in `run_dedupe_df`** — prevents schema mismatch from mixed-type columns
- **Guard `auto_select` against empty keys** in blocker

## Test plan
- [x] 1,181 existing tests pass
- [x] Zero-config `dedupe_df()` on UK GIAS schools register (52,288 rows, 135 columns) — 3,854 clusters in 175s, no OOM/segfault
- [x] `dedupe_df()` with explicit config on same dataset — 13,788 clusters in 158s
- [x] GoldenPipe full pipeline on same dataset — all 4 stages SUCCESS in 40s

🤖 Generated with [Claude Code](https://claude.com/claude-code)