### PR TITLE
feat: llm_auto flag + memory/review queue auto-enablement

### DIFF
--- a/goldenmatch/_api.py
+++ b/goldenmatch/_api.py
@@ -269,6 +269,7 @@ def dedupe_df(
     blocking: list[str] | None = None,
     threshold: float | None = None,
     llm_scorer: bool = False,
+    llm_auto: bool = False,
     backend: str | None = None,
     source_name: str = "dataframe",
 ) -> DedupeResult:
@@ -304,7 +305,7 @@ def dedupe_df(
         else:
             # Zero-config: defer auto-config to inside pipeline (after GoldenCheck/GoldenFlow)
             from goldenmatch.config.schemas import GoldenMatchConfig
-            config = GoldenMatchConfig()
+            config = GoldenMatchConfig(llm_auto=llm_auto)
             _auto_config = True
             _auto_config_provider = _detect_llm_provider() if llm_scorer else None
 

--- a/goldenmatch/config/schemas.py
+++ b/goldenmatch/config/schemas.py
@@ -426,6 +426,7 @@ class GoldenMatchConfig(BaseModel):
     transform: TransformConfig | None = None
     llm_boost: bool = False
     llm_scorer: LLMScorerConfig | None = None
+    llm_auto: bool = False
     domain: DomainConfig | None = None
     backend: str | None = None  # None (default Polars), "ray", "duckdb"
     memory: MemoryConfig | None = None

--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -12,10 +12,13 @@ import polars as pl
 from goldenmatch.config.schemas import (
     BlockingConfig,
     BlockingKeyConfig,
+    BudgetConfig,
     GoldenMatchConfig,
     GoldenRulesConfig,
+    LLMScorerConfig,
     MatchkeyConfig,
     MatchkeyField,
+    MemoryConfig,
     OutputConfig,
 )
 from goldenmatch.core.profiler import _guess_type
@@ -970,7 +973,7 @@ def select_model(row_count: int, has_embedding_columns: bool, threshold: int = 5
 
 # ── Main entry point ──────────────────────────────────────────────────────
 
-def auto_configure_df(df: pl.DataFrame, llm_provider: str | None = None, domain_config=None) -> GoldenMatchConfig:
+def auto_configure_df(df: pl.DataFrame, llm_provider: str | None = None, domain_config=None, llm_auto: bool = False) -> GoldenMatchConfig:
     """Auto-generate a GoldenMatchConfig from a DataFrame.
 
     Profiles columns by name heuristics and data sampling, then builds
@@ -1104,12 +1107,36 @@ def auto_configure_df(df: pl.DataFrame, llm_provider: str | None = None, domain_
     has_fuzzy = any(mk.type in ("weighted", "probabilistic") for mk in matchkeys)
     blocking = build_blocking(profiles, df, llm_provider=llm_provider) if has_fuzzy else None
 
+    # ── LLM auto-config ──
+    llm_scorer_config = None
+    if llm_auto:
+        import os
+        provider = None
+        if os.environ.get("ANTHROPIC_API_KEY"):
+            provider = "anthropic"
+        elif os.environ.get("OPENAI_API_KEY"):
+            provider = "openai"
+
+        if provider:
+            llm_scorer_config = LLMScorerConfig(
+                enabled=True,
+                candidate_lo=0.60,
+                candidate_hi=0.90,
+                auto_threshold=0.90,
+                budget=BudgetConfig(max_cost_usd=0.05),
+            )
+            logger.info("LLM scorer auto-enabled (provider=%s, budget=$0.05)", provider)
+        else:
+            logger.info("llm_auto=True but no API key found (OPENAI_API_KEY or ANTHROPIC_API_KEY)")
+
     # Build config
     config = GoldenMatchConfig(
         matchkeys=matchkeys,
         blocking=blocking,
         golden_rules=GoldenRulesConfig(default_strategy="most_complete"),
         output=OutputConfig(),
+        llm_scorer=llm_scorer_config,
+        memory=MemoryConfig(enabled=True),
     )
 
     return config

--- a/goldenmatch/core/pipeline.py
+++ b/goldenmatch/core/pipeline.py
@@ -227,11 +227,17 @@ def _run_dedupe_pipeline(
     if auto_config:
         from goldenmatch.core.autoconfig import auto_configure_df
         combined_df_tmp = combined_lf.collect()
-        auto_cfg = auto_configure_df(combined_df_tmp, llm_provider=auto_config_llm_provider)
+        auto_cfg = auto_configure_df(
+            combined_df_tmp,
+            llm_provider=auto_config_llm_provider,
+            llm_auto=config.llm_auto,
+        )
         config.matchkeys = auto_cfg.matchkeys
         config.match_settings = auto_cfg.match_settings
         config.blocking = auto_cfg.blocking
         config.golden_rules = auto_cfg.golden_rules
+        config.llm_scorer = auto_cfg.llm_scorer
+        config.memory = auto_cfg.memory
         matchkeys = config.get_matchkeys()
         logger.info("Auto-configured from cleaned data: %d matchkeys", len(matchkeys))
         combined_lf = combined_df_tmp.lazy()

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -972,3 +972,85 @@ class TestDomainAwareAutoConfig:
         domain_fields = [f for f in all_fields if f and f.startswith("__")]
         assert len(domain_fields) == 0
         assert len(config.get_matchkeys()) > 0
+
+
+class TestLLMMemoryAutoEnablement:
+    """Tests for LLM + memory auto-enablement in auto-config."""
+
+    def test_llm_auto_with_api_key(self):
+        """When llm_auto=True and API key available, LLM scorer is configured."""
+        from goldenmatch.core.autoconfig import auto_configure_df
+        from unittest.mock import patch
+
+        df = pl.DataFrame({
+            "name": ["John Smith", "Jane Doe", "Bob Wilson"],
+            "email": ["john@test.com", "jane@test.com", "bob@test.com"],
+        })
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}):
+            config = auto_configure_df(df, llm_auto=True)
+
+        assert config.llm_scorer is not None
+        assert config.llm_scorer.enabled is True
+        assert config.llm_scorer.budget is not None
+        assert config.llm_scorer.budget.max_cost_usd == 0.05
+
+    def test_llm_auto_without_api_key(self):
+        """When llm_auto=True but no API key, LLM scorer stays None."""
+        from goldenmatch.core.autoconfig import auto_configure_df
+        from unittest.mock import patch
+        import os
+
+        df = pl.DataFrame({
+            "name": ["John Smith", "Jane Doe", "Bob Wilson"],
+            "email": ["john@test.com", "jane@test.com", "bob@test.com"],
+        })
+
+        env_remove = {k: "" for k in ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]}
+        with patch.dict("os.environ", env_remove):
+            os.environ.pop("OPENAI_API_KEY", None)
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+            config = auto_configure_df(df, llm_auto=True)
+
+        assert config.llm_scorer is None
+
+    def test_llm_auto_off_default(self):
+        """When llm_auto=False (default), LLM scorer is never set."""
+        from goldenmatch.core.autoconfig import auto_configure_df
+        from unittest.mock import patch
+
+        df = pl.DataFrame({
+            "name": ["John Smith", "Jane Doe", "Bob Wilson"],
+            "email": ["john@test.com", "jane@test.com", "bob@test.com"],
+        })
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}):
+            config = auto_configure_df(df, llm_auto=False)
+
+        assert config.llm_scorer is None
+
+    def test_memory_auto_enabled(self):
+        """Zero-config auto-config should enable memory store."""
+        from goldenmatch.core.autoconfig import auto_configure_df
+
+        df = pl.DataFrame({
+            "name": ["John Smith", "Jane Doe", "Bob Wilson"],
+            "email": ["john@test.com", "jane@test.com", "bob@test.com"],
+        })
+
+        config = auto_configure_df(df)
+        assert config.memory is not None
+        assert config.memory.enabled is True
+
+    def test_golden_rules_set(self):
+        """Zero-config should set golden rules with most_complete strategy."""
+        from goldenmatch.core.autoconfig import auto_configure_df
+
+        df = pl.DataFrame({
+            "name": ["John Smith", "Jane Doe", "Bob Wilson"],
+            "email": ["john@test.com", "jane@test.com", "bob@test.com"],
+        })
+
+        config = auto_configure_df(df)
+        assert config.golden_rules is not None
+        assert config.golden_rules.default_strategy == "most_complete"


### PR DESCRIPTION
## Summary
- Add `llm_auto: bool = False` on `GoldenMatchConfig` — when True and API key in env, auto-config enables LLM scorer with $0.05 budget cap
- Auto-config always enables memory store (SQLite backend for persistent corrections)
- Pipeline forwards `llm_scorer` and `memory` from auto-configured config
- 5 new tests, 88 key tests passing

## Test plan
- [x] llm_auto=True + API key: LLM scorer configured with budget
- [x] llm_auto=True + no key: scorer stays None, no error
- [x] llm_auto=False (default): scorer untouched even with key
- [x] Memory auto-enabled in zero-config
- [x] Golden rules set with most_complete strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)