### PR TITLE
fix(js): bump pprl test timeout + v0.3.1

### DIFF
--- a/packages/goldenmatch-js/package.json
+++ b/packages/goldenmatch-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/goldenmatch-js/tests/unit/pprl-protocol.test.ts
+++ b/packages/goldenmatch-js/tests/unit/pprl-protocol.test.ts
@@ -199,7 +199,7 @@ describe("runPPRL", () => {
     expect(hits).toBeGreaterThanOrEqual(7);
   });
 
-  it("runs end-to-end with security_level standard/high/paranoid and finds same true pairs", () => {
+  it("runs end-to-end with security_level standard/high/paranoid and finds same true pairs", { timeout: 15000 }, () => {
     const { a, b } = twoPartiesWithOverlap();
     const baseFields: string[] = ["first_name", "last_name", "email"];
 


### PR DESCRIPTION
Pre-existing pprl flake caused goldenmatch-js-v0.3.0 publish-npm workflow failure (run 24472319544). Bump the test timeout to 15s, bump to v0.3.1, re-tag to trigger a clean npm publish.