### PR TITLE
feat: add GoldenFlow integration

### DIFF
--- a/goldenmatch/config/schemas.py
+++ b/goldenmatch/config/schemas.py
@@ -288,6 +288,12 @@ class QualityConfig(BaseModel):
     domain: str | None = None  # "healthcare" | "finance" | "ecommerce"
 
 
+class TransformConfig(BaseModel):
+    """GoldenFlow integration config for data transformation."""
+    enabled: bool = True       # auto-detected: True if goldenflow installed
+    mode: Literal["silent", "announced", "disabled"] = "announced"
+
+
 class StandardizationConfig(BaseModel):
     rules: dict[str, list[str]] = Field(default_factory=dict)
 
@@ -417,6 +423,7 @@ class GoldenMatchConfig(BaseModel):
     standardization: StandardizationConfig | None = None
     validation: ValidationConfig | None = None
     quality: QualityConfig | None = None
+    transform: TransformConfig | None = None
     llm_boost: bool = False
     llm_scorer: LLMScorerConfig | None = None
     domain: DomainConfig | None = None

--- a/goldenmatch/core/pipeline.py
+++ b/goldenmatch/core/pipeline.py
@@ -203,6 +203,17 @@ def _run_dedupe_pipeline(
             logger.info("GoldenCheck: %d fixes applied", len(gc_fixes))
         combined_lf = combined_df_tmp.lazy()
 
+    # ── Step 1.4b: GOLDENFLOW TRANSFORM (if available) ──
+    # Runs after GoldenCheck (validates) and before autofix (remaining cleanup).
+    # Not in _run_match_pipeline -- add there if match pipeline gains a quality step.
+    if config.transform is None or config.transform.mode != "disabled":
+        from goldenmatch.core.transform import run_transform
+        combined_df_tmp = combined_lf.collect()
+        combined_df_tmp, gf_fixes = run_transform(combined_df_tmp, config.transform)
+        if gf_fixes:
+            logger.info("GoldenFlow: %d transforms applied", len(gf_fixes))
+        combined_lf = combined_df_tmp.lazy()
+
     # ── Step 1.5a: AUTO-FIX + VALIDATION ──
     if config.validation and config.validation.auto_fix:
         combined_df_tmp = combined_lf.collect()

--- a/goldenmatch/core/transform.py
+++ b/goldenmatch/core/transform.py
@@ -1,0 +1,75 @@
+"""GoldenFlow integration -- data transformation before matching."""
+from __future__ import annotations
+
+import logging
+
+import polars as pl
+
+logger = logging.getLogger(__name__)
+
+
+def _goldenflow_available() -> bool:
+    """Check if goldenflow is installed."""
+    try:
+        import goldenflow  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _do_transform(df: pl.DataFrame):
+    """Call goldenflow.transform_df. Separated for testability."""
+    from goldenflow import transform_df
+    return transform_df(df)
+
+
+def run_transform(
+    df: pl.DataFrame,
+    config=None,
+) -> tuple[pl.DataFrame, list[dict]]:
+    """Run GoldenFlow transform if available.
+
+    Returns (transformed_df, list_of_fixes) matching autofix format.
+    Falls back gracefully if goldenflow is not installed.
+    """
+    if not _goldenflow_available():
+        return df, []
+
+    # Parse config
+    enabled = True
+    mode = "announced"
+
+    if config is not None:
+        mode = getattr(config, "mode", "announced")
+        enabled = getattr(config, "enabled", True)
+
+    if not enabled or mode == "disabled":
+        return df, []
+
+    result = _do_transform(df)
+
+    # Convert manifest to autofix-compatible format
+    fixes = []
+    for record in result.manifest.records:
+        fixes.append({
+            "fix": f"goldenflow:{record.transform_name}",
+            "column": record.column,
+            "rows_affected": record.rows_affected,
+            "detail": (
+                f"{record.transform_name}: {record.rows_affected} rows"
+                + (f" (e.g., {record.sample_before[0]} -> {record.sample_after[0]})"
+                   if record.sample_before and record.sample_after else "")
+            ),
+        })
+
+    if mode == "announced" and fixes:
+        fix_types = set(record.transform_name for record in result.manifest.records)
+        print(
+            f"GoldenFlow: transforming data... "
+            f"{len(fixes)} transforms applied "
+            f"({', '.join(sorted(fix_types))})"
+        )
+    elif mode == "announced":
+        print("GoldenFlow: transforming data... no transforms needed")
+
+    return result.df, fixes

--- a/goldenmatch/core/transform.py
+++ b/goldenmatch/core/transform.py
@@ -46,7 +46,11 @@ def run_transform(
     if not enabled or mode == "disabled":
         return df, []
 
-    result = _do_transform(df)
+    try:
+        result = _do_transform(df)
+    except Exception:
+        logger.warning("GoldenFlow: transform failed, skipping", exc_info=True)
+        return df, []
 
     # Convert manifest to autofix-compatible format
     fixes = []

--- a/goldenmatch/core/transform.py
+++ b/goldenmatch/core/transform.py
@@ -13,7 +13,8 @@ def _goldenflow_available() -> bool:
     try:
         import goldenflow  # noqa: F401
         return True
-    except ImportError:
+    except ImportError as e:
+        logger.debug("goldenflow not available: %s", e)
         return False
 
 
@@ -33,6 +34,11 @@ def run_transform(
     Falls back gracefully if goldenflow is not installed.
     """
     if not _goldenflow_available():
+        if config is not None and getattr(config, "enabled", True):
+            logger.warning(
+                "GoldenFlow transforms configured but goldenflow is not installed. "
+                "Install with: pip install goldenmatch[transform]"
+            )
         return df, []
 
     # Parse config
@@ -68,12 +74,11 @@ def run_transform(
 
     if mode == "announced" and fixes:
         fix_types = set(record.transform for record in result.manifest.records)
-        print(
-            f"GoldenFlow: transforming data... "
-            f"{len(fixes)} transforms applied "
-            f"({', '.join(sorted(fix_types))})"
+        logger.info(
+            "GoldenFlow: %d transforms applied (%s)",
+            len(fixes), ", ".join(sorted(fix_types)),
         )
     elif mode == "announced":
-        print("GoldenFlow: transforming data... no transforms needed")
+        logger.info("GoldenFlow: no transforms needed")
 
     return result.df, fixes

--- a/goldenmatch/core/transform.py
+++ b/goldenmatch/core/transform.py
@@ -52,18 +52,18 @@ def run_transform(
     fixes = []
     for record in result.manifest.records:
         fixes.append({
-            "fix": f"goldenflow:{record.transform_name}",
+            "fix": f"goldenflow:{record.transform}",
             "column": record.column,
-            "rows_affected": record.rows_affected,
+            "rows_affected": record.affected_rows,
             "detail": (
-                f"{record.transform_name}: {record.rows_affected} rows"
+                f"{record.transform}: {record.affected_rows} rows"
                 + (f" (e.g., {record.sample_before[0]} -> {record.sample_after[0]})"
                    if record.sample_before and record.sample_after else "")
             ),
         })
 
     if mode == "announced" and fixes:
-        fix_types = set(record.transform_name for record in result.manifest.records)
+        fix_types = set(record.transform for record in result.manifest.records)
         print(
             f"GoldenFlow: transforming data... "
             f"{len(fixes)} transforms applied "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,11 @@ agent = [
 quality = [
     "goldencheck>=0.5.0",
 ]
+transform = [
+    "goldenflow>=1.0.0",
+]
 all = [
-    "goldenmatch[embeddings,llm,postgres,mcp,quality]",
+    "goldenmatch[embeddings,llm,postgres,mcp,quality,transform]",
 ]
 
 [project.scripts]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,6 +1,7 @@
 """Tests for GoldenFlow integration."""
 from __future__ import annotations
 
+import logging
 from unittest.mock import patch
 from dataclasses import dataclass
 
@@ -67,8 +68,8 @@ def test_enabled_false():
     assert fixes == []
 
 
-def test_transform_applied_announced(capsys):
-    """Announced mode applies transforms and prints summary."""
+def test_transform_applied_announced(caplog):
+    """Announced mode applies transforms and logs summary."""
     df = _sample_df()
     transformed_df = df.with_columns(pl.lit("+15551234567").alias("phone"))
 
@@ -86,7 +87,8 @@ def test_transform_applied_announced(capsys):
     )
 
     with patch("goldenmatch.core.transform._goldenflow_available", return_value=True), \
-         patch("goldenmatch.core.transform._do_transform", return_value=mock_result):
+         patch("goldenmatch.core.transform._do_transform", return_value=mock_result), \
+         caplog.at_level(logging.INFO, logger="goldenmatch.core.transform"):
         result_df, fixes = run_transform(df)
 
     assert result_df.equals(transformed_df)
@@ -97,13 +99,11 @@ def test_transform_applied_announced(capsys):
     assert "(555) 123-4567" in fixes[0]["detail"]
     assert "+15551234567" in fixes[0]["detail"]
 
-    captured = capsys.readouterr()
-    assert "GoldenFlow" in captured.out
-    assert "phone_e164" in captured.out
+    assert any("phone_e164" in r.message for r in caplog.records)
 
 
-def test_transform_applied_silent(capsys):
-    """Silent mode applies transforms without printing."""
+def test_transform_applied_silent(caplog):
+    """Silent mode applies transforms without logging."""
     from goldenmatch.config.schemas import TransformConfig
     df = _sample_df()
     transformed_df = df.clone()
@@ -123,12 +123,12 @@ def test_transform_applied_silent(capsys):
 
     config = TransformConfig(mode="silent")
     with patch("goldenmatch.core.transform._goldenflow_available", return_value=True), \
-         patch("goldenmatch.core.transform._do_transform", return_value=mock_result):
+         patch("goldenmatch.core.transform._do_transform", return_value=mock_result), \
+         caplog.at_level(logging.INFO, logger="goldenmatch.core.transform"):
         result_df, fixes = run_transform(df, config)
 
     assert len(fixes) == 1
-    captured = capsys.readouterr()
-    assert captured.out == ""
+    assert not any("GoldenFlow" in r.message for r in caplog.records)
 
 
 def test_empty_manifest():

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -12,9 +12,9 @@ from goldenmatch.core.transform import run_transform
 
 @dataclass
 class _MockTransformRecord:
-    transform_name: str
+    transform: str
     column: str
-    rows_affected: int
+    affected_rows: int
     sample_before: list[str]
     sample_after: list[str]
 
@@ -77,9 +77,9 @@ def test_transform_applied_announced(capsys):
         df=transformed_df,
         manifest=_MockManifest(records=[
             _MockTransformRecord(
-                transform_name="phone_e164",
+                transform="phone_e164",
                 column="phone",
-                rows_affected=2,
+                affected_rows=2,
                 sample_before=["(555) 123-4567"],
                 sample_after=["+15551234567"],
             ),
@@ -113,9 +113,9 @@ def test_transform_applied_silent(capsys):
         df=transformed_df,
         manifest=_MockManifest(records=[
             _MockTransformRecord(
-                transform_name="whitespace_strip",
+                transform="whitespace_strip",
                 column="name",
-                rows_affected=1,
+                affected_rows=1,
                 sample_before=[" John "],
                 sample_after=["John"],
             ),
@@ -155,9 +155,9 @@ def test_manifest_conversion_no_samples():
         df=df,
         manifest=_MockManifest(records=[
             _MockTransformRecord(
-                transform_name="unicode_nfc",
+                transform="unicode_nfc",
                 column="name",
-                rows_affected=3,
+                affected_rows=3,
                 sample_before=[],
                 sample_after=[],
             ),

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,173 @@
+"""Tests for GoldenFlow integration."""
+from __future__ import annotations
+
+from unittest.mock import patch
+from dataclasses import dataclass
+
+import polars as pl
+import pytest
+
+from goldenmatch.core.transform import run_transform
+
+
+@dataclass
+class _MockTransformRecord:
+    transform_name: str
+    column: str
+    rows_affected: int
+    sample_before: list[str]
+    sample_after: list[str]
+
+
+@dataclass
+class _MockManifest:
+    records: list[_MockTransformRecord]
+
+
+@dataclass
+class _MockTransformResult:
+    df: pl.DataFrame
+    manifest: _MockManifest
+
+
+def _sample_df():
+    return pl.DataFrame({
+        "name": ["John", "Jane"],
+        "phone": ["(555) 123-4567", "555.987.6543"],
+    })
+
+
+def test_goldenflow_not_installed():
+    """When goldenflow is not installed, returns df unchanged."""
+    df = _sample_df()
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=False):
+        result_df, fixes = run_transform(df)
+    assert result_df.equals(df)
+    assert fixes == []
+
+
+def test_disabled_via_config():
+    """mode='disabled' skips transform."""
+    from goldenmatch.config.schemas import TransformConfig
+    df = _sample_df()
+    config = TransformConfig(mode="disabled")
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=True):
+        result_df, fixes = run_transform(df, config)
+    assert result_df.equals(df)
+    assert fixes == []
+
+
+def test_enabled_false():
+    """enabled=False skips transform."""
+    from goldenmatch.config.schemas import TransformConfig
+    df = _sample_df()
+    config = TransformConfig(enabled=False)
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=True):
+        result_df, fixes = run_transform(df, config)
+    assert result_df.equals(df)
+    assert fixes == []
+
+
+def test_transform_applied_announced(capsys):
+    """Announced mode applies transforms and prints summary."""
+    df = _sample_df()
+    transformed_df = df.with_columns(pl.lit("+15551234567").alias("phone"))
+
+    mock_result = _MockTransformResult(
+        df=transformed_df,
+        manifest=_MockManifest(records=[
+            _MockTransformRecord(
+                transform_name="phone_e164",
+                column="phone",
+                rows_affected=2,
+                sample_before=["(555) 123-4567"],
+                sample_after=["+15551234567"],
+            ),
+        ]),
+    )
+
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=True), \
+         patch("goldenmatch.core.transform._do_transform", return_value=mock_result):
+        result_df, fixes = run_transform(df)
+
+    assert result_df.equals(transformed_df)
+    assert len(fixes) == 1
+    assert fixes[0]["fix"] == "goldenflow:phone_e164"
+    assert fixes[0]["column"] == "phone"
+    assert fixes[0]["rows_affected"] == 2
+    assert "(555) 123-4567" in fixes[0]["detail"]
+    assert "+15551234567" in fixes[0]["detail"]
+
+    captured = capsys.readouterr()
+    assert "GoldenFlow" in captured.out
+    assert "phone_e164" in captured.out
+
+
+def test_transform_applied_silent(capsys):
+    """Silent mode applies transforms without printing."""
+    from goldenmatch.config.schemas import TransformConfig
+    df = _sample_df()
+    transformed_df = df.clone()
+
+    mock_result = _MockTransformResult(
+        df=transformed_df,
+        manifest=_MockManifest(records=[
+            _MockTransformRecord(
+                transform_name="whitespace_strip",
+                column="name",
+                rows_affected=1,
+                sample_before=[" John "],
+                sample_after=["John"],
+            ),
+        ]),
+    )
+
+    config = TransformConfig(mode="silent")
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=True), \
+         patch("goldenmatch.core.transform._do_transform", return_value=mock_result):
+        result_df, fixes = run_transform(df, config)
+
+    assert len(fixes) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_empty_manifest():
+    """No transforms needed returns df unchanged with empty fixes."""
+    df = _sample_df()
+    mock_result = _MockTransformResult(
+        df=df,
+        manifest=_MockManifest(records=[]),
+    )
+
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=True), \
+         patch("goldenmatch.core.transform._do_transform", return_value=mock_result):
+        result_df, fixes = run_transform(df)
+
+    assert result_df.equals(df)
+    assert fixes == []
+
+
+def test_manifest_conversion_no_samples():
+    """Manifest records without samples still produce valid fix dicts."""
+    df = _sample_df()
+    mock_result = _MockTransformResult(
+        df=df,
+        manifest=_MockManifest(records=[
+            _MockTransformRecord(
+                transform_name="unicode_nfc",
+                column="name",
+                rows_affected=3,
+                sample_before=[],
+                sample_after=[],
+            ),
+        ]),
+    )
+
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=True), \
+         patch("goldenmatch.core.transform._do_transform", return_value=mock_result):
+        result_df, fixes = run_transform(df)
+
+    assert len(fixes) == 1
+    assert fixes[0]["fix"] == "goldenflow:unicode_nfc"
+    assert "->" not in fixes[0]["detail"]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 from dataclasses import dataclass
 
 import polars as pl
-import pytest
 
 from goldenmatch.core.transform import run_transform
 
@@ -171,3 +170,13 @@ def test_manifest_conversion_no_samples():
     assert len(fixes) == 1
     assert fixes[0]["fix"] == "goldenflow:unicode_nfc"
     assert "->" not in fixes[0]["detail"]
+
+
+def test_do_transform_exception_graceful_degradation():
+    """If goldenflow crashes, returns original df with empty fixes."""
+    df = _sample_df()
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=True), \
+         patch("goldenmatch.core.transform._do_transform", side_effect=RuntimeError("goldenflow bug")):
+        result_df, fixes = run_transform(df)
+    assert result_df.equals(df)
+    assert fixes == []


### PR DESCRIPTION
## Summary
- Add `core/transform.py` wrapping `goldenflow.transform_df()` with graceful fallback when not installed
- Add `TransformConfig` Pydantic model (enabled, mode: announced/silent/disabled)
- Pipeline step 1.4b: GoldenFlow runs after GoldenCheck, before autofix in dedupe pipeline
- Optional dep: `pip install goldenmatch[transform]` (requires `goldenflow>=1.0.0`)
- 7 new tests (all mocked), 1267 total passing, 0 regressions

## Test plan
- [x] goldenflow not installed: returns df unchanged
- [x] mode=disabled / enabled=False: skips transform
- [x] announced mode: applies transforms, prints summary
- [x] silent mode: applies transforms, no output
- [x] empty manifest: no transforms needed
- [x] manifest records without samples: graceful handling
- [x] Full regression suite: 1267 passed in 54s

🤖 Generated with [Claude Code](https://claude.com/claude-code)