### PR TITLE
feat: iterative LLM calibration, auto-config fixes, ANN hybrid blocking

### DIFF
--- a/goldenmatch/config/schemas.py
+++ b/goldenmatch/config/schemas.py
@@ -356,7 +356,11 @@ class LLMScorerConfig(BaseModel):
     auto_threshold: float = 0.95  # auto-accept pairs above this
     candidate_lo: float = 0.75  # lower bound of LLM scoring range
     candidate_hi: float = 0.95  # upper bound (same as auto_threshold)
-    batch_size: int = 20
+    batch_size: int = 75
+    max_workers: int = 5  # concurrent LLM requests
+    calibration_sample_size: int = 100  # pairs per calibration round
+    calibration_max_rounds: int = 5  # max calibration iterations
+    calibration_convergence_delta: float = 0.01  # stop when threshold shift < this
     budget: BudgetConfig | None = None
     mode: str = "pairwise"  # "pairwise" (legacy) or "cluster" (in-context LLM clustering)
     cluster_max_size: int = 100  # max records per LLM cluster block

--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -231,6 +231,7 @@ def _llm_classify_columns(
     High-confidence classifications (date, geo, email, identifier) are trusted.
     """
     import json as _json
+    import urllib.error
 
     # Filter to ambiguous profiles
     high_confidence_types = {"date", "geo", "email", "identifier"}
@@ -267,7 +268,7 @@ def _llm_classify_columns(
 
     try:
         raw = _call_llm_for_blocking(prompt, provider)
-    except Exception as e:
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError, KeyError) as e:
         logger.warning("LLM column classification failed: %s. Using heuristics only.", e)
         return profiles
 
@@ -280,8 +281,11 @@ def _llm_classify_columns(
             if text.startswith("json"):
                 text = text[4:]
         data = _json.loads(text)
-    except (ValueError, IndexError):
-        logger.warning("LLM column classification returned unparseable response.")
+    except (ValueError, IndexError) as e:
+        logger.warning(
+            "LLM column classification returned unparseable response (error: %s). "
+            "Raw response (first 200 chars): %.200s", e, raw,
+        )
         return profiles
 
     # Normalize type aliases
@@ -303,6 +307,8 @@ def _llm_classify_columns(
     profile_by_name = {p.name: p for p in profiles}
     for col_name, llm_type in classifications.items():
         if col_name not in profile_by_name:
+            continue
+        if not isinstance(llm_type, str):
             continue
         p = profile_by_name[col_name]
         # Only correct ambiguous columns

--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -31,6 +31,7 @@ _NAME_PATTERNS = re.compile(
 _EMAIL_PATTERNS = re.compile(r"(email|e.?mail|email.?addr)", re.IGNORECASE)
 _PHONE_PATTERNS = re.compile(r"(phone|tel|mobile|fax|cell)", re.IGNORECASE)
 _ZIP_PATTERNS = re.compile(r"(zip|postal|postcode|zip.?code)", re.IGNORECASE)
+_PRICE_PATTERNS = re.compile(r"(price|cost|amount|revenue|salary|fee|charge|total|balance)", re.IGNORECASE)
 _ADDRESS_PATTERNS = re.compile(r"(address|street|addr|line.?1|line.?2)", re.IGNORECASE)
 _GEO_PATTERNS = re.compile(r"((?<![a-z])city|^state$|state.?cd|^country$|province|region|(?<![a-z])county)", re.IGNORECASE)
 _DATE_PATTERNS = re.compile(r"(date|_dt$|_date$|registr|created|updated|birth.?d|dob)", re.IGNORECASE)
@@ -48,19 +49,26 @@ class ColumnProfile:
     col_type: str  # email, name, phone, zip, address, geo, identifier, description, numeric, date, string
     confidence: float  # 0.0 to 1.0
     sample_values: list[str] = field(default_factory=list)
+    null_rate: float = 0.0  # fraction of nulls (0-1)
+    cardinality_ratio: float = 0.0  # unique values / total rows (0-1)
+    avg_len: float = 0.0  # average string length
 
 
 def _classify_by_name(col_name: str) -> str | None:
     """Phase 1: classify column by name pattern matching.
 
-    Order matters: more specific patterns (date, geo) are checked before
-    broader ones (name, phone) to avoid misclassification (e.g., city names
-    matching the name pattern, or date columns matching the phone pattern).
+    Order matters: ID and price before phone/zip to prevent data profiling
+    from overriding name-based classification (e.g., 7-digit IDs as phones,
+    5-digit prices as zips).
     """
     if _DATE_PATTERNS.search(col_name):
         return "date"
     if _EMAIL_PATTERNS.search(col_name):
         return "email"
+    if _ID_PATTERNS.search(col_name):
+        return "identifier"
+    if _PRICE_PATTERNS.search(col_name):
+        return "numeric"
     if _ZIP_PATTERNS.search(col_name):
         return "zip"
     if _GEO_PATTERNS.search(col_name):
@@ -71,8 +79,6 @@ def _classify_by_name(col_name: str) -> str | None:
         return "phone"
     if _NAME_PATTERNS.search(col_name):
         return "name"
-    if _ID_PATTERNS.search(col_name):
-        return "identifier"
     return None
 
 
@@ -111,6 +117,7 @@ def _classify_by_data(values: list[str]) -> tuple[str, float]:
 
 def profile_columns(
     df: pl.DataFrame, sample_size: int = 1000, max_columns: int = 40,
+    llm_provider: str | None = None,
 ) -> list[ColumnProfile]:
     """Classify columns by type using name heuristics + data profiling.
 
@@ -154,10 +161,18 @@ def profile_columns(
         dtype = str(df[col_name].dtype)
 
         # Get non-null string values for profiling
+        col_series = sample[col_name]
+        total_rows = col_series.len()
+        null_count = col_series.null_count()
+        null_rate = null_count / total_rows if total_rows > 0 else 0.0
+
         values = [
-            str(v) for v in sample[col_name].drop_nulls().to_list()
+            str(v) for v in col_series.drop_nulls().to_list()
             if v is not None and str(v).strip()
         ]
+
+        cardinality_ratio = len(set(values)) / total_rows if total_rows > 0 else 0.0
+        avg_len = sum(len(v) for v in values) / len(values) if values else 0.0
 
         # Phase 1: name heuristics
         name_type = _classify_by_name(col_name)
@@ -169,7 +184,7 @@ def profile_columns(
         # (date, geo) because data profiling frequently misclassifies them
         # (e.g., ISO dates look like phone numbers, city names look like person names).
         # For other types, Phase 2 (data) wins when it contradicts Phase 1 (name).
-        _name_authoritative = {"date", "geo"}
+        _name_authoritative = {"date", "geo", "identifier", "numeric"}
         if name_type and name_type in _name_authoritative:
             # Name pattern is authoritative for date/geo — trust it
             col_type = name_type
@@ -195,7 +210,121 @@ def profile_columns(
             col_type=col_type,
             confidence=confidence,
             sample_values=values[:5],
+            null_rate=null_rate,
+            cardinality_ratio=cardinality_ratio,
+            avg_len=avg_len,
         ))
+
+    # LLM correction pass for ambiguous columns
+    if llm_provider and profiles:
+        profiles = _llm_classify_columns(profiles, llm_provider)
+
+    return profiles
+
+
+def _llm_classify_columns(
+    profiles: list[ColumnProfile], provider: str,
+) -> list[ColumnProfile]:
+    """Use LLM to correct ambiguous column classifications and rank match fields.
+
+    Only sends columns with low confidence or generic types (string, numeric).
+    High-confidence classifications (date, geo, email, identifier) are trusted.
+    """
+    import json as _json
+
+    # Filter to ambiguous profiles
+    high_confidence_types = {"date", "geo", "email", "identifier"}
+    ambiguous = [
+        p for p in profiles
+        if p.confidence < 0.8 or p.col_type in ("string", "numeric")
+        if p.col_type not in high_confidence_types
+    ]
+
+    if not ambiguous:
+        return profiles
+
+    # Build prompt
+    col_lines = []
+    for p in ambiguous:
+        samples = ", ".join(p.sample_values[:5]) if p.sample_values else "no samples"
+        col_lines.append(f'  "{p.name}": [{samples}]')
+
+    all_col_names = [p.name for p in profiles if p.col_type not in high_confidence_types]
+
+    prompt = (
+        "You are classifying database columns for entity matching/deduplication.\n\n"
+        "For each column below, provide:\n"
+        '1. "type": one of: identifier, name, description, numeric, date, geo, '
+        "email, phone, zip, address, price, string\n"
+        '2. "match_rank": rank the top 5 columns most useful for entity matching '
+        "(1=most useful). Only rank columns that would help identify duplicate records.\n\n"
+        "Columns with sample values:\n"
+        + "\n".join(col_lines)
+        + "\n\nAll columns available for ranking: " + ", ".join(all_col_names)
+        + '\n\nRespond in JSON: {"classifications": {"col_name": "type", ...}, '
+        '"match_ranking": ["col1", "col2", "col3", "col4", "col5"]}'
+    )
+
+    try:
+        raw = _call_llm_for_blocking(prompt, provider)
+    except Exception as e:
+        logger.warning("LLM column classification failed: %s. Using heuristics only.", e)
+        return profiles
+
+    # Parse response
+    try:
+        # Extract JSON from response (may be wrapped in markdown)
+        text = raw.strip()
+        if "```" in text:
+            text = text.split("```")[1]
+            if text.startswith("json"):
+                text = text[4:]
+        data = _json.loads(text)
+    except (ValueError, IndexError):
+        logger.warning("LLM column classification returned unparseable response.")
+        return profiles
+
+    # Normalize type aliases
+    _type_aliases = {
+        "id": "identifier", "ids": "identifier",
+        "desc": "description", "text": "string",
+        "location": "geo", "city": "geo", "state": "geo",
+        "postal": "zip", "postcode": "zip",
+        "cost": "numeric", "price": "numeric", "amount": "numeric",
+        "tel": "phone", "telephone": "phone",
+    }
+    valid_types = {
+        "identifier", "name", "description", "numeric", "date", "geo",
+        "email", "phone", "zip", "address", "string",
+    }
+
+    # Apply type corrections
+    classifications = data.get("classifications", {})
+    profile_by_name = {p.name: p for p in profiles}
+    for col_name, llm_type in classifications.items():
+        if col_name not in profile_by_name:
+            continue
+        p = profile_by_name[col_name]
+        # Only correct ambiguous columns
+        if p.col_type in high_confidence_types:
+            continue
+        normalized = _type_aliases.get(llm_type.lower(), llm_type.lower())
+        if normalized in valid_types:
+            logger.info("LLM reclassified '%s': %s -> %s", col_name, p.col_type, normalized)
+            p.col_type = normalized
+            p.confidence = 0.85
+
+    # Apply match ranking (stored as metadata for build_matchkeys to use)
+    match_ranking = data.get("match_ranking", [])
+    if match_ranking:
+        # Store ranking as a special attribute on profiles
+        for rank, col_name in enumerate(match_ranking[:5]):
+            if col_name in profile_by_name:
+                # Use a high utility boost so LLM-ranked fields sort first
+                p = profile_by_name[col_name]
+                p.cardinality_ratio = max(p.cardinality_ratio, 0.9 - rank * 0.1)
+                p.avg_len = max(p.avg_len, 40 - rank * 5)
+        logger.info("LLM match ranking: %s", match_ranking[:5])
 
     return profiles
 
@@ -304,9 +433,18 @@ def build_matchkeys(
         ))
 
     # Limit fuzzy fields to prevent OOM on wide datasets
+    # Rank by match utility: cardinality * completeness * string length
     max_fuzzy_fields = 5
     if len(all_weighted) > max_fuzzy_fields:
-        all_weighted.sort(key=lambda f: f.weight or 0.0, reverse=True)
+        profile_lookup = {p.name: p for p in profiles}
+
+        def _field_utility(f: MatchkeyField) -> float:
+            if not f.field or f.field not in profile_lookup:
+                return f.weight or 0.0
+            p = profile_lookup[f.field]
+            return p.cardinality_ratio * (1 - p.null_rate) * min(p.avg_len / 20, 1.0)
+
+        all_weighted.sort(key=_field_utility, reverse=True)
         dropped = [f.field for f in all_weighted[max_fuzzy_fields:] if f.field]
         all_weighted = all_weighted[:max_fuzzy_fields]
         logger.info(
@@ -741,7 +879,7 @@ def auto_configure_df(df: pl.DataFrame, llm_provider: str | None = None) -> Gold
     logger.info("Auto-configuring %d rows, %d columns", total_rows, len(df.columns))
 
     # Profile columns
-    profiles = profile_columns(df)
+    profiles = profile_columns(df, llm_provider=llm_provider)
 
     logger.info(
         "Detected column types: %s",

--- a/goldenmatch/core/blocker.py
+++ b/goldenmatch/core/blocker.py
@@ -75,7 +75,16 @@ def _build_static_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Block
                 continue
 
             if size > config.max_block_size:
-                if config.skip_oversized:
+                if config.skip_oversized and config.ann_column:
+                    # ANN fallback: embed oversized block's records and sub-block
+                    ann_sub = _ann_sub_block(
+                        group_df, config.ann_column, config.ann_top_k,
+                        config.ann_model, config.max_block_size, key_str,
+                    )
+                    if ann_sub:
+                        results.extend(ann_sub)
+                    continue
+                elif config.skip_oversized:
                     logger.warning(
                         f"Block {key_str!r} has {size} records "
                         f"(exceeds max_block_size={config.max_block_size}). Skipping."
@@ -92,6 +101,113 @@ def _build_static_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Block
                 df=group_df.lazy(),
             ))
 
+    return results
+
+
+def _ann_sub_block(
+    block_df: pl.DataFrame,
+    ann_column: str,
+    ann_top_k: int,
+    ann_model: str,
+    max_block_size: int,
+    parent_key: str,
+) -> list[BlockResult]:
+    """ANN fallback for oversized blocks.
+
+    Embeds only the unique text values in the block, maps embeddings back
+    to all records, then uses FAISS to find neighbors and create sub-blocks.
+    """
+    from goldenmatch.core.ann_blocker import ANNBlocker
+    from goldenmatch.core.cluster import UnionFind
+    from goldenmatch.core.embedder import get_embedder
+
+    size = len(block_df)
+
+    # Cap: only ANN sub-block moderately oversized blocks (up to 10x max_block_size)
+    # Truly massive blocks (60K+) would still be too expensive to embed
+    if size > max_block_size * 10:
+        logger.info(
+            "ANN fallback: block %r has %d records (>%dx max). Too large, skipping.",
+            parent_key, size, 10,
+        )
+        return []
+
+    if ann_column not in block_df.columns:
+        logger.warning(
+            "ANN fallback: column %r not in block %r. Skipping %d records.",
+            ann_column, parent_key, size,
+        )
+        return []
+
+    # Deduplicate texts — embed only unique values
+    all_texts = block_df[ann_column].to_list()
+    unique_texts = list(set(t for t in all_texts if t is not None and str(t).strip()))
+
+    if len(unique_texts) < 2:
+        logger.info("ANN fallback: block %r has <2 unique texts. Skipping.", parent_key)
+        return []
+
+    logger.info(
+        "ANN fallback: block %r has %d records, %d unique texts. Embedding...",
+        parent_key, size, len(unique_texts),
+    )
+
+    embedder = get_embedder(ann_model)
+    unique_embeddings = embedder.embed_column(
+        unique_texts, cache_key=f"ann_sub_{parent_key}",
+    )
+
+    # Map unique embeddings back to all records
+    text_to_idx = {t: i for i, t in enumerate(unique_texts)}
+    record_indices = []  # index into unique_embeddings for each record
+    valid_records = []   # indices into block_df that have valid text
+    for i, t in enumerate(all_texts):
+        if t is not None and str(t).strip() and t in text_to_idx:
+            record_indices.append(text_to_idx[t])
+            valid_records.append(i)
+
+    if len(valid_records) < 2:
+        return []
+
+    import numpy as np
+    record_embeddings = unique_embeddings[np.array(record_indices)]
+
+    # Build FAISS index and query
+    blocker = ANNBlocker(top_k=min(ann_top_k, len(valid_records) - 1))
+    blocker.build_index(record_embeddings)
+    pairs = blocker.query(record_embeddings)
+
+    # Group into sub-blocks via Union-Find
+    row_ids = block_df["__row_id__"].to_list()
+    uf = UnionFind()
+    for a, b in pairs:
+        real_a = valid_records[a]
+        real_b = valid_records[b]
+        uf.add(real_a)
+        uf.add(real_b)
+        uf.union(real_a, real_b)
+
+    clusters = uf.get_clusters()
+    results: list[BlockResult] = []
+    n_oversized = 0
+    for members in clusters:
+        if len(members) < 2:
+            continue
+        member_list = sorted(members)
+        if len(member_list) > max_block_size:
+            n_oversized += 1
+            continue  # still too big even after ANN sub-blocking
+        sub_df = block_df[member_list]
+        results.append(BlockResult(
+            block_key=f"{parent_key}_ann_{min(member_list)}",
+            df=sub_df.lazy(),
+            strategy="ann",
+        ))
+
+    logger.info(
+        "ANN fallback: block %r -> %d sub-blocks (%d still oversized)",
+        parent_key, len(results), n_oversized,
+    )
     return results
 
 
@@ -320,6 +436,9 @@ def _build_multi_pass_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[B
             keys=[pass_config],
             max_block_size=config.max_block_size,
             skip_oversized=config.skip_oversized,
+            ann_column=config.ann_column,
+            ann_top_k=config.ann_top_k,
+            ann_model=config.ann_model,
         )
         blocks = _build_static_blocks(lf, temp_config)
         for block in blocks:

--- a/goldenmatch/core/blocker.py
+++ b/goldenmatch/core/blocker.py
@@ -77,12 +77,18 @@ def _build_static_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Block
             if size > config.max_block_size:
                 if config.skip_oversized and config.ann_column:
                     # ANN fallback: embed oversized block's records and sub-block
-                    ann_sub = _ann_sub_block(
-                        group_df, config.ann_column, config.ann_top_k,
-                        config.ann_model, config.max_block_size, key_str,
-                    )
-                    if ann_sub:
-                        results.extend(ann_sub)
+                    try:
+                        ann_sub = _ann_sub_block(
+                            group_df, config.ann_column, config.ann_top_k,
+                            config.ann_model, config.max_block_size, key_str,
+                        )
+                        if ann_sub:
+                            results.extend(ann_sub)
+                    except Exception:
+                        logger.error(
+                            "ANN sub-blocking failed for block %r (%d records). Skipping block.",
+                            key_str, size, exc_info=True,
+                        )
                     continue
                 elif config.skip_oversized:
                     logger.warning(
@@ -196,7 +202,11 @@ def _ann_sub_block(
         member_list = sorted(members)
         if len(member_list) > max_block_size:
             n_oversized += 1
-            continue  # still too big even after ANN sub-blocking
+            logger.warning(
+                "ANN sub-block from %r still has %d records (> max %d). Skipping.",
+                parent_key, len(member_list), max_block_size,
+            )
+            continue
         sub_df = block_df[member_list]
         results.append(BlockResult(
             block_key=f"{parent_key}_ann_{min(member_list)}",

--- a/goldenmatch/core/embedder.py
+++ b/goldenmatch/core/embedder.py
@@ -79,7 +79,19 @@ _embedders: dict[str, Embedder] = {}
 
 
 def get_embedder(model_name: str = "all-MiniLM-L6-v2") -> Embedder:
-    """Return a cached Embedder instance for *model_name*."""
+    """Return a cached Embedder instance, using GPU routing when available.
+
+    Checks GOLDENMATCH_GPU_MODE to select the right backend:
+    - vertex: uses VertexEmbedder (Google Vertex AI, no local GPU needed)
+    - remote: uses RemoteEmbedder (custom endpoint)
+    - local/cpu_safe: uses local sentence-transformers Embedder
+    """
     if model_name not in _embedders:
-        _embedders[model_name] = Embedder(model_name)
+        from goldenmatch.core.gpu import detect_gpu_mode, GPUMode
+        mode = detect_gpu_mode()
+        if mode == GPUMode.VERTEX:
+            from goldenmatch.core.vertex_embedder import VertexEmbedder
+            _embedders[model_name] = VertexEmbedder()
+        else:
+            _embedders[model_name] = Embedder(model_name)
     return _embedders[model_name]

--- a/goldenmatch/core/embedder.py
+++ b/goldenmatch/core/embedder.py
@@ -87,11 +87,29 @@ def get_embedder(model_name: str = "all-MiniLM-L6-v2") -> Embedder:
     - local/cpu_safe: uses local sentence-transformers Embedder
     """
     if model_name not in _embedders:
-        from goldenmatch.core.gpu import detect_gpu_mode, GPUMode
-        mode = detect_gpu_mode()
-        if mode == GPUMode.VERTEX:
-            from goldenmatch.core.vertex_embedder import VertexEmbedder
-            _embedders[model_name] = VertexEmbedder()
+        try:
+            from goldenmatch.core.gpu import detect_gpu_mode, GPUMode
+            mode = detect_gpu_mode()
+        except Exception:
+            logger.warning("GPU detection failed, defaulting to local embedder.", exc_info=True)
+            mode = None
+
+        if mode is not None and mode.value == "vertex":
+            try:
+                from goldenmatch.core.vertex_embedder import VertexEmbedder
+                logger.info("GPU mode=vertex: using VertexEmbedder (ignoring model_name=%s)", model_name)
+                _embedders[model_name] = VertexEmbedder()
+            except ImportError:
+                logger.error(
+                    "GOLDENMATCH_GPU_MODE=vertex but google-cloud-aiplatform is not installed. "
+                    "Install with: pip install goldenmatch[vertex]. Falling back to local embedder."
+                )
+                _embedders[model_name] = Embedder(model_name)
+            except Exception as e:
+                logger.error(
+                    "VertexEmbedder initialization failed: %s. Falling back to local embedder.", e,
+                )
+                _embedders[model_name] = Embedder(model_name)
         else:
             _embedders[model_name] = Embedder(model_name)
     return _embedders[model_name]

--- a/goldenmatch/core/llm_budget.py
+++ b/goldenmatch/core/llm_budget.py
@@ -26,7 +26,7 @@ class BudgetTracker:
 
     def __init__(self, config: BudgetConfig) -> None:
         self._config = config
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._total_input_tokens = 0
         self._total_output_tokens = 0
         self._total_calls = 0
@@ -100,25 +100,27 @@ class BudgetTracker:
 
     @property
     def budget_exhausted(self) -> bool:
-        if (
-            self._config.max_cost_usd is not None
-            and self._total_cost >= self._config.max_cost_usd
-        ):
-            return True
-        if (
-            self._config.max_calls is not None
-            and self._total_calls >= self._config.max_calls
-        ):
-            return True
-        return False
+        with self._lock:
+            if (
+                self._config.max_cost_usd is not None
+                and self._total_cost >= self._config.max_cost_usd
+            ):
+                return True
+            if (
+                self._config.max_calls is not None
+                and self._total_calls >= self._config.max_calls
+            ):
+                return True
+            return False
 
     @property
     def budget_remaining_pct(self) -> float:
-        if self._config.max_cost_usd is not None and self._config.max_cost_usd > 0:
-            return max(0.0, 100.0 * (1 - self._total_cost / self._config.max_cost_usd))
-        if self._config.max_calls is not None and self._config.max_calls > 0:
-            return max(0.0, 100.0 * (1 - self._total_calls / self._config.max_calls))
-        return 100.0
+        with self._lock:
+            if self._config.max_cost_usd is not None and self._config.max_cost_usd > 0:
+                return max(0.0, 100.0 * (1 - self._total_cost / self._config.max_cost_usd))
+            if self._config.max_calls is not None and self._config.max_calls > 0:
+                return max(0.0, 100.0 * (1 - self._total_calls / self._config.max_calls))
+            return 100.0
 
     def summary(self) -> dict:
         """Return summary dict for EngineStats / lineage."""

--- a/goldenmatch/core/llm_budget.py
+++ b/goldenmatch/core/llm_budget.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 
 from goldenmatch.config.schemas import BudgetConfig
 
@@ -25,6 +26,7 @@ class BudgetTracker:
 
     def __init__(self, config: BudgetConfig) -> None:
         self._config = config
+        self._lock = threading.Lock()
         self._total_input_tokens = 0
         self._total_output_tokens = 0
         self._total_calls = 0
@@ -33,40 +35,42 @@ class BudgetTracker:
         self._models_used: dict[str, int] = {}
 
     def can_send(self, estimated_tokens: int) -> bool:
-        """Check if we can send a batch without exceeding budget."""
-        if self.budget_exhausted:
-            return False
-        if self._config.max_cost_usd is not None:
-            est_cost = self._estimate_cost(estimated_tokens, 0, "gpt-4o-mini")
-            if self._total_cost + est_cost > self._config.max_cost_usd:
+        """Check if we can send a batch without exceeding budget. Thread-safe."""
+        with self._lock:
+            if self.budget_exhausted:
                 return False
-        return True
+            if self._config.max_cost_usd is not None:
+                est_cost = self._estimate_cost(estimated_tokens, 0, "gpt-4o-mini")
+                if self._total_cost + est_cost > self._config.max_cost_usd:
+                    return False
+            return True
 
     def record_usage(
         self, input_tokens: int, output_tokens: int, model: str,
     ) -> None:
-        """Record token usage from an API call."""
+        """Record token usage from an API call. Thread-safe."""
         cost = self._estimate_cost(input_tokens, output_tokens, model)
-        self._total_input_tokens += input_tokens
-        self._total_output_tokens += output_tokens
-        self._total_calls += 1
-        self._total_cost += cost
-        self._models_used[model] = self._models_used.get(model, 0) + 1
+        with self._lock:
+            self._total_input_tokens += input_tokens
+            self._total_output_tokens += output_tokens
+            self._total_calls += 1
+            self._total_cost += cost
+            self._models_used[model] = self._models_used.get(model, 0) + 1
 
-        if self._config.escalation_model and model == self._config.escalation_model:
-            self._escalation_cost += cost
+            if self._config.escalation_model and model == self._config.escalation_model:
+                self._escalation_cost += cost
 
-        if (
-            self._config.max_cost_usd
-            and self._config.warn_at_pct
-            and self.budget_remaining_pct <= (100 - self._config.warn_at_pct)
-        ):
-            logger.warning(
-                "LLM budget %.0f%% consumed ($%.4f / $%.2f)",
-                100 - self.budget_remaining_pct,
-                self._total_cost,
-                self._config.max_cost_usd,
-            )
+            if (
+                self._config.max_cost_usd
+                and self._config.warn_at_pct
+                and self.budget_remaining_pct <= (100 - self._config.warn_at_pct)
+            ):
+                logger.warning(
+                    "LLM budget %.0f%% consumed ($%.4f / $%.2f)",
+                    100 - self.budget_remaining_pct,
+                    self._total_cost,
+                    self._config.max_cost_usd,
+                )
 
     def select_model(self, pair_score: float, default_model: str) -> str:
         """Select model based on pair score and escalation config."""

--- a/goldenmatch/core/llm_scorer.py
+++ b/goldenmatch/core/llm_scorer.py
@@ -277,6 +277,7 @@ def _batch_score(
         if budget:
             estimated_tokens = len(batch_idx) * 80
             if not budget.can_send(estimated_tokens):
+                logger.debug("Budget exhausted, skipping batch of %d pairs.", len(batch_idx))
                 return {}
 
         # Build prompt
@@ -335,9 +336,17 @@ def _batch_score(
                     time.sleep(wait)
                     continue
                 logger.error("LLM API error: %s", e)
-                return {idx: False for idx in batch_idx}
+                return {}
+            except (urllib.error.URLError, OSError) as e:
+                if attempt < 2:
+                    wait = (attempt + 1) * 5
+                    logger.warning("LLM network error: %s. Retrying in %ds...", e, wait)
+                    time.sleep(wait)
+                    continue
+                logger.error("LLM network error (unrecoverable): %s", e)
+                return {}
 
-        return {idx: False for idx in batch_idx}
+        return {}
 
     # Sequential fast path for small workloads
     if len(all_batches) <= 2 or max_workers <= 1:
@@ -367,7 +376,15 @@ def _batch_score(
             futures[fut] = batch_idx
 
         for fut in as_completed(futures):
-            batch_result = fut.result()
+            try:
+                batch_result = fut.result()
+            except Exception:
+                batch_idx = futures[fut]
+                logger.error(
+                    "LLM batch scoring failed for %d pairs. Skipping batch.",
+                    len(batch_idx), exc_info=True,
+                )
+                continue
             results.update(batch_result)
             completed += 1
             if completed % 10 == 0 or completed == len(futures):
@@ -438,7 +455,7 @@ def _stratified_sample(
     bins: list[list[int]] = [[] for _ in range(n_bins)]
     for i in available:
         score = pairs[i][2]
-        bin_idx = min(int((score - score_lo) / bin_width), n_bins - 1)
+        bin_idx = max(0, min(int((score - score_lo) / bin_width), n_bins - 1))
         bins[bin_idx].append(i)
 
     total_available = len(available)
@@ -540,6 +557,13 @@ def _iterative_calibrate(
             provider, api_key, model, batch_size,
             budget=budget, max_workers=max_workers,
         )
+
+        if not round_results:
+            logger.warning(
+                "LLM calibration round %d: no results returned (budget exhausted or API failure). Stopping.",
+                round_num,
+            )
+            break
 
         for idx, is_match in round_results.items():
             all_labels[idx] = (pairs[idx][2], is_match)

--- a/goldenmatch/core/llm_scorer.py
+++ b/goldenmatch/core/llm_scorer.py
@@ -23,6 +23,7 @@ import logging
 import os
 import time
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import polars as pl
 
@@ -39,6 +40,7 @@ def llm_score_pairs(
     api_key: str | None = None,
     model: str | None = None,
     batch_size: int = 20,
+    max_workers: int = 5,
     display_columns: list[str] | None = None,
     config: "LLMScorerConfig | None" = None,
     return_budget: bool = False,
@@ -66,17 +68,24 @@ def llm_score_pairs(
 
     Returns:
         Updated pairs list (or tuple with budget summary if return_budget=True).
-        LLM-approved pairs get score=1.0, LLM-rejected pairs get score=0.0,
-        others unchanged.
+        LLM-approved pairs get score=1.0. LLM-rejected or unconfirmed pairs
+        keep their original fuzzy score (never demoted).
     """
     from goldenmatch.config.schemas import LLMScorerConfig
 
     # Resolve config -> individual params
+    calibration_sample_size = 100
+    calibration_max_rounds = 5
+    calibration_convergence_delta = 0.01
     if config is not None:
         auto_threshold = config.auto_threshold
         candidate_lo = config.candidate_lo
         candidate_hi = config.candidate_hi
         batch_size = config.batch_size
+        max_workers = config.max_workers
+        calibration_sample_size = config.calibration_sample_size
+        calibration_max_rounds = config.calibration_max_rounds
+        calibration_convergence_delta = config.calibration_convergence_delta
         if config.provider:
             provider = config.provider
         if config.model:
@@ -134,24 +143,6 @@ def llm_score_pairs(
         len(auto_accept), auto_threshold, len(candidates), candidate_lo, candidate_hi, len(below),
     )
 
-    # Adaptive candidate range: if too many candidates for the budget,
-    # raise candidate_lo to target the most ambiguous pairs only
-    max_candidates = (budget._config.max_calls if budget and budget._config.max_calls else 500) * batch_size
-    if len(candidates) > max_candidates:
-        candidate_scores = sorted([pairs[i][2] for i in candidates], reverse=True)
-        adaptive_lo = candidate_scores[max_candidates - 1]
-        # Re-classify: keep only pairs above the new threshold
-        new_candidates = [i for i in candidates if pairs[i][2] >= adaptive_lo]
-        dropped = len(candidates) - len(new_candidates)
-        below.extend(i for i in candidates if pairs[i][2] < adaptive_lo)
-        candidates = new_candidates
-        logger.info(
-            "Adaptive range: raised candidate_lo from %.2f to %.2f "
-            "(%d candidates -> %d, %d dropped to keep within budget)",
-            candidate_lo, adaptive_lo, dropped + len(candidates),
-            len(candidates), dropped,
-        )
-
     if not candidates:
         result = list(pairs)
         for i in auto_accept:
@@ -170,32 +161,76 @@ def llm_score_pairs(
 
     # Score candidates with LLM
     t0 = time.perf_counter()
-    llm_results = _batch_score(
-        candidates, pairs, row_lookup, cols,
-        provider, api_key, model, batch_size,
-        budget=budget,
-    )
-    elapsed = time.perf_counter() - t0
 
-    n_match = sum(1 for v in llm_results.values() if v)
-    logger.info(
-        "LLM scored %d pairs in %.1fs: %d matches, %d non-matches",
-        len(llm_results), elapsed, n_match, len(llm_results) - n_match,
-    )
+    if len(candidates) > calibration_sample_size:
+        # Iterative calibration path
+        learned_threshold, llm_results = _iterative_calibrate(
+            candidates, pairs, row_lookup, cols,
+            provider, api_key, model, batch_size,
+            budget=budget, max_workers=max_workers,
+            sample_size=calibration_sample_size,
+            max_rounds=calibration_max_rounds,
+            convergence_delta=calibration_convergence_delta,
+            candidate_lo=candidate_lo,
+            candidate_hi=candidate_hi,
+        )
 
-    # Build result
-    result = list(pairs)
-    for i in auto_accept:
-        a, b, _ = result[i]
-        result[i] = (a, b, 1.0)
-    for i in candidates:
-        a, b, s = result[i]
-        if i in llm_results:
-            if llm_results[i]:
+        elapsed = time.perf_counter() - t0
+
+        # Build result: auto-accept
+        result = list(pairs)
+        for i in auto_accept:
+            a, b, _ = result[i]
+            result[i] = (a, b, 1.0)
+
+        # Apply LLM labels to sampled pairs
+        for i, is_match in llm_results.items():
+            if is_match:
+                a, b, _ = result[i]
                 result[i] = (a, b, 1.0)
-            else:
-                result[i] = (a, b, 0.0)
-        # else: budget ran out mid-scoring, keep original score
+            # else: keep original fuzzy score (never demote)
+
+        # Apply learned threshold to unsampled pairs
+        n_promoted = 0
+        n_unchanged = 0
+        for i in candidates:
+            if i not in llm_results:
+                if pairs[i][2] >= learned_threshold:
+                    a, b, _ = result[i]
+                    result[i] = (a, b, 1.0)
+                    n_promoted += 1
+                else:
+                    n_unchanged += 1
+
+        logger.info(
+            "LLM calibration applied in %.1fs: %d promoted, %d unchanged",
+            elapsed, n_promoted + sum(1 for m in llm_results.values() if m), n_unchanged,
+        )
+    else:
+        # Direct scoring path: few candidates, score them all
+        llm_results = _batch_score(
+            candidates, pairs, row_lookup, cols,
+            provider, api_key, model, batch_size,
+            budget=budget, max_workers=max_workers,
+        )
+        elapsed = time.perf_counter() - t0
+
+        n_match = sum(1 for v in llm_results.values() if v)
+        logger.info(
+            "LLM scored %d pairs in %.1fs: %d matches, %d non-matches",
+            len(llm_results), elapsed, n_match, len(llm_results) - n_match,
+        )
+
+        # Build result
+        result = list(pairs)
+        for i in auto_accept:
+            a, b, _ = result[i]
+            result[i] = (a, b, 1.0)
+        for i in candidates:
+            if i in llm_results and llm_results[i]:
+                a, b, _ = result[i]
+                result[i] = (a, b, 1.0)
+            # else: keep original fuzzy score (never demote)
 
     return _return(result)
 
@@ -221,19 +256,28 @@ def _batch_score(
     model: str,
     batch_size: int,
     budget: "BudgetTracker | None" = None,
+    max_workers: int = 5,
 ) -> dict[int, bool]:
-    """Score candidate pairs in batches. Returns {pair_index: is_match}."""
+    """Score candidate pairs in batches with concurrent requests.
+
+    Returns {pair_index: is_match}.
+    """
     results: dict[int, bool] = {}
 
+    # Pre-build all batch slices
+    all_batches: list[list[int]] = []
     for bi in range(0, len(candidate_indices), batch_size):
-        # Check budget before each batch
-        if budget:
-            estimated_tokens = batch_size * 80  # rough estimate per pair
-            if not budget.can_send(estimated_tokens):
-                logger.info("LLM budget exhausted after %d/%d pairs.", bi, len(candidate_indices))
-                break
+        all_batches.append(candidate_indices[bi:bi + batch_size])
 
-        batch_idx = candidate_indices[bi:bi + batch_size]
+    total_pairs = len(candidate_indices)
+
+    def _score_one_batch(batch_idx: list[int]) -> dict[int, bool]:
+        """Score a single batch via LLM. Called from worker threads."""
+        # Check budget (thread-safe via lock in BudgetTracker)
+        if budget:
+            estimated_tokens = len(batch_idx) * 80
+            if not budget.can_send(estimated_tokens):
+                return {}
 
         # Build prompt
         prompt_parts = [
@@ -250,7 +294,7 @@ def _batch_score(
 
         prompt = "\n".join(prompt_parts)
 
-        # Call LLM
+        # Call LLM with retries
         for attempt in range(3):
             try:
                 if provider == "openai":
@@ -262,7 +306,6 @@ def _batch_score(
                         prompt, api_key, model, max_tokens=len(batch_idx) * 10,
                     )
 
-                # Record budget usage
                 if budget:
                     budget.record_usage(
                         input_tokens=in_tok, output_tokens=out_tok, model=model,
@@ -277,15 +320,14 @@ def _batch_score(
                     elif "NO" in line:
                         batch_results.append(False)
 
-                # Pad if parsing missed some
                 while len(batch_results) < len(batch_idx):
                     batch_results.append(False)
 
-                for k, idx in enumerate(batch_idx):
-                    if k < len(batch_results):
-                        results[idx] = batch_results[k]
-
-                break
+                return {
+                    idx: batch_results[k]
+                    for k, idx in enumerate(batch_idx)
+                    if k < len(batch_results)
+                }
             except urllib.error.HTTPError as e:
                 if e.code == 429 and attempt < 2:
                     wait = (attempt + 1) * 5
@@ -293,15 +335,252 @@ def _batch_score(
                     time.sleep(wait)
                     continue
                 logger.error("LLM API error: %s", e)
-                # Mark batch as non-match on failure
-                for idx in batch_idx:
-                    results[idx] = False
-                break
+                return {idx: False for idx in batch_idx}
 
-        if (bi // batch_size) % 10 == 0 and bi > 0:
-            logger.info("  LLM progress: %d/%d pairs", bi + len(batch_idx), len(candidate_indices))
+        return {idx: False for idx in batch_idx}
+
+    # Sequential fast path for small workloads
+    if len(all_batches) <= 2 or max_workers <= 1:
+        for bi, batch_idx in enumerate(all_batches):
+            batch_result = _score_one_batch(batch_idx)
+            if not batch_result and budget and budget.budget_exhausted:
+                logger.info("LLM budget exhausted after %d/%d pairs.",
+                            bi * batch_size, total_pairs)
+                break
+            results.update(batch_result)
+            if (bi + 1) % 10 == 0:
+                logger.info("  LLM progress: %d/%d pairs",
+                            min((bi + 1) * batch_size, total_pairs), total_pairs)
+        return results
+
+    # Concurrent path
+    completed = 0
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {}
+        for batch_idx in all_batches:
+            # Pre-check budget before submitting (avoid wasting threads)
+            if budget and budget.budget_exhausted:
+                logger.info("LLM budget exhausted, skipping remaining %d batches.",
+                            len(all_batches) - len(futures))
+                break
+            fut = pool.submit(_score_one_batch, batch_idx)
+            futures[fut] = batch_idx
+
+        for fut in as_completed(futures):
+            batch_result = fut.result()
+            results.update(batch_result)
+            completed += 1
+            if completed % 10 == 0 or completed == len(futures):
+                logger.info("  LLM progress: %d/%d batches (%d pairs scored)",
+                            completed, len(futures), len(results))
 
     return results
+
+
+def _compute_threshold(labels: dict[int, tuple[float, bool]]) -> float:
+    """Find optimal threshold separating YES from NO labels via grid search.
+
+    Args:
+        labels: {pair_index: (fuzzy_score, is_match)} from LLM responses.
+
+    Returns:
+        Optimal threshold score. Pairs at or above this are matches.
+    """
+    yes_scores = [s for s, m in labels.values() if m]
+    no_scores = [s for s, m in labels.values() if not m]
+
+    if not yes_scores:
+        return max(s for s, _ in labels.values()) + 0.001
+    if not no_scores:
+        return min(s for s, _ in labels.values()) - 0.001
+
+    if max(no_scores) < min(yes_scores):
+        return (max(no_scores) + min(yes_scores)) / 2
+
+    all_scores = sorted(set(yes_scores + no_scores))
+    best_threshold = (max(no_scores) + min(yes_scores)) / 2
+    best_cost = float("inf")
+
+    for i in range(len(all_scores) - 1):
+        candidate = (all_scores[i] + all_scores[i + 1]) / 2
+        cost = 0
+        for score, is_match in labels.values():
+            if is_match and score < candidate:
+                cost += 1
+            elif not is_match and score >= candidate:
+                cost += 1
+        if cost < best_cost:
+            best_cost = cost
+            best_threshold = candidate
+
+    return best_threshold
+
+
+def _stratified_sample(
+    candidate_indices: list[int],
+    pairs: list[tuple[int, int, float]],
+    sample_size: int,
+    score_lo: float,
+    score_hi: float,
+    already_scored: set[int],
+) -> list[int]:
+    """Stratified sample across the score range for round 1."""
+    import random as _random
+
+    available = [i for i in candidate_indices if i not in already_scored]
+    if len(available) <= sample_size:
+        return available
+
+    score_range = score_hi - score_lo
+    bin_width = max(0.01, score_range / 20)
+    n_bins = max(1, int(score_range / bin_width))
+
+    bins: list[list[int]] = [[] for _ in range(n_bins)]
+    for i in available:
+        score = pairs[i][2]
+        bin_idx = min(int((score - score_lo) / bin_width), n_bins - 1)
+        bins[bin_idx].append(i)
+
+    total_available = len(available)
+    result: list[int] = []
+    remaining_quota = sample_size
+
+    for b in bins:
+        if not b or remaining_quota <= 0:
+            continue
+        quota = max(1, round(sample_size * len(b) / total_available))
+        quota = min(quota, remaining_quota, len(b))
+        result.extend(_random.sample(b, quota))
+        remaining_quota -= quota
+
+    if len(result) < sample_size:
+        remaining = [i for i in available if i not in set(result)]
+        extra = min(sample_size - len(result), len(remaining))
+        if extra > 0:
+            result.extend(_random.sample(remaining, extra))
+
+    return result[:sample_size]
+
+
+def _focused_sample(
+    candidate_indices: list[int],
+    pairs: list[tuple[int, int, float]],
+    sample_size: int,
+    threshold: float,
+    band_width: float,
+    already_scored: set[int],
+) -> list[int]:
+    """Focused sample near the learned threshold for rounds 2+."""
+    import random as _random
+
+    lo = threshold - band_width
+    hi = threshold + band_width
+
+    available = [
+        i for i in candidate_indices
+        if i not in already_scored and lo <= pairs[i][2] <= hi
+    ]
+
+    if len(available) <= sample_size:
+        return available
+
+    return _random.sample(available, sample_size)
+
+
+def _iterative_calibrate(
+    candidate_indices: list[int],
+    pairs: list[tuple[int, int, float]],
+    row_lookup: dict[int, dict],
+    cols: list[str],
+    provider: str,
+    api_key: str,
+    model: str,
+    batch_size: int,
+    budget: "BudgetTracker | None" = None,
+    max_workers: int = 5,
+    sample_size: int = 100,
+    max_rounds: int = 5,
+    convergence_delta: float = 0.01,
+    candidate_lo: float = 0.75,
+    candidate_hi: float = 0.95,
+) -> tuple[float, dict[int, bool]]:
+    """Iterative LLM calibration: sample, score, learn threshold, repeat.
+
+    Returns (learned_threshold, {pair_index: is_match} for scored pairs).
+    """
+    all_labels: dict[int, tuple[float, bool]] = {}
+    all_llm_results: dict[int, bool] = {}
+    already_scored: set[int] = set()
+    prev_threshold = (candidate_lo + candidate_hi) / 2
+
+    for round_num in range(1, max_rounds + 1):
+        if budget and budget.budget_exhausted:
+            logger.info("LLM calibration: budget exhausted before round %d.", round_num)
+            break
+
+        if round_num == 1:
+            sample = _stratified_sample(
+                candidate_indices, pairs, sample_size,
+                score_lo=candidate_lo, score_hi=candidate_hi,
+                already_scored=already_scored,
+            )
+        else:
+            sample = _focused_sample(
+                candidate_indices, pairs, sample_size,
+                threshold=prev_threshold, band_width=0.03,
+                already_scored=already_scored,
+            )
+
+        if not sample:
+            logger.info("LLM calibration round %d: no unscored pairs to sample. Stopping.", round_num)
+            break
+
+        round_results = _batch_score(
+            sample, pairs, row_lookup, cols,
+            provider, api_key, model, batch_size,
+            budget=budget, max_workers=max_workers,
+        )
+
+        for idx, is_match in round_results.items():
+            all_labels[idx] = (pairs[idx][2], is_match)
+            all_llm_results[idx] = is_match
+            already_scored.add(idx)
+
+        if not all_labels:
+            break
+        threshold = _compute_threshold(all_labels)
+
+        n_match = sum(1 for m in round_results.values() if m)
+        n_no = len(round_results) - n_match
+        sample_scores = [pairs[i][2] for i in sample]
+        score_lo_round = min(sample_scores) if sample_scores else 0
+        score_hi_round = max(sample_scores) if sample_scores else 0
+
+        if round_num == 1:
+            logger.info(
+                "LLM calibration round %d: %d pairs (%.3f-%.3f), %d match, %d non-match -> threshold %.3f",
+                round_num, len(round_results), score_lo_round, score_hi_round,
+                n_match, n_no, threshold,
+            )
+        else:
+            delta = abs(threshold - prev_threshold)
+            logger.info(
+                "LLM calibration round %d: %d pairs (%.3f-%.3f), %d match, %d non-match -> threshold %.3f (delta %.3f)",
+                round_num, len(round_results), score_lo_round, score_hi_round,
+                n_match, n_no, threshold, delta,
+            )
+
+            if abs(threshold - prev_threshold) < convergence_delta:
+                logger.info(
+                    "LLM calibration converged after %d rounds (%d pairs). Threshold: %.3f",
+                    round_num, len(all_llm_results), threshold,
+                )
+                prev_threshold = threshold
+                break
+
+        prev_threshold = threshold
+
+    return prev_threshold, all_llm_results
 
 
 def _call_openai(

--- a/tests/test_ann_subblock.py
+++ b/tests/test_ann_subblock.py
@@ -1,0 +1,135 @@
+"""Tests for ANN sub-block fallback in blocker."""
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+from unittest.mock import patch, MagicMock
+
+from goldenmatch.core.blocker import _ann_sub_block, _build_static_blocks
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+
+
+class TestANNSubBlock:
+    def _make_block_df(self, n, ann_col="__text__", text_fn=None):
+        """Create a block DataFrame with __row_id__ and ann_column."""
+        if text_fn is None:
+            text_fn = lambda i: f"model_{i % 5}"  # 5 unique texts
+        return pl.DataFrame({
+            "__row_id__": list(range(n)),
+            ann_col: [text_fn(i) for i in range(n)],
+            "name": [f"record_{i}" for i in range(n)],
+        })
+
+    def test_too_large_returns_empty(self):
+        """Blocks >10x max_block_size should be skipped."""
+        df = self._make_block_df(11000)
+        result = _ann_sub_block(df, "__text__", 20, "model", 1000, "test_block")
+        assert result == []
+
+    def test_missing_column_returns_empty(self):
+        """Missing ann_column should return empty."""
+        df = self._make_block_df(2000)
+        result = _ann_sub_block(df, "nonexistent_col", 20, "model", 1000, "test_block")
+        assert result == []
+
+    def test_single_unique_text_returns_empty(self):
+        """<2 unique texts should return empty."""
+        df = self._make_block_df(2000, text_fn=lambda i: "same_text")
+        result = _ann_sub_block(df, "__text__", 20, "model", 1000, "test_block")
+        assert result == []
+
+    def test_happy_path_creates_subblocks(self):
+        """ANN sub-blocking should create sub-blocks from oversized block."""
+        n = 2000
+        # 10 unique texts, records cycle through them
+        df = self._make_block_df(n, text_fn=lambda i: f"equipment_{i % 10}")
+
+        # Mock embedder: return 10 embeddings (one per unique text)
+        mock_embedder = MagicMock()
+        dim = 8
+        # Each unique text gets a distinct embedding direction
+        unique_embeddings = np.random.RandomState(42).randn(10, dim).astype(np.float32)
+        unique_embeddings /= np.linalg.norm(unique_embeddings, axis=1, keepdims=True)
+        mock_embedder.embed_column.return_value = unique_embeddings
+
+        # Mock ANNBlocker: return pairs that cluster nearby texts
+        mock_blocker_cls = MagicMock()
+        mock_blocker = MagicMock()
+        mock_blocker_cls.return_value = mock_blocker
+        # Pair up consecutive text indices: (0,1), (2,3), (4,5), (6,7), (8,9)
+        mock_blocker.query.return_value = [(0, 1), (2, 3), (4, 5), (6, 7), (8, 9)]
+
+        with patch("goldenmatch.core.embedder.get_embedder", return_value=mock_embedder):
+            with patch("goldenmatch.core.ann_blocker.ANNBlocker", mock_blocker_cls):
+                result = _ann_sub_block(df, "__text__", 20, "model", 1000, "test_block")
+
+        assert len(result) > 0
+        # All sub-blocks should have strategy "ann"
+        for block in result:
+            assert block.strategy == "ann"
+        # Total records in sub-blocks should be <= original
+        total = sum(len(b.df.collect()) for b in result)
+        assert total <= n
+
+
+class TestStaticBlocksANNFallback:
+    def test_ann_fallback_triggered_for_oversized(self):
+        """When skip_oversized=True and ann_column is set, oversized blocks use ANN fallback."""
+        # Create data that produces one oversized block
+        df = pl.DataFrame({
+            "__row_id__": list(range(50)),
+            "key": ["A"] * 50,  # all in one block
+            "__text__": [f"text_{i % 5}" for i in range(50)],
+        })
+
+        config = BlockingConfig(
+            keys=[BlockingKeyConfig(fields=["key"])],
+            max_block_size=10,  # block of 50 exceeds this
+            skip_oversized=True,
+            ann_column="__text__",
+            ann_top_k=5,
+        )
+
+        with patch("goldenmatch.core.blocker._ann_sub_block") as mock_ann:
+            mock_ann.return_value = []  # just verify it's called
+            _build_static_blocks(df.lazy(), config)
+            mock_ann.assert_called_once()
+
+    def test_ann_fallback_not_triggered_without_ann_column(self):
+        """Without ann_column, oversized blocks are just skipped."""
+        df = pl.DataFrame({
+            "__row_id__": list(range(50)),
+            "key": ["A"] * 50,
+        })
+
+        config = BlockingConfig(
+            keys=[BlockingKeyConfig(fields=["key"])],
+            max_block_size=10,
+            skip_oversized=True,
+            # no ann_column
+        )
+
+        with patch("goldenmatch.core.blocker._ann_sub_block") as mock_ann:
+            result = _build_static_blocks(df.lazy(), config)
+            mock_ann.assert_not_called()
+            assert len(result) == 0  # block skipped
+
+    def test_ann_fallback_error_doesnt_crash(self):
+        """If ANN sub-blocking raises, the block is skipped gracefully."""
+        df = pl.DataFrame({
+            "__row_id__": list(range(50)),
+            "key": ["A"] * 50,
+            "__text__": [f"text_{i}" for i in range(50)],
+        })
+
+        config = BlockingConfig(
+            keys=[BlockingKeyConfig(fields=["key"])],
+            max_block_size=10,
+            skip_oversized=True,
+            ann_column="__text__",
+        )
+
+        with patch("goldenmatch.core.blocker._ann_sub_block", side_effect=RuntimeError("FAISS failed")):
+            result = _build_static_blocks(df.lazy(), config)
+            assert len(result) == 0  # block skipped, no crash

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -56,9 +56,27 @@ class TestClassifyByName:
         assert _classify_by_name("customer_id") == "identifier"
         assert _classify_by_name("sku") == "identifier"
 
+    def test_price(self):
+        assert _classify_by_name("SalePrice") == "numeric"
+        assert _classify_by_name("amount") == "numeric"
+        assert _classify_by_name("total_cost") == "numeric"
+        assert _classify_by_name("revenue") == "numeric"
+
+    def test_id_before_phone(self):
+        """ID pattern should match before phone — SalesID is an ID, not a phone."""
+        assert _classify_by_name("SalesID") == "identifier"
+        assert _classify_by_name("MachineID") == "identifier"
+        assert _classify_by_name("PhoneID") == "identifier"
+        assert _classify_by_name("TelephoneId") == "identifier"
+
+    def test_phone_still_works(self):
+        """Phone columns without ID suffix still classified as phone."""
+        assert _classify_by_name("phone") == "phone"
+        assert _classify_by_name("mobile") == "phone"
+        assert _classify_by_name("fax_number") == "phone"
+
     def test_unknown(self):
         assert _classify_by_name("foobar") is None
-        assert _classify_by_name("amount") is None
 
 
 class TestClassifyByData:
@@ -114,6 +132,66 @@ class TestProfileColumns:
         })
         profiles = profile_columns(df)
         assert all(p.name != "__row_id__" for p in profiles)
+
+
+class TestIdentifierNotOverridden:
+    """Identifier columns should not be overridden by phone/zip data profiling."""
+
+    def test_id_column_with_numeric_data(self):
+        """SalesID with 7-digit integers should stay 'identifier', not become 'phone'."""
+        df = pl.DataFrame({
+            "SalesID": [str(1139246 + i) for i in range(100)],
+            "name": [f"Record {i}" for i in range(100)],
+        })
+        profiles = profile_columns(df)
+        types = {p.name: p.col_type for p in profiles}
+        assert types["SalesID"] == "identifier"
+
+    def test_price_column_not_zip(self):
+        """SalePrice with 5-digit values should be 'numeric', not 'zip'."""
+        df = pl.DataFrame({
+            "SalePrice": [str(v) for v in [66000, 57000, 10000, 38500, 11000] * 20],
+            "name": [f"Record {i}" for i in range(100)],
+        })
+        profiles = profile_columns(df)
+        types = {p.name: p.col_type for p in profiles}
+        assert types["SalePrice"] == "numeric"
+
+
+class TestUtilityRanking:
+    """Fuzzy field truncation should rank by match utility, not column order."""
+
+    def test_high_utility_field_kept(self):
+        """A high-cardinality, long-string field should rank above short low-cardinality ones."""
+        profiles = [
+            ColumnProfile("UsageBand", "Utf8", "name", 0.7,
+                          sample_values=["Low", "Medium", "High"],
+                          cardinality_ratio=0.01, avg_len=4.0),
+            ColumnProfile("ProductSize", "Utf8", "name", 0.7,
+                          sample_values=["Small", "Large"],
+                          cardinality_ratio=0.005, avg_len=5.0),
+            ColumnProfile("Drive_System", "Utf8", "name", 0.7,
+                          sample_values=["2WD", "4WD"],
+                          cardinality_ratio=0.005, avg_len=3.0),
+            ColumnProfile("Enclosure", "Utf8", "name", 0.7,
+                          sample_values=["OROPS", "EROPS"],
+                          cardinality_ratio=0.005, avg_len=5.0),
+            ColumnProfile("Forks", "Utf8", "name", 0.7,
+                          sample_values=["Yes", "No"],
+                          cardinality_ratio=0.005, avg_len=3.0),
+            ColumnProfile("Ride_Control", "Utf8", "name", 0.7,
+                          sample_values=["Yes", "No"],
+                          cardinality_ratio=0.005, avg_len=3.0),
+            ColumnProfile("fiModelDesc", "Utf8", "string", 0.5,
+                          sample_values=["580D LL", "310SE", "416D 4x4x4"],
+                          cardinality_ratio=0.8, avg_len=12.0),
+        ]
+        mks = build_matchkeys(profiles)
+        weighted = [mk for mk in mks if mk.type == "weighted"]
+        assert len(weighted) == 1
+        field_names = [f.field for f in weighted[0].fields if f.field]
+        # fiModelDesc should be included despite being last in column order
+        assert "fiModelDesc" in field_names
 
 
 class TestBuildMatchkeys:

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -473,6 +473,90 @@ class TestLLMBlockingKeySuggestion:
         assert config is not None
 
 
+class TestLLMColumnClassification:
+    """Test LLM-assisted column classification in profile_columns."""
+
+    def test_happy_path_corrects_ambiguous_types(self):
+        """LLM response should override ambiguous classifications."""
+        from goldenmatch.core.autoconfig import _llm_classify_columns, ColumnProfile
+
+        profiles = [
+            ColumnProfile("SalesID", "Utf8", "phone", 0.7, ["1139246", "1139248"]),
+            ColumnProfile("SalePrice", "Utf8", "zip", 0.7, ["66000", "57000"]),
+            ColumnProfile("fiModelDesc", "Utf8", "string", 0.3, ["580D", "310SE"]),
+            ColumnProfile("state", "Utf8", "geo", 0.9, ["CA", "TX"]),  # high confidence, should NOT change
+        ]
+
+        llm_response = '{"classifications": {"SalesID": "identifier", "SalePrice": "numeric", "fiModelDesc": "description"}, "match_ranking": ["fiModelDesc", "SalesID", "SalePrice"]}'
+
+        with patch("goldenmatch.core.autoconfig._call_llm_for_blocking", return_value=llm_response):
+            result = _llm_classify_columns(profiles, "openai")
+
+        types = {p.name: p.col_type for p in result}
+        assert types["SalesID"] == "identifier"
+        assert types["SalePrice"] == "numeric"
+        assert types["fiModelDesc"] == "description"
+        assert types["state"] == "geo"  # unchanged (high confidence)
+
+    def test_markdown_wrapped_json(self):
+        """LLM response wrapped in markdown code blocks should be parsed."""
+        from goldenmatch.core.autoconfig import _llm_classify_columns, ColumnProfile
+
+        profiles = [
+            ColumnProfile("col1", "Utf8", "string", 0.3, ["abc"]),
+        ]
+
+        llm_response = '```json\n{"classifications": {"col1": "name"}, "match_ranking": ["col1"]}\n```'
+
+        with patch("goldenmatch.core.autoconfig._call_llm_for_blocking", return_value=llm_response):
+            result = _llm_classify_columns(profiles, "openai")
+
+        assert result[0].col_type == "name"
+
+    def test_unparseable_response_returns_original(self):
+        """Garbage LLM response should return profiles unchanged."""
+        from goldenmatch.core.autoconfig import _llm_classify_columns, ColumnProfile
+
+        profiles = [
+            ColumnProfile("col1", "Utf8", "string", 0.3, ["abc"]),
+        ]
+
+        with patch("goldenmatch.core.autoconfig._call_llm_for_blocking", return_value="not json at all"):
+            result = _llm_classify_columns(profiles, "openai")
+
+        assert result[0].col_type == "string"  # unchanged
+
+    def test_api_failure_returns_original(self):
+        """LLM API failure should return profiles unchanged."""
+        from goldenmatch.core.autoconfig import _llm_classify_columns, ColumnProfile
+        import urllib.error
+
+        profiles = [
+            ColumnProfile("col1", "Utf8", "string", 0.3, ["abc"]),
+        ]
+
+        with patch("goldenmatch.core.autoconfig._call_llm_for_blocking",
+                    side_effect=urllib.error.URLError("network down")):
+            result = _llm_classify_columns(profiles, "openai")
+
+        assert result[0].col_type == "string"
+
+    def test_non_string_type_ignored(self):
+        """LLM returning non-string type values should not crash."""
+        from goldenmatch.core.autoconfig import _llm_classify_columns, ColumnProfile
+
+        profiles = [
+            ColumnProfile("col1", "Utf8", "string", 0.3, ["abc"]),
+        ]
+
+        llm_response = '{"classifications": {"col1": 123}, "match_ranking": []}'
+
+        with patch("goldenmatch.core.autoconfig._call_llm_for_blocking", return_value=llm_response):
+            result = _llm_classify_columns(profiles, "openai")
+
+        assert result[0].col_type == "string"  # unchanged, 123 ignored
+
+
 class TestCompoundBlockingIntegration:
     """Integration test: auto_configure_df on a wide dataset with oversized single-column blocks."""
 

--- a/tests/test_llm_calibration.py
+++ b/tests/test_llm_calibration.py
@@ -1,0 +1,359 @@
+"""Tests for iterative LLM calibration."""
+from __future__ import annotations
+
+import pytest
+
+
+class TestComputeThreshold:
+    """Test the grid-search threshold computation."""
+
+    def test_clean_separation(self):
+        """When matches and non-matches are cleanly separated, threshold lands between."""
+        from goldenmatch.core.llm_scorer import _compute_threshold
+        # All NO below 0.85, all YES above
+        labels = {
+            0: (0.80, False),
+            1: (0.82, False),
+            2: (0.84, False),
+            3: (0.86, True),
+            4: (0.88, True),
+            5: (0.90, True),
+            6: (0.92, True),
+        }
+        threshold = _compute_threshold(labels)
+        assert 0.84 < threshold < 0.86
+
+    def test_clean_separation_exact(self):
+        """Exercises the max(no) < min(yes) fast path."""
+        from goldenmatch.core.llm_scorer import _compute_threshold
+        labels = {
+            0: (0.80, False),
+            1: (0.82, False),
+            2: (0.90, True),
+            3: (0.92, True),
+        }
+        threshold = _compute_threshold(labels)
+        # Should be midpoint of gap: (0.82 + 0.90) / 2 = 0.86
+        assert 0.85 <= threshold <= 0.87
+
+    def test_all_yes(self):
+        """When all labels are YES, threshold should be at or below minimum score."""
+        from goldenmatch.core.llm_scorer import _compute_threshold
+        labels = {
+            0: (0.80, True),
+            1: (0.85, True),
+            2: (0.90, True),
+        }
+        threshold = _compute_threshold(labels)
+        assert threshold <= 0.80
+
+    def test_all_no(self):
+        """When all labels are NO, threshold should be above the max score."""
+        from goldenmatch.core.llm_scorer import _compute_threshold
+        labels = {
+            0: (0.80, False),
+            1: (0.85, False),
+            2: (0.90, False),
+        }
+        threshold = _compute_threshold(labels)
+        assert threshold > 0.90
+
+    def test_overlapping_scores(self):
+        """When there is overlap, threshold minimizes misclassifications."""
+        from goldenmatch.core.llm_scorer import _compute_threshold
+        labels = {
+            0: (0.80, False),
+            1: (0.82, False),
+            2: (0.84, True),   # overlap
+            3: (0.85, False),  # overlap
+            4: (0.87, True),
+            5: (0.90, True),
+            6: (0.92, True),
+        }
+        threshold = _compute_threshold(labels)
+        assert 0.83 <= threshold <= 0.88
+
+
+import random
+
+
+class TestStratifiedSample:
+    """Test round 1 stratified sampling."""
+
+    def test_covers_full_range(self):
+        from goldenmatch.core.llm_scorer import _stratified_sample
+        pairs = [(i, i+1, 0.80 + 0.15 * (i / 999)) for i in range(1000)]
+        candidate_indices = list(range(1000))
+        sample = _stratified_sample(
+            candidate_indices, pairs, sample_size=100,
+            score_lo=0.80, score_hi=0.95, already_scored=set(),
+        )
+        assert len(sample) == 100
+        sample_scores = sorted(pairs[i][2] for i in sample)
+        assert sample_scores[0] < 0.83
+        assert sample_scores[-1] > 0.92
+
+    def test_respects_already_scored(self):
+        from goldenmatch.core.llm_scorer import _stratified_sample
+        pairs = [(i, i+1, 0.80 + 0.15 * (i / 99)) for i in range(100)]
+        candidate_indices = list(range(100))
+        already_scored = set(range(50))
+        sample = _stratified_sample(
+            candidate_indices, pairs, sample_size=100,
+            score_lo=0.80, score_hi=0.95, already_scored=already_scored,
+        )
+        assert len(sample) == 50
+        assert not (set(sample) & already_scored)
+
+    def test_fewer_candidates_than_sample_size(self):
+        from goldenmatch.core.llm_scorer import _stratified_sample
+        pairs = [(i, i+1, 0.85) for i in range(10)]
+        candidate_indices = list(range(10))
+        sample = _stratified_sample(
+            candidate_indices, pairs, sample_size=100,
+            score_lo=0.80, score_hi=0.95, already_scored=set(),
+        )
+        assert len(sample) == 10
+
+
+class TestFocusedSample:
+    """Test round 2+ focused sampling near threshold."""
+
+    def test_samples_near_threshold(self):
+        from goldenmatch.core.llm_scorer import _focused_sample
+        pairs = [(i, i+1, 0.80 + 0.15 * (i / 999)) for i in range(1000)]
+        candidate_indices = list(range(1000))
+        sample = _focused_sample(
+            candidate_indices, pairs, sample_size=100,
+            threshold=0.87, band_width=0.03,
+            already_scored=set(),
+        )
+        for i in sample:
+            assert 0.84 - 0.001 <= pairs[i][2] <= 0.90 + 0.001
+
+    def test_respects_already_scored(self):
+        from goldenmatch.core.llm_scorer import _focused_sample
+        pairs = [(i, i+1, 0.87) for i in range(100)]
+        candidate_indices = list(range(100))
+        already_scored = set(range(80))
+        sample = _focused_sample(
+            candidate_indices, pairs, sample_size=100,
+            threshold=0.87, band_width=0.03,
+            already_scored=already_scored,
+        )
+        assert len(sample) == 20
+        assert not (set(sample) & already_scored)
+
+
+from unittest.mock import patch, MagicMock
+
+
+class TestIterativeCalibrate:
+    """Test the full calibration loop with mocked LLM."""
+
+    def _make_pairs_and_lookup(self, n=500):
+        pairs = []
+        for i in range(n):
+            score = 0.80 + 0.15 * (i / (n - 1))
+            pairs.append((i * 2, i * 2 + 1, score))
+        row_lookup = {r: {"name": f"record_{r}"} for r in range(n * 2 + 2)}
+        candidate_indices = list(range(n))
+        return pairs, row_lookup, candidate_indices
+
+    def test_converges_in_few_rounds(self):
+        from goldenmatch.core.llm_scorer import _iterative_calibrate
+
+        pairs, row_lookup, candidates = self._make_pairs_and_lookup(500)
+        real_threshold = 0.87
+
+        def mock_batch_score(candidate_indices, pairs, row_lookup, cols,
+                             provider, api_key, model, batch_size,
+                             budget=None, max_workers=1):
+            return {i: pairs[i][2] >= real_threshold for i in candidate_indices}
+
+        with patch("goldenmatch.core.llm_scorer._batch_score", side_effect=mock_batch_score):
+            threshold, llm_results = _iterative_calibrate(
+                candidates, pairs, row_lookup, ["name"],
+                "openai", "fake-key", "gpt-4o-mini", 75,
+                sample_size=100, max_rounds=5,
+                convergence_delta=0.01,
+                candidate_lo=0.80, candidate_hi=0.95,
+            )
+
+        assert 0.85 <= threshold <= 0.89
+        assert 100 <= len(llm_results) <= 400
+
+    def test_accumulates_labels_across_rounds(self):
+        """Labels from all rounds should be preserved in llm_results."""
+        from goldenmatch.core.llm_scorer import _iterative_calibrate
+
+        pairs, row_lookup, candidates = self._make_pairs_and_lookup(500)
+
+        call_count = 0
+        def mock_batch_score(candidate_indices, pairs, row_lookup, cols,
+                             provider, api_key, model, batch_size,
+                             budget=None, max_workers=1):
+            nonlocal call_count
+            call_count += 1
+            return {i: pairs[i][2] >= 0.87 for i in candidate_indices}
+
+        with patch("goldenmatch.core.llm_scorer._batch_score", side_effect=mock_batch_score):
+            threshold, llm_results = _iterative_calibrate(
+                candidates, pairs, row_lookup, ["name"],
+                "openai", "fake-key", "gpt-4o-mini", 75,
+                sample_size=50, max_rounds=5,
+                convergence_delta=0.01,
+                candidate_lo=0.80, candidate_hi=0.95,
+            )
+
+        # Should have results from multiple rounds
+        assert len(llm_results) >= 50  # at least round 1
+        # If converged in 2 rounds, should have ~100 labels
+        if call_count >= 2:
+            assert len(llm_results) >= 80  # accumulated from both rounds
+
+    def test_budget_exhaustion_mid_calibration(self):
+        from goldenmatch.core.llm_scorer import _iterative_calibrate
+        from goldenmatch.core.llm_budget import BudgetTracker
+        from goldenmatch.config.schemas import BudgetConfig
+
+        pairs, row_lookup, candidates = self._make_pairs_and_lookup(500)
+        budget = BudgetTracker(BudgetConfig(max_calls=1))
+
+        def mock_batch_score(candidate_indices, pairs, row_lookup, cols,
+                             provider, api_key, model, batch_size,
+                             budget=None, max_workers=1):
+            if budget:
+                budget.record_usage(100, 50, model)
+            return {i: pairs[i][2] >= 0.87 for i in candidate_indices}
+
+        with patch("goldenmatch.core.llm_scorer._batch_score", side_effect=mock_batch_score):
+            threshold, llm_results = _iterative_calibrate(
+                candidates, pairs, row_lookup, ["name"],
+                "openai", "fake-key", "gpt-4o-mini", 75,
+                budget=budget,
+                sample_size=100, max_rounds=5,
+                convergence_delta=0.01,
+                candidate_lo=0.80, candidate_hi=0.95,
+            )
+
+        assert isinstance(threshold, float)
+        assert len(llm_results) > 0
+
+    def test_immediate_convergence(self):
+        """With convergence_delta=1.0, should stop after round 1."""
+        from goldenmatch.core.llm_scorer import _iterative_calibrate
+
+        pairs, row_lookup, candidates = self._make_pairs_and_lookup(500)
+
+        call_count = 0
+        def mock_batch_score(candidate_indices, pairs, row_lookup, cols,
+                             provider, api_key, model, batch_size,
+                             budget=None, max_workers=1):
+            nonlocal call_count
+            call_count += 1
+            return {i: pairs[i][2] >= 0.87 for i in candidate_indices}
+
+        with patch("goldenmatch.core.llm_scorer._batch_score", side_effect=mock_batch_score):
+            threshold, llm_results = _iterative_calibrate(
+                candidates, pairs, row_lookup, ["name"],
+                "openai", "fake-key", "gpt-4o-mini", 75,
+                sample_size=100, max_rounds=5,
+                convergence_delta=1.0,  # always converges
+                candidate_lo=0.80, candidate_hi=0.95,
+            )
+
+        # Round 1 runs, then round 2 runs and convergence check passes
+        # (delta from midpoint 0.875 to ~0.87 is < 1.0)
+        assert len(llm_results) <= 200  # at most 2 rounds
+
+
+import polars as pl
+
+
+class TestLLMScorePairsCalibration:
+    """End-to-end test of llm_score_pairs with calibration path."""
+
+    def test_large_candidate_set_uses_calibration(self):
+        """When candidates > sample_size, calibration is used."""
+        from goldenmatch.core.llm_scorer import llm_score_pairs
+        from goldenmatch.config.schemas import LLMScorerConfig
+
+        n = 500
+        pairs = [(i * 2, i * 2 + 1, 0.80 + 0.15 * (i / (n - 1))) for i in range(n)]
+        pairs.extend([(1001, 1002, 0.98), (1003, 1004, 0.99)])
+
+        df = pl.DataFrame({
+            "__row_id__": list(range(n * 2 + 5)),
+            "name": [f"record_{i}" for i in range(n * 2 + 5)],
+        })
+
+        config = LLMScorerConfig(
+            enabled=True,
+            provider="openai",
+            model="gpt-4o-mini",
+            auto_threshold=0.95,
+            candidate_lo=0.80,
+            candidate_hi=0.95,
+            calibration_sample_size=100,
+        )
+
+        real_threshold = 0.87
+
+        def mock_batch_score(candidate_indices, pairs, row_lookup, cols,
+                             provider, api_key, model, batch_size,
+                             budget=None, max_workers=5):
+            return {i: pairs[i][2] >= real_threshold for i in candidate_indices}
+
+        with patch("goldenmatch.core.llm_scorer._batch_score", side_effect=mock_batch_score):
+            with patch("goldenmatch.core.llm_scorer._detect_provider", return_value=("openai", "fake-key")):
+                result = llm_score_pairs(pairs, df, config=config)
+
+        # Auto-accept pairs should be 1.0
+        assert result[500][2] == 1.0
+        assert result[501][2] == 1.0
+
+        # Pairs above learned threshold should be promoted
+        promoted = [r for r in result[:500] if r[2] == 1.0]
+        assert len(promoted) > 0
+
+        # Pairs below learned threshold keep original score (NOT 0.0)
+        kept = [r for r in result[:500] if r[2] != 1.0]
+        for a, b, s in kept:
+            assert s > 0
+
+    def test_small_candidate_set_uses_direct_scoring(self):
+        """When candidates <= sample_size, all are scored directly."""
+        from goldenmatch.core.llm_scorer import llm_score_pairs
+        from goldenmatch.config.schemas import LLMScorerConfig
+
+        n = 50
+        pairs = [(i * 2, i * 2 + 1, 0.85) for i in range(n)]
+
+        df = pl.DataFrame({
+            "__row_id__": list(range(n * 2 + 1)),
+            "name": [f"record_{i}" for i in range(n * 2 + 1)],
+        })
+
+        config = LLMScorerConfig(
+            enabled=True,
+            provider="openai",
+            model="gpt-4o-mini",
+            candidate_lo=0.80,
+            calibration_sample_size=100,
+        )
+
+        def mock_batch_score(candidate_indices, pairs, row_lookup, cols,
+                             provider, api_key, model, batch_size,
+                             budget=None, max_workers=5):
+            return {i: (i % 2 == 0) for i in candidate_indices}
+
+        with patch("goldenmatch.core.llm_scorer._batch_score", side_effect=mock_batch_score):
+            with patch("goldenmatch.core.llm_scorer._detect_provider", return_value=("openai", "fake-key")):
+                result = llm_score_pairs(pairs, df, config=config)
+
+        for i, (a, b, s) in enumerate(result):
+            if i % 2 == 0:
+                assert s == 1.0  # LLM said YES
+            else:
+                assert s == 0.85  # LLM said NO -> keep original (never demote)

--- a/tests/test_llm_calibration.py
+++ b/tests/test_llm_calibration.py
@@ -357,3 +357,192 @@ class TestLLMScorePairsCalibration:
                 assert s == 1.0  # LLM said YES
             else:
                 assert s == 0.85  # LLM said NO -> keep original (never demote)
+
+
+import threading
+from unittest.mock import patch, MagicMock
+
+
+class TestConcurrentBatchScoring:
+    """Test the ThreadPoolExecutor path in _batch_score."""
+
+    def test_concurrent_path_collects_all_results(self):
+        """With max_workers=3 and >2 batches, concurrent path should collect all pair results."""
+        from goldenmatch.core.llm_scorer import _batch_score
+
+        # Create enough pairs for >2 batches at batch_size=5
+        n = 20
+        pairs = [(i * 2, i * 2 + 1, 0.85) for i in range(n)]
+        row_lookup = {r: {"name": f"rec_{r}"} for r in range(n * 2 + 2)}
+        candidate_indices = list(range(n))
+
+        call_count = 0
+        lock = threading.Lock()
+
+        def mock_openai(prompt, api_key, model, max_tokens=100):
+            nonlocal call_count
+            with lock:
+                call_count += 1
+            # Count pairs in prompt by counting "A:"
+            n_pairs = prompt.count("A:")
+            lines = "\n".join(f"{i+1}. YES" for i in range(n_pairs))
+            return lines, 100, 50
+
+        with patch("goldenmatch.core.llm_scorer._call_openai", side_effect=mock_openai):
+            results = _batch_score(
+                candidate_indices, pairs, row_lookup, ["name"],
+                "openai", "fake-key", "gpt-4o-mini", 5,  # batch_size=5 -> 4 batches
+                max_workers=3,
+            )
+
+        # All 20 pairs should have results
+        assert len(results) == 20
+        # All should be True (we returned YES for all)
+        assert all(v is True for v in results.values())
+        # Should have used multiple batches
+        assert call_count == 4  # 20 pairs / 5 per batch
+
+    def test_sequential_path_for_small_batches(self):
+        """With <=2 batches, should use sequential path."""
+        from goldenmatch.core.llm_scorer import _batch_score
+
+        pairs = [(0, 1, 0.85), (2, 3, 0.85)]
+        row_lookup = {r: {"name": f"rec_{r}"} for r in range(5)}
+
+        def mock_openai(prompt, api_key, model, max_tokens=100):
+            return "1. YES\n2. YES", 50, 20
+
+        with patch("goldenmatch.core.llm_scorer._call_openai", side_effect=mock_openai):
+            results = _batch_score(
+                [0, 1], pairs, row_lookup, ["name"],
+                "openai", "fake-key", "gpt-4o-mini", 10,  # batch_size=10 -> 1 batch
+                max_workers=5,
+            )
+
+        assert len(results) == 2
+
+
+class TestBudgetTrackerThreadSafety:
+    """Test that BudgetTracker is thread-safe under concurrent access."""
+
+    def test_concurrent_record_usage(self):
+        """Multiple threads calling record_usage should produce correct totals."""
+        from goldenmatch.core.llm_budget import BudgetTracker
+        from goldenmatch.config.schemas import BudgetConfig
+
+        budget = BudgetTracker(BudgetConfig(max_cost_usd=100.0))
+        n_threads = 10
+        calls_per_thread = 100
+
+        def worker():
+            for _ in range(calls_per_thread):
+                budget.record_usage(100, 50, "gpt-4o-mini")
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert budget.total_calls == n_threads * calls_per_thread
+
+    def test_budget_exhaustion_under_concurrency(self):
+        """Budget should eventually stop allowing sends under concurrent load."""
+        from goldenmatch.core.llm_budget import BudgetTracker
+        from goldenmatch.config.schemas import BudgetConfig
+
+        budget = BudgetTracker(BudgetConfig(max_calls=10))
+
+        sent_count = 0
+        lock = threading.Lock()
+
+        def worker():
+            nonlocal sent_count
+            for _ in range(100):
+                if budget.can_send(100):
+                    budget.record_usage(100, 50, "gpt-4o-mini")
+                    with lock:
+                        sent_count += 1
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Should not exceed max_calls by much (race window is small)
+        assert budget.total_calls <= 15  # some overshoot acceptable due to race
+        assert budget.budget_exhausted
+
+
+class TestGetEmbedderRouting:
+    """Test that get_embedder returns the right backend based on GPU mode."""
+
+    def test_vertex_mode_returns_vertex_embedder(self):
+        """When GPU mode is VERTEX, get_embedder should return VertexEmbedder."""
+        from goldenmatch.core.embedder import get_embedder, _embedders
+        from goldenmatch.core.gpu import GPUMode
+
+        # Clear cache
+        _embedders.clear()
+
+        mock_vertex = MagicMock()
+        mock_vertex_cls = MagicMock(return_value=mock_vertex)
+
+        # detect_gpu_mode is imported inside get_embedder, so patch at source
+        with patch("goldenmatch.core.gpu.detect_gpu_mode", return_value=GPUMode.VERTEX):
+            # Patch vertex_embedder module so the inner import succeeds
+            with patch.dict("sys.modules", {"goldenmatch.core.vertex_embedder": MagicMock(VertexEmbedder=mock_vertex_cls)}):
+                result = get_embedder("test-model")
+
+        assert result is mock_vertex
+        _embedders.clear()
+
+    def test_cpu_mode_returns_local_embedder(self):
+        """When GPU mode is CPU_SAFE, get_embedder should return local Embedder."""
+        from goldenmatch.core.embedder import get_embedder, _embedders, Embedder
+        from goldenmatch.core.gpu import GPUMode
+
+        _embedders.clear()
+
+        with patch("goldenmatch.core.gpu.detect_gpu_mode", return_value=GPUMode.CPU_SAFE):
+            result = get_embedder("test-model")
+
+        assert isinstance(result, Embedder)
+        assert result.model_name == "test-model"
+        _embedders.clear()
+
+    def test_gpu_detection_failure_falls_back_to_local(self):
+        """If detect_gpu_mode raises, should fall back to local Embedder."""
+        from goldenmatch.core.embedder import get_embedder, _embedders, Embedder
+
+        _embedders.clear()
+
+        with patch("goldenmatch.core.gpu.detect_gpu_mode", side_effect=RuntimeError("torch hang")):
+            result = get_embedder("test-model")
+
+        assert isinstance(result, Embedder)
+        _embedders.clear()
+
+    def test_vertex_import_failure_falls_back_to_local(self):
+        """If VertexEmbedder can't be imported, should fall back to local."""
+        from goldenmatch.core.embedder import get_embedder, _embedders, Embedder
+        from goldenmatch.core.gpu import GPUMode
+
+        _embedders.clear()
+
+        with patch("goldenmatch.core.gpu.detect_gpu_mode", return_value=GPUMode.VERTEX):
+            # Make the vertex_embedder import fail
+            import sys
+            original = sys.modules.get("goldenmatch.core.vertex_embedder")
+            sys.modules["goldenmatch.core.vertex_embedder"] = None  # force ImportError
+            try:
+                result = get_embedder("test-model")
+            finally:
+                if original is not None:
+                    sys.modules["goldenmatch.core.vertex_embedder"] = original
+                else:
+                    sys.modules.pop("goldenmatch.core.vertex_embedder", None)
+
+        assert isinstance(result, Embedder)
+        _embedders.clear()


### PR DESCRIPTION
## Summary

- **Iterative LLM calibration**: Replaces brute-force LLM scoring with stratified sampling + grid-search threshold learning. Samples ~100 pairs per round, converges in 2-3 rounds (~200 pairs, ~$0.01) instead of scoring 37,500 pairs (~$0.50). Includes concurrent requests via ThreadPoolExecutor and thread-safe BudgetTracker.
- **Auto-config classification fixes**: ID patterns checked before phone/zip, price patterns prevent zip misclassification, utility-based fuzzy field ranking replaces column-order truncation, LLM-assisted column classification for ambiguous types.
- **ANN hybrid blocking**: Oversized blocks fall back to ANN sub-blocking via Vertex AI embeddings. Embeds only unique text values (e.g., 61K records → 187 unique texts). Multi-pass blocking passes ANN config to static builder. `get_embedder()` respects GPU routing.

## Benchmark (Bulldozer 401K rows)

| Metric | Before | After |
|---|---|---|
| Clusters | 28,703 | 27,937 |
| Records matched | 383,701 | 384,650 |
| Singletons | 17,424 | 16,475 |
| LLM pairs scored | 37,500 | 200 |
| LLM cost | ~$0.50 | ~$0.01 |
| LLM phase time | ~25 min | ~42s |
| Confidence >= 0.4 | 77.1% | 87.7% |
| False positives (34 lost) | Present | Correctly removed |

## Test plan

- [x] 16 new tests in `test_llm_calibration.py` (threshold, sampling, calibration loop, e2e)
- [x] 6 new + 1 updated tests in `test_autoconfig.py` (ID before phone, price, utility ranking)
- [x] All 170 related tests pass
- [x] Full test suite passes (PostgreSQL teardown errors on Windows are pre-existing)
- [x] Bulldozer 401K benchmark completed successfully with improved accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)