### PR TITLE
feat: compound geo columns with name in auto-config blocking

### DIFF
--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -923,6 +923,47 @@ def build_blocking(
     if name_cols:
         pattern_names = [p for p in name_cols if _classify_by_name(p.name) == "name"]
         best_name = (pattern_names[0] if pattern_names else name_cols[0]).name
+
+        # Check for geo columns to compound with name — prevents cross-region
+        # false positives (e.g., same hospital name in different states)
+        geo_cols = [
+            p for p in profiles
+            if p.col_type == "geo"
+            and _null_rate(p.name) <= max_null_rate
+        ]
+        best_geo = None
+        if geo_cols:
+            # Pick the geo column that reduces max block size the most
+            geo_results: list[tuple[ColumnProfile, int]] = []
+            for g in geo_cols:
+                try:
+                    max_block = df.group_by([g.name, best_name]).len().get_column("len").max()
+                    geo_results.append((g, max_block))
+                except Exception:
+                    continue
+            if geo_results:
+                geo_results.sort(key=lambda x: x[1])
+                candidate, candidate_block = geo_results[0]
+                if candidate_block <= max_safe_block:
+                    best_geo = candidate.name
+                    logger.info(
+                        "Geo-compound blocking: [%s, %s] -> max_block=%d",
+                        best_geo, best_name, candidate_block,
+                    )
+
+        if best_geo:
+            return BlockingConfig(
+                keys=[BlockingKeyConfig(fields=[best_geo, best_name], transforms=["lowercase", "strip"])],
+                strategy="multi_pass",
+                passes=[
+                    BlockingKeyConfig(fields=[best_geo, best_name], transforms=["lowercase", "strip"]),
+                    BlockingKeyConfig(fields=[best_geo, best_name], transforms=["lowercase", "substring:0:5"]),
+                    BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "soundex"]),
+                ],
+                max_block_size=max_safe_block,
+                skip_oversized=True,
+            )
+
         return BlockingConfig(
             keys=[BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "soundex"])],
             strategy="multi_pass",

--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -938,7 +938,8 @@ def build_blocking(
             for g in geo_cols:
                 try:
                     max_block = df.group_by([g.name, best_name]).len().get_column("len").max()
-                    geo_results.append((g, max_block))
+                    if max_block is not None:
+                        geo_results.append((g, max_block))
                 except Exception:
                     continue
             if geo_results:

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -274,6 +274,54 @@ class TestBuildBlocking:
         blocking = build_blocking(profiles, df)
         assert blocking.strategy == "canopy"
 
+    def test_name_with_geo_compounds_blocking(self):
+        """When geo columns exist, name-based blocking should compound with geo."""
+        profiles = [
+            ColumnProfile("facility_name", "Utf8", "name", 0.9, cardinality_ratio=0.8),
+            ColumnProfile("state", "Utf8", "geo", 0.9, cardinality_ratio=0.01),
+            ColumnProfile("address", "Utf8", "address", 0.7, cardinality_ratio=0.9),
+        ]
+        # Create data where name-only blocking produces large blocks
+        # but state+name produces small blocks
+        states = ["AL", "CA", "NY", "TX", "FL"]
+        names = ["MEMORIAL HOSPITAL", "COMMUNITY HOSPITAL", "ST LUKES"]
+        rows = []
+        for s in states:
+            for n in names:
+                rows.append({"facility_name": n, "state": s, "address": f"123 {s} ST"})
+        df = pl.DataFrame(rows)
+        blocking = build_blocking(profiles, df)
+        # Primary key should include both geo and name
+        primary_fields = blocking.keys[0].fields
+        assert "state" in primary_fields, f"Expected 'state' in blocking keys, got {primary_fields}"
+        assert "facility_name" in primary_fields
+
+    def test_name_without_geo_stays_name_only(self):
+        """Without geo columns, name-based blocking should remain name-only."""
+        profiles = [
+            ColumnProfile("name", "Utf8", "name", 0.9),
+            ColumnProfile("description", "Utf8", "description", 0.7),
+        ]
+        df = pl.DataFrame({"name": ["John", "Jane", "Bob"], "description": ["a", "b", "c"]})
+        blocking = build_blocking(profiles, df)
+        assert blocking.strategy == "multi_pass"
+        assert blocking.keys[0].fields == ["name"]
+
+    def test_geo_compound_high_null_geo_skipped(self):
+        """Geo columns with >20% nulls should not be used for compound blocking."""
+        profiles = [
+            ColumnProfile("name", "Utf8", "name", 0.9),
+            ColumnProfile("state", "Utf8", "geo", 0.9, null_rate=0.3),
+        ]
+        # 40% nulls in state column
+        df = pl.DataFrame({
+            "name": ["John", "Jane", "Bob", "Alice", "Eve"],
+            "state": ["AL", "CA", None, None, "NY"],
+        })
+        blocking = build_blocking(profiles, df)
+        # Should fall back to name-only since geo has high null rate
+        assert blocking.keys[0].fields == ["name"]
+
 
 class TestSelectModel:
     def test_no_embeddings(self):


### PR DESCRIPTION
## Summary
- When auto-config falls through to name-based blocking, it now checks for geo columns (state, city, county) and compounds them with the name column
- Prevents cross-region false positives where hospitals with the same name in different states were landing in the same block
- Picks the geo column that reduces max block size the most while staying under the safe block limit

## Test plan
- [x] 3 new tests in `test_autoconfig.py`: geo compounds with name, no-geo stays name-only, high-null geo skipped
- [x] All 90 autoconfig tests pass
- [x] Verified on CMS Hospital General Information dataset (5,426 records)

🤖 Generated with [Claude Code](https://claude.com/claude-code)