### PR TITLE
fix: skip gitignored-dataset tests on CI

### DIFF
--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -1321,14 +1321,26 @@ def test_classify_by_data_prose_not_multi_name():
 def test_autoconfig_parity_pins_unchanged():
     """Pin test: AutoConfigDecisions refactor must not change output for the
     three benchmarks. If this fails, the refactor changed behavior - fix the
-    refactor, not the pin file."""
+    refactor, not the pin file.
+
+    Benchmark datasets are gitignored; this test is effectively local-dev
+    only. CI skips it gracefully. Contributors who want to exercise the
+    parity guard should run `python tests/parity/capture_autoconfig_output.py`
+    after pulling the Leipzig DBLP-ACM dataset into tests/benchmarks/datasets/.
+    """
     import json
     import sys
     from pathlib import Path
 
     import polars as pl
+    import pytest
 
     repo_root = Path(__file__).parent.parent
+    dblp_path = repo_root / "tests" / "benchmarks" / "datasets" / "DBLP-ACM" / "DBLP2.csv"
+    if not dblp_path.exists():
+        pytest.skip(
+            "DBLP-ACM dataset not present (gitignored, local-dev only)"
+        )
     # Import pin_config from the capture script (not a normal test import)
     sys.path.insert(0, str(repo_root / "tests" / "parity"))
     from capture_autoconfig_output import pin_config  # type: ignore

--- a/tests/test_autoconfig_verify.py
+++ b/tests/test_autoconfig_verify.py
@@ -408,9 +408,18 @@ def test_preflight_check5_drops_empty_matchkey_after_record_embedding_removal():
 
 
 def test_auto_configure_df_dblp_acm_does_not_crash():
+    """Regression test for the v1.5.0 preflight fix: zero-config dedupe_df
+    on biblio-style data no longer crashes with 'Missing required columns'.
+
+    Benchmark datasets are gitignored; CI skips gracefully. Full integration
+    coverage lives in tests/test_autoconfig_benchmarks.py (marked @benchmark).
+    """
     from pathlib import Path
+    import pytest
     from goldenmatch._api import dedupe_df
     d = Path("tests/benchmarks/datasets/DBLP-ACM")
+    if not (d / "DBLP2.csv").exists():
+        pytest.skip("DBLP-ACM dataset not present (gitignored, local-dev only)")
     dblp = pl.read_csv(d / "DBLP2.csv", encoding="utf8-lossy", ignore_errors=True)
     acm  = pl.read_csv(d / "ACM.csv", encoding="utf8-lossy", ignore_errors=True)
     df = pl.concat([dblp, acm], how="diagonal_relaxed")


### PR DESCRIPTION
## Problem

Two tests added in #44 (`test_autoconfig_parity_pins_unchanged`, `test_auto_configure_df_dblp_acm_does_not_crash`) try to read \`tests/benchmarks/datasets/DBLP-ACM/DBLP2.csv\`, but that directory is gitignored (\`.gitignore:17\`). CI fails with \`FileNotFoundError\`.

## Fix

Both tests now \`pytest.skip\` when the dataset file is absent. No behavior change on developer machines that have the data locally.

## Test plan
- [x] Both tests still PASS locally (data present) — verified.
- [ ] CI turns green after merge.