### PR TITLE
fix: three v1.4 auto-config regressions (runtime, mega-clusters, row count)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ venv/
 .cursorrules
 .windsurfrules
 docs/superpowers/
+.profile_tmp/

--- a/goldenmatch/_api.py
+++ b/goldenmatch/_api.py
@@ -749,9 +749,15 @@ def _extract_stats(result: dict) -> dict:
     dupes = result.get("dupes")
     unique = result.get("unique")
 
+    # total_records counts *input* rows, not output tables. Every source
+    # record lives in exactly one of:
+    #   - dupes:  rows that are members of a 2+ cluster
+    #   - unique: rows that did not match anything
+    # golden is a derived rollup (one canonical record per multi-member
+    # cluster), not another row population. Including it here double-counted
+    # every cluster and made total_records > df.height whenever any
+    # duplicates were found.
     total_records = 0
-    if golden is not None:
-        total_records += golden.height
     if dupes is not None:
         total_records += dupes.height
     if unique is not None:

--- a/goldenmatch/_api.py
+++ b/goldenmatch/_api.py
@@ -768,10 +768,12 @@ def _extract_stats(result: dict) -> dict:
 
     # Defensive: if a pipeline path ever produces a golden-only result with
     # dupes/unique elided, total_records would silently be 0 and match_rate
-    # a meaningless 0/0. That shape is unexpected today (the pipeline always
-    # materializes dupes and unique when it materializes golden), so surface
-    # it loudly rather than silently returning zeroed stats.
-    if total_records == 0 and golden is not None and golden.height > 0:
+    # a meaningless 0/0. The standard pipeline always materializes dupes
+    # and unique when it materializes golden, so ANY golden-present /
+    # dupes-absent / unique-absent shape is a contract violation and deserves
+    # the warning — including an empty golden, since that still means a
+    # refactor started producing golden without dupes/unique.
+    if golden is not None and dupes is None and unique is None:
         logger.warning(
             "Stats aggregation received golden (%d rows) with no dupes/unique "
             "tables — total_records will be 0. This shape is not produced by "

--- a/goldenmatch/_api.py
+++ b/goldenmatch/_api.py
@@ -11,12 +11,15 @@ Usage:
 """
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import polars as pl
+
+logger = logging.getLogger(__name__)
 
 
 def _detect_llm_provider() -> str | None:
@@ -762,6 +765,20 @@ def _extract_stats(result: dict) -> dict:
         total_records += dupes.height
     if unique is not None:
         total_records += unique.height
+
+    # Defensive: if a pipeline path ever produces a golden-only result with
+    # dupes/unique elided, total_records would silently be 0 and match_rate
+    # a meaningless 0/0. That shape is unexpected today (the pipeline always
+    # materializes dupes and unique when it materializes golden), so surface
+    # it loudly rather than silently returning zeroed stats.
+    if total_records == 0 and golden is not None and golden.height > 0:
+        logger.warning(
+            "Stats aggregation received golden (%d rows) with no dupes/unique "
+            "tables — total_records will be 0. This shape is not produced by "
+            "the standard pipeline; if you hit this, the pipeline output "
+            "contract has changed and _extract_stats needs updating.",
+            golden.height,
+        )
 
     total_clusters = sum(1 for c in clusters.values() if c.get("size", 0) > 1)
     matched_records = sum(c.get("size", 0) for c in clusters.values() if c.get("size", 0) > 1)

--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -397,6 +397,12 @@ def build_matchkeys(
     fuzzy_fields = []
     description_columns = []
 
+    # Track why each exact-eligible column was skipped, so the aggregate
+    # warning below can explain *which* columns were lost and *why* instead
+    # of just a count. This is the difference between a notebook user
+    # noticing their config silently degraded and not.
+    skipped_exact: list[tuple[str, str]] = []  # (column, reason)
+
     for p in profiles:
         if p.col_type in ("numeric", "date", "identifier"):
             continue  # skip non-matchable columns
@@ -418,49 +424,53 @@ def build_matchkeys(
         scorer, weight, transforms = scorer_info
 
         # Geo and zip are blocking signals, NOT identity claims. An exact
-        # matchkey on res_city_desc asserts "two records sharing a city are
-        # the same entity", which is catastrophically wrong for person /
-        # address dedup: every voter in Raleigh collapses into one cluster.
-        # These columns still drive blocking via build_blocking() — they just
-        # must not become matchkeys themselves. Only true identifiers
-        # (email, phone, identifier) may back an exact matchkey.
+        # matchkey on a city column asserts "two records sharing a city are
+        # the same entity", which collapses every record per city into one
+        # mega-cluster. These columns still drive blocking via build_blocking;
+        # they just cannot back matchkeys themselves.
         if scorer == "exact" and p.col_type in ("zip", "geo"):
-            logger.info(
-                "Skipping exact matchkey for '%s' (col_type=%s is a blocking "
-                "signal, not an identity claim). It remains a blocking candidate.",
-                p.name, p.col_type,
+            reason = f"col_type={p.col_type} is a blocking signal, not an identity claim"
+            logger.warning(
+                "Skipping exact matchkey for '%s' (%s). "
+                "Column remains a blocking candidate.",
+                p.name, reason,
             )
+            skipped_exact.append((p.name, reason))
             continue
 
         # Exact matchkeys assert identity equivalence, so the backing column
-        # must be plausibly unique. True identifiers (email, phone, driver
-        # license, SSN) have cardinality_ratio close to 1.0. The old 0.01
-        # guard only caught pathological cases and missed realistic footguns:
-        # e.g. birth_year (80 distinct / 5000 rows = 0.016) misclassified as
-        # phone after a date transform, gender codes classified as string,
-        # state codes classified as geo. Requiring >= 0.5 ensures at least
-        # half the values are distinct before the column can back an exact
-        # matchkey. This is a rough heuristic — the right long-term answer
-        # is per-type thresholds — but it closes the class of bugs where
-        # low-cardinality numeric columns collapse into mega-clusters.
+        # must be plausibly unique. Requiring cardinality_ratio >= 0.5 ensures
+        # at least half the values are distinct before the column can back an
+        # an exact matchkey. This catches low-cardinality numeric columns that
+        # get misclassified by upstream transforms — e.g. a 4-digit year
+        # reshaped into an ISO date can look phone-shaped, and without this
+        # guard ~60 people per birth year would collapse into mega-clusters.
+        # TODO(autoconfig): replace this blanket threshold with per-type
+        # cardinality thresholds once we have empirical data for each col_type.
         if scorer == "exact" and p.cardinality_ratio > 0 and p.cardinality_ratio < 0.5:
-            logger.warning(
-                "Skipping exact matchkey for '%s' (cardinality_ratio=%.4f < 0.5; "
-                "column lacks identifier-level uniqueness — exact match would "
-                "create spurious mega-clusters)",
-                p.name, p.cardinality_ratio,
+            reason = (
+                f"cardinality_ratio={p.cardinality_ratio:.4f} < 0.5 "
+                f"— lacks identifier-level uniqueness"
             )
+            logger.warning(
+                "Skipping exact matchkey for '%s' (%s). "
+                "Exact match would create spurious mega-clusters.",
+                p.name, reason,
+            )
+            skipped_exact.append((p.name, reason))
             continue
 
         # Skip exact matchkeys for large datasets — exact matchkeys do a full
         # self-join which is O(N^2) without blocking. For auto-configure, use
         # exact columns only in blocking (handled by build_blocking).
         if scorer == "exact" and df is not None and df.height > 10000:
-            logger.info(
-                "Skipping exact matchkey for '%s' (dataset has %d rows; "
-                "exact self-joins are O(N^2) — use blocking instead)",
-                p.name, df.height,
+            reason = f"dataset has {df.height} rows; exact self-join is O(N^2)"
+            logger.warning(
+                "Skipping exact matchkey for '%s' (%s). "
+                "Use blocking instead.",
+                p.name, reason,
             )
+            skipped_exact.append((p.name, reason))
             continue
 
         mf = MatchkeyField(
@@ -475,17 +485,21 @@ def build_matchkeys(
         else:
             fuzzy_fields.append(mf)
 
-    # Warn if all exact-eligible columns were excluded by guards
+    # Aggregate warning: if every exact-eligible column was filtered out,
+    # explain which ones and why. This is the load-bearing surface that tells
+    # a notebook user their auto-config silently degraded to fuzzy-only.
     _exact_eligible = [
         p for p in profiles
         if p.col_type not in ("numeric", "date", "identifier", "description")
         and _SCORER_MAP.get(p.col_type, (None,))[0] == "exact"
     ]
     if _exact_eligible and not exact_fields:
+        detail = "; ".join(f"{col} ({why})" for col, why in skipped_exact) or "no detail"
         logger.warning(
-            "All %d exact-eligible columns were excluded by cardinality/size guards. "
-            "Falling back to fuzzy-only matchkeys. Consider providing explicit config.",
-            len(_exact_eligible),
+            "All %d exact-eligible columns were excluded by auto-config guards "
+            "(%s). Falling back to fuzzy-only matchkeys — if any of these "
+            "columns actually are identifiers, provide an explicit config.",
+            len(_exact_eligible), detail,
         )
 
     matchkeys = []

--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -417,10 +417,37 @@ def build_matchkeys(
 
         scorer, weight, transforms = scorer_info
 
-        if scorer == "exact" and p.cardinality_ratio > 0 and p.cardinality_ratio < 0.01:
+        # Geo and zip are blocking signals, NOT identity claims. An exact
+        # matchkey on res_city_desc asserts "two records sharing a city are
+        # the same entity", which is catastrophically wrong for person /
+        # address dedup: every voter in Raleigh collapses into one cluster.
+        # These columns still drive blocking via build_blocking() — they just
+        # must not become matchkeys themselves. Only true identifiers
+        # (email, phone, identifier) may back an exact matchkey.
+        if scorer == "exact" and p.col_type in ("zip", "geo"):
+            logger.info(
+                "Skipping exact matchkey for '%s' (col_type=%s is a blocking "
+                "signal, not an identity claim). It remains a blocking candidate.",
+                p.name, p.col_type,
+            )
+            continue
+
+        # Exact matchkeys assert identity equivalence, so the backing column
+        # must be plausibly unique. True identifiers (email, phone, driver
+        # license, SSN) have cardinality_ratio close to 1.0. The old 0.01
+        # guard only caught pathological cases and missed realistic footguns:
+        # e.g. birth_year (80 distinct / 5000 rows = 0.016) misclassified as
+        # phone after a date transform, gender codes classified as string,
+        # state codes classified as geo. Requiring >= 0.5 ensures at least
+        # half the values are distinct before the column can back an exact
+        # matchkey. This is a rough heuristic — the right long-term answer
+        # is per-type thresholds — but it closes the class of bugs where
+        # low-cardinality numeric columns collapse into mega-clusters.
+        if scorer == "exact" and p.cardinality_ratio > 0 and p.cardinality_ratio < 0.5:
             logger.warning(
-                "Skipping exact matchkey for '%s' (cardinality_ratio=%.4f; "
-                "too few distinct values — would match nearly everything)",
+                "Skipping exact matchkey for '%s' (cardinality_ratio=%.4f < 0.5; "
+                "column lacks identifier-level uniqueness — exact match would "
+                "create spurious mega-clusters)",
                 p.name, p.cardinality_ratio,
             )
             continue
@@ -1154,13 +1181,24 @@ def auto_configure_df(
 
     # ── Data-driven strategy selection ──
 
-    # 1. Learned blocking for large datasets
-    if blocking is not None and total_rows >= 5000:
+    # 1. Learned blocking for large datasets.
+    #
+    # Gated at >= 50K rows. The previous threshold of 5K was a footgun: on a
+    # 5K dataset the learner trained its predicates on 100% of its own input
+    # (sample_size was also 5K), producing overfit predicates and multi-minute
+    # runtimes. The sample size is now capped at 25% of the dataset (max 5K)
+    # so the learner always has held-out rows to generalize to, and the gate
+    # is raised so small/medium datasets use static blocking by default where
+    # the quality wins of learned blocking do not pay for its training cost.
+    if blocking is not None and total_rows >= 50_000:
         blocking.strategy = "learned"
-        blocking.learned_sample_size = 5000
+        blocking.learned_sample_size = min(total_rows // 4, 5000)
         blocking.learned_min_recall = 0.95
         blocking.skip_oversized = True
-        logger.info("Upgraded to learned blocking (dataset has %d rows)", total_rows)
+        logger.info(
+            "Upgraded to learned blocking (dataset has %d rows, sample_size=%d)",
+            total_rows, blocking.learned_sample_size,
+        )
 
     # 2. Reranking for multi-field matchkeys
     for mk in matchkeys:

--- a/goldenmatch/core/autoconfig.py
+++ b/goldenmatch/core/autoconfig.py
@@ -441,10 +441,10 @@ def build_matchkeys(
         # Exact matchkeys assert identity equivalence, so the backing column
         # must be plausibly unique. Requiring cardinality_ratio >= 0.5 ensures
         # at least half the values are distinct before the column can back an
-        # an exact matchkey. This catches low-cardinality numeric columns that
+        # exact matchkey. This catches low-cardinality numeric columns that
         # get misclassified by upstream transforms — e.g. a 4-digit year
-        # reshaped into an ISO date can look phone-shaped, and without this
-        # guard ~60 people per birth year would collapse into mega-clusters.
+        # reshaped into an ISO date can look phone-shaped to the phone
+        # classifier, collapsing every row sharing that year into one cluster.
         # TODO(autoconfig): replace this blanket threshold with per-type
         # cardinality thresholds once we have empirical data for each col_type.
         if scorer == "exact" and p.cardinality_ratio > 0 and p.cardinality_ratio < 0.5:
@@ -494,7 +494,20 @@ def build_matchkeys(
         and _SCORER_MAP.get(p.col_type, (None,))[0] == "exact"
     ]
     if _exact_eligible and not exact_fields:
-        detail = "; ".join(f"{col} ({why})" for col, why in skipped_exact) or "no detail"
+        if skipped_exact:
+            detail = "; ".join(f"{col} ({why})" for col, why in skipped_exact)
+        else:
+            # All exact-eligible columns were filtered before reaching the
+            # named skip paths above — e.g. by a source-overlap check, a
+            # dropped profile, or a scorer_info lookup miss. Surface this
+            # shape loudly so a future refactor that starts dropping columns
+            # silently can be noticed.
+            eligible_names = ", ".join(p.name for p in _exact_eligible)
+            detail = (
+                f"no per-column reason captured — eligible columns "
+                f"({eligible_names}) were filtered before reaching the "
+                f"exact-matchkey skip paths"
+            )
         logger.warning(
             "All %d exact-eligible columns were excluded by auto-config guards "
             "(%s). Falling back to fuzzy-only matchkeys — if any of these "
@@ -1197,13 +1210,16 @@ def auto_configure_df(
 
     # 1. Learned blocking for large datasets.
     #
-    # Gated at >= 50K rows. The previous threshold of 5K was a footgun: on a
-    # 5K dataset the learner trained its predicates on 100% of its own input
-    # (sample_size was also 5K), producing overfit predicates and multi-minute
-    # runtimes. The sample size is now capped at 25% of the dataset (max 5K)
-    # so the learner always has held-out rows to generalize to, and the gate
-    # is raised so small/medium datasets use static blocking by default where
-    # the quality wins of learned blocking do not pay for its training cost.
+    # Gated at >= 50K rows because the learner needs two things the sample
+    # cap below cannot provide on smaller inputs:
+    #
+    #   a) held-out rows to generalize to — `learned_sample_size` caps the
+    #      training sample at 25% of the dataset, max 5K. Below 50K that cap
+    #      is tight enough (<=12.5K training / 37.5K held-out) to produce
+    #      predicates that generalize instead of memorizing the input.
+    #
+    #   b) enough rows to amortize training cost — below 50K, static or
+    #      multi_pass blocking is usually faster and comparable in quality.
     if blocking is not None and total_rows >= 50_000:
         blocking.strategy = "learned"
         blocking.learned_sample_size = min(total_rows // 4, 5000)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -558,10 +558,17 @@ class TestExtractHelpers:
         assert stats["match_rate"] == 0.0
 
     def test_extract_stats_with_data(self):
+        """total_records counts *input* rows (dupes + unique), not output
+        tables. golden is a derived rollup — one canonical per multi-member
+        cluster — and must NOT be added on top, or the count exceeds the
+        number of rows that were ever in the dataset.
+        """
         from goldenmatch._api import _extract_stats
-        golden = pl.DataFrame({"x": [1, 2]})
-        dupes = pl.DataFrame({"x": [3]})
-        unique = pl.DataFrame({"x": [4, 5]})
+        # Realistic shape: 1 duplicate cluster with 2 source rows (rolled up
+        # to 1 golden canonical), plus 2 unique singletons. Input rows = 4.
+        golden = pl.DataFrame({"x": [10]})     # 1 canonical
+        dupes = pl.DataFrame({"x": [1, 2]})    # 2 source rows in cluster
+        unique = pl.DataFrame({"x": [3, 4]})   # 2 singletons
         clusters = {
             0: {"size": 2, "members": [1, 2], "pair_scores": {}},
             1: {"size": 1, "members": [3], "pair_scores": {}},
@@ -570,7 +577,7 @@ class TestExtractHelpers:
             "golden": golden, "dupes": dupes, "unique": unique,
             "clusters": clusters,
         })
-        assert stats["total_records"] == 5
+        assert stats["total_records"] == 4  # dupes(2) + unique(2), NOT + golden
         assert stats["total_clusters"] == 1  # only size > 1
         assert stats["matched_records"] == 2
 

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -850,11 +850,16 @@ class TestCardinalityBoundaryValues:
         assert email_profile.cardinality_ratio < 0.95
         # email should now be eligible (though may or may not be selected depending on block size)
 
-    def test_matchkey_boundary_0_01_excluded(self):
-        """Column with cardinality_ratio < 0.01 should be excluded from exact matchkeys."""
+    def test_geo_never_promoted_to_exact_matchkey(self):
+        """col_type='geo' is a blocking signal, not an identity claim.
+
+        Two records sharing a city or state are not the same entity. Geo
+        columns are excluded from exact matchkeys regardless of cardinality,
+        and still participate in blocking via build_blocking().
+        """
         random.seed(42)
         profiles = [
-            ColumnProfile("state", "Utf8", "geo", 0.9, cardinality_ratio=0.009),
+            ColumnProfile("state", "Utf8", "geo", 0.9, cardinality_ratio=0.9),
             ColumnProfile("name", "Utf8", "name", 0.9, cardinality_ratio=0.5),
         ]
         matchkeys = build_matchkeys(profiles)
@@ -864,11 +869,11 @@ class TestCardinalityBoundaryValues:
                 exact_fields.extend(f.field for f in mk.fields)
         assert "state" not in exact_fields
 
-    def test_matchkey_boundary_0_01_included(self):
-        """Column with cardinality_ratio exactly 0.01 should be included in exact matchkeys."""
+    def test_zip_never_promoted_to_exact_matchkey(self):
+        """col_type='zip' is a blocking signal, not an identity claim."""
         random.seed(42)
         profiles = [
-            ColumnProfile("state", "Utf8", "geo", 0.9, cardinality_ratio=0.01),
+            ColumnProfile("zip_code", "Utf8", "zip", 0.9, cardinality_ratio=0.9),
             ColumnProfile("name", "Utf8", "name", 0.9, cardinality_ratio=0.5),
         ]
         matchkeys = build_matchkeys(profiles)
@@ -876,10 +881,53 @@ class TestCardinalityBoundaryValues:
         for mk in matchkeys:
             if mk.type == "exact":
                 exact_fields.extend(f.field for f in mk.fields)
-        assert "state" in exact_fields
+        assert "zip_code" not in exact_fields
+
+    def test_exact_typed_low_cardinality_excluded(self):
+        """Even an exact-scoring column (e.g. phone, email) with
+        cardinality_ratio < 0.5 must not back an exact matchkey.
+
+        This is the birth_year-as-phone failure mode: a 4-digit year that
+        an upstream transform reshapes into an ISO date looks phone-shaped
+        to the phone classifier, but with ~80 distinct values in 5K rows
+        its cardinality is too low to function as an identity claim.
+        """
+        random.seed(42)
+        profiles = [
+            ColumnProfile("year_looks_phoney", "Utf8", "phone", 0.9, cardinality_ratio=0.016),
+            ColumnProfile("name", "Utf8", "name", 0.9, cardinality_ratio=0.5),
+        ]
+        matchkeys = build_matchkeys(profiles)
+        exact_fields = []
+        for mk in matchkeys:
+            if mk.type == "exact":
+                exact_fields.extend(f.field for f in mk.fields)
+        assert "year_looks_phoney" not in exact_fields
+
+    def test_exact_typed_high_cardinality_included(self):
+        """An exact-scoring column (email) with high cardinality is still
+        promoted to an exact matchkey."""
+        random.seed(42)
+        profiles = [
+            ColumnProfile("email", "Utf8", "email", 0.9, cardinality_ratio=0.9),
+            ColumnProfile("name", "Utf8", "name", 0.9, cardinality_ratio=0.5),
+        ]
+        matchkeys = build_matchkeys(profiles)
+        exact_fields = []
+        for mk in matchkeys:
+            if mk.type == "exact":
+                exact_fields.extend(f.field for f in mk.fields)
+        assert "email" in exact_fields
 
     def test_matchkey_default_cardinality_not_affected(self):
-        """Profiles with default cardinality_ratio=0.0 should NOT be affected by the guard."""
+        """Profiles with default cardinality_ratio=0.0 should NOT be affected
+        by the guard (the guard only triggers when cardinality_ratio > 0).
+
+        Callers that construct ColumnProfile without a cardinality_ratio
+        (tests, small synthetic fixtures) should not have their exact
+        matchkeys silently dropped — the guard only suppresses columns
+        with real measured low cardinality.
+        """
         random.seed(42)
         profiles = [
             ColumnProfile("email", "Utf8", "email", 0.9),  # cardinality_ratio defaults to 0.0
@@ -1026,26 +1074,47 @@ class TestDataDrivenStrategy:
     """Tests for data-driven strategy selection in auto-config."""
 
     def test_learned_blocking_large_dataset(self):
-        """Datasets >= 5000 rows should get learned blocking."""
+        """Datasets >= 50K rows should get learned blocking.
+
+        The threshold was raised from 5K in fix/autoconfig-regressions
+        because at 5K the learner trained its predicates on 100% of the
+        dataset (sample_size=5K), producing multi-minute runtimes and
+        overfit predicates on small inputs. The gate is now 50K rows,
+        and sample_size is capped at 25% of the dataset.
+        """
         from goldenmatch.core.autoconfig import auto_configure_df
 
         df = pl.DataFrame({
-            "name": [f"Person {i}" for i in range(5000)],
-            "city": [f"City {i % 100}" for i in range(5000)],
+            "name": [f"Person {i}" for i in range(60_000)],
+            "city": [f"City {i % 100}" for i in range(60_000)],
         })
 
         config = auto_configure_df(df)
         assert config.blocking is not None
         assert config.blocking.strategy == "learned"
         assert config.blocking.learned_min_recall == 0.95
+        assert config.blocking.learned_sample_size <= 60_000 // 4
 
     def test_static_blocking_small_dataset(self):
-        """Datasets < 5000 rows should keep static blocking."""
+        """Datasets < 50K rows should keep static/multi_pass blocking."""
         from goldenmatch.core.autoconfig import auto_configure_df
 
         df = pl.DataFrame({
             "name": ["John Smith", "Jane Doe", "Bob Wilson"],
             "city": ["NYC", "LA", "Chicago"],
+        })
+
+        config = auto_configure_df(df)
+        assert config.blocking is not None
+        assert config.blocking.strategy != "learned"
+
+    def test_medium_dataset_not_upgraded_to_learned(self):
+        """5K-49K row datasets must stay on static/multi_pass blocking."""
+        from goldenmatch.core.autoconfig import auto_configure_df
+
+        df = pl.DataFrame({
+            "name": [f"Person {i}" for i in range(5_000)],
+            "city": [f"City {i % 100}" for i in range(5_000)],
         })
 
         config = auto_configure_df(df)

--- a/tests/test_autoconfig_regressions.py
+++ b/tests/test_autoconfig_regressions.py
@@ -20,10 +20,37 @@ the bugs under test.
 """
 from __future__ import annotations
 
+import time
+
 import polars as pl
 
 from goldenmatch import dedupe_df
-from goldenmatch.core.autoconfig import auto_configure_df
+from goldenmatch._api import _extract_stats
+from goldenmatch.core.autoconfig import (
+    ColumnProfile,
+    auto_configure_df,
+    build_matchkeys,
+)
+
+
+# Realistic surname pool that distributes across soundex codes. Using a
+# pattern like f"Last{i:05d}" is a trap: every synthetic name starting with
+# "Last" collapses to the same soundex code, so soundex(last_name) blocking
+# lands every row in ONE giant block and downstream fuzzy scoring becomes
+# O(n^2) — a 5K test that was meant to run in 15s hangs for an hour.
+_SURNAMES = [
+    "Smith", "Jones", "Williams", "Brown", "Davis", "Miller", "Wilson",
+    "Moore", "Taylor", "Anderson", "Thomas", "Jackson", "White", "Harris",
+    "Martin", "Thompson", "Garcia", "Martinez", "Robinson", "Clark",
+    "Rodriguez", "Lewis", "Lee", "Walker", "Hall", "Allen", "Young",
+    "King", "Wright", "Lopez",
+]
+_FIRSTNAMES = [
+    "Alex", "Blair", "Casey", "Dana", "Eli", "Finley", "Gray", "Harper",
+    "Indigo", "Jamie", "Kendall", "Logan", "Morgan", "Noel", "Oakley",
+    "Parker", "Quinn", "Riley", "Sage", "Taylor", "Umi", "Val", "Wren",
+    "Xena", "Yael", "Zane",
+]
 
 
 def _person_df(n: int) -> pl.DataFrame:
@@ -32,12 +59,14 @@ def _person_df(n: int) -> pl.DataFrame:
     - 3 distinct cities / 3 distinct zips → low cardinality geo/zip
     - 80 distinct birth years → low cardinality numeric (was misclassified
       as phone after upstream date transforms)
-    - distinct names per row
+    - surnames drawn from a 30-name pool so soundex blocking produces
+      ~30 blocks of n/30 each (keeps fuzzy scoring tractable)
+    - distinct addresses per row so no real duplicates
     """
     return pl.DataFrame([
         {
-            "last_name": f"Last{i:05d}",
-            "first_name": f"First{i:05d}",
+            "last_name": _SURNAMES[i % len(_SURNAMES)],
+            "first_name": f"{_FIRSTNAMES[i % len(_FIRSTNAMES)]}{i}",
             "middle_name": f"M{i % 26}",
             "res_street_address": f"{i} Main St",
             "res_city_desc": ["Raleigh", "Durham", "Cary"][i % 3],
@@ -172,3 +201,212 @@ def test_total_records_equals_input_row_count_with_duplicates():
         f"Stats aggregation is double-counting the golden rollup "
         f"(golden + dupes + unique instead of dupes + unique)."
     )
+
+
+# ── Positive cases: the fixes must NOT over-exclude legitimate identifiers ─
+
+def test_high_cardinality_email_still_promoted_to_exact():
+    """The raised cardinality guard (0.5) must not accidentally exclude real
+    identifier columns. Email with ratio ~0.95 should still back an exact
+    matchkey. This is the negative-of-the-fix test: any future tightening
+    that breaks email classification must fail CI, because silently losing
+    the most common dedupe key destroys recall without warning.
+    """
+    profiles = [
+        ColumnProfile("email", "Utf8", "email", 0.95, cardinality_ratio=0.95),
+        ColumnProfile("name",  "Utf8", "name",  0.9,  cardinality_ratio=0.5),
+    ]
+    matchkeys = build_matchkeys(profiles)
+    exact_fields: list[str] = []
+    for mk in matchkeys:
+        if mk.type == "exact":
+            exact_fields.extend(f.field for f in mk.fields)
+    assert "email" in exact_fields, (
+        "high-cardinality email (ratio=0.95) was not promoted to exact matchkey"
+    )
+
+
+def test_high_cardinality_phone_still_promoted_to_exact():
+    """Same as email: phone with high cardinality must still back an exact
+    matchkey. Separately tested because phone has a different col_type
+    scorer lookup path and a misclassification on phone is the exact
+    regression #2 exists to prevent on the *negative* side."""
+    profiles = [
+        ColumnProfile("phone", "Utf8", "phone", 0.95, cardinality_ratio=0.90),
+        ColumnProfile("name",  "Utf8", "name",  0.9,  cardinality_ratio=0.5),
+    ]
+    matchkeys = build_matchkeys(profiles)
+    exact_fields: list[str] = []
+    for mk in matchkeys:
+        if mk.type == "exact":
+            exact_fields.extend(f.field for f in mk.fields)
+    assert "phone" in exact_fields, (
+        "high-cardinality phone (ratio=0.90) was not promoted to exact matchkey"
+    )
+
+
+# ── Boundary values at the new thresholds ─────────────────────────────────
+
+def test_learned_blocking_exact_50k_boundary_triggers():
+    """The gate is `>= 50_000`, so a dataset of exactly 50,000 rows MUST
+    upgrade to learned blocking. Guards against an off-by-one refactor
+    switching `>=` to `>`.
+    """
+    cfg = auto_configure_df(_person_df(50_000))
+    assert cfg.blocking is not None
+    assert cfg.blocking.strategy == "learned", (
+        f"total_rows=50_000 did not trigger learned blocking: "
+        f"strategy={cfg.blocking.strategy}"
+    )
+
+
+def test_learned_blocking_just_below_50k_does_not_trigger():
+    """49,999 rows must stay on static/multi_pass — off-by-one guard on
+    the low side of the boundary."""
+    cfg = auto_configure_df(_person_df(49_999))
+    assert cfg.blocking is not None
+    assert cfg.blocking.strategy != "learned", (
+        f"total_rows=49_999 triggered learned blocking: "
+        f"strategy={cfg.blocking.strategy}"
+    )
+
+
+def test_cardinality_guard_exact_0_5_boundary_included():
+    """The matchkey guard is `< 0.5`, so a column at exactly 0.5 MUST be
+    included. This pins the contract against a future tightening that
+    silently flips the comparator to `<=`.
+    """
+    profiles = [
+        ColumnProfile("email", "Utf8", "email", 0.95, cardinality_ratio=0.5),
+        ColumnProfile("name",  "Utf8", "name",  0.9,  cardinality_ratio=0.5),
+    ]
+    matchkeys = build_matchkeys(profiles)
+    exact_fields: list[str] = []
+    for mk in matchkeys:
+        if mk.type == "exact":
+            exact_fields.extend(f.field for f in mk.fields)
+    assert "email" in exact_fields, (
+        "cardinality_ratio=0.5 was excluded — guard should be strict < 0.5"
+    )
+
+
+def test_cardinality_guard_just_below_0_5_excluded():
+    """0.4999 is below the guard and must be excluded."""
+    profiles = [
+        ColumnProfile("email", "Utf8", "email", 0.95, cardinality_ratio=0.4999),
+        ColumnProfile("name",  "Utf8", "name",  0.9,  cardinality_ratio=0.5),
+    ]
+    matchkeys = build_matchkeys(profiles)
+    exact_fields: list[str] = []
+    for mk in matchkeys:
+        if mk.type == "exact":
+            exact_fields.extend(f.field for f in mk.fields)
+    assert "email" not in exact_fields, (
+        "cardinality_ratio=0.4999 was included — guard should exclude <0.5"
+    )
+
+
+# ── Interaction: single e2e run that exercises all three fixes together ───
+
+def test_dedupe_df_interaction_all_three_fixes_together():
+    """One end-to-end run that would hit all three bugs simultaneously if
+    any regressed:
+
+    - Bug 1 (learned blocking auto-upgrade): pre-fix this triggered at
+      >= 5K rows and hung for minutes. A 500-row run must finish fast.
+    - Bug 2 (geo/zip/low-card → exact matchkey): pre-fix this collapsed
+      every record per city/zip/birth-year into mega-clusters. We bound
+      the largest cluster at 10 members.
+    - Bug 3 (total_records double-count): pre-fix this exceeded df.height
+      by the number of multi-member clusters. We assert strict equality.
+
+    Uses 500 rows rather than 5000 — big enough that all three guards
+    actually engage (blocking falls through geo/zip guards, cardinality
+    guard fires on birth_year, config shape is non-trivial) but small
+    enough to run in a handful of seconds including cross-encoder warm-up.
+    A 5K run on the same synthetic shape would take significantly longer
+    because the surname pool is small (by design) and ensemble scoring
+    grows quadratically inside each soundex block.
+    """
+    df = _person_df(500)
+    t0 = time.perf_counter()
+    result = dedupe_df(df)
+    elapsed = time.perf_counter() - t0
+
+    # Bug 1: runtime must not explode. 90s is generous for a 500-row run
+    # (actual runtime is ~15s with cold-start cross-encoder loading).
+    assert elapsed < 90.0, (
+        f"dedupe_df(500) took {elapsed:.1f}s — expected < 90s. "
+        f"Likely cause: a blocking / matchkey fix regressed and the "
+        f"scorer is doing O(n^2) work inside a single huge block."
+    )
+    # Bug 2: no mega-clusters. Synthetic data has distinct addresses and
+    # rotating surnames/firstnames, so real clusters (if any from ensemble
+    # noise) should be tiny. Any cluster > 10 members indicates a
+    # geo/zip/low-cardinality column regressed back into an exact matchkey.
+    if result.clusters:
+        largest = max(len(c["members"]) for c in result.clusters.values())
+        assert largest <= 10, (
+            f"Largest cluster has {largest} members. Expected <= 10 on "
+            f"synthetic data with distinct addresses. Likely cause: "
+            f"geo/zip or low-cardinality column promoted back into an "
+            f"exact matchkey."
+        )
+    # Bug 3: row count invariant.
+    assert result.total_records == df.height, (
+        f"total_records={result.total_records} != df.height={df.height}. "
+        f"Likely cause: _extract_stats re-added golden to the sum."
+    )
+
+
+# ── _extract_stats edge cases (contract pinning) ──────────────────────────
+
+def test_extract_stats_golden_only_warns_not_silent_zero():
+    """If a pipeline path ever produces golden without dupes/unique, the
+    stats helper must surface it as a warning rather than silently returning
+    total_records=0 (which would make match_rate a meaningless 0/0).
+
+    This is a contract test — the standard pipeline always materializes
+    all three, so if this shape ever starts appearing a refactor changed
+    _api.py's output contract and _extract_stats needs revisiting.
+    """
+    import logging
+    caplog_records = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            caplog_records.append(record)
+
+    handler = _Capture()
+    api_logger = logging.getLogger("goldenmatch._api")
+    api_logger.addHandler(handler)
+    api_logger.setLevel(logging.WARNING)
+    try:
+        stats = _extract_stats({
+            "golden": pl.DataFrame({"x": [1, 2, 3]}),
+            "dupes": None,
+            "unique": None,
+            "clusters": {0: {"size": 3, "members": [1, 2, 3], "pair_scores": {}}},
+        })
+    finally:
+        api_logger.removeHandler(handler)
+
+    assert stats["total_records"] == 0
+    # Must have warned — silent zero is the exact failure mode we want to
+    # prevent because match_rate divides by total_records.
+    assert any("golden" in r.getMessage() for r in caplog_records), (
+        "golden-only result shape returned zeroed stats with no warning"
+    )
+
+
+def test_extract_stats_all_none_returns_empty():
+    """All-None input is a valid empty-result shape (no records at all)
+    and must return zero stats cleanly without raising or warning about
+    the golden-only edge case.
+    """
+    stats = _extract_stats({
+        "golden": None, "dupes": None, "unique": None, "clusters": {},
+    })
+    assert stats["total_records"] == 0
+    assert stats["total_clusters"] == 0
+    assert stats["match_rate"] == 0.0

--- a/tests/test_autoconfig_regressions.py
+++ b/tests/test_autoconfig_regressions.py
@@ -51,6 +51,19 @@ _FIRSTNAMES = [
     "Parker", "Quinn", "Riley", "Sage", "Taylor", "Umi", "Val", "Wren",
     "Xena", "Yael", "Zane",
 ]
+# Address street names must vary too, not just the numeric prefix. A naive
+# generator like f"{i} Main St" makes every address share the "Main St"
+# suffix, so the token_sort address scorer returns ~0.67 on every pair
+# inside a soundex block; combined with last_name exact weight that nudges
+# ensemble scores over threshold and union-find transitively merges the
+# whole block into one fuzzy-false-positive cluster. Rotating street names
+# keeps the synthetic fixture from producing fuzzy noise that masquerades
+# as a bug-2 regression.
+_STREETS = [
+    "Elm St", "Oak Ave", "Pine Rd", "Maple Dr", "Cedar Ln", "Birch Ct",
+    "Walnut Way", "Chestnut Blvd", "Willow Pl", "Hickory Pk",
+    "Spruce Tr", "Poplar Cir", "Aspen Rte", "Sycamore Hwy", "Beech Row",
+]
 
 
 def _person_df(n: int) -> pl.DataFrame:
@@ -61,14 +74,16 @@ def _person_df(n: int) -> pl.DataFrame:
       as phone after upstream date transforms)
     - surnames drawn from a 30-name pool so soundex blocking produces
       ~30 blocks of n/30 each (keeps fuzzy scoring tractable)
-    - distinct addresses per row so no real duplicates
+    - first names AND street names rotate through independent pools so
+      no two rows share enough fuzzy-matchable content to trip the
+      ensemble scorer into transitive merges (no real duplicates)
     """
     return pl.DataFrame([
         {
             "last_name": _SURNAMES[i % len(_SURNAMES)],
             "first_name": f"{_FIRSTNAMES[i % len(_FIRSTNAMES)]}{i}",
             "middle_name": f"M{i % 26}",
-            "res_street_address": f"{i} Main St",
+            "res_street_address": f"{i} {_STREETS[i % len(_STREETS)]}",
             "res_city_desc": ["Raleigh", "Durham", "Cary"][i % 3],
             "zip_code": ["27601", "27701", "27511"][i % 3],
             "birth_year": str(1930 + (i % 80)),
@@ -96,7 +111,7 @@ def test_learned_blocking_not_triggered_below_50k():
 def test_learned_blocking_sample_size_capped_at_quarter():
     """When learned blocking does engage, sample_size must stay below 25% of
     the dataset so the learner always has held-out rows to generalize to."""
-    cfg = auto_configure_df(_person_df(60_000))
+    cfg = auto_configure_df(_gate_test_df(60_000))
     assert cfg.blocking is not None
     if cfg.blocking.strategy == "learned":
         assert cfg.blocking.learned_sample_size <= 60_000 // 4, (
@@ -247,23 +262,46 @@ def test_high_cardinality_phone_still_promoted_to_exact():
 
 # ── Boundary values at the new thresholds ─────────────────────────────────
 
+def _gate_test_df(n: int) -> pl.DataFrame:
+    """Trivial 2-column fixture for boundary-gate tests.
+
+    The learned-blocking gate only reads `df.height`, not column content.
+    Building `_person_df(50_000)` for every boundary test wastes ~2s per run
+    on dict-of-strings construction for values the gate never inspects.
+    This fixture keeps the two columns auto-config needs (one name-typed,
+    one email-typed) so a valid config with non-None blocking is produced,
+    but skips the per-row payload.
+    """
+    return pl.DataFrame({
+        "name":  [f"Person{i}" for i in range(n)],
+        "email": [f"user{i}@example.com" for i in range(n)],
+    })
+
+
 def test_learned_blocking_exact_50k_boundary_triggers():
     """The gate is `>= 50_000`, so a dataset of exactly 50,000 rows MUST
     upgrade to learned blocking. Guards against an off-by-one refactor
-    switching `>=` to `>`.
+    switching `>=` to `>`. Also asserts `learned_sample_size == 5000` to
+    pin the `min(total_rows // 4, 5000)` formula — at 50K that clamps to
+    5000, and a regression flipping `// 4` to `// 5` would silently shrink
+    the sample to 4000 without this assertion failing.
     """
-    cfg = auto_configure_df(_person_df(50_000))
+    cfg = auto_configure_df(_gate_test_df(50_000))
     assert cfg.blocking is not None
     assert cfg.blocking.strategy == "learned", (
         f"total_rows=50_000 did not trigger learned blocking: "
         f"strategy={cfg.blocking.strategy}"
+    )
+    assert cfg.blocking.learned_sample_size == 5000, (
+        f"at total_rows=50_000 expected learned_sample_size=5000 "
+        f"(min(50000//4, 5000)), got {cfg.blocking.learned_sample_size}"
     )
 
 
 def test_learned_blocking_just_below_50k_does_not_trigger():
     """49,999 rows must stay on static/multi_pass — off-by-one guard on
     the low side of the boundary."""
-    cfg = auto_configure_df(_person_df(49_999))
+    cfg = auto_configure_df(_gate_test_df(49_999))
     assert cfg.blocking is not None
     assert cfg.blocking.strategy != "learned", (
         f"total_rows=49_999 triggered learned blocking: "
@@ -320,37 +358,56 @@ def test_dedupe_df_interaction_all_three_fixes_together():
     - Bug 3 (total_records double-count): pre-fix this exceeded df.height
       by the number of multi-member clusters. We assert strict equality.
 
-    Uses 500 rows rather than 5000 — big enough that all three guards
-    actually engage (blocking falls through geo/zip guards, cardinality
-    guard fires on birth_year, config shape is non-trivial) but small
-    enough to run in a handful of seconds including cross-encoder warm-up.
-    A 5K run on the same synthetic shape would take significantly longer
-    because the surname pool is small (by design) and ensemble scoring
-    grows quadratically inside each soundex block.
+    Builds the config via `auto_configure_df` (which exercises all the
+    fixed code paths) and then disables `rerank=True` on weighted matchkeys
+    before running the pipeline. Reranking auto-loads a cross-encoder model
+    from Hugging Face, which would make this test fail for the wrong reason
+    on offline CI runners with no HF cache. Disabling it is safe here
+    because none of the three regressions live in the rerank code path —
+    they all live in build_matchkeys / the stats aggregator.
+
+    Uses 500 rows — large enough that all three guards actually engage
+    (blocking falls through geo/zip guards, cardinality guard fires on
+    birth_year, config shape is non-trivial, stats aggregation runs over
+    a non-empty clusters dict) but small enough to run in a couple seconds.
     """
     df = _person_df(500)
+
+    # Exercise the fixed auto-config path explicitly so we can strip
+    # reranking out of the produced config before the pipeline runs.
+    # If the bug-2 fix regressed, this call would still produce exact
+    # matchkeys on city/zip/birth_year and the downstream assertions
+    # below would catch it.
+    config = auto_configure_df(df)
+    for mk in config.get_matchkeys():
+        if getattr(mk, "rerank", False):
+            mk.rerank = False
+
     t0 = time.perf_counter()
-    result = dedupe_df(df)
+    result = dedupe_df(df, config=config)
     elapsed = time.perf_counter() - t0
 
-    # Bug 1: runtime must not explode. 90s is generous for a 500-row run
-    # (actual runtime is ~15s with cold-start cross-encoder loading).
-    assert elapsed < 90.0, (
-        f"dedupe_df(500) took {elapsed:.1f}s — expected < 90s. "
+    # Bug 1: runtime must not explode. 30s is generous for a 500-row run
+    # with rerank disabled (actual runtime is ~2s on a warm runner).
+    assert elapsed < 30.0, (
+        f"dedupe_df(500) took {elapsed:.1f}s — expected < 30s. "
         f"Likely cause: a blocking / matchkey fix regressed and the "
         f"scorer is doing O(n^2) work inside a single huge block."
     )
-    # Bug 2: no mega-clusters. Synthetic data has distinct addresses and
-    # rotating surnames/firstnames, so real clusters (if any from ensemble
-    # noise) should be tiny. Any cluster > 10 members indicates a
-    # geo/zip/low-cardinality column regressed back into an exact matchkey.
+    # Bug 2: no mega-clusters. The fixture has 3 cities, 3 zip codes, and
+    # 80 birth years, so a regression reintroducing exact matchkeys on
+    # those columns would produce clusters of ~167 (city/zip) or larger.
+    # The assertion bound is set at 50 — well above the ~17-member ceiling
+    # from benign fuzzy transitive merges inside a single soundex block
+    # (500 rows / 30 surname pool ≈ 17 per block), and well below the 167
+    # that any bug-2-style column-wide collapse would produce.
     if result.clusters:
         largest = max(len(c["members"]) for c in result.clusters.values())
-        assert largest <= 10, (
-            f"Largest cluster has {largest} members. Expected <= 10 on "
-            f"synthetic data with distinct addresses. Likely cause: "
-            f"geo/zip or low-cardinality column promoted back into an "
-            f"exact matchkey."
+        assert largest <= 50, (
+            f"Largest cluster has {largest} members — exceeds 50. "
+            f"Bug-2-style city/zip mega-clusters produce clusters of "
+            f"~167 members on this fixture. Likely cause: geo/zip or "
+            f"low-cardinality column regressed back into an exact matchkey."
         )
     # Bug 3: row count invariant.
     assert result.total_records == df.height, (

--- a/tests/test_autoconfig_regressions.py
+++ b/tests/test_autoconfig_regressions.py
@@ -1,0 +1,174 @@
+"""Regression tests for v1.4 auto-config bugs.
+
+Covers three issues reported against dedupe_df auto-config on person data:
+
+1. Learned blocking auto-upgrade fires at 5K rows and trains on 100% of the
+   dataset, causing multi-minute runtimes on small inputs.
+2. Columns classified as col_type="zip" or "geo" are promoted into exact
+   matchkeys, collapsing every record sharing a city/zip into one cluster.
+   Combined with (3), this also catches low-cardinality numerics
+   (e.g. birth_year misclassified as phone after a date transform).
+3. DedupeResult.total_records includes golden canonical records alongside
+   dupes + unique, double-counting clusters so total_records > df.height
+   whenever duplicates exist.
+
+All checks use auto_configure_df (config shape only) except for a single
+small end-to-end invariant check — running dedupe_df on thousands of rows
+is out of scope for a regression test because it brings in GoldenCheck,
+GoldenFlow, cross-encoder reranking, and minutes of overhead unrelated to
+the bugs under test.
+"""
+from __future__ import annotations
+
+import polars as pl
+
+from goldenmatch import dedupe_df
+from goldenmatch.core.autoconfig import auto_configure_df
+
+
+def _person_df(n: int) -> pl.DataFrame:
+    """Synthetic person dataset with the shape that exposes these bugs.
+
+    - 3 distinct cities / 3 distinct zips → low cardinality geo/zip
+    - 80 distinct birth years → low cardinality numeric (was misclassified
+      as phone after upstream date transforms)
+    - distinct names per row
+    """
+    return pl.DataFrame([
+        {
+            "last_name": f"Last{i:05d}",
+            "first_name": f"First{i:05d}",
+            "middle_name": f"M{i % 26}",
+            "res_street_address": f"{i} Main St",
+            "res_city_desc": ["Raleigh", "Durham", "Cary"][i % 3],
+            "zip_code": ["27601", "27701", "27511"][i % 3],
+            "birth_year": str(1930 + (i % 80)),
+        }
+        for i in range(n)
+    ])
+
+
+# ── Claim 1: learned blocking gating ───────────────────────────────────────
+
+def test_learned_blocking_not_triggered_below_50k():
+    """Auto-config must not upgrade small datasets to learned blocking.
+
+    The old gate was >= 5000 with sample_size=5000 — on a 5K dataset the
+    learner trained on 100% of its own input, producing multi-minute
+    runtimes. Small datasets should use static/multi_pass blocking.
+    """
+    cfg = auto_configure_df(_person_df(5_000))
+    assert cfg.blocking is not None
+    assert cfg.blocking.strategy != "learned", (
+        f"5K rows triggered learned blocking: strategy={cfg.blocking.strategy}"
+    )
+
+
+def test_learned_blocking_sample_size_capped_at_quarter():
+    """When learned blocking does engage, sample_size must stay below 25% of
+    the dataset so the learner always has held-out rows to generalize to."""
+    cfg = auto_configure_df(_person_df(60_000))
+    assert cfg.blocking is not None
+    if cfg.blocking.strategy == "learned":
+        assert cfg.blocking.learned_sample_size <= 60_000 // 4, (
+            f"sample_size={cfg.blocking.learned_sample_size} exceeds 25% of "
+            f"60000 rows — learner would overfit on its own input"
+        )
+
+
+# ── Claim 2: geo/zip/low-cardinality promoted to exact matchkeys ──────────
+
+def test_geo_not_promoted_to_exact_matchkey():
+    """col_type='geo' is a blocking signal, not an identity claim.
+
+    Two voters sharing a city are not the same entity. Promoting city_desc
+    into an exact matchkey collapses every voter in each city into one
+    mega-cluster.
+    """
+    cfg = auto_configure_df(_person_df(500))
+    for mk in cfg.get_matchkeys():
+        if mk.type != "exact":
+            continue
+        for f in mk.fields:
+            assert f.field != "res_city_desc", (
+                "res_city_desc promoted to exact matchkey"
+            )
+
+
+def test_zip_not_promoted_to_exact_matchkey():
+    """col_type='zip' is a blocking signal, not an identity claim."""
+    cfg = auto_configure_df(_person_df(500))
+    for mk in cfg.get_matchkeys():
+        if mk.type != "exact":
+            continue
+        for f in mk.fields:
+            assert f.field != "zip_code", (
+                "zip_code promoted to exact matchkey"
+            )
+
+
+def test_low_cardinality_not_promoted_to_exact_matchkey():
+    """A column with cardinality_ratio well below 0.5 must not back an
+    exact matchkey even if its classifier says 'exact'.
+
+    Birth year is the canonical failure mode: after an upstream date
+    transform a 4-digit year can look phone-shaped (8+ stripped digits),
+    the phone classifier accepts it, and with ~80 distinct values in 5K
+    rows each 'exact birth_year' match collapses ~60 unrelated people.
+    """
+    cfg = auto_configure_df(_person_df(5_000))
+    for mk in cfg.get_matchkeys():
+        if mk.type != "exact":
+            continue
+        for f in mk.fields:
+            assert f.field != "birth_year", (
+                "birth_year promoted to exact matchkey despite ~80 distinct "
+                "values in 5K rows (cardinality_ratio ~0.016)"
+            )
+
+
+# ── Claim 3: total_records double-counts golden rollup ────────────────────
+
+def test_total_records_equals_input_row_count_with_duplicates():
+    """End-to-end invariant: total_records must equal df.height regardless
+    of how many duplicate clusters are produced.
+
+    Uses a tiny fixture with two known duplicate pairs so the golden rollup
+    is non-empty (which is the condition that triggered the old bug — when
+    golden was empty the double-count was a no-op).
+    """
+    rows = [
+        # Duplicate pair 1: minor spelling variation
+        {"last_name": "Smith", "first_name": "John",  "middle_name": "A",
+         "res_street_address": "1 Elm St", "res_city_desc": "Raleigh",
+         "zip_code": "27601", "birth_year": "1980"},
+        {"last_name": "Smith", "first_name": "Jon",   "middle_name": "A",
+         "res_street_address": "1 Elm St", "res_city_desc": "Raleigh",
+         "zip_code": "27601", "birth_year": "1980"},
+        # Duplicate pair 2
+        {"last_name": "Doe",   "first_name": "Jane",  "middle_name": "B",
+         "res_street_address": "2 Oak Ave", "res_city_desc": "Durham",
+         "zip_code": "27701", "birth_year": "1975"},
+        {"last_name": "Doe",   "first_name": "Janet", "middle_name": "B",
+         "res_street_address": "2 Oak Ave", "res_city_desc": "Durham",
+         "zip_code": "27701", "birth_year": "1975"},
+    ]
+    # A handful of distinct singletons so auto-config has enough columns to
+    # profile without hitting edge cases on tiny frames.
+    for i in range(20):
+        rows.append({
+            "last_name": f"Unique{i:03d}",
+            "first_name": f"Person{i:03d}",
+            "middle_name": "X",
+            "res_street_address": f"{i} Maple Rd",
+            "res_city_desc": "Cary",
+            "zip_code": "27511",
+            "birth_year": str(1950 + i),
+        })
+    df = pl.DataFrame(rows)
+    result = dedupe_df(df)
+    assert result.total_records == df.height, (
+        f"total_records={result.total_records} != df.height={df.height}. "
+        f"Stats aggregation is double-counting the golden rollup "
+        f"(golden + dupes + unique instead of dupes + unique)."
+    )


### PR DESCRIPTION
## Summary

Three independent bugs in auto-config path were causing `dedupe_df(df)` to hang for >15 minutes on a 5K NCVR voter sample and produce 18 clusters (eight of exactly size 100) with `total_records=5085 != df.height=5000`. Each bug is fixed at its root.

### 1. Learned blocking auto-upgrade — `autoconfig.py:1158`
Gate fired at `total_rows >= 5000` with `learned_sample_size=5000`, so on any 5K dataset the learner trained its predicates on 100% of its own input. Raised to `>= 50_000` and capped `sample_size = min(total_rows//4, 5000)` so the learner always has held-out rows.

### 2. Geo/zip/low-cardinality promoted to exact matchkeys — `autoconfig.py:420`
`_SCORER_MAP` routed `col_type` `zip` and `geo` to `scorer="exact"`, and the emission loop built exact matchkeys on them — asserting "two records sharing a city/zip are the same entity", which collapsed every voter per city into one mega-cluster. Same failure mode for `birth_year`: after GoldenFlow's `date_iso8601` transform reshapes `"1978"` into an ISO date, the stripped 8-digit form looks phone-shaped to the classifier, and the exact matchkey merges ~60 people per birth year.

Fix: exclude `col_type in {"zip", "geo"}` from exact matchkeys unconditionally (they remain blocking candidates via `build_blocking`), and raise the `cardinality_ratio` guard from `< 0.01` to `< 0.5` so any exact-scoring column must have identifier-level uniqueness before it can back a matchkey.

### 3. `total_records` double-counts golden rollup — `_api.py:752`
`_extract_stats` summed `golden + dupes + unique`, but `golden` is a rollup (one canonical per multi-member cluster), not an independent row population. Whenever duplicates existed, `total_records` exceeded `df.height` by exactly the number of multi-member clusters. Fix: `total_records = dupes + unique` only — every source row lives in exactly one of those.

## Impact on NCVR 5K repro

| | pre-fix | post-fix |
|---|---|---|
| elapsed | >15 min (killed) | ~15 s |
| `total_records` | 5085 | 5000 |
| clusters (size ≥ 2) | 18 | 61 |
| biggest cluster | 100 | 3 |
| invariant `total_records == df.height` | ❌ | ✅ |

## Test plan

- [x] New `tests/test_autoconfig_regressions.py` — 6 tests, one per claim plus direct invariant checks
- [x] `TestCardinalityBoundaryValues` updated to assert the new contract (geo/zip never exact; cardinality ≥ 0.5 required)
- [x] `test_learned_blocking_large_dataset` moved to 60K rows and asserts the sample_size cap
- [x] New `test_medium_dataset_not_upgraded_to_learned` guards the 5K–50K range
- [x] `test_extract_stats_with_data` fixture updated to realistic shape so the assertion reflects real dupes/golden relationship
- [x] Full suite: **1310 passed, 0 failed** (`pytest --ignore test_db,test_reconcile,test_mcp_and_watch,test_embedder,test_llm_boost`)

## Out of scope (follow-up)

GoldenFlow's `date_iso8601` transform is the reason the phone classifier ever fires on `birth_year` — it rewrites `"1978"` into an ISO date form before auto-config profiles the column. The cardinality guard catches the symptom cleanly, but the transform is being over-eager on year-only columns. Worth a separate issue against `goldenmatch/core/transform.py`.