### PR TITLE
fix: silence Smithery -32601 (v1.4.4)

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,5 +1,5 @@
 FROM python:3.12-slim
-
+# cache-bust: v1.4.4 (empty resources/prompts handlers)
 WORKDIR /app
 
 COPY . .

--- a/goldenmatch/__init__.py
+++ b/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"
 
 # ── High-level API (convenience functions) ────────────────────────────────
 from goldenmatch._api import (

--- a/goldenmatch/mcp/server.py
+++ b/goldenmatch/mcp/server.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import Tool, TextContent
+from mcp.types import Tool, TextContent, Resource, Prompt
 
 from goldenmatch.mcp.agent_tools import AGENT_TOOLS, handle_agent_tool
 
@@ -408,6 +408,14 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
                 },
             ),
         ]
+
+    @server.list_resources()
+    async def list_resources() -> list[Resource]:
+        return []
+
+    @server.list_prompts()
+    async def list_prompts() -> list[Prompt]:
+        return []
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.4.3"
+version = "1.4.4"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.benzsevern/goldenmatch",
   "title": "GoldenMatch",
   "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. 30 MCP tools. DQBench ER: 95.30.",
-  "version": "1.4.1",
+  "version": "1.4.4",
   "repository": {
     "url": "https://github.com/benzsevern/goldenmatch.git",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "1.4.1",
+      "version": "1.4.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- Register empty list_resources/list_prompts handlers so Smithery stops hitting -32601 on probe.
- Bump version + server.json + cache-bust Dockerfile.mcp.

## Test plan
- [x] create_server() smoke test
- [ ] Smithery reconnect shows no warning after Railway redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)