### PR TITLE
fix: auto-config cross-source overlap + embedding fallback

### DIFF
--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -542,6 +542,7 @@ def _build_compound_blocking(
         p for p in profiles
         if p.col_type not in ("numeric", "date", "identifier")
         and _null_rate(p.name) <= max_null_rate
+        and _check_source_overlap(df, p.name) > 0.0
     ]
     if len(candidates) < 2:
         return None
@@ -766,6 +767,44 @@ def _llm_suggest_blocking_keys(
     )
 
 
+# ── Cross-source overlap ──────────────────────────────────────────────────
+
+
+def _check_source_overlap(df: pl.DataFrame, col: str) -> float:
+    """Compute value overlap ratio for a column across sources.
+
+    Returns |intersection| / |union| of unique values per source.
+    Returns 1.0 if no __source__ column or only one source (no check needed).
+    """
+    if "__source__" not in df.columns:
+        return 1.0
+
+    sources = df["__source__"].unique().to_list()
+    if len(sources) < 2:
+        return 1.0
+
+    value_sets = []
+    for src in sources:
+        vals = set(
+            df.filter(pl.col("__source__") == src)[col]
+            .drop_nulls()
+            .cast(pl.Utf8)
+            .to_list()
+        )
+        value_sets.append(vals)
+
+    intersection = value_sets[0]
+    union = value_sets[0]
+    for vs in value_sets[1:]:
+        intersection = intersection & vs
+        union = union | vs
+
+    if not union:
+        return 1.0
+
+    return len(intersection) / len(union)
+
+
 # ── Blocking generation ────────────────────────────────────────────────────
 
 def build_blocking(
@@ -786,8 +825,24 @@ def build_blocking(
         if p.col_type in ("email", "phone", "zip", "identifier")
         and _null_rate(p.name) <= max_null_rate
         and p.cardinality_ratio < 0.95
+        and _check_source_overlap(df, p.name) > 0.0
     ]
-    name_cols = [p for p in profiles if p.col_type == "name"]
+    # Log skipped columns
+    for p in profiles:
+        if (p.col_type in ("email", "phone", "zip", "identifier")
+                and _null_rate(p.name) <= max_null_rate
+                and p.cardinality_ratio < 0.95
+                and _check_source_overlap(df, p.name) == 0.0):
+            sources = df["__source__"].unique().to_list() if "__source__" in df.columns else []
+            logger.warning(
+                "Blocking key '%s' has 0%% overlap between sources %s -- skipping",
+                p.name, ", ".join(str(s) for s in sources),
+            )
+    name_cols = [
+        p for p in profiles
+        if p.col_type == "name"
+        and _check_source_overlap(df, p.name) > 0.0
+    ]
     text_cols = [p for p in profiles if p.col_type in ("description", "string", "address")]
 
     def _max_block_size(col_name: str) -> int:

--- a/goldenmatch/core/scorer.py
+++ b/goldenmatch/core/scorer.py
@@ -148,12 +148,16 @@ def _fuzzy_score_matrix(
 ) -> np.ndarray:
     """NxN fuzzy score matrix using rapidfuzz cdist or embedding cosine similarity."""
     if scorer_name == "embedding":
-        from goldenmatch.core.embedder import get_embedder
+        try:
+            from goldenmatch.core.embedder import get_embedder
 
-        embedder = get_embedder(model_name)
-        embeddings = embedder.embed_column(values, cache_key=f"_block_{id(values)}")
-        sim = embedder.cosine_similarity_matrix(embeddings)
-        return np.asarray(sim, dtype=np.float64)
+            embedder = get_embedder(model_name)
+            embeddings = embedder.embed_column(values, cache_key=f"_block_{id(values)}")
+            sim = embedder.cosine_similarity_matrix(embeddings)
+            return np.asarray(sim, dtype=np.float64)
+        except Exception:
+            logger.warning("Embedding scorer failed, falling back to token_sort", exc_info=True)
+            scorer_name = "token_sort"
 
     # Replace None with empty string for cdist (we handle nulls separately)
     clean = [v if v is not None else "" for v in values]
@@ -423,10 +427,21 @@ def find_fuzzy_matches(
         all_expensive_fields = list(fuzzy_fields) + list(record_emb_fields)
         for f_idx, f in enumerate(all_expensive_fields):
             if f.scorer == "record_embedding":
-                scores = _record_embedding_score_matrix(
-                    block_df, f.columns, model_name=f.model or "all-MiniLM-L6-v2",
-                    column_weights=f.column_weights,
-                )
+                try:
+                    scores = _record_embedding_score_matrix(
+                        block_df, f.columns, model_name=f.model or "all-MiniLM-L6-v2",
+                        column_weights=f.column_weights,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Record embedding scorer failed for columns %s, falling back to token_sort",
+                        f.columns, exc_info=True,
+                    )
+                    concat_values = []
+                    for row in block_df.to_dicts():
+                        parts = [str(row.get(c, "") or "") for c in (f.columns or [])]
+                        concat_values.append(" ".join(parts))
+                    scores = _fuzzy_score_matrix(concat_values, "token_sort")
                 fuzzy_numerator += scores * f.weight
                 fuzzy_denominator += f.weight
             else:

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -843,3 +843,50 @@ class TestCardinalityBoundaryValues:
             if mk.type == "exact":
                 exact_fields.extend(f.field for f in mk.fields)
         assert "email" in exact_fields, "Default cardinality_ratio=0.0 should not trigger the guard"
+
+
+class TestCrossSourceOverlap:
+    """Tests for _check_source_overlap blocking guard."""
+
+    def test_zero_overlap_skips_blocking_key(self):
+        """Blocking key with zero overlap between sources should return 0.0."""
+        from goldenmatch.core.autoconfig import _check_source_overlap
+
+        df = pl.DataFrame({
+            "venue": ["VLDB", "SIGMOD", "VLDB", "Very Large Databases", "SIGMOD Conf"],
+            "__source__": ["A", "A", "A", "B", "B"],
+        })
+        overlap = _check_source_overlap(df, "venue")
+        assert overlap == 0.0
+
+    def test_full_overlap_passes(self):
+        """Blocking key with overlap should return > 0.0."""
+        from goldenmatch.core.autoconfig import _check_source_overlap
+
+        df = pl.DataFrame({
+            "year": [2020, 2021, 2022, 2020, 2021],
+            "__source__": ["A", "A", "A", "B", "B"],
+        })
+        overlap = _check_source_overlap(df, "year")
+        assert overlap > 0.0
+
+    def test_no_source_column_returns_one(self):
+        """Without __source__ column, should return 1.0 (no check)."""
+        from goldenmatch.core.autoconfig import _check_source_overlap
+
+        df = pl.DataFrame({
+            "venue": ["VLDB", "SIGMOD", "VLDB"],
+        })
+        overlap = _check_source_overlap(df, "venue")
+        assert overlap == 1.0
+
+    def test_single_source_returns_one(self):
+        """With only one source, should return 1.0."""
+        from goldenmatch.core.autoconfig import _check_source_overlap
+
+        df = pl.DataFrame({
+            "venue": ["VLDB", "SIGMOD"],
+            "__source__": ["A", "A"],
+        })
+        overlap = _check_source_overlap(df, "venue")
+        assert overlap == 1.0

--- a/tests/test_embedding_fallback.py
+++ b/tests/test_embedding_fallback.py
@@ -1,0 +1,47 @@
+"""Tests for embedding scorer fallback to token_sort."""
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+
+from goldenmatch.core.scorer import _fuzzy_score_matrix
+
+
+def test_embedding_failure_falls_back_to_token_sort(caplog):
+    """When embedding scorer fails, falls back to token_sort."""
+    values = ["hello world", "hello world", "goodbye moon"]
+
+    mock_embedder = MagicMock()
+    mock_embedder.embed_column.side_effect = OSError("HF auth failed")
+
+    with patch("goldenmatch.core.embedder.get_embedder", return_value=mock_embedder), \
+         caplog.at_level(logging.WARNING, logger="goldenmatch.core.scorer"):
+        scores = _fuzzy_score_matrix(values, "embedding")
+
+    assert scores.shape == (3, 3)
+    assert scores[0, 1] == 1.0  # identical strings
+    assert scores[0, 2] < 1.0   # different strings
+    assert any("falling back to token_sort" in r.message for r in caplog.records)
+
+
+def test_embedding_import_error_falls_back(caplog):
+    """When embedder module can't be imported, falls back to token_sort."""
+    values = ["alpha beta", "alpha beta", "gamma delta"]
+
+    with patch.dict("sys.modules", {"goldenmatch.core.embedder": None}), \
+         caplog.at_level(logging.WARNING, logger="goldenmatch.core.scorer"):
+        scores = _fuzzy_score_matrix(values, "embedding")
+
+    assert scores.shape == (3, 3)
+    assert scores[0, 1] == 1.0
+
+
+def test_non_embedding_scorer_unaffected():
+    """token_sort scorer should work normally (no fallback needed)."""
+    values = ["hello world", "world hello", "goodbye"]
+
+    scores = _fuzzy_score_matrix(values, "token_sort")
+    assert scores.shape == (3, 3)
+    assert scores[0, 1] > 0.9  # token_sort handles reordering


### PR DESCRIPTION
## Summary
- Add cross-source blocking overlap detection: when `__source__` exists, skip blocking keys with zero value overlap between sources (fixes DBLP-ACM venue blocking failure)
- Add embedding scorer fallback: when embedding model fails (HF auth, Vertex AI, missing dep), fall back to token_sort instead of crashing
- 7 new tests (4 overlap, 3 fallback), 1275 total passing, 0 regressions

## Test plan
- [x] Zero overlap blocking key skipped with warning
- [x] Full overlap key selected normally
- [x] No `__source__` column: no check (backward compatible)
- [x] Single source: no check
- [x] Embedding OSError: falls back to token_sort with warning
- [x] Embedding ImportError: falls back to token_sort
- [x] Non-embedding scorer unaffected
- [x] Full regression suite: 1275 passed in 65s

🤖 Generated with [Claude Code](https://claude.com/claude-code)