### PR TITLE
feat: expose GoldenCheck and GoldenFlow via MCP tools and A2A skills

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,8 +52,8 @@
 - `goldenmatch/core/agent.py` -- AgentSession, profile_for_agent, select_strategy, build_alternatives. Autonomous ER: profiles data -> detects domain -> selects strategy -> runs pipeline -> returns reasoning
 - `goldenmatch/core/review_queue.py` -- ReviewQueue (memory/SQLite/Postgres backends), ReviewItem, gate_pairs(). Confidence gating: >0.95 auto-merge, 0.75-0.95 review, <0.75 reject
 - `goldenmatch/core/memory/` -- Learning Memory: persistent corrections + rule learning. `store.py` (MemoryStore, SQLite/Postgres CRUD, trust-based upsert), `corrections.py` (apply_corrections with dual-hash staleness detection), `learner.py` (MemoryLearner, threshold tuning from 10+ corrections). Config: `MemoryConfig` in schemas.py, optional `memory:` YAML section
-- `goldenmatch/a2a/` -- A2A protocol server (aiohttp). Agent card at `/.well-known/agent.json`, 8 skills, task lifecycle, SSE streaming. CLI: `goldenmatch agent-serve --port 8200`
-- `goldenmatch/mcp/agent_tools.py` -- 10 agent-level MCP tools (additive to existing). Each creates own AgentSession (no shared global state)
+- `goldenmatch/a2a/` -- A2A protocol server (aiohttp). Agent card at `/.well-known/agent.json`, 10 skills, task lifecycle, SSE streaming. CLI: `goldenmatch agent-serve --port 8200`
+- `goldenmatch/mcp/agent_tools.py` -- 13 agent-level MCP tools (additive to existing). Each creates own AgentSession (no shared global state)
 - `_api.py` has DataFrame entry points: `dedupe_df()`, `match_df()`, `score_strings()`, `score_pair_df()`, `explain_pair_df()` -- used by SQL extensions
 - `pipeline.py` refactored: `_run_dedupe_pipeline()` and `_run_match_pipeline()` extracted as shared internal functions, called by both file-based and DataFrame-based entry points
 - `goldenmatch/core/` — pipeline modules (no Textual dependency)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,8 @@
 - `goldenmatch/core/agent.py` -- AgentSession, profile_for_agent, select_strategy, build_alternatives. Autonomous ER: profiles data -> detects domain -> selects strategy -> runs pipeline -> returns reasoning
 - `goldenmatch/core/review_queue.py` -- ReviewQueue (memory/SQLite/Postgres backends), ReviewItem, gate_pairs(). Confidence gating: >0.95 auto-merge, 0.75-0.95 review, <0.75 reject
 - `goldenmatch/core/memory/` -- Learning Memory: persistent corrections + rule learning. `store.py` (MemoryStore, SQLite/Postgres CRUD, trust-based upsert), `corrections.py` (apply_corrections with dual-hash staleness detection), `learner.py` (MemoryLearner, threshold tuning from 10+ corrections). Config: `MemoryConfig` in schemas.py, optional `memory:` YAML section
-- `goldenmatch/a2a/` -- A2A protocol server (aiohttp). Agent card at `/.well-known/agent.json`, 8 skills, task lifecycle, SSE streaming. CLI: `goldenmatch agent-serve --port 8200`
-- `goldenmatch/mcp/agent_tools.py` -- 10 agent-level MCP tools (additive to existing). Each creates own AgentSession (no shared global state)
+- `goldenmatch/a2a/` -- A2A protocol server (aiohttp). Agent card at `/.well-known/agent.json`, 10 skills, task lifecycle, SSE streaming. CLI: `goldenmatch agent-serve --port 8200`
+- `goldenmatch/mcp/agent_tools.py` -- 13 agent-level MCP tools (additive to existing). Each creates own AgentSession (no shared global state)
 - `_api.py` has DataFrame entry points: `dedupe_df()`, `match_df()`, `score_strings()`, `score_pair_df()`, `explain_pair_df()` -- used by SQL extensions
 - `pipeline.py` refactored: `_run_dedupe_pipeline()` and `_run_match_pipeline()` extracted as shared internal functions, called by both file-based and DataFrame-based entry points
 - `goldenmatch/core/` — pipeline modules (no Textual dependency)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-04-06
+
+### Added
+- **MCP tools for data quality** — `scan_quality` (scan without fixing), `fix_quality` (scan + apply fixes with safe/moderate mode), `run_transforms` (GoldenFlow phone/date/Unicode normalization). All 3 tools validate file paths, handle write failures gracefully, and include logging
+- **A2A skills for data quality** — `quality` (scan + fix via GoldenCheck) and `transform` (normalize via GoldenFlow) skills added to the Agent-to-Agent protocol
+- `run_transform(strict=True)` parameter — MCP/A2A handlers surface transform failures instead of silently returning unmodified data
+- `_scan_only()` now returns serialized findings so MCP tools can inspect quality issues without duplicating the scan
+- 10 new tests: happy-path coverage with mocked deps, file validation, write failure handling
+
+### Fixed
+- Eliminated redundant double-scan in `scan_quality` MCP handler (was scanning data twice and reaching into goldencheck internals)
+- Temp file cleanup handles `PermissionError` on Windows (file locks no longer leak orphaned temp files)
+- `_serialise_result` exception clause narrowed from `Exception` to `ImportError`
+- `fix_quality` test assertion strengthened to check error message content
+
 ## [1.4.0] - 2026-04-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,13 @@
 - `goldenmatch/core/agent.py` -- AgentSession, profile_for_agent, select_strategy, build_alternatives. Autonomous ER: profiles data -> detects domain -> selects strategy -> runs pipeline -> returns reasoning
 - `goldenmatch/core/review_queue.py` -- ReviewQueue (memory/SQLite/Postgres backends), ReviewItem, gate_pairs(). Confidence gating: >0.95 auto-merge, 0.75-0.95 review, <0.75 reject
 - `goldenmatch/core/memory/` -- Learning Memory: persistent corrections + rule learning. `store.py` (MemoryStore, SQLite/Postgres CRUD, trust-based upsert), `corrections.py` (apply_corrections with dual-hash staleness detection), `learner.py` (MemoryLearner, threshold tuning from 10+ corrections). Config: `MemoryConfig` in schemas.py, optional `memory:` YAML section
-- `goldenmatch/a2a/` -- A2A protocol server (aiohttp). Agent card at `/.well-known/agent.json`, 8 skills, task lifecycle, SSE streaming. CLI: `goldenmatch agent-serve --port 8200`
-- `goldenmatch/mcp/agent_tools.py` -- 10 agent-level MCP tools (additive to existing). Each creates own AgentSession (no shared global state)
+- `goldenmatch/a2a/` -- A2A protocol server (aiohttp). Agent card at `/.well-known/agent.json`, 10 skills, task lifecycle, SSE streaming. CLI: `goldenmatch agent-serve --port 8200`
+- `goldenmatch/mcp/agent_tools.py` -- 13 agent-level MCP tools (additive to existing). Each creates own AgentSession (no shared global state)
+- Adding MCP tools: add Tool to `AGENT_TOOLS` in `mcp/agent_tools.py`, add dispatch handler in `_dispatch()`, update server card tool count in `mcp/server.py` (line ~1002)
+- Adding A2A skills: add entry to `_SKILLS` in `a2a/server.py`, add dispatch handler in `a2a/skills.py`, update `test_agent_card_has_N_skills` assertion in `tests/test_a2a.py`
+- MCP/A2A handlers must validate `file_path` param, catch `FileNotFoundError` on `pl.read_csv`, and wrap `write_csv(output_path)` in try/except to preserve results on write failure
+- `run_transform(strict=True)` re-raises exceptions instead of silently returning unmodified data — use from MCP/A2A handlers where callers explicitly requested transforms
+- `_scan_only()` in `quality.py` returns serialized findings dicts (not empty list) so MCP tools can inspect them without reaching into goldencheck internals
 - `_api.py` has DataFrame entry points: `dedupe_df()`, `match_df()`, `score_strings()`, `score_pair_df()`, `explain_pair_df()` -- used by SQL extensions
 - `pipeline.py` refactored: `_run_dedupe_pipeline()` and `_run_match_pipeline()` extracted as shared internal functions, called by both file-based and DataFrame-based entry points
 - `goldenmatch/core/` — pipeline modules (no Textual dependency)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ goldenmatch demo
 - **Fellegi-Sunter probabilistic matching** — EM-trained m/u probabilities, automatic threshold estimation, comparison vectors with 2/3-level agreement
 - **Vertex AI embeddings** — 85%+ F1 accuracy with no GPU needed (Google Cloud managed API)
 - **Database sync** — incremental Postgres matching with persistent ANN index and golden record versioning
-- **REST API + MCP Server** — real-time matching via HTTP or Claude Desktop (27 tools: match, unmerge, explain, config advisor, etc.)
+- **REST API + MCP Server** — real-time matching via HTTP or Claude Desktop (30 tools: match, unmerge, explain, config advisor, data quality, transforms, etc.)
 - **Review queue** — REST endpoint surfaces borderline pairs for data steward approval/rejection
 - **Lineage tracking** — every merge decision saved to a JSON sidecar with per-field score breakdown and golden record provenance
 - **Daemon mode** — `goldenmatch watch --daemon` runs as a service with health endpoint and PID file
@@ -254,7 +254,7 @@ Guides you through GPU mode selection, Vertex AI / Colab / local GPU configurati
 | Privacy-preserving (PPRL) | Built-in (92.4% F1) | No | No | No | No |
 | Interactive TUI | Yes | No | No | No | No |
 | Golden record synthesis | 5 strategies | No | No | No | No |
-| MCP server (AI integration) | Yes (27 tools) | No | No | No | No |
+| MCP server (AI integration) | Yes (30 tools) | No | No | No | No |
 | Database sync | Postgres + DuckDB | No | No | No | Spark/DuckDB |
 | Single `pip install` | Yes | Yes | Yes | No (Java/Spark) | Yes |
 | Polars-native | Yes | No (pandas) | No (pandas) | No (Spark) | Yes (DuckDB) |
@@ -698,7 +698,7 @@ pip install goldenmatch[mcp]
 goldenmatch mcp-serve data.csv
 ```
 
-27 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, and synthesize golden records.
+30 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, and synthesize golden records.
 
 ## Architecture
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -52,7 +52,7 @@ Add to `claude_desktop_config.json`:
 
 ---
 
-## Agent Capabilities (8 Skills)
+## Agent Capabilities (10 Skills)
 
 | Skill | What It Does |
 |-------|-------------|
@@ -64,6 +64,8 @@ Add to `claude_desktop_config.json`:
 | `review` | Present borderline matches for approval |
 | `compare_strategies` | Run multiple approaches, report metrics |
 | `pprl` | Privacy-preserving mode for sensitive data |
+| `quality` | Scan and fix data quality issues (encoding, Unicode, format violations) using GoldenCheck |
+| `transform` | Normalize data formats (phone E.164, dates ISO, categorical spelling) using GoldenFlow |
 
 ---
 
@@ -185,7 +187,7 @@ matches = session.match_sources("new_customers.csv", "master.csv")
 
 ---
 
-## MCP Tools (10 Agent-Level)
+## MCP Tools (13 Agent-Level)
 
 | Tool | Description |
 |------|-------------|
@@ -199,6 +201,9 @@ matches = session.match_sources("new_customers.csv", "master.csv")
 | `agent_approve_reject` | Process review decisions |
 | `agent_compare_strategies` | Compare ER approaches |
 | `suggest_pprl` | Check if PPRL is needed |
+| `scan_quality` | Run GoldenCheck data quality scan, return issues without fixing |
+| `fix_quality` | Run GoldenCheck scan and apply fixes (safe or moderate mode) |
+| `run_transforms` | Run GoldenFlow transforms (phone E.164, dates ISO, Unicode) |
 
 These are additive -- existing MCP tools (`suggest_config`, `list_domains`, etc.) continue to work.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -378,9 +378,9 @@ goldenmatch label pairs.csv                          # Label training pairs
 
 ## Interfaces
 
-- **MCP Server**: `goldenmatch mcp-serve` — 10 tools for Claude Desktop integration
-- **Remote MCP**: https://goldenmatch-mcp-production.up.railway.app/mcp/ (27 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
-- **A2A Server**: `goldenmatch agent-serve --port 8200` — 8 skills via Agent-to-Agent protocol
+- **MCP Server**: `goldenmatch mcp-serve` — 13 tools for Claude Desktop integration
+- **Remote MCP**: https://goldenmatch-mcp-production.up.railway.app/mcp/ (30 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- **A2A Server**: `goldenmatch agent-serve --port 8200` — 10 skills via Agent-to-Agent protocol
 - **REST API**: `goldenmatch serve` on port 8000 — match, clusters, explain, reviews endpoints
 - **CLI**: 20+ Typer commands
 - **Python API**: `import goldenmatch` — ~101 exports

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -3,9 +3,9 @@
 > Entity resolution toolkit — deduplicate records and match across datasets using fuzzy, probabilistic, and LLM-powered scoring. MST cluster auto-splitting, quality-weighted survivorship, field-level provenance.
 
 ## Interfaces
-- MCP Server: `goldenmatch mcp-serve` (10 tools: analyze, configure, deduplicate, match, explain, review, compare strategies, PPRL)
-- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (27 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
-- A2A Server: `goldenmatch agent-serve --port 8200` (8 skills)
+- MCP Server: `goldenmatch mcp-serve` (13 tools: analyze, configure, deduplicate, match, explain, review, compare strategies, PPRL, scan quality, fix quality, run transforms)
+- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (30 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- A2A Server: `goldenmatch agent-serve --port 8200` (10 skills)
 - CLI: `goldenmatch dedupe`, `goldenmatch match`, + 18 more commands
 - Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~101 exports
 - REST API: `goldenmatch serve` on port 8000

--- a/goldenmatch/__init__.py
+++ b/goldenmatch/__init__.py
@@ -27,7 +27,8 @@ Quick start:
 
 All features are accessible via `import goldenmatch as gm`.
 """
-__version__ = "1.4.0"
+
+__version__ = "1.4.1"
 
 # ── High-level API (convenience functions) ────────────────────────────────
 from goldenmatch._api import (

--- a/goldenmatch/a2a/server.py
+++ b/goldenmatch/a2a/server.py
@@ -74,6 +74,20 @@ _SKILLS = [
         "inputModes": ["application/json"],
         "outputModes": ["application/json"],
     },
+    {
+        "id": "quality",
+        "name": "Quality",
+        "description": "Scan and fix data quality issues (encoding, Unicode, format violations) using GoldenCheck.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "transform",
+        "name": "Transform",
+        "description": "Normalize data formats (phone E.164, dates ISO, categorical spelling, Unicode) using GoldenFlow.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
 ]
 
 

--- a/goldenmatch/a2a/skills.py
+++ b/goldenmatch/a2a/skills.py
@@ -107,24 +107,40 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
         if not _goldencheck_available():
             return {"error": "goldencheck not installed. pip install goldenmatch[quality]"}
 
-        df = pl.read_csv(
-            params["file_path"], encoding="utf8-lossy", ignore_errors=True,
-        )
+        file_path = params.get("file_path")
+        if not file_path:
+            return {"error": "Missing required parameter: file_path"}
+
+        try:
+            df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
+        except FileNotFoundError:
+            return {"error": f"File not found: {file_path}"}
+        except Exception as exc:
+            return {"error": f"Could not read CSV '{file_path}': {exc}"}
+
         fix_mode = params.get("fix_mode", "safe")
         domain = params.get("domain")
         qc = QualityConfig(mode="silent", fix_mode=fix_mode, domain=domain)
         fixed_df, fixes = run_quality_check(df, qc)
 
         output_path = params.get("output_path")
+        write_error = None
         if output_path:
-            fixed_df.write_csv(output_path)
+            try:
+                fixed_df.write_csv(output_path)
+            except Exception as exc:
+                write_error = f"Results computed but failed to write to '{output_path}': {exc}"
+                output_path = None
 
-        return {
+        result = {
             "total_records": fixed_df.height,
             "fixes_applied": len(fixes),
             "fixes": fixes,
             "output_path": output_path,
         }
+        if write_error:
+            result["write_error"] = write_error
+        return result
 
     if skill_id == "transform":
         import polars as pl
@@ -134,22 +150,38 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
         if not _goldenflow_available():
             return {"error": "goldenflow not installed. pip install goldenmatch[transform]"}
 
-        df = pl.read_csv(
-            params["file_path"], encoding="utf8-lossy", ignore_errors=True,
-        )
+        file_path = params.get("file_path")
+        if not file_path:
+            return {"error": "Missing required parameter: file_path"}
+
+        try:
+            df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
+        except FileNotFoundError:
+            return {"error": f"File not found: {file_path}"}
+        except Exception as exc:
+            return {"error": f"Could not read CSV '{file_path}': {exc}"}
+
         tc = TransformConfig(mode="silent")
-        transformed_df, fixes = run_transform(df, tc)
+        transformed_df, fixes = run_transform(df, tc, strict=True)
 
         output_path = params.get("output_path")
+        write_error = None
         if output_path:
-            transformed_df.write_csv(output_path)
+            try:
+                transformed_df.write_csv(output_path)
+            except Exception as exc:
+                write_error = f"Results computed but failed to write to '{output_path}': {exc}"
+                output_path = None
 
-        return {
+        result = {
             "total_records": transformed_df.height,
             "transforms_applied": len(fixes),
             "transforms": fixes,
             "output_path": output_path,
         }
+        if write_error:
+            result["write_error"] = write_error
+        return result
 
     raise ValueError(f"Unknown skill: {skill_id}")
 
@@ -165,7 +197,7 @@ def _serialise_result(obj: Any) -> dict:
                 if isinstance(v, pl.DataFrame):
                     out[k] = {"rows": v.height, "columns": v.columns}
                     continue
-            except Exception:
+            except ImportError:
                 pass
             if isinstance(v, dict):
                 out[k] = _serialise_result(v)

--- a/goldenmatch/a2a/skills.py
+++ b/goldenmatch/a2a/skills.py
@@ -20,7 +20,7 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
     ----------
     skill_id : str
         One of: analyze_data, configure, deduplicate, match, explain,
-        review, compare_strategies, pprl.
+        review, compare_strategies, pprl, quality, transform.
     params : dict
         Skill-specific parameters.
 
@@ -98,6 +98,58 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
             fields=params.get("fields", []),
         )
         return _serialise_result({"result": result})
+
+    if skill_id == "quality":
+        import polars as pl
+        from goldenmatch.core.quality import _goldencheck_available, run_quality_check
+        from goldenmatch.config.schemas import QualityConfig
+
+        if not _goldencheck_available():
+            return {"error": "goldencheck not installed. pip install goldenmatch[quality]"}
+
+        df = pl.read_csv(
+            params["file_path"], encoding="utf8-lossy", ignore_errors=True,
+        )
+        fix_mode = params.get("fix_mode", "safe")
+        domain = params.get("domain")
+        qc = QualityConfig(mode="silent", fix_mode=fix_mode, domain=domain)
+        fixed_df, fixes = run_quality_check(df, qc)
+
+        output_path = params.get("output_path")
+        if output_path:
+            fixed_df.write_csv(output_path)
+
+        return {
+            "total_records": fixed_df.height,
+            "fixes_applied": len(fixes),
+            "fixes": fixes,
+            "output_path": output_path,
+        }
+
+    if skill_id == "transform":
+        import polars as pl
+        from goldenmatch.core.transform import _goldenflow_available, run_transform
+        from goldenmatch.config.schemas import TransformConfig
+
+        if not _goldenflow_available():
+            return {"error": "goldenflow not installed. pip install goldenmatch[transform]"}
+
+        df = pl.read_csv(
+            params["file_path"], encoding="utf8-lossy", ignore_errors=True,
+        )
+        tc = TransformConfig(mode="silent")
+        transformed_df, fixes = run_transform(df, tc)
+
+        output_path = params.get("output_path")
+        if output_path:
+            transformed_df.write_csv(output_path)
+
+        return {
+            "total_records": transformed_df.height,
+            "transforms_applied": len(fixes),
+            "transforms": fixes,
+            "output_path": output_path,
+        }
 
     raise ValueError(f"Unknown skill: {skill_id}")
 

--- a/goldenmatch/core/quality.py
+++ b/goldenmatch/core/quality.py
@@ -71,7 +71,10 @@ def _scan_only(
         findings, _ = scan_file(tmp_path, domain=domain)
         findings = apply_confidence_downgrade(findings, llm_boost=False)
     finally:
-        tmp_path.unlink(missing_ok=True)
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            logger.debug("Could not delete temp file %s", tmp_path)
 
     errors = sum(1 for f in findings if f.severity == Severity.ERROR)
     warnings = sum(1 for f in findings if f.severity == Severity.WARNING)
@@ -116,7 +119,10 @@ def _scan_and_fix(
         findings, _ = scan_file(tmp_path, domain=domain)
         findings = apply_confidence_downgrade(findings, llm_boost=False)
     finally:
-        tmp_path.unlink(missing_ok=True)
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            logger.debug("Could not delete temp file %s", tmp_path)
 
     # Apply fixes
     fixed_df, report = apply_fixes(df, findings, mode=fix_mode)

--- a/goldenmatch/core/quality.py
+++ b/goldenmatch/core/quality.py
@@ -82,7 +82,19 @@ def _scan_only(
             len(findings), errors, warnings,
         )
 
-    return df, []
+    # Return findings as dicts so callers (MCP tools) can inspect them
+    issues = []
+    for f in findings:
+        issues.append({
+            "rule": f.rule_id,
+            "severity": f.severity.value if hasattr(f.severity, "value") else str(f.severity),
+            "column": f.column,
+            "message": f.message,
+            "rows_affected": f.rows_affected,
+            "confidence": round(f.confidence, 2) if hasattr(f, "confidence") else None,
+        })
+
+    return df, issues
 
 
 def _scan_and_fix(

--- a/goldenmatch/core/transform.py
+++ b/goldenmatch/core/transform.py
@@ -27,11 +27,20 @@ def _do_transform(df: pl.DataFrame):
 def run_transform(
     df: pl.DataFrame,
     config=None,
+    *,
+    strict: bool = False,
 ) -> tuple[pl.DataFrame, list[dict]]:
     """Run GoldenFlow transform if available.
 
     Returns (transformed_df, list_of_fixes) matching autofix format.
     Falls back gracefully if goldenflow is not installed.
+
+    Parameters
+    ----------
+    strict : bool
+        If True, re-raise exceptions instead of silently returning
+        unmodified data. Use from MCP/A2A handlers where callers
+        explicitly requested transforms.
     """
     if not _goldenflow_available():
         if config is not None and getattr(config, "enabled", True):
@@ -56,6 +65,8 @@ def run_transform(
         result = _do_transform(df)
     except Exception:
         logger.warning("GoldenFlow: transform failed, skipping", exc_info=True)
+        if strict:
+            raise
         return df, []
 
     # Convert manifest to autofix-compatible format

--- a/goldenmatch/mcp/agent_tools.py
+++ b/goldenmatch/mcp/agent_tools.py
@@ -410,33 +410,7 @@ def _dispatch(name: str, args: dict, session_cls: type) -> dict:
 
         df = pl.read_csv(args["file_path"], encoding="utf8-lossy", ignore_errors=True)
         qc = QualityConfig(mode="silent", fix_mode="none", domain=args.get("domain"))
-        _, _ = run_quality_check(df, qc)
-
-        # Re-run scan to capture findings for the response
-        from goldencheck.engine.scanner import scan_file
-        from goldencheck.engine.confidence import apply_confidence_downgrade
-        import tempfile
-        from pathlib import Path as _Path
-
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-            df.write_csv(tmp.name)
-            tmp_path = _Path(tmp.name)
-        try:
-            findings, _ = scan_file(tmp_path, domain=args.get("domain"))
-            findings = apply_confidence_downgrade(findings, llm_boost=False)
-        finally:
-            tmp_path.unlink(missing_ok=True)
-
-        issues = []
-        for f in findings:
-            issues.append({
-                "rule": f.rule_id,
-                "severity": f.severity.value if hasattr(f.severity, "value") else str(f.severity),
-                "column": f.column,
-                "message": f.message,
-                "rows_affected": f.rows_affected,
-                "confidence": round(f.confidence, 2) if hasattr(f, "confidence") else None,
-            })
+        _, issues = run_quality_check(df, qc)
 
         return {
             "file": args["file_path"],

--- a/goldenmatch/mcp/agent_tools.py
+++ b/goldenmatch/mcp/agent_tools.py
@@ -139,6 +139,83 @@ AGENT_TOOLS = [
             "required": ["file_path"],
         },
     ),
+    Tool(
+        name="scan_quality",
+        description=(
+            "Run GoldenCheck data quality scan on a CSV file. "
+            "Returns issues found (encoding errors, Unicode problems, format violations) "
+            "without applying fixes. Requires goldencheck: pip install goldenmatch[quality]"
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to the CSV file to scan",
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "Optional domain hint (healthcare, finance, ecommerce)",
+                },
+            },
+            "required": ["file_path"],
+        },
+    ),
+    Tool(
+        name="fix_quality",
+        description=(
+            "Run GoldenCheck scan and apply fixes to a CSV file. "
+            "Returns the fixed data summary and a manifest of all fixes applied. "
+            "Requires goldencheck: pip install goldenmatch[quality]"
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to the CSV file to fix",
+                },
+                "fix_mode": {
+                    "type": "string",
+                    "enum": ["safe", "moderate"],
+                    "description": "Fix aggressiveness: safe (conservative) or moderate (balanced). Default: safe",
+                    "default": "safe",
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "Optional domain hint (healthcare, finance, ecommerce)",
+                },
+                "output_path": {
+                    "type": "string",
+                    "description": "Optional path to save the fixed CSV. If omitted, returns summary only.",
+                },
+            },
+            "required": ["file_path"],
+        },
+    ),
+    Tool(
+        name="run_transforms",
+        description=(
+            "Run GoldenFlow data transforms on a CSV file. "
+            "Normalizes phone numbers (E.164), dates (ISO), categorical spelling, "
+            "and Unicode issues. Returns a manifest of transforms applied. "
+            "Requires goldenflow: pip install goldenmatch[transform]"
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to the CSV file to transform",
+                },
+                "output_path": {
+                    "type": "string",
+                    "description": "Optional path to save the transformed CSV. If omitted, returns summary only.",
+                },
+            },
+            "required": ["file_path"],
+        },
+    ),
 ]
 
 _AGENT_TOOL_NAMES = frozenset(t.name for t in AGENT_TOOLS)
@@ -319,6 +396,108 @@ def _dispatch(name: str, args: dict, session_cls: type) -> dict:
                 if needs_pprl
                 else "Standard matching is safe for this data. PPRL is optional."
             ),
+        }
+
+    if name == "scan_quality":
+        import polars as pl
+        from goldenmatch.core.quality import _goldencheck_available, run_quality_check
+        from goldenmatch.config.schemas import QualityConfig
+
+        if not _goldencheck_available():
+            return {
+                "error": "goldencheck is not installed. Install with: pip install goldenmatch[quality]",
+            }
+
+        df = pl.read_csv(args["file_path"], encoding="utf8-lossy", ignore_errors=True)
+        qc = QualityConfig(mode="silent", fix_mode="none", domain=args.get("domain"))
+        _, _ = run_quality_check(df, qc)
+
+        # Re-run scan to capture findings for the response
+        from goldencheck.engine.scanner import scan_file
+        from goldencheck.engine.confidence import apply_confidence_downgrade
+        import tempfile
+        from pathlib import Path as _Path
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+            df.write_csv(tmp.name)
+            tmp_path = _Path(tmp.name)
+        try:
+            findings, _ = scan_file(tmp_path, domain=args.get("domain"))
+            findings = apply_confidence_downgrade(findings, llm_boost=False)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        issues = []
+        for f in findings:
+            issues.append({
+                "rule": f.rule_id,
+                "severity": f.severity.value if hasattr(f.severity, "value") else str(f.severity),
+                "column": f.column,
+                "message": f.message,
+                "rows_affected": f.rows_affected,
+                "confidence": round(f.confidence, 2) if hasattr(f, "confidence") else None,
+            })
+
+        return {
+            "file": args["file_path"],
+            "total_records": df.height,
+            "issues_found": len(issues),
+            "issues": issues,
+        }
+
+    if name == "fix_quality":
+        import polars as pl
+        from goldenmatch.core.quality import _goldencheck_available, run_quality_check
+        from goldenmatch.config.schemas import QualityConfig
+
+        if not _goldencheck_available():
+            return {
+                "error": "goldencheck is not installed. Install with: pip install goldenmatch[quality]",
+            }
+
+        df = pl.read_csv(args["file_path"], encoding="utf8-lossy", ignore_errors=True)
+        fix_mode = args.get("fix_mode", "safe")
+        domain = args.get("domain")
+        qc = QualityConfig(mode="silent", fix_mode=fix_mode, domain=domain)
+        fixed_df, fixes = run_quality_check(df, qc)
+
+        output_path = args.get("output_path")
+        if output_path:
+            fixed_df.write_csv(output_path)
+
+        return {
+            "file": args["file_path"],
+            "fix_mode": fix_mode,
+            "total_records": fixed_df.height,
+            "fixes_applied": len(fixes),
+            "fixes": fixes,
+            "output_path": output_path,
+        }
+
+    if name == "run_transforms":
+        import polars as pl
+        from goldenmatch.core.transform import _goldenflow_available, run_transform
+        from goldenmatch.config.schemas import TransformConfig
+
+        if not _goldenflow_available():
+            return {
+                "error": "goldenflow is not installed. Install with: pip install goldenmatch[transform]",
+            }
+
+        df = pl.read_csv(args["file_path"], encoding="utf8-lossy", ignore_errors=True)
+        tc = TransformConfig(mode="silent")
+        transformed_df, fixes = run_transform(df, tc)
+
+        output_path = args.get("output_path")
+        if output_path:
+            transformed_df.write_csv(output_path)
+
+        return {
+            "file": args["file_path"],
+            "total_records": transformed_df.height,
+            "transforms_applied": len(fixes),
+            "transforms": fixes,
+            "output_path": output_path,
         }
 
     return {"error": f"Unknown agent tool: {name}"}

--- a/goldenmatch/mcp/agent_tools.py
+++ b/goldenmatch/mcp/agent_tools.py
@@ -408,12 +408,24 @@ def _dispatch(name: str, args: dict, session_cls: type) -> dict:
                 "error": "goldencheck is not installed. Install with: pip install goldenmatch[quality]",
             }
 
-        df = pl.read_csv(args["file_path"], encoding="utf8-lossy", ignore_errors=True)
+        file_path = args.get("file_path")
+        if not file_path:
+            return {"error": "Missing required parameter: file_path"}
+
+        try:
+            df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
+        except FileNotFoundError:
+            return {"error": f"File not found: {file_path}"}
+        except Exception as exc:
+            return {"error": f"Could not read CSV '{file_path}': {exc}"}
+
+        logger.info("scan_quality: scanning %s (%d records)", file_path, df.height)
         qc = QualityConfig(mode="silent", fix_mode="none", domain=args.get("domain"))
         _, issues = run_quality_check(df, qc)
+        logger.info("scan_quality: found %d issues", len(issues))
 
         return {
-            "file": args["file_path"],
+            "file": file_path,
             "total_records": df.height,
             "issues_found": len(issues),
             "issues": issues,
@@ -429,24 +441,44 @@ def _dispatch(name: str, args: dict, session_cls: type) -> dict:
                 "error": "goldencheck is not installed. Install with: pip install goldenmatch[quality]",
             }
 
-        df = pl.read_csv(args["file_path"], encoding="utf8-lossy", ignore_errors=True)
+        file_path = args.get("file_path")
+        if not file_path:
+            return {"error": "Missing required parameter: file_path"}
+
+        try:
+            df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
+        except FileNotFoundError:
+            return {"error": f"File not found: {file_path}"}
+        except Exception as exc:
+            return {"error": f"Could not read CSV '{file_path}': {exc}"}
+
         fix_mode = args.get("fix_mode", "safe")
         domain = args.get("domain")
+        logger.info("fix_quality: fixing %s (mode=%s)", file_path, fix_mode)
         qc = QualityConfig(mode="silent", fix_mode=fix_mode, domain=domain)
         fixed_df, fixes = run_quality_check(df, qc)
+        logger.info("fix_quality: %d fixes applied", len(fixes))
 
         output_path = args.get("output_path")
+        write_error = None
         if output_path:
-            fixed_df.write_csv(output_path)
+            try:
+                fixed_df.write_csv(output_path)
+            except Exception as exc:
+                write_error = f"Results computed but failed to write to '{output_path}': {exc}"
+                output_path = None
 
-        return {
-            "file": args["file_path"],
+        result = {
+            "file": file_path,
             "fix_mode": fix_mode,
             "total_records": fixed_df.height,
             "fixes_applied": len(fixes),
             "fixes": fixes,
             "output_path": output_path,
         }
+        if write_error:
+            result["write_error"] = write_error
+        return result
 
     if name == "run_transforms":
         import polars as pl
@@ -458,20 +490,40 @@ def _dispatch(name: str, args: dict, session_cls: type) -> dict:
                 "error": "goldenflow is not installed. Install with: pip install goldenmatch[transform]",
             }
 
-        df = pl.read_csv(args["file_path"], encoding="utf8-lossy", ignore_errors=True)
+        file_path = args.get("file_path")
+        if not file_path:
+            return {"error": "Missing required parameter: file_path"}
+
+        try:
+            df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
+        except FileNotFoundError:
+            return {"error": f"File not found: {file_path}"}
+        except Exception as exc:
+            return {"error": f"Could not read CSV '{file_path}': {exc}"}
+
+        logger.info("run_transforms: transforming %s (%d records)", file_path, df.height)
         tc = TransformConfig(mode="silent")
-        transformed_df, fixes = run_transform(df, tc)
+        transformed_df, fixes = run_transform(df, tc, strict=True)
+        logger.info("run_transforms: %d transforms applied", len(fixes))
 
         output_path = args.get("output_path")
+        write_error = None
         if output_path:
-            transformed_df.write_csv(output_path)
+            try:
+                transformed_df.write_csv(output_path)
+            except Exception as exc:
+                write_error = f"Results computed but failed to write to '{output_path}': {exc}"
+                output_path = None
 
-        return {
-            "file": args["file_path"],
+        result = {
+            "file": file_path,
             "total_records": transformed_df.height,
             "transforms_applied": len(fixes),
             "transforms": fixes,
             "output_path": output_path,
         }
+        if write_error:
+            result["write_error"] = write_error
+        return result
 
     return {"error": f"Unknown agent tool: {name}"}

--- a/goldenmatch/mcp/server.py
+++ b/goldenmatch/mcp/server.py
@@ -999,7 +999,7 @@ async def run_server_http(
     async def server_card(request):
         return JSONResponse({
             "name": "GoldenMatch",
-            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 27 MCP tools for matching, explaining, reviewing, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
+            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 30 MCP tools for matching, explaining, reviewing, data quality, transforms, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
             "homepage": "https://github.com/benzsevern/goldenmatch",
             "iconUrl": "https://avatars.githubusercontent.com/u/192581748"
         })

--- a/llms.txt
+++ b/llms.txt
@@ -3,9 +3,9 @@
 > Entity resolution toolkit — deduplicate records and match across datasets using fuzzy, probabilistic, and LLM-powered scoring.
 
 ## Interfaces
-- MCP Server: `goldenmatch mcp-serve` (10 tools: analyze, configure, deduplicate, match, explain, review, compare strategies, PPRL)
-- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (27 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
-- A2A Server: `goldenmatch agent-serve --port 8200` (8 skills)
+- MCP Server: `goldenmatch mcp-serve` (13 tools: analyze, configure, deduplicate, match, explain, review, compare strategies, PPRL, scan quality, fix quality, run transforms)
+- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (30 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- A2A Server: `goldenmatch agent-serve --port 8200` (10 skills)
 - CLI: `goldenmatch dedupe`, `goldenmatch match`, + 18 more commands
 - Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~101 exports
 - REST API: `goldenmatch serve` on port 8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenmatch"
-version = "1.4.0"
+
+version = "1.4.1"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -34,11 +34,11 @@ def test_agent_card_has_required_fields():
     assert card["authentication"]["schemes"] == ["bearer"]
 
 
-def test_agent_card_has_8_skills():
+def test_agent_card_has_10_skills():
     from goldenmatch.a2a.server import build_agent_card
 
     card = build_agent_card("http://localhost:8080")
-    assert len(card["skills"]) == 8
+    assert len(card["skills"]) == 10
 
 
 def test_agent_card_skills_have_modes():
@@ -142,3 +142,108 @@ def test_dispatch_unknown_skill():
 
     with pytest.raises(ValueError, match="Unknown skill"):
         dispatch_skill("nonexistent_skill", {})
+
+
+def test_agent_card_has_quality_and_transform_skills():
+    from goldenmatch.a2a.server import build_agent_card
+
+    card = build_agent_card("http://localhost:8080")
+    skill_ids = {s["id"] for s in card["skills"]}
+    assert "quality" in skill_ids
+    assert "transform" in skill_ids
+
+
+def test_dispatch_quality_without_goldencheck(tmp_path):
+    """quality skill returns error when goldencheck is not installed."""
+    import polars as pl
+    from unittest.mock import patch
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    csv_path = tmp_path / "data.csv"
+    pl.DataFrame({"name": ["Alice"]}).write_csv(str(csv_path))
+
+    with patch("goldenmatch.core.quality._goldencheck_available", return_value=False):
+        result = dispatch_skill("quality", {"file_path": str(csv_path)})
+    assert "error" in result
+    assert "goldencheck" in result["error"].lower()
+
+
+def test_dispatch_transform_without_goldenflow(tmp_path):
+    """transform skill returns error when goldenflow is not installed."""
+    import polars as pl
+    from unittest.mock import patch
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    csv_path = tmp_path / "data.csv"
+    pl.DataFrame({"name": ["Alice"]}).write_csv(str(csv_path))
+
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=False):
+        result = dispatch_skill("transform", {"file_path": str(csv_path)})
+    assert "error" in result
+    assert "goldenflow" in result["error"].lower()
+
+
+# ── MCP agent tools: quality & transforms ───────────────────────────────────
+
+
+def test_mcp_scan_quality_tool_registered():
+    """scan_quality tool is in the AGENT_TOOLS list."""
+    from goldenmatch.mcp.agent_tools import AGENT_TOOLS
+
+    names = {t.name for t in AGENT_TOOLS}
+    assert "scan_quality" in names
+    assert "fix_quality" in names
+    assert "run_transforms" in names
+
+
+def test_mcp_scan_quality_without_goldencheck(tmp_path):
+    """scan_quality returns error when goldencheck is not installed."""
+    import polars as pl
+    from unittest.mock import patch
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    csv_path = tmp_path / "data.csv"
+    pl.DataFrame({"name": ["Alice"]}).write_csv(str(csv_path))
+
+    with patch("goldenmatch.core.quality._goldencheck_available", return_value=False):
+        result = handle_agent_tool("scan_quality", {"file_path": str(csv_path)})
+
+    text = result[0].text
+    parsed = json.loads(text)
+    assert "error" in parsed
+    assert "goldencheck" in parsed["error"].lower()
+
+
+def test_mcp_fix_quality_without_goldencheck(tmp_path):
+    """fix_quality returns error when goldencheck is not installed."""
+    import polars as pl
+    from unittest.mock import patch
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    csv_path = tmp_path / "data.csv"
+    pl.DataFrame({"name": ["Alice"]}).write_csv(str(csv_path))
+
+    with patch("goldenmatch.core.quality._goldencheck_available", return_value=False):
+        result = handle_agent_tool("fix_quality", {"file_path": str(csv_path)})
+
+    text = result[0].text
+    parsed = json.loads(text)
+    assert "error" in parsed
+
+
+def test_mcp_run_transforms_without_goldenflow(tmp_path):
+    """run_transforms returns error when goldenflow is not installed."""
+    import polars as pl
+    from unittest.mock import patch
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    csv_path = tmp_path / "data.csv"
+    pl.DataFrame({"name": ["Alice"]}).write_csv(str(csv_path))
+
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=False):
+        result = handle_agent_tool("run_transforms", {"file_path": str(csv_path)})
+
+    text = result[0].text
+    parsed = json.loads(text)
+    assert "error" in parsed
+    assert "goldenflow" in parsed["error"].lower()

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -229,6 +229,7 @@ def test_mcp_fix_quality_without_goldencheck(tmp_path):
     text = result[0].text
     parsed = json.loads(text)
     assert "error" in parsed
+    assert "goldencheck" in parsed["error"].lower()
 
 
 def test_mcp_run_transforms_without_goldenflow(tmp_path):
@@ -247,3 +248,211 @@ def test_mcp_run_transforms_without_goldenflow(tmp_path):
     parsed = json.loads(text)
     assert "error" in parsed
     assert "goldenflow" in parsed["error"].lower()
+
+
+# ── File validation ────────────────────────────────────────────────────────
+
+
+def test_mcp_scan_quality_file_not_found():
+    """scan_quality returns actionable error for missing file."""
+    from unittest.mock import patch
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    with patch("goldenmatch.core.quality._goldencheck_available", return_value=True):
+        result = handle_agent_tool("scan_quality", {"file_path": "/nonexistent/data.csv"})
+
+    parsed = json.loads(result[0].text)
+    assert "error" in parsed
+    assert "not found" in parsed["error"].lower() or "could not read" in parsed["error"].lower()
+
+
+def test_mcp_scan_quality_missing_file_path():
+    """scan_quality returns error when file_path is missing."""
+    from unittest.mock import patch
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    with patch("goldenmatch.core.quality._goldencheck_available", return_value=True):
+        result = handle_agent_tool("scan_quality", {})
+
+    parsed = json.loads(result[0].text)
+    assert "error" in parsed
+    assert "file_path" in parsed["error"].lower()
+
+
+def test_a2a_quality_file_not_found():
+    """A2A quality skill returns error for missing file."""
+    from unittest.mock import patch
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    with patch("goldenmatch.core.quality._goldencheck_available", return_value=True):
+        result = dispatch_skill("quality", {"file_path": "/nonexistent/data.csv"})
+    assert "error" in result
+    assert "not found" in result["error"].lower() or "could not read" in result["error"].lower()
+
+
+def test_a2a_quality_missing_file_path():
+    """A2A quality skill returns error when file_path is missing."""
+    from unittest.mock import patch
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    with patch("goldenmatch.core.quality._goldencheck_available", return_value=True):
+        result = dispatch_skill("quality", {})
+    assert "error" in result
+    assert "file_path" in result["error"].lower()
+
+
+# ── Happy-path tests (mocked deps) ─────────────────────────────────────────
+
+
+def test_mcp_scan_quality_happy_path(tmp_path):
+    """scan_quality returns correct response shape when goldencheck works."""
+    import polars as pl
+    from unittest.mock import patch
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    csv_path = tmp_path / "data.csv"
+    pl.DataFrame({"name": ["Alice", "Bob"], "email": ["a@x.com", "b@x.com"]}).write_csv(str(csv_path))
+
+    mock_issues = [
+        {"rule": "ENC001", "severity": "warning", "column": "name",
+         "message": "Mixed encoding", "rows_affected": 1, "confidence": 0.9},
+    ]
+
+    with patch("goldenmatch.core.quality._goldencheck_available", return_value=True), \
+         patch("goldenmatch.core.quality.run_quality_check", return_value=(pl.DataFrame(), mock_issues)):
+        result = handle_agent_tool("scan_quality", {"file_path": str(csv_path)})
+
+    parsed = json.loads(result[0].text)
+    assert "error" not in parsed
+    assert parsed["total_records"] == 2
+    assert parsed["issues_found"] == 1
+    assert parsed["issues"] == mock_issues
+    assert parsed["file"] == str(csv_path)
+
+
+def test_mcp_fix_quality_happy_path(tmp_path):
+    """fix_quality returns fixes and writes output file."""
+    import polars as pl
+    from unittest.mock import patch
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    csv_path = tmp_path / "data.csv"
+    out_path = tmp_path / "fixed.csv"
+    df = pl.DataFrame({"name": ["Alice"], "email": ["a@x.com"]})
+    df.write_csv(str(csv_path))
+
+    mock_fixes = [{"fix": "goldencheck:encoding", "column": "name",
+                   "rows_affected": 1, "detail": "encoding: 1 rows"}]
+
+    with patch("goldenmatch.core.quality._goldencheck_available", return_value=True), \
+         patch("goldenmatch.core.quality.run_quality_check", return_value=(df, mock_fixes)):
+        result = handle_agent_tool("fix_quality", {
+            "file_path": str(csv_path), "fix_mode": "moderate",
+            "output_path": str(out_path),
+        })
+
+    parsed = json.loads(result[0].text)
+    assert "error" not in parsed
+    assert parsed["fix_mode"] == "moderate"
+    assert parsed["fixes_applied"] == 1
+    assert parsed["output_path"] == str(out_path)
+    assert out_path.exists()
+
+
+def test_mcp_run_transforms_happy_path(tmp_path):
+    """run_transforms returns transforms and writes output file."""
+    import polars as pl
+    from unittest.mock import patch
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    csv_path = tmp_path / "data.csv"
+    out_path = tmp_path / "transformed.csv"
+    df = pl.DataFrame({"phone": ["5551234567"]})
+    df.write_csv(str(csv_path))
+
+    mock_fixes = [{"fix": "goldenflow:phone_e164", "column": "phone",
+                   "rows_affected": 1, "detail": "phone_e164: 1 rows"}]
+
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=True), \
+         patch("goldenmatch.core.transform.run_transform", return_value=(df, mock_fixes)):
+        result = handle_agent_tool("run_transforms", {
+            "file_path": str(csv_path), "output_path": str(out_path),
+        })
+
+    parsed = json.loads(result[0].text)
+    assert "error" not in parsed
+    assert parsed["transforms_applied"] == 1
+    assert parsed["output_path"] == str(out_path)
+    assert out_path.exists()
+
+
+def test_a2a_quality_happy_path(tmp_path):
+    """A2A quality skill returns correct response with fixes."""
+    import polars as pl
+    from unittest.mock import patch
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    csv_path = tmp_path / "data.csv"
+    df = pl.DataFrame({"name": ["Alice"]})
+    df.write_csv(str(csv_path))
+
+    mock_fixes = [{"fix": "goldencheck:unicode", "column": "name",
+                   "rows_affected": 1, "detail": "unicode: 1 rows"}]
+
+    with patch("goldenmatch.core.quality._goldencheck_available", return_value=True), \
+         patch("goldenmatch.core.quality.run_quality_check", return_value=(df, mock_fixes)):
+        result = dispatch_skill("quality", {"file_path": str(csv_path)})
+
+    assert "error" not in result
+    assert result["fixes_applied"] == 1
+    assert result["total_records"] == 1
+
+
+def test_a2a_transform_happy_path(tmp_path):
+    """A2A transform skill returns correct response."""
+    import polars as pl
+    from unittest.mock import patch
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    csv_path = tmp_path / "data.csv"
+    df = pl.DataFrame({"date": ["01/15/2024"]})
+    df.write_csv(str(csv_path))
+
+    mock_fixes = [{"fix": "goldenflow:date_iso", "column": "date",
+                   "rows_affected": 1, "detail": "date_iso: 1 rows"}]
+
+    with patch("goldenmatch.core.transform._goldenflow_available", return_value=True), \
+         patch("goldenmatch.core.transform.run_transform", return_value=(df, mock_fixes)):
+        result = dispatch_skill("transform", {"file_path": str(csv_path)})
+
+    assert "error" not in result
+    assert result["transforms_applied"] == 1
+
+
+# ── Output write failure ───────────────────────────────────────────────────
+
+
+def test_mcp_fix_quality_write_failure_preserves_results(tmp_path):
+    """fix_quality preserves results when output write fails."""
+    import polars as pl
+    from unittest.mock import patch
+    from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+    csv_path = tmp_path / "data.csv"
+    df = pl.DataFrame({"name": ["Alice"]})
+    df.write_csv(str(csv_path))
+
+    mock_fixes = [{"fix": "goldencheck:encoding", "column": "name",
+                   "rows_affected": 1, "detail": "test"}]
+
+    with patch("goldenmatch.core.quality._goldencheck_available", return_value=True), \
+         patch("goldenmatch.core.quality.run_quality_check", return_value=(df, mock_fixes)):
+        result = handle_agent_tool("fix_quality", {
+            "file_path": str(csv_path),
+            "output_path": "/nonexistent/dir/out.csv",
+        })
+
+    parsed = json.loads(result[0].text)
+    assert parsed["fixes_applied"] == 1
+    assert "write_error" in parsed
+    assert parsed["output_path"] is None


### PR DESCRIPTION
## Summary
- Add 3 new MCP tools: `scan_quality`, `fix_quality`, `run_transforms` — agents can now inspect and fix data quality before running the pipeline
- Add 2 new A2A skills: `quality`, `transform` — same capabilities exposed via the A2A protocol
- Update server card description (27 → 30 tools)
- Bump version to 1.3.3
- 7 new tests covering tool registration, graceful degradation when optional deps are missing

## Test plan
- [x] All 18 A2A tests pass (`pytest tests/test_a2a.py`)
- [x] Full suite passes (1258 tests, 0 failures)
- [ ] After merge, verify Railway auto-deploys and Smithery picks up new tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)