### PR TITLE
feat: add CCMS cluster comparison & sensitivity analysis

### DIFF
--- a/goldenmatch/__init__.py
+++ b/goldenmatch/__init__.py
@@ -168,6 +168,9 @@ from goldenmatch.core.scorer import rerank_top_pairs
 from goldenmatch.core.diff import generate_diff
 from goldenmatch.core.rollback import rollback_run
 
+# ── Cluster comparison (CCMS) ──────────────────────────────────────────
+from goldenmatch.core.compare_clusters import compare_clusters, CompareResult
+
 # ── Output ───────────────────────────────────────────────────────────────
 from goldenmatch.output.writer import write_output
 from goldenmatch.output.report import generate_dedupe_report
@@ -254,6 +257,8 @@ __all__ = [
     "rerank_top_pairs",
     # Diff / Rollback
     "generate_diff", "rollback_run",
+    # Cluster comparison
+    "compare_clusters", "CompareResult",
     # Output
     "write_output", "generate_dedupe_report",
     # REST API Client

--- a/goldenmatch/__init__.py
+++ b/goldenmatch/__init__.py
@@ -170,6 +170,7 @@ from goldenmatch.core.rollback import rollback_run
 
 # ── Cluster comparison (CCMS) ──────────────────────────────────────────
 from goldenmatch.core.compare_clusters import compare_clusters, CompareResult
+from goldenmatch.core.sensitivity import run_sensitivity, SensitivityResult, SweepParam
 
 # ── Output ───────────────────────────────────────────────────────────────
 from goldenmatch.output.writer import write_output
@@ -259,6 +260,7 @@ __all__ = [
     "generate_diff", "rollback_run",
     # Cluster comparison
     "compare_clusters", "CompareResult",
+    "run_sensitivity", "SensitivityResult", "SweepParam",
     # Output
     "write_output", "generate_dedupe_report",
     # REST API Client

--- a/goldenmatch/cli/compare.py
+++ b/goldenmatch/cli/compare.py
@@ -58,6 +58,14 @@ def compare_clusters_cmd(
     Classifies each cluster from file A into: unchanged, merged,
     partitioned, or overlapping relative to file B.
     """
+    _VALID_CASES = {"unchanged", "merged", "partitioned", "overlapping"}
+    if case_type and case_type not in _VALID_CASES:
+        err_console.print(
+            f"[red]Invalid case type '{case_type}'. "
+            f"Valid options: {', '.join(sorted(_VALID_CASES))}[/red]"
+        )
+        raise typer.Exit(1)
+
     path_a = Path(file_a)
     path_b = Path(file_b)
 

--- a/goldenmatch/cli/compare.py
+++ b/goldenmatch/cli/compare.py
@@ -1,0 +1,139 @@
+"""CLI compare-clusters command for GoldenMatch."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from goldenmatch.core.compare_clusters import compare_clusters
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def _load_clusters(path: Path) -> dict[int, dict]:
+    """Load clusters from a JSON file.
+
+    Handles pair_scores keys stored as "a,b" strings by converting
+    back to (int, int) tuples.
+    """
+    raw = json.loads(path.read_text(encoding="utf-8"))
+
+    # Accept either {"clusters": {...}} or bare cluster dict
+    if "clusters" in raw and isinstance(raw["clusters"], dict):
+        raw = raw["clusters"]
+
+    clusters: dict[int, dict] = {}
+    for cid_str, info in raw.items():
+        cid = int(cid_str)
+        # Reconstruct pair_scores with tuple keys
+        pair_scores = {}
+        for k, v in info.get("pair_scores", {}).items():
+            if isinstance(k, str) and "," in k:
+                parts = k.split(",")
+                pair_scores[(int(parts[0]), int(parts[1]))] = v
+            else:
+                pair_scores[k] = v
+        info["pair_scores"] = pair_scores
+        clusters[cid] = info
+    return clusters
+
+
+def compare_clusters_cmd(
+    file_a: str = typer.Argument(..., help="First cluster JSON file (baseline / ER1)"),
+    file_b: str = typer.Argument(..., help="Second cluster JSON file (comparison / ER2)"),
+    details: bool = typer.Option(False, "--details", "-d", help="Show per-cluster transformation details"),
+    case_type: Optional[str] = typer.Option(
+        None, "--case-type",
+        help="Filter details by case: unchanged, merged, partitioned, overlapping",
+    ),
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Save results to JSON"),
+) -> None:
+    """Compare two ER clustering outcomes using the CCMS framework.
+
+    Classifies each cluster from file A into: unchanged, merged,
+    partitioned, or overlapping relative to file B.
+    """
+    path_a = Path(file_a)
+    path_b = Path(file_b)
+
+    for p in (path_a, path_b):
+        if not p.exists():
+            err_console.print(f"[red]File not found: {p}[/red]")
+            raise typer.Exit(1)
+
+    try:
+        clusters_a = _load_clusters(path_a)
+        clusters_b = _load_clusters(path_b)
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        err_console.print(f"[red]Error reading cluster files:[/red] {exc}")
+        raise typer.Exit(1)
+
+    try:
+        result = compare_clusters(clusters_a, clusters_b)
+    except ValueError as exc:
+        err_console.print(f"[red]Comparison error:[/red] {exc}")
+        raise typer.Exit(1)
+
+    # Summary table
+    table = Table(title="CCMS Cluster Comparison", show_header=True)
+    table.add_column("Metric", style="bold cyan")
+    table.add_column("Value", justify="right")
+    table.add_column("% of ER1", justify="right", style="dim")
+
+    s = result.summary()
+    table.add_row("Unchanged (UC)", str(s["unchanged"]), f"{s['unchanged_pct']:.1%}")
+    table.add_row("Merged (MC)", str(s["merged"]), f"{s['merged_pct']:.1%}")
+    table.add_row("Partitioned (PC)", str(s["partitioned"]), f"{s['partitioned_pct']:.1%}")
+    table.add_row("Overlapping (OC)", str(s["overlapping"]), f"{s['overlapping_pct']:.1%}")
+    table.add_row("", "", "")
+    table.add_row("Total References", str(s["rc"]), "")
+    table.add_row("ER1 Clusters", str(s["cc1"]), "")
+    table.add_row("ER2 Clusters", str(s["cc2"]), "")
+    table.add_row("ER1 Singletons", str(s["sc1"]), "")
+    table.add_row("ER2 Singletons", str(s["sc2"]), "")
+    table.add_row("TWI", f"{s['twi']:.4f}", "")
+
+    console.print(table)
+
+    # Details
+    if details:
+        detail_table = Table(title="Cluster Details", show_header=True)
+        detail_table.add_column("ER1 Cluster", style="bold", justify="right")
+        detail_table.add_column("Case", style="cyan")
+        detail_table.add_column("Members", style="dim")
+        detail_table.add_column("ER2 Mapping")
+
+        for case in result.cases:
+            if case_type and case.case != case_type:
+                continue
+            er2_str = ", ".join(
+                f"{cid}: {members}" for cid, members in case.er2_clusters.items()
+            )
+            detail_table.add_row(
+                str(case.cluster_id),
+                case.case,
+                str(case.members),
+                er2_str,
+            )
+
+        console.print(detail_table)
+
+    # Output JSON
+    if output:
+        out = s.copy()
+        out["cases"] = [
+            {
+                "cluster_id": c.cluster_id,
+                "case": c.case,
+                "members": c.members,
+                "er2_clusters": {str(k): v for k, v in c.er2_clusters.items()},
+            }
+            for c in result.cases
+        ]
+        output.write_text(json.dumps(out, indent=2), encoding="utf-8")
+        console.print(f"\n[green]Results saved to {output}[/green]")

--- a/goldenmatch/cli/main.py
+++ b/goldenmatch/cli/main.py
@@ -29,6 +29,7 @@ from goldenmatch.cli.pprl import pprl_app
 from goldenmatch.cli.label import label_cmd
 from goldenmatch.cli.agent_serve import agent_serve_cmd
 from goldenmatch.cli.compare import compare_clusters_cmd
+from goldenmatch.cli.sensitivity import sensitivity_cmd
 from goldenmatch.prefs.store import PresetStore
 
 LOGO = r"""[bold bright_yellow]
@@ -110,6 +111,7 @@ app.command("label", help="Build ground truth by labeling record pairs interacti
 app.command("agent-serve", help="Start the A2A agent server for AI-to-AI discovery.")(agent_serve_cmd)
 app.command("incremental", help="Match new records against an existing base dataset.")(incremental_cmd)
 app.command("compare-clusters", help="Compare two ER clustering outcomes (CCMS).")(compare_clusters_cmd)
+app.command("sensitivity", help="Analyze parameter sensitivity using CCMS comparison.")(sensitivity_cmd)
 
 
 @app.command("analyze-blocking")

--- a/goldenmatch/cli/main.py
+++ b/goldenmatch/cli/main.py
@@ -28,6 +28,7 @@ from goldenmatch.cli.incremental import incremental_cmd
 from goldenmatch.cli.pprl import pprl_app
 from goldenmatch.cli.label import label_cmd
 from goldenmatch.cli.agent_serve import agent_serve_cmd
+from goldenmatch.cli.compare import compare_clusters_cmd
 from goldenmatch.prefs.store import PresetStore
 
 LOGO = r"""[bold bright_yellow]
@@ -108,6 +109,7 @@ app.add_typer(pprl_app, name="pprl")
 app.command("label", help="Build ground truth by labeling record pairs interactively.")(label_cmd)
 app.command("agent-serve", help="Start the A2A agent server for AI-to-AI discovery.")(agent_serve_cmd)
 app.command("incremental", help="Match new records against an existing base dataset.")(incremental_cmd)
+app.command("compare-clusters", help="Compare two ER clustering outcomes (CCMS).")(compare_clusters_cmd)
 
 
 @app.command("analyze-blocking")

--- a/goldenmatch/cli/sensitivity.py
+++ b/goldenmatch/cli/sensitivity.py
@@ -1,0 +1,135 @@
+"""CLI sensitivity command for GoldenMatch."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from goldenmatch.cli.dedupe import _parse_file_source, _resolve_column_maps
+from goldenmatch.config.loader import load_config
+from goldenmatch.core.sensitivity import SweepParam, run_sensitivity
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def _parse_sweep(sweep_str: str) -> SweepParam:
+    """Parse a sweep string like 'threshold:0.70:0.95:0.05'."""
+    parts = sweep_str.split(":")
+    if len(parts) != 4:
+        raise typer.BadParameter(
+            f"Sweep format must be 'field:start:stop:step', got '{sweep_str}'"
+        )
+    field = parts[0]
+    try:
+        start = float(parts[1])
+        stop = float(parts[2])
+        step = float(parts[3])
+    except ValueError:
+        raise typer.BadParameter(
+            f"Sweep start/stop/step must be numbers, got '{sweep_str}'"
+        )
+    if step <= 0:
+        raise typer.BadParameter("Sweep step must be positive")
+    if start > stop:
+        raise typer.BadParameter("Sweep start must be <= stop")
+    return SweepParam(field=field, start=start, stop=stop, step=step)
+
+
+def sensitivity_cmd(
+    files: list[str] = typer.Argument(..., help="Input files (path or path:source_name)"),
+    config: Path = typer.Option(..., "--config", "-c", help="Config YAML path"),
+    sweep: list[str] = typer.Option(..., "--sweep", "-s", help="Sweep spec: field:start:stop:step (repeatable)"),
+    sample: Optional[int] = typer.Option(None, "--sample", help="Random sample size for speed"),
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Save results to JSON"),
+) -> None:
+    """Analyze parameter sensitivity using CCMS cluster comparison.
+
+    Sweeps each parameter independently, comparing clusters against a baseline.
+
+    Example:
+        goldenmatch sensitivity data.csv -c config.yaml --sweep threshold:0.70:0.95:0.05
+    """
+    cfg = load_config(str(config))
+
+    parsed = [_parse_file_source(f) for f in files]
+    file_specs = _resolve_column_maps(parsed, cfg)
+
+    sweep_params = [_parse_sweep(s) for s in sweep]
+
+    console.print("[bold]Running sensitivity analysis...[/bold]")
+    console.print(f"  Sweeping {len(sweep_params)} parameter(s)")
+    if sample:
+        console.print(f"  Sample size: {sample}")
+    console.print()
+
+    try:
+        results = run_sensitivity(
+            file_specs=file_specs,
+            config=cfg,
+            sweep_params=sweep_params,
+            sample_size=sample,
+        )
+    except ValueError as exc:
+        err_console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1)
+
+    # Display results per parameter
+    for r in results:
+        table = Table(
+            title=f"Sensitivity: {r.param.field} (baseline={r.baseline_value})",
+            show_header=True,
+        )
+        table.add_column("Value", style="bold", justify="right")
+        table.add_column("UC", justify="right")
+        table.add_column("MC", justify="right")
+        table.add_column("PC", justify="right")
+        table.add_column("OC", justify="right")
+        table.add_column("CC2", justify="right")
+        table.add_column("TWI", justify="right")
+        table.add_column("UC%", justify="right", style="cyan")
+
+        # Find best UC% for highlighting
+        best_uc = max(
+            (p.comparison.unchanged for p in r.points), default=0
+        )
+
+        for pt in r.points:
+            c = pt.comparison
+            uc_pct = c.unchanged / (c.cc1 or 1)
+            is_best = c.unchanged == best_uc
+            style = "bold green" if is_best else ""
+            table.add_row(
+                f"{pt.param_value:.4f}",
+                str(c.unchanged),
+                str(c.merged),
+                str(c.partitioned),
+                str(c.overlapping),
+                str(c.cc2),
+                f"{c.twi:.4f}",
+                f"{uc_pct:.1%}",
+                style=style,
+            )
+
+        console.print(table)
+
+        report = r.stability_report()
+        console.print(
+            f"  [bold]Stability plateau:[/bold] {r.param.field} = {report['best_value']} "
+            f"({report['best_unchanged_pct']:.1%} unchanged)\n"
+        )
+
+    # Output JSON
+    if output:
+        out = []
+        for r in results:
+            report = r.stability_report()
+            report["field"] = r.param.field
+            report["baseline_value"] = r.baseline_value
+            out.append(report)
+        output.write_text(json.dumps(out, indent=2), encoding="utf-8")
+        console.print(f"[green]Results saved to {output}[/green]")

--- a/goldenmatch/cli/sensitivity.py
+++ b/goldenmatch/cli/sensitivity.py
@@ -74,7 +74,7 @@ def sensitivity_cmd(
             sweep_params=sweep_params,
             sample_size=sample,
         )
-    except ValueError as exc:
+    except Exception as exc:
         err_console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1)
 

--- a/goldenmatch/core/compare_clusters.py
+++ b/goldenmatch/core/compare_clusters.py
@@ -1,0 +1,178 @@
+"""CCMS — Case Count Metric System for comparing ER clustering outcomes.
+
+Based on: Talburt et al., "Case Count Metric for Comparative Analysis of
+Entity Resolution Results" (arXiv:2601.02824v1, Jan 2026).
+
+Classifies each cluster from ER1 into one of four transformation cases
+relative to ER2: unchanged, merged, partitioned, or overlapping.
+"""
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ClusterCase:
+    """Classification of a single ER1 cluster's transformation to ER2."""
+    cluster_id: int
+    case: str  # "unchanged" | "merged" | "partitioned" | "overlapping"
+    members: list[int]
+    er2_clusters: dict[int, list[int]]
+
+
+@dataclass
+class CompareResult:
+    """Result of comparing two sets of ER clusters."""
+    unchanged: int = 0
+    merged: int = 0
+    partitioned: int = 0
+    overlapping: int = 0
+    rc: int = 0
+    cc1: int = 0
+    cc2: int = 0
+    sc1: int = 0
+    sc2: int = 0
+    twi: float = 0.0
+    cases: list[ClusterCase] = field(default_factory=list)
+
+    def summary(self) -> dict:
+        """Return a summary dict of all metrics."""
+        total = self.cc1 or 1
+        return {
+            "unchanged": self.unchanged,
+            "merged": self.merged,
+            "partitioned": self.partitioned,
+            "overlapping": self.overlapping,
+            "rc": self.rc,
+            "cc1": self.cc1,
+            "cc2": self.cc2,
+            "sc1": self.sc1,
+            "sc2": self.sc2,
+            "twi": round(self.twi, 4),
+            "unchanged_pct": round(self.unchanged / total, 4),
+            "merged_pct": round(self.merged / total, 4),
+            "partitioned_pct": round(self.partitioned / total, 4),
+            "overlapping_pct": round(self.overlapping / total, 4),
+        }
+
+
+def compare_clusters(
+    clusters_a: dict[int, dict],
+    clusters_b: dict[int, dict],
+) -> CompareResult:
+    """Compare two ER clustering outcomes on the same dataset.
+
+    Classifies each cluster in clusters_a (ER1) into one of four
+    transformation cases relative to clusters_b (ER2).
+
+    Args:
+        clusters_a: Baseline clusters (ER1). Standard GoldenMatch format.
+        clusters_b: Comparison clusters (ER2). Same format.
+
+    Returns:
+        CompareResult with counts, TWI, and per-cluster case details.
+
+    Raises:
+        ValueError: If the two cluster dicts cover different row IDs.
+    """
+    # Extract member sets
+    ids_a: set[int] = set()
+    sets_a: dict[int, set[int]] = {}
+    for cid, info in clusters_a.items():
+        members = set(info["members"])
+        sets_a[cid] = members
+        ids_a |= members
+
+    ids_b: set[int] = set()
+    sets_b: dict[int, set[int]] = {}
+    for cid, info in clusters_b.items():
+        members = set(info["members"])
+        sets_b[cid] = members
+        ids_b |= members
+
+    if ids_a != ids_b:
+        diff = ids_a.symmetric_difference(ids_b)
+        only_a = ids_a - ids_b
+        only_b = ids_b - ids_a
+        raise ValueError(
+            f"Cluster dicts cover different row IDs. "
+            f"{len(only_a)} IDs only in A, {len(only_b)} IDs only in B. "
+            f"First few: {sorted(diff)[:10]}"
+        )
+
+    rc = len(ids_a)
+
+    # Build reverse lookup: row_id -> ER2 cluster ID
+    row_to_b: dict[int, int] = {}
+    for cid, members in sets_b.items():
+        for m in members:
+            row_to_b[m] = cid
+
+    # Classify each ER1 cluster
+    cases: list[ClusterCase] = []
+    uc = mc = pc = oc = 0
+    non_empty_intersections = 0
+
+    for cid_a, members_a in sets_a.items():
+        # Find which ER2 clusters this ER1 cluster's members map to
+        er2_mapping: dict[int, list[int]] = defaultdict(list)
+        for m in members_a:
+            cid_b = row_to_b[m]
+            er2_mapping[cid_b].append(m)
+
+        non_empty_intersections += len(er2_mapping)
+
+        # Classify
+        if len(er2_mapping) == 1:
+            cid_b = next(iter(er2_mapping))
+            if sets_b[cid_b] == members_a:
+                case = "unchanged"
+                uc += 1
+            else:
+                case = "merged"
+                mc += 1
+        else:
+            # Multiple ER2 clusters intersect this ER1 cluster
+            all_subsets = all(
+                sets_b[cid_b] <= members_a for cid_b in er2_mapping
+            )
+            if all_subsets:
+                case = "partitioned"
+                pc += 1
+            else:
+                case = "overlapping"
+                oc += 1
+
+        cases.append(ClusterCase(
+            cluster_id=cid_a,
+            case=case,
+            members=sorted(members_a),
+            er2_clusters={k: sorted(v) for k, v in er2_mapping.items()},
+        ))
+
+    cc1 = len(clusters_a)
+    cc2 = len(clusters_b)
+    sc1 = sum(1 for s in sets_a.values() if len(s) == 1)
+    sc2 = sum(1 for s in sets_b.values() if len(s) == 1)
+
+    # TWI = sqrt(CC1 * CC2) / V
+    if non_empty_intersections > 0:
+        twi = math.sqrt(cc1 * cc2) / non_empty_intersections
+    else:
+        twi = 1.0 if cc1 == 0 and cc2 == 0 else 0.0
+
+    return CompareResult(
+        unchanged=uc,
+        merged=mc,
+        partitioned=pc,
+        overlapping=oc,
+        rc=rc,
+        cc1=cc1,
+        cc2=cc2,
+        sc1=sc1,
+        sc2=sc2,
+        twi=twi,
+        cases=cases,
+    )

--- a/goldenmatch/core/sensitivity.py
+++ b/goldenmatch/core/sensitivity.py
@@ -107,7 +107,8 @@ def _get_current_value(field: str, config: GoldenMatchConfig) -> float:
         for mk in config.get_matchkeys():
             if mk.name == name:
                 return mk.threshold if mk.threshold is not None else 0.85
-    return 0.0
+
+    raise ValueError(f"Cannot read current value for field '{field}' -- no handler defined")
 
 
 def _apply_value(field: str, value: float, config: GoldenMatchConfig) -> None:
@@ -131,6 +132,8 @@ def _apply_value(field: str, value: float, config: GoldenMatchConfig) -> None:
             if mk.name == name:
                 mk.threshold = value
                 return
+
+    raise ValueError(f"Cannot apply sweep value for field '{field}' -- no handler defined")
 
 
 def _generate_values(param: SweepParam) -> list[float]:
@@ -218,11 +221,15 @@ def run_sensitivity(
             _apply_value(param.field, value, sweep_config)
 
             logger.info("  %s = %s", param.field, value)
-            sweep_result = run_dedupe(effective_specs, sweep_config)
-            sweep_clusters = sweep_result["clusters"]
-
-            comparison = compare_clusters(baseline_clusters, sweep_clusters)
-            points.append(SweepPoint(param_value=value, comparison=comparison))
+            try:
+                sweep_result = run_dedupe(effective_specs, sweep_config)
+                sweep_clusters = sweep_result["clusters"]
+                comparison = compare_clusters(baseline_clusters, sweep_clusters)
+                points.append(SweepPoint(param_value=value, comparison=comparison))
+            except Exception as exc:
+                logger.error(
+                    "Sweep point %s=%s failed: %s", param.field, value, exc
+                )
 
         results.append(SensitivityResult(
             param=param,

--- a/goldenmatch/core/sensitivity.py
+++ b/goldenmatch/core/sensitivity.py
@@ -1,0 +1,233 @@
+"""Parameter sensitivity analysis using CCMS cluster comparison.
+
+Sweeps configuration parameters across a range, running the pipeline
+for each value and comparing the resulting clusters against a baseline.
+"""
+from __future__ import annotations
+
+import copy
+import logging
+from dataclasses import dataclass, field
+
+from goldenmatch.config.schemas import GoldenMatchConfig
+from goldenmatch.core.compare_clusters import CompareResult, compare_clusters
+from goldenmatch.core.pipeline import run_dedupe
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_FIELDS = {
+    "threshold",
+    "blocking.max_block_size",
+    # matchkey.<name>.threshold handled dynamically
+}
+
+
+@dataclass
+class SweepParam:
+    """Definition of a parameter to sweep."""
+    field: str
+    start: float
+    stop: float
+    step: float
+
+
+@dataclass
+class SweepPoint:
+    """Result of a single sweep value."""
+    param_value: float
+    comparison: CompareResult
+
+
+@dataclass
+class SensitivityResult:
+    """Result of sweeping one parameter across a range."""
+    param: SweepParam
+    baseline_value: float
+    points: list[SweepPoint] = field(default_factory=list)
+
+    def stability_report(self) -> dict:
+        """Identify the value range with the most unchanged clusters."""
+        if not self.points:
+            return {"best_value": self.baseline_value, "best_unchanged_pct": 1.0, "points": []}
+
+        best = max(self.points, key=lambda p: p.comparison.unchanged)
+        total = best.comparison.cc1 or 1
+        return {
+            "best_value": best.param_value,
+            "best_unchanged_pct": round(best.comparison.unchanged / total, 4),
+            "points": [
+                {
+                    "value": p.param_value,
+                    "unchanged": p.comparison.unchanged,
+                    "merged": p.comparison.merged,
+                    "partitioned": p.comparison.partitioned,
+                    "overlapping": p.comparison.overlapping,
+                    "twi": round(p.comparison.twi, 4),
+                }
+                for p in self.points
+            ],
+        }
+
+
+def _validate_field(field: str, config: GoldenMatchConfig) -> None:
+    """Validate that a sweep field is supported and exists in config."""
+    if field in SUPPORTED_FIELDS:
+        return
+    if field.startswith("matchkey.") and field.endswith(".threshold"):
+        name = field.split(".")[1]
+        matchkeys = config.get_matchkeys()
+        if not any(mk.name == name for mk in matchkeys):
+            available = [mk.name for mk in matchkeys]
+            raise ValueError(
+                f"Matchkey '{name}' not found in config. Available: {available}"
+            )
+        return
+    raise ValueError(
+        f"Unsupported sweep field '{field}'. "
+        f"Supported: {sorted(SUPPORTED_FIELDS)} or 'matchkey.<name>.threshold'"
+    )
+
+
+def _get_current_value(field: str, config: GoldenMatchConfig) -> float:
+    """Get the current value of a sweep field from the config."""
+    if field == "threshold":
+        matchkeys = config.get_matchkeys()
+        fuzzy = [mk for mk in matchkeys if mk.threshold is not None]
+        if fuzzy:
+            return fuzzy[0].threshold
+        return 0.85  # default
+
+    if field == "blocking.max_block_size":
+        if config.blocking:
+            return float(config.blocking.max_block_size)
+        return 5000.0
+
+    if field.startswith("matchkey.") and field.endswith(".threshold"):
+        name = field.split(".")[1]
+        for mk in config.get_matchkeys():
+            if mk.name == name:
+                return mk.threshold if mk.threshold is not None else 0.85
+    return 0.0
+
+
+def _apply_value(field: str, value: float, config: GoldenMatchConfig) -> None:
+    """Apply a sweep value to the config (mutates in-place)."""
+    if field == "threshold":
+        for mk in config.get_matchkeys():
+            if mk.threshold is not None:
+                mk.threshold = value
+        return
+
+    if field == "blocking.max_block_size":
+        if config.blocking is None:
+            from goldenmatch.config.schemas import BlockingConfig
+            config.blocking = BlockingConfig()
+        config.blocking.max_block_size = int(value)
+        return
+
+    if field.startswith("matchkey.") and field.endswith(".threshold"):
+        name = field.split(".")[1]
+        for mk in config.get_matchkeys():
+            if mk.name == name:
+                mk.threshold = value
+                return
+
+
+def _generate_values(param: SweepParam) -> list[float]:
+    """Generate the list of values to sweep."""
+    values = []
+    v = param.start
+    while v <= param.stop + 1e-9:  # epsilon for float comparison
+        values.append(round(v, 6))
+        v += param.step
+    return values
+
+
+def _sample_files(file_specs: list, sample_size: int, seed: int = 42) -> list:
+    """Load, sample, and write to temp files. Returns new file_specs."""
+    import tempfile
+
+    import polars as pl
+
+    from goldenmatch.core.ingest import load_file
+
+    frames = []
+    for spec in file_specs:
+        path = spec[0] if isinstance(spec, tuple) else spec
+        lf = load_file(path)
+        frames.append(lf.collect())
+
+    combined = pl.concat(frames) if len(frames) > 1 else frames[0]
+    if sample_size < combined.height:
+        combined = combined.sample(n=sample_size, seed=seed)
+
+    # Write sampled data to a temp file
+    tmp = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
+    combined.write_parquet(tmp.name)
+    tmp.close()
+
+    source_name = file_specs[0][1] if isinstance(file_specs[0], tuple) and len(file_specs[0]) > 1 else "sampled"
+    return [(tmp.name, source_name)]
+
+
+def run_sensitivity(
+    file_specs: list,
+    config: GoldenMatchConfig,
+    sweep_params: list[SweepParam],
+    sample_size: int | None = None,
+) -> list[SensitivityResult]:
+    """Run parameter sensitivity analysis.
+
+    Sweeps each parameter independently, comparing each run's clusters
+    against a baseline run.
+
+    Args:
+        file_specs: File specs for the pipeline (same as run_dedupe).
+        config: Base config to use.
+        sweep_params: Parameters to sweep.
+        sample_size: If set, randomly sample this many records before sweeping.
+
+    Returns:
+        One SensitivityResult per sweep parameter.
+    """
+    for param in sweep_params:
+        _validate_field(param.field, config)
+
+    # Sample data once, reuse for all runs
+    effective_specs = file_specs
+    if sample_size is not None:
+        effective_specs = _sample_files(file_specs, sample_size)
+
+    # Run baseline
+    baseline_config = copy.deepcopy(config)
+    logger.info("Running baseline pipeline...")
+    baseline_result = run_dedupe(effective_specs, baseline_config)
+    baseline_clusters = baseline_result["clusters"]
+
+    results: list[SensitivityResult] = []
+
+    for param in sweep_params:
+        baseline_value = _get_current_value(param.field, config)
+        values = _generate_values(param)
+        points: list[SweepPoint] = []
+
+        logger.info("Sweeping %s: %s", param.field, values)
+
+        for value in values:
+            sweep_config = copy.deepcopy(config)
+            _apply_value(param.field, value, sweep_config)
+
+            logger.info("  %s = %s", param.field, value)
+            sweep_result = run_dedupe(effective_specs, sweep_config)
+            sweep_clusters = sweep_result["clusters"]
+
+            comparison = compare_clusters(baseline_clusters, sweep_clusters)
+            points.append(SweepPoint(param_value=value, comparison=comparison))
+
+        results.append(SensitivityResult(
+            param=param,
+            baseline_value=baseline_value,
+            points=points,
+        ))
+
+    return results

--- a/goldenmatch/core/sensitivity.py
+++ b/goldenmatch/core/sensitivity.py
@@ -114,9 +114,13 @@ def _get_current_value(field: str, config: GoldenMatchConfig) -> float:
 def _apply_value(field: str, value: float, config: GoldenMatchConfig) -> None:
     """Apply a sweep value to the config (mutates in-place)."""
     if field == "threshold":
+        applied = False
         for mk in config.get_matchkeys():
             if mk.threshold is not None:
                 mk.threshold = value
+                applied = True
+        if not applied:
+            logger.warning("No fuzzy matchkeys found to apply threshold sweep")
         return
 
     if field == "blocking.max_block_size":

--- a/tests/test_compare_clusters.py
+++ b/tests/test_compare_clusters.py
@@ -1,0 +1,175 @@
+"""Tests for CCMS cluster comparison."""
+import pytest
+
+from goldenmatch.core.compare_clusters import compare_clusters, CompareResult
+
+
+def test_identical_clusters_all_unchanged():
+    """Two identical cluster dicts should produce all unchanged, TWI=1.0."""
+    clusters_a = {
+        1: {"members": [1, 2, 3], "size": 3, "pair_scores": {}, "oversized": False},
+        2: {"members": [4, 5], "size": 2, "pair_scores": {}, "oversized": False},
+        3: {"members": [6], "size": 1, "pair_scores": {}, "oversized": False},
+    }
+    clusters_b = {
+        10: {"members": [1, 2, 3], "size": 3, "pair_scores": {}, "oversized": False},
+        20: {"members": [4, 5], "size": 2, "pair_scores": {}, "oversized": False},
+        30: {"members": [6], "size": 1, "pair_scores": {}, "oversized": False},
+    }
+    result = compare_clusters(clusters_a, clusters_b)
+    assert isinstance(result, CompareResult)
+    assert result.unchanged == 3
+    assert result.merged == 0
+    assert result.partitioned == 0
+    assert result.overlapping == 0
+    assert result.cc1 == 3
+    assert result.cc2 == 3
+    assert result.sc1 == 1
+    assert result.sc2 == 1
+    assert result.twi == 1.0
+    assert result.rc == 6
+
+
+def test_merged_case():
+    """ER1 cluster is proper subset of an ER2 cluster."""
+    clusters_a = {
+        1: {"members": [1, 2], "size": 2, "pair_scores": {}, "oversized": False},
+        2: {"members": [3], "size": 1, "pair_scores": {}, "oversized": False},
+    }
+    clusters_b = {
+        10: {"members": [1, 2, 3], "size": 3, "pair_scores": {}, "oversized": False},
+    }
+    result = compare_clusters(clusters_a, clusters_b)
+    assert result.merged == 2
+    assert result.unchanged == 0
+
+
+def test_partitioned_case():
+    """ER1 cluster split into multiple ER2 clusters, no external members added."""
+    clusters_a = {
+        1: {"members": [1, 2, 3, 4], "size": 4, "pair_scores": {}, "oversized": False},
+    }
+    clusters_b = {
+        10: {"members": [1, 2], "size": 2, "pair_scores": {}, "oversized": False},
+        20: {"members": [3, 4], "size": 2, "pair_scores": {}, "oversized": False},
+    }
+    result = compare_clusters(clusters_a, clusters_b)
+    assert result.partitioned == 1
+    assert result.unchanged == 0
+    assert result.cc1 == 1
+    assert result.cc2 == 2
+
+
+def test_overlapping_case():
+    """ER1 cluster members redistributed with members from other ER1 clusters."""
+    clusters_a = {
+        1: {"members": [1, 2, 3], "size": 3, "pair_scores": {}, "oversized": False},
+        2: {"members": [4, 5, 6], "size": 3, "pair_scores": {}, "oversized": False},
+    }
+    clusters_b = {
+        10: {"members": [1, 2, 4], "size": 3, "pair_scores": {}, "oversized": False},
+        20: {"members": [3, 5, 6], "size": 3, "pair_scores": {}, "oversized": False},
+    }
+    result = compare_clusters(clusters_a, clusters_b)
+    assert result.overlapping == 2
+    assert result.unchanged == 0
+
+
+def test_mixed_cases_paper_example():
+    """Table 1 from the CCMS paper: 16 references, 7 ER1 clusters, 8 ER2 clusters."""
+    clusters_a = {
+        1: {"members": [1], "size": 1, "pair_scores": {}, "oversized": False},
+        2: {"members": [2, 3], "size": 2, "pair_scores": {}, "oversized": False},
+        3: {"members": [4, 5, 6], "size": 3, "pair_scores": {}, "oversized": False},
+        4: {"members": [7], "size": 1, "pair_scores": {}, "oversized": False},
+        5: {"members": [8, 9, 10], "size": 3, "pair_scores": {}, "oversized": False},
+        6: {"members": [11, 12, 13], "size": 3, "pair_scores": {}, "oversized": False},
+        7: {"members": [14, 15, 16], "size": 3, "pair_scores": {}, "oversized": False},
+    }
+    clusters_b = {
+        10: {"members": [1], "size": 1, "pair_scores": {}, "oversized": False},
+        20: {"members": [2, 3], "size": 2, "pair_scores": {}, "oversized": False},
+        30: {"members": [4, 5, 6, 7], "size": 4, "pair_scores": {}, "oversized": False},
+        40: {"members": [8, 9], "size": 2, "pair_scores": {}, "oversized": False},
+        50: {"members": [10], "size": 1, "pair_scores": {}, "oversized": False},
+        60: {"members": [11, 12, 14, 15], "size": 4, "pair_scores": {}, "oversized": False},
+        70: {"members": [13], "size": 1, "pair_scores": {}, "oversized": False},
+        80: {"members": [16], "size": 1, "pair_scores": {}, "oversized": False},
+    }
+    result = compare_clusters(clusters_a, clusters_b)
+    assert result.unchanged == 2
+    assert result.merged == 2
+    assert result.partitioned == 1
+    assert result.overlapping == 2
+    assert result.cc1 == 7
+    assert result.cc2 == 8
+    assert result.rc == 16
+
+
+def test_mismatched_row_ids_raises():
+    """Different row ID sets should raise ValueError."""
+    clusters_a = {
+        1: {"members": [1, 2], "size": 2, "pair_scores": {}, "oversized": False},
+    }
+    clusters_b = {
+        1: {"members": [1, 3], "size": 2, "pair_scores": {}, "oversized": False},
+    }
+    with pytest.raises(ValueError, match="different row IDs"):
+        compare_clusters(clusters_a, clusters_b)
+
+
+def test_singleton_counts():
+    """Singleton counts should be computed correctly."""
+    clusters_a = {
+        1: {"members": [1], "size": 1, "pair_scores": {}, "oversized": False},
+        2: {"members": [2], "size": 1, "pair_scores": {}, "oversized": False},
+        3: {"members": [3, 4], "size": 2, "pair_scores": {}, "oversized": False},
+    }
+    clusters_b = {
+        10: {"members": [1], "size": 1, "pair_scores": {}, "oversized": False},
+        20: {"members": [2, 3, 4], "size": 3, "pair_scores": {}, "oversized": False},
+    }
+    result = compare_clusters(clusters_a, clusters_b)
+    assert result.sc1 == 2
+    assert result.sc2 == 1
+
+
+def test_asymmetry_uc_same_mc_pc_swap():
+    """compare(A,B) vs compare(B,A): UC same, MC/PC may swap, TWI symmetric."""
+    clusters_a = {
+        1: {"members": [1, 2, 3, 4], "size": 4, "pair_scores": {}, "oversized": False},
+    }
+    clusters_b = {
+        10: {"members": [1, 2], "size": 2, "pair_scores": {}, "oversized": False},
+        20: {"members": [3, 4], "size": 2, "pair_scores": {}, "oversized": False},
+    }
+    ab = compare_clusters(clusters_a, clusters_b)
+    ba = compare_clusters(clusters_b, clusters_a)
+    assert ab.unchanged == ba.unchanged
+    assert ab.partitioned == 1
+    assert ba.merged == 2
+    assert abs(ab.twi - ba.twi) < 1e-9
+
+
+def test_empty_clusters():
+    """Both empty cluster dicts should produce zero counts, TWI=1.0."""
+    result = compare_clusters({}, {})
+    assert result.unchanged == 0
+    assert result.rc == 0
+    assert result.twi == 1.0
+
+
+def test_summary_dict():
+    """summary() should return all expected keys with correct types."""
+    clusters = {
+        1: {"members": [1, 2], "size": 2, "pair_scores": {}, "oversized": False},
+    }
+    result = compare_clusters(clusters, clusters)
+    s = result.summary()
+    expected_keys = {
+        "unchanged", "merged", "partitioned", "overlapping",
+        "rc", "cc1", "cc2", "sc1", "sc2", "twi",
+        "unchanged_pct", "merged_pct", "partitioned_pct", "overlapping_pct",
+    }
+    assert set(s.keys()) == expected_keys
+    assert s["unchanged_pct"] == 1.0

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,0 +1,117 @@
+"""Tests for parameter sensitivity analysis."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from goldenmatch.core.sensitivity import (
+    SweepParam, SweepPoint, SensitivityResult, run_sensitivity,
+    _validate_field, _generate_values,
+)
+from goldenmatch.core.compare_clusters import CompareResult
+
+
+def _make_clusters(cluster_map: dict[int, list[int]]) -> dict[int, dict]:
+    """Helper to build cluster dicts from {cid: [members]} shorthand."""
+    return {
+        cid: {"members": sorted(members), "size": len(members), "pair_scores": {}, "oversized": False}
+        for cid, members in cluster_map.items()
+    }
+
+
+def test_sweep_baseline_unchanged():
+    """When sweep value equals baseline, comparison should show all unchanged."""
+    baseline_clusters = _make_clusters({1: [1, 2], 2: [3, 4]})
+    sweep = SweepParam(field="threshold", start=0.85, stop=0.85, step=0.05)
+
+    mock_config = MagicMock()
+    mock_config.get_matchkeys.return_value = [
+        MagicMock(name="fuzzy", threshold=0.85, type="weighted"),
+    ]
+
+    with patch("goldenmatch.core.sensitivity.run_dedupe") as mock_run:
+        mock_run.return_value = {"clusters": baseline_clusters}
+        results = run_sensitivity(
+            file_specs=[("fake.csv", "test")],
+            config=mock_config,
+            sweep_params=[sweep],
+        )
+
+    assert len(results) == 1
+    r = results[0]
+    assert isinstance(r, SensitivityResult)
+    assert r.baseline_value == 0.85
+    assert len(r.points) == 1
+    assert r.points[0].comparison.unchanged == 2
+    assert r.points[0].comparison.twi == 1.0
+
+
+def test_invalid_sweep_field_raises():
+    """Invalid field name should raise ValueError."""
+    config = MagicMock()
+    config.get_matchkeys.return_value = []
+    with pytest.raises(ValueError, match="Unsupported sweep field"):
+        _validate_field("nonexistent_field", config)
+
+
+def test_generate_values_single_point():
+    """start == stop should produce a single value."""
+    param = SweepParam(field="threshold", start=0.85, stop=0.85, step=0.05)
+    values = _generate_values(param)
+    assert values == [0.85]
+
+
+def test_generate_values_range():
+    """Should generate correct range of values."""
+    param = SweepParam(field="threshold", start=0.70, stop=0.90, step=0.10)
+    values = _generate_values(param)
+    assert values == [0.7, 0.8, 0.9]
+
+
+def test_sweep_multiple_values():
+    """Sweeping across 3 values should produce 3 SweepPoints."""
+    clusters_1 = _make_clusters({1: [1, 2], 2: [3, 4]})
+    clusters_2 = _make_clusters({1: [1, 2, 3, 4]})  # merged
+    clusters_3 = _make_clusters({1: [1], 2: [2], 3: [3], 4: [4]})  # all singletons
+
+    sweep = SweepParam(field="threshold", start=0.70, stop=0.90, step=0.10)
+    call_count = [0]
+    return_values = [
+        {"clusters": clusters_1},  # baseline
+        {"clusters": clusters_2},  # 0.70
+        {"clusters": clusters_1},  # 0.80 (same as baseline)
+        {"clusters": clusters_3},  # 0.90
+    ]
+
+    def mock_run(*args, **kwargs):
+        result = return_values[call_count[0]]
+        call_count[0] += 1
+        return result
+
+    with patch("goldenmatch.core.sensitivity.run_dedupe", side_effect=mock_run):
+        results = run_sensitivity(
+            file_specs=[("fake.csv", "test")],
+            config=MagicMock(),
+            sweep_params=[sweep],
+        )
+
+    assert len(results) == 1
+    assert len(results[0].points) == 3
+    assert results[0].points[1].comparison.unchanged == 2  # 0.80 = baseline
+
+
+def test_stability_report():
+    """stability_report() should identify best unchanged value."""
+    clusters = _make_clusters({1: [1, 2], 2: [3, 4]})
+    sweep = SweepParam(field="threshold", start=0.85, stop=0.85, step=0.05)
+
+    with patch("goldenmatch.core.sensitivity.run_dedupe") as mock_run:
+        mock_run.return_value = {"clusters": clusters}
+        results = run_sensitivity(
+            file_specs=[("fake.csv", "test")],
+            config=MagicMock(),
+            sweep_params=[sweep],
+        )
+
+    report = results[0].stability_report()
+    assert report["best_value"] == 0.85
+    assert report["best_unchanged_pct"] == 1.0
+    assert len(report["points"]) == 1


### PR DESCRIPTION
## Summary
- Add `compare_clusters()` function implementing the CCMS (Case Count Metric System) from Talburt et al. (arXiv:2601.02824v1) for comparing two ER clustering outcomes without ground truth
- Add `run_sensitivity()` engine for parameter sweep analysis — varies threshold/blocking settings, compares each run against a baseline
- Add `goldenmatch compare-clusters` CLI command for ad-hoc cluster comparison
- Add `goldenmatch sensitivity` CLI command for automated parameter tuning
- 16 new tests (10 comparison, 6 sensitivity), 0 regressions on full suite (1260 passed)

## Test plan
- [x] All four CCMS cases tested: unchanged, merged, partitioned, overlapping
- [x] Paper Table 1 example (16 refs, 7 ER1 clusters, 8 ER2 clusters) validated
- [x] Edge cases: mismatched IDs (ValueError), empty clusters, asymmetry, TWI symmetry
- [x] Sensitivity sweep with mocked pipeline: single point, multi-value, stability report
- [x] Full regression suite: 1260 passed in 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)