### PR TITLE
feat: goldensuite-mcp aggregator + 7-image ghcr publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pkg: [goldenmatch, goldencheck, goldenflow, goldenpipe, infermap]
+        pkg: [goldenmatch, goldencheck, goldenflow, goldenpipe, infermap, goldensuite-mcp]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -1,0 +1,134 @@
+name: publish-containers
+
+# Builds and pushes 7 container images to ghcr.io/benzsevern/*:
+#   goldensuite-mcp, goldenmatch-mcp, goldencheck-mcp, goldenflow-mcp,
+#   goldenpipe-mcp, infermap-mcp, goldenmatch-extensions
+#
+# Triggers:
+#   - push to main           -> all 7 images, tagged :latest and :main-<sha7>
+#   - tag <name>-v<X.Y.Z>    -> only that image, tagged :v<X.Y.Z>, :v<X.Y>, :latest
+#                              where <name> is one of: goldensuite-mcp, goldenmatch-mcp,
+#                              goldencheck-mcp, goldenflow-mcp, goldenpipe-mcp,
+#                              infermap-mcp, goldenmatch-extensions
+#
+# Multi-arch: linux/amd64 + linux/arm64 (QEMU emulation for arm64 on GH runners).
+# Auth: GITHUB_TOKEN (built-in, no PAT needed for ghcr.io).
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'goldensuite-mcp-v*'
+      - 'goldenmatch-mcp-v*'
+      - 'goldencheck-mcp-v*'
+      - 'goldenflow-mcp-v*'
+      - 'goldenpipe-mcp-v*'
+      - 'infermap-mcp-v*'
+      - 'goldenmatch-extensions-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: goldensuite-mcp
+            dockerfile: packages/python/goldensuite-mcp/Dockerfile.mcp
+            context: .
+          - image: goldenmatch-mcp
+            dockerfile: packages/python/goldenmatch/Dockerfile.mcp
+            context: packages/python/goldenmatch
+          - image: goldencheck-mcp
+            dockerfile: packages/python/goldencheck/Dockerfile.mcp
+            context: packages/python/goldencheck
+          - image: goldenflow-mcp
+            dockerfile: packages/python/goldenflow/Dockerfile.mcp
+            context: packages/python/goldenflow
+          - image: goldenpipe-mcp
+            dockerfile: packages/python/goldenpipe/Dockerfile.mcp
+            context: packages/python/goldenpipe
+          - image: infermap-mcp
+            dockerfile: packages/python/infermap/Dockerfile.mcp
+            context: packages/python/infermap
+          - image: goldenmatch-extensions
+            dockerfile: packages/rust/extensions/Dockerfile
+            context: packages/rust/extensions
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # If this is a tag push, skip jobs whose image doesn't match the tag prefix.
+      # We do this with an `if:` on the steps below by comparing matrix.image to
+      # the prefix extracted from the ref. workflow_dispatch and push-to-main
+      # always run all images.
+      - name: Determine whether to build this image
+        id: gate
+        run: |
+          set -euo pipefail
+          ref="${GITHUB_REF#refs/tags/}"
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            # tag push: only build if matrix image prefix matches the tag
+            prefix="${ref%-v*}"
+            if [[ "$prefix" == "${{ matrix.image }}" ]]; then
+              echo "build=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "build=false" >> "$GITHUB_OUTPUT"
+              echo "Skipping ${{ matrix.image }}: tag $ref targets $prefix"
+            fi
+          else
+            # main push or workflow_dispatch: build everything
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up QEMU
+        if: steps.gate.outputs.build == 'true'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        if: steps.gate.outputs.build == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        if: steps.gate.outputs.build == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        if: steps.gate.outputs.build == 'true'
+        id: tags
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=main-{{sha}},enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=match,pattern=^${{ matrix.image }}-v(.*)$,group=1
+            type=match,pattern=^${{ matrix.image }}-v(\d+\.\d+)\.\d+$,group=1
+          labels: |
+            org.opencontainers.image.title=${{ matrix.image }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=MIT
+
+      - name: Build and push
+        if: steps.gate.outputs.build == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: ${{ steps.tags.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -68,6 +68,360 @@ def _initialize(file_paths: list[str], config_path: str | None = None) -> None:
     )
 
 
+
+# Base (non-agent) tools — module-level so goldensuite-mcp aggregator can
+# import the full goldenmatch tool surface without instantiating a Server.
+_BASE_TOOLS = [
+    Tool(
+        name="get_stats",
+        description="Get dataset statistics: record count, cluster count, match rate, cluster sizes.",
+        inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
+        name="find_duplicates",
+        description="Find duplicate matches for a record. Provide field values to search against the loaded dataset.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "record": {
+                    "type": "object",
+                    "description": "Record fields to match (e.g. {\"name\": \"John Smith\", \"zip\": \"10001\"})",
+                },
+                "top_k": {
+                    "type": "integer",
+                    "description": "Max results to return (default 5)",
+                    "default": 5,
+                },
+            },
+            "required": ["record"],
+        },
+    ),
+    Tool(
+        name="explain_match",
+        description="Explain why two records match or don't match. Shows per-field score breakdown.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "record_a": {
+                    "type": "object",
+                    "description": "First record fields",
+                },
+                "record_b": {
+                    "type": "object",
+                    "description": "Second record fields",
+                },
+            },
+            "required": ["record_a", "record_b"],
+        },
+    ),
+    Tool(
+        name="list_clusters",
+        description="List duplicate clusters found in the dataset. Returns cluster IDs, sizes, and member counts.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "min_size": {
+                    "type": "integer",
+                    "description": "Minimum cluster size to include (default 2)",
+                    "default": 2,
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max clusters to return (default 20)",
+                    "default": 20,
+                },
+            },
+        },
+    ),
+    Tool(
+        name="get_cluster",
+        description="Get details of a specific cluster: all member records and their field values.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "cluster_id": {
+                    "type": "integer",
+                    "description": "Cluster ID to look up",
+                },
+            },
+            "required": ["cluster_id"],
+        },
+    ),
+    Tool(
+        name="get_golden_record",
+        description="Get the merged golden (canonical) record for a cluster.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "cluster_id": {
+                    "type": "integer",
+                    "description": "Cluster ID",
+                },
+            },
+            "required": ["cluster_id"],
+        },
+    ),
+    Tool(
+        name="match_record",
+        description=(
+            "Match a single record against the loaded dataset in real-time. "
+            "Paste a record's fields and instantly see if it matches any existing record. "
+            "Uses the configured matchkeys, scorers, and thresholds. "
+            "Example: {\"name\": \"John Smith\", \"email\": \"john@test.com\", \"zip\": \"10001\"}"
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "record": {
+                    "type": "object",
+                    "description": "Record fields to match against the dataset",
+                },
+                "threshold": {
+                    "type": "number",
+                    "description": "Minimum score to consider a match (default: use config threshold)",
+                },
+                "top_k": {
+                    "type": "integer",
+                    "description": "Max matches to return (default 5)",
+                    "default": 5,
+                },
+            },
+            "required": ["record"],
+        },
+    ),
+    Tool(
+        name="unmerge_record",
+        description=(
+            "Remove a record from its cluster. The record becomes a singleton. "
+            "Remaining cluster members are re-clustered using stored pair scores. "
+            "Use this to fix bad merges."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "record_id": {
+                    "type": "integer",
+                    "description": "Row ID of the record to unmerge",
+                },
+            },
+            "required": ["record_id"],
+        },
+    ),
+    Tool(
+        name="shatter_cluster",
+        description=(
+            "Break an entire cluster into individual records. "
+            "All members become singletons. Use when a cluster is completely wrong."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "cluster_id": {
+                    "type": "integer",
+                    "description": "Cluster ID to shatter",
+                },
+            },
+            "required": ["cluster_id"],
+        },
+    ),
+    Tool(
+        name="suggest_config",
+        description=(
+            "Analyze bad merges and suggest config changes. "
+            "Provide examples of incorrect merges (pairs that should NOT have matched) "
+            "and GoldenMatch will identify which fields/thresholds to tighten. "
+            "Example: [{\"record_a\": {...}, \"record_b\": {...}, \"reason\": \"different people\"}]"
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "bad_merges": {
+                    "type": "array",
+                    "description": "List of bad merge examples with record_a, record_b, and optional reason",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "record_a": {"type": "object"},
+                            "record_b": {"type": "object"},
+                            "reason": {"type": "string"},
+                        },
+                        "required": ["record_a", "record_b"],
+                    },
+                },
+            },
+            "required": ["bad_merges"],
+        },
+    ),
+    Tool(
+        name="profile_data",
+        description="Get data quality profile: column types, null rates, unique counts, sample values.",
+        inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
+        name="export_results",
+        description="Export matching results to a file (CSV or JSON).",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "output_path": {
+                    "type": "string",
+                    "description": "File path to save results",
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["csv", "json"],
+                    "description": "Output format (default csv)",
+                    "default": "csv",
+                },
+            },
+            "required": ["output_path"],
+        },
+    ),
+    Tool(
+        name="list_domains",
+        description="List available domain extraction rulebooks (built-in + user-defined).",
+        inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
+        name="create_domain",
+        description="Create a custom domain extraction rulebook. Define patterns for a specific data domain (medical devices, automotive parts, real estate, etc.).",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Domain name (e.g. 'medical_devices', 'automotive_parts')",
+                },
+                "signals": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Column name keywords that trigger this domain (e.g. ['ndc', 'fda', 'implant'])",
+                },
+                "identifier_patterns": {
+                    "type": "object",
+                    "description": "Named regex patterns for domain identifiers (e.g. {'ndc': '\\\\b(\\\\d{5}-\\\\d{4}-\\\\d{2})\\\\b'})",
+                },
+                "brand_patterns": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Brand/manufacturer names to extract (e.g. ['Medtronic', 'Abbott'])",
+                },
+                "attribute_patterns": {
+                    "type": "object",
+                    "description": "Named regex patterns for domain attributes (e.g. {'size': '\\\\b(\\\\d+mm)\\\\b'})",
+                },
+                "stop_words": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Words to strip during name normalization",
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": ["local", "global"],
+                    "description": "Save locally (.goldenmatch/domains/) or globally (~/.goldenmatch/domains/). Default: local.",
+                    "default": "local",
+                },
+            },
+            "required": ["name", "signals"],
+        },
+    ),
+    Tool(
+        name="test_domain",
+        description="Test a domain extraction rulebook against sample records. Shows what features would be extracted from the loaded data.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "domain_name": {
+                    "type": "string",
+                    "description": "Name of the domain rulebook to test",
+                },
+                "sample_size": {
+                    "type": "integer",
+                    "description": "Number of records to test (default 10)",
+                    "default": 10,
+                },
+            },
+            "required": ["domain_name"],
+        },
+    ),
+    Tool(
+        name="pprl_auto_config",
+        description=(
+            "Analyze the loaded dataset and recommend optimal PPRL (privacy-preserving record linkage) configuration. "
+            "Returns recommended fields, bloom filter parameters, threshold, and explanation."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "security_level": {
+                    "type": "string",
+                    "enum": ["standard", "high", "paranoid"],
+                    "description": "Security level (default: high)",
+                    "default": "high",
+                },
+                "use_llm": {
+                    "type": "boolean",
+                    "description": "Use LLM for enhanced recommendations (requires API key)",
+                    "default": False,
+                },
+            },
+        },
+    ),
+    Tool(
+        name="pprl_link",
+        description=(
+            "Run privacy-preserving record linkage between two parties' data. "
+            "Computes bloom filters, matches records without sharing raw data. "
+            "Specify fields, threshold, and security level."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "file_a": {
+                    "type": "string",
+                    "description": "Path to party A's CSV file",
+                },
+                "file_b": {
+                    "type": "string",
+                    "description": "Path to party B's CSV file",
+                },
+                "fields": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Field names to match on (e.g. ['first_name', 'last_name', 'zip_code'])",
+                },
+                "threshold": {
+                    "type": "number",
+                    "description": "Match threshold (default: auto-detected)",
+                },
+                "security_level": {
+                    "type": "string",
+                    "enum": ["standard", "high", "paranoid"],
+                    "default": "high",
+                },
+            },
+            "required": ["file_a", "file_b", "fields"],
+        },
+    ),
+]
+
+# TOOLS is the union of agent tools + base tools, in the same order list_tools returns.
+TOOLS = AGENT_TOOLS + _BASE_TOOLS
+
+
+def dispatch(name: str, args: dict) -> dict:
+    """Unified dispatcher used by goldensuite-mcp aggregator.
+
+    Routes agent-level tool calls to AgentSession via agent_tools._dispatch, and
+    base tool calls to _handle_tool. Returns a JSON-serializable dict for both.
+    """
+    if name in _AGENT_TOOL_NAMES:
+        from goldenmatch.core.agent import AgentSession
+        from goldenmatch.mcp.agent_tools import _dispatch as _agent_dispatch
+        return _agent_dispatch(name, args, AgentSession)
+    return _handle_tool(name, args)
+
+
 def create_server(file_paths: list[str] | None = None, config_path: str | None = None) -> Server:
     """Create and configure the MCP server."""
 
@@ -78,339 +432,7 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:
-        return AGENT_TOOLS + [
-            Tool(
-                name="get_stats",
-                description="Get dataset statistics: record count, cluster count, match rate, cluster sizes.",
-                inputSchema={"type": "object", "properties": {}},
-            ),
-            Tool(
-                name="find_duplicates",
-                description="Find duplicate matches for a record. Provide field values to search against the loaded dataset.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "record": {
-                            "type": "object",
-                            "description": "Record fields to match (e.g. {\"name\": \"John Smith\", \"zip\": \"10001\"})",
-                        },
-                        "top_k": {
-                            "type": "integer",
-                            "description": "Max results to return (default 5)",
-                            "default": 5,
-                        },
-                    },
-                    "required": ["record"],
-                },
-            ),
-            Tool(
-                name="explain_match",
-                description="Explain why two records match or don't match. Shows per-field score breakdown.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "record_a": {
-                            "type": "object",
-                            "description": "First record fields",
-                        },
-                        "record_b": {
-                            "type": "object",
-                            "description": "Second record fields",
-                        },
-                    },
-                    "required": ["record_a", "record_b"],
-                },
-            ),
-            Tool(
-                name="list_clusters",
-                description="List duplicate clusters found in the dataset. Returns cluster IDs, sizes, and member counts.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "min_size": {
-                            "type": "integer",
-                            "description": "Minimum cluster size to include (default 2)",
-                            "default": 2,
-                        },
-                        "limit": {
-                            "type": "integer",
-                            "description": "Max clusters to return (default 20)",
-                            "default": 20,
-                        },
-                    },
-                },
-            ),
-            Tool(
-                name="get_cluster",
-                description="Get details of a specific cluster: all member records and their field values.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "cluster_id": {
-                            "type": "integer",
-                            "description": "Cluster ID to look up",
-                        },
-                    },
-                    "required": ["cluster_id"],
-                },
-            ),
-            Tool(
-                name="get_golden_record",
-                description="Get the merged golden (canonical) record for a cluster.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "cluster_id": {
-                            "type": "integer",
-                            "description": "Cluster ID",
-                        },
-                    },
-                    "required": ["cluster_id"],
-                },
-            ),
-            Tool(
-                name="match_record",
-                description=(
-                    "Match a single record against the loaded dataset in real-time. "
-                    "Paste a record's fields and instantly see if it matches any existing record. "
-                    "Uses the configured matchkeys, scorers, and thresholds. "
-                    "Example: {\"name\": \"John Smith\", \"email\": \"john@test.com\", \"zip\": \"10001\"}"
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "record": {
-                            "type": "object",
-                            "description": "Record fields to match against the dataset",
-                        },
-                        "threshold": {
-                            "type": "number",
-                            "description": "Minimum score to consider a match (default: use config threshold)",
-                        },
-                        "top_k": {
-                            "type": "integer",
-                            "description": "Max matches to return (default 5)",
-                            "default": 5,
-                        },
-                    },
-                    "required": ["record"],
-                },
-            ),
-            Tool(
-                name="unmerge_record",
-                description=(
-                    "Remove a record from its cluster. The record becomes a singleton. "
-                    "Remaining cluster members are re-clustered using stored pair scores. "
-                    "Use this to fix bad merges."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "record_id": {
-                            "type": "integer",
-                            "description": "Row ID of the record to unmerge",
-                        },
-                    },
-                    "required": ["record_id"],
-                },
-            ),
-            Tool(
-                name="shatter_cluster",
-                description=(
-                    "Break an entire cluster into individual records. "
-                    "All members become singletons. Use when a cluster is completely wrong."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "cluster_id": {
-                            "type": "integer",
-                            "description": "Cluster ID to shatter",
-                        },
-                    },
-                    "required": ["cluster_id"],
-                },
-            ),
-            Tool(
-                name="suggest_config",
-                description=(
-                    "Analyze bad merges and suggest config changes. "
-                    "Provide examples of incorrect merges (pairs that should NOT have matched) "
-                    "and GoldenMatch will identify which fields/thresholds to tighten. "
-                    "Example: [{\"record_a\": {...}, \"record_b\": {...}, \"reason\": \"different people\"}]"
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "bad_merges": {
-                            "type": "array",
-                            "description": "List of bad merge examples with record_a, record_b, and optional reason",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "record_a": {"type": "object"},
-                                    "record_b": {"type": "object"},
-                                    "reason": {"type": "string"},
-                                },
-                                "required": ["record_a", "record_b"],
-                            },
-                        },
-                    },
-                    "required": ["bad_merges"],
-                },
-            ),
-            Tool(
-                name="profile_data",
-                description="Get data quality profile: column types, null rates, unique counts, sample values.",
-                inputSchema={"type": "object", "properties": {}},
-            ),
-            Tool(
-                name="export_results",
-                description="Export matching results to a file (CSV or JSON).",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "output_path": {
-                            "type": "string",
-                            "description": "File path to save results",
-                        },
-                        "format": {
-                            "type": "string",
-                            "enum": ["csv", "json"],
-                            "description": "Output format (default csv)",
-                            "default": "csv",
-                        },
-                    },
-                    "required": ["output_path"],
-                },
-            ),
-            Tool(
-                name="list_domains",
-                description="List available domain extraction rulebooks (built-in + user-defined).",
-                inputSchema={"type": "object", "properties": {}},
-            ),
-            Tool(
-                name="create_domain",
-                description="Create a custom domain extraction rulebook. Define patterns for a specific data domain (medical devices, automotive parts, real estate, etc.).",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": "Domain name (e.g. 'medical_devices', 'automotive_parts')",
-                        },
-                        "signals": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "Column name keywords that trigger this domain (e.g. ['ndc', 'fda', 'implant'])",
-                        },
-                        "identifier_patterns": {
-                            "type": "object",
-                            "description": "Named regex patterns for domain identifiers (e.g. {'ndc': '\\\\b(\\\\d{5}-\\\\d{4}-\\\\d{2})\\\\b'})",
-                        },
-                        "brand_patterns": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "Brand/manufacturer names to extract (e.g. ['Medtronic', 'Abbott'])",
-                        },
-                        "attribute_patterns": {
-                            "type": "object",
-                            "description": "Named regex patterns for domain attributes (e.g. {'size': '\\\\b(\\\\d+mm)\\\\b'})",
-                        },
-                        "stop_words": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "Words to strip during name normalization",
-                        },
-                        "scope": {
-                            "type": "string",
-                            "enum": ["local", "global"],
-                            "description": "Save locally (.goldenmatch/domains/) or globally (~/.goldenmatch/domains/). Default: local.",
-                            "default": "local",
-                        },
-                    },
-                    "required": ["name", "signals"],
-                },
-            ),
-            Tool(
-                name="test_domain",
-                description="Test a domain extraction rulebook against sample records. Shows what features would be extracted from the loaded data.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "domain_name": {
-                            "type": "string",
-                            "description": "Name of the domain rulebook to test",
-                        },
-                        "sample_size": {
-                            "type": "integer",
-                            "description": "Number of records to test (default 10)",
-                            "default": 10,
-                        },
-                    },
-                    "required": ["domain_name"],
-                },
-            ),
-            Tool(
-                name="pprl_auto_config",
-                description=(
-                    "Analyze the loaded dataset and recommend optimal PPRL (privacy-preserving record linkage) configuration. "
-                    "Returns recommended fields, bloom filter parameters, threshold, and explanation."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "security_level": {
-                            "type": "string",
-                            "enum": ["standard", "high", "paranoid"],
-                            "description": "Security level (default: high)",
-                            "default": "high",
-                        },
-                        "use_llm": {
-                            "type": "boolean",
-                            "description": "Use LLM for enhanced recommendations (requires API key)",
-                            "default": False,
-                        },
-                    },
-                },
-            ),
-            Tool(
-                name="pprl_link",
-                description=(
-                    "Run privacy-preserving record linkage between two parties' data. "
-                    "Computes bloom filters, matches records without sharing raw data. "
-                    "Specify fields, threshold, and security level."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "file_a": {
-                            "type": "string",
-                            "description": "Path to party A's CSV file",
-                        },
-                        "file_b": {
-                            "type": "string",
-                            "description": "Path to party B's CSV file",
-                        },
-                        "fields": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "Field names to match on (e.g. ['first_name', 'last_name', 'zip_code'])",
-                        },
-                        "threshold": {
-                            "type": "number",
-                            "description": "Match threshold (default: auto-detected)",
-                        },
-                        "security_level": {
-                            "type": "string",
-                            "enum": ["standard", "high", "paranoid"],
-                            "default": "high",
-                        },
-                    },
-                    "required": ["file_a", "file_b", "fields"],
-                },
-            ),
-        ]
+        return AGENT_TOOLS + _BASE_TOOLS
 
     @server.list_resources()
     async def list_resources() -> list[Resource]:

--- a/packages/python/goldenpipe/goldenpipe/mcp/server.py
+++ b/packages/python/goldenpipe/goldenpipe/mcp/server.py
@@ -72,6 +72,40 @@ def explain_pipeline_tool(config_path: str) -> dict[str, Any]:
         return {"error": str(e)}
 
 
+def _build_tools() -> list:
+    """Build the Tool list. Lazy so import doesn't fail without mcp installed."""
+    return [
+        Tool(name="list_stages", description="List all discovered pipeline stages",
+             inputSchema={"type": "object", "properties": {}}),
+        Tool(name="validate_pipeline", description="Validate pipeline wiring",
+             inputSchema={"type": "object", "properties": {
+                 "pipeline": {"type": "string"},
+                 "stages": {"type": "array", "items": {"type": "string"}},
+             }, "required": ["pipeline", "stages"]}),
+        Tool(name="run_pipeline", description="Run a pipeline on a file",
+             inputSchema={"type": "object", "properties": {
+                 "source": {"type": "string"},
+                 "config_path": {"type": "string"},
+             }, "required": ["source"]}),
+        Tool(name="explain_pipeline", description="Explain what a pipeline config does",
+             inputSchema={"type": "object", "properties": {
+                 "config_path": {"type": "string"},
+             }, "required": ["config_path"]}),
+    ]
+
+
+# Module-level surfaces for goldensuite-mcp (the in-process aggregator).
+# TOOLS is a list of mcp.types.Tool objects; HANDLERS maps tool name -> callable
+# that takes the arguments dict and returns a JSON-serializable result.
+TOOLS = _build_tools() if HAS_MCP else []
+HANDLERS = {
+    "list_stages": lambda args: list_stages_tool(),
+    "validate_pipeline": lambda args: validate_pipeline_tool(**args),
+    "run_pipeline": lambda args: run_pipeline_tool(**args),
+    "explain_pipeline": lambda args: explain_pipeline_tool(**args),
+}
+
+
 def create_server() -> "Server":
     """Create and configure the MCP server instance."""
     if not HAS_MCP:
@@ -81,24 +115,7 @@ def create_server() -> "Server":
 
     @server.list_tools()
     async def handle_list_tools():
-        return [
-            Tool(name="list_stages", description="List all discovered pipeline stages",
-                 inputSchema={"type": "object", "properties": {}}),
-            Tool(name="validate_pipeline", description="Validate pipeline wiring",
-                 inputSchema={"type": "object", "properties": {
-                     "pipeline": {"type": "string"},
-                     "stages": {"type": "array", "items": {"type": "string"}},
-                 }, "required": ["pipeline", "stages"]}),
-            Tool(name="run_pipeline", description="Run a pipeline on a file",
-                 inputSchema={"type": "object", "properties": {
-                     "source": {"type": "string"},
-                     "config_path": {"type": "string"},
-                 }, "required": ["source"]}),
-            Tool(name="explain_pipeline", description="Explain what a pipeline config does",
-                 inputSchema={"type": "object", "properties": {
-                     "config_path": {"type": "string"},
-                 }, "required": ["config_path"]}),
-        ]
+        return TOOLS
 
     @server.list_resources()
     async def handle_list_resources() -> list[Resource]:
@@ -110,17 +127,14 @@ def create_server() -> "Server":
 
     @server.call_tool()
     async def handle_call_tool(name: str, arguments: dict):
-        if name == "list_stages":
-            result = list_stages_tool()
-        elif name == "validate_pipeline":
-            result = validate_pipeline_tool(**arguments)
-        elif name == "run_pipeline":
-            result = run_pipeline_tool(**arguments)
-        elif name == "explain_pipeline":
-            result = explain_pipeline_tool(**arguments)
-        else:
+        handler = HANDLERS.get(name)
+        if handler is None:
             result = {"error": f"Unknown tool: {name}"}
-
+        else:
+            try:
+                result = handler(arguments)
+            except Exception as exc:
+                result = {"error": str(exc)}
         return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
 
     return server

--- a/packages/python/goldensuite-mcp/Dockerfile.mcp
+++ b/packages/python/goldensuite-mcp/Dockerfile.mcp
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Copy the entire monorepo so workspace deps resolve via uv. The build context
+# for this image is the repository root (set in the publish workflow).
+COPY . /app
+
+# Install the goldensuite-mcp package and all sub-packages it depends on.
+# Use uv for workspace-aware install; fall back to pip if uv isn't present.
+RUN pip install --no-cache-dir uv \
+    && uv pip install --system --no-cache \
+        ./packages/python/goldenmatch \
+        ./packages/python/goldencheck \
+        ./packages/python/goldenflow \
+        ./packages/python/goldenpipe \
+        ./packages/python/infermap \
+        ./packages/python/goldensuite-mcp
+
+EXPOSE 8300
+
+CMD ["goldensuite-mcp", "serve", "--transport", "http", "--port", "8300"]

--- a/packages/python/goldensuite-mcp/README.md
+++ b/packages/python/goldensuite-mcp/README.md
@@ -1,0 +1,103 @@
+# goldensuite-mcp
+
+> One MCP server exposing **every** Golden Suite tool — `goldenmatch`, `goldencheck`, `goldenflow`, `goldenpipe`, `infermap` — under a single endpoint.
+
+```bash
+pip install goldensuite-mcp
+goldensuite-mcp serve --transport http --port 8300
+```
+
+Or via container:
+
+```bash
+docker run -p 8300:8300 ghcr.io/benzsevern/goldensuite-mcp:latest
+```
+
+## What it does
+
+`goldensuite-mcp` imports each sub-package's MCP tool list and dispatcher, composes them into a single `mcp.server.Server` instance, and serves them over stdio or Streamable HTTP.
+
+You point your MCP client at one endpoint and get the full Golden Suite — entity resolution, data quality scanning, transforms, pipeline orchestration, and schema mapping.
+
+## Tool collisions
+
+Tool names register on a **first-wins** basis. The registration order is:
+
+1. **goldenmatch** — entity resolution (headline package; its tools win collisions)
+2. **goldencheck** — data quality scanning
+3. **goldenflow** — transforms & standardizers
+4. **goldenpipe** — pipeline orchestrator
+5. **infermap** — schema mapping
+
+If two packages register a tool with the same name, the later one is shadowed. **Shadowed tools are logged at WARNING level when the server starts**, so you can see exactly what happened:
+
+```
+WARNING goldensuite_mcp.server: tool collision: 'profile' from goldenflow shadowed by earlier goldencheck (first-wins)
+```
+
+If you need a shadowed tool, use that package's standalone MCP server instead (e.g. `goldenflow mcp-serve`).
+
+## Claude Desktop / Claude Code config
+
+```json
+{
+  "mcpServers": {
+    "goldensuite": {
+      "command": "goldensuite-mcp",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+Or the hosted variant (when one is published):
+
+```json
+{
+  "mcpServers": {
+    "goldensuite": {
+      "url": "https://goldensuite-mcp.example/mcp/"
+    }
+  }
+}
+```
+
+## Why an aggregator?
+
+The Golden Suite ships five Python packages, each with its own MCP server (`goldenmatch mcp-serve`, `goldencheck mcp-serve`, …). For a deployer running all five behind one Claude Desktop config, that's five processes and five mounts.
+
+`goldensuite-mcp` is the convenience option:
+- One process, one mount, all the tools
+- Identical Tool definitions (no proxying or naming changes)
+- Sub-package MCP servers continue to work standalone for narrower deployments
+
+## Architecture
+
+```
+                 ┌──────────────────────────────────────────┐
+                 │   goldensuite-mcp Server                  │
+                 │   (one mcp.server.Server instance)        │
+                 └─────────────┬────────────────────────────┘
+                               │ aggregates
+        ┌──────────────────────┼──────────────────────┐
+        ▼                      ▼                      ▼
+   goldenmatch.mcp       goldencheck.mcp        goldenflow.mcp     ...
+   TOOLS + dispatch      TOOLS + dispatch       TOOLS + handle_tool
+```
+
+Each sub-package exposes its `TOOLS` list and a dispatcher at module scope (`goldenmatch.mcp.server.dispatch`, `goldencheck.mcp.server._TOOL_HANDLERS`, etc.). The aggregator imports those, normalizes Tool format (some are `Tool` objects, some are dicts), and binds tool names to the right dispatcher.
+
+No subprocess overhead, no IPC. All tool calls execute in-process.
+
+## Standalone vs aggregator
+
+| Use case | Recommend |
+|---|---|
+| Need only one Golden Suite package's tools | `<package> mcp-serve` (standalone) |
+| Want everything in one MCP endpoint | `goldensuite-mcp serve` |
+| Care about tool collisions | Read the WARNING logs at startup, or use standalone |
+| Need different versions of sub-packages on different endpoints | Use standalone |
+
+## License
+
+MIT — see [LICENSE](../../LICENSE) at repo root.

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
@@ -1,0 +1,16 @@
+"""goldensuite-mcp — one MCP server, all Golden Suite tools.
+
+Aggregates the MCP tool surfaces of:
+- goldenmatch (entity resolution)
+- goldencheck (data quality)
+- goldenflow  (data transformation)
+- goldenpipe  (orchestrator)
+- infermap    (schema mapping)
+
+into a single Server. Tools register first-wins on name collisions; collisions
+are logged at startup so deployers know which tool was shadowed.
+"""
+from goldensuite_mcp.server import create_server
+
+__version__ = "0.1.0"
+__all__ = ["create_server", "__version__"]

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/cli.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/cli.py
@@ -1,0 +1,101 @@
+"""goldensuite-mcp CLI — `goldensuite-mcp serve [--transport stdio|http] [--port N]`."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+
+
+def _serve_stdio() -> None:
+    from mcp.server.stdio import stdio_server
+
+    from goldensuite_mcp.server import create_server
+
+    async def main() -> None:
+        server = create_server()
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(read_stream, write_stream, server.create_initialization_options())
+
+    asyncio.run(main())
+
+
+def _serve_http(host: str, port: int) -> None:
+    import contextlib
+    from collections.abc import AsyncIterator
+
+    import uvicorn
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse
+    from starlette.routing import Mount, Route
+
+    from goldensuite_mcp.server import create_server
+
+    server = create_server()
+    session_manager = StreamableHTTPSessionManager(app=server, stateless=True)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(app: Starlette) -> AsyncIterator[None]:
+        async with session_manager.run():
+            yield
+
+    async def server_card(request):
+        return JSONResponse(
+            {
+                "name": "goldensuite-mcp",
+                "description": (
+                    "One MCP server exposing every Golden Suite tool — "
+                    "goldenmatch, goldencheck, goldenflow, goldenpipe, infermap. "
+                    "First-wins on tool-name collisions; collisions are logged at startup."
+                ),
+                "homepage": "https://github.com/benzsevern/goldenmatch",
+                "iconUrl": "https://avatars.githubusercontent.com/u/192581748",
+            }
+        )
+
+    app = Starlette(
+        lifespan=lifespan,
+        routes=[
+            Route("/.well-known/mcp/server-card.json", server_card),
+            Mount("/mcp", app=session_manager.handle_request),
+        ],
+    )
+
+    uvicorn.run(app, host=host, port=port)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    parser = argparse.ArgumentParser(prog="goldensuite-mcp")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("serve", help="Run the aggregated MCP server.")
+    s.add_argument(
+        "--transport",
+        choices=["stdio", "http"],
+        default="stdio",
+        help="Transport (default: stdio).",
+    )
+    s.add_argument("--host", default="0.0.0.0", help="HTTP host (default 0.0.0.0).")
+    s.add_argument("--port", type=int, default=8300, help="HTTP port (default 8300).")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "serve":
+        if args.transport == "http":
+            _serve_http(args.host, args.port)
+        else:
+            _serve_stdio()
+        return 0
+
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
@@ -1,0 +1,185 @@
+"""Aggregator MCP server that exposes every Golden Suite tool from one endpoint.
+
+Each sub-package exposes (via its mcp.server module):
+- TOOLS: list[mcp.types.Tool] OR list[dict] (goldenflow uses dicts)
+- a dispatcher callable taking (name, args) -> dict (handler returns a JSON-serializable dict)
+
+The aggregator imports those, normalizes Tool format, applies first-wins on name
+collisions, and builds one Server that routes call_tool to the originating
+sub-package's dispatcher.
+
+Tool collisions are logged WARNING at server creation so deployers can see
+which tool shadowed which; the user explicitly opted into first-wins (no
+package prefixing) so this is an information-only signal.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from mcp.server import Server
+from mcp.types import Tool, TextContent
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Sub-package adapters
+# ---------------------------------------------------------------------------
+# Each adapter returns (tools, dispatch). Tools are normalized to mcp.types.Tool.
+# Dispatch is a Callable[[str, dict], dict] — handler returns a serializable dict.
+
+
+def _normalize_tools(raw_tools: list) -> list[Tool]:
+    """Accept either Tool objects or dicts (goldenflow style); return Tool list."""
+    out: list[Tool] = []
+    for t in raw_tools:
+        if isinstance(t, Tool):
+            out.append(t)
+        elif isinstance(t, dict):
+            out.append(Tool(**t))
+        else:
+            logger.warning("Skipping unrecognized tool entry of type %s", type(t).__name__)
+    return out
+
+
+def _adapt_goldenmatch() -> tuple[list[Tool], Callable[[str, dict], dict]]:
+    from goldenmatch.mcp import server as gm
+
+    return _normalize_tools(list(gm.TOOLS)), gm.dispatch
+
+
+def _adapt_goldencheck() -> tuple[list[Tool], Callable[[str, dict], dict]]:
+    from goldencheck.mcp import server as gc
+
+    handlers = gc._TOOL_HANDLERS
+
+    def dispatch(name: str, args: dict) -> dict:
+        h = handlers.get(name)
+        if h is None:
+            return {"error": f"goldencheck: unknown tool {name!r}"}
+        return h(args)
+
+    return _normalize_tools(list(gc.TOOLS)), dispatch
+
+
+def _adapt_goldenflow() -> tuple[list[Tool], Callable[[str, dict], dict]]:
+    from goldenflow.mcp import server as gf
+
+    def dispatch(name: str, args: dict) -> dict:
+        # goldenflow.handle_tool returns a JSON string, not a dict.
+        raw = gf.handle_tool(name, args)
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return {"result": raw}
+
+    return _normalize_tools(list(gf.TOOLS)), dispatch
+
+
+def _adapt_goldenpipe() -> tuple[list[Tool], Callable[[str, dict], dict]]:
+    from goldenpipe.mcp import server as gp
+
+    handlers = gp.HANDLERS
+
+    def dispatch(name: str, args: dict) -> dict:
+        h = handlers.get(name)
+        if h is None:
+            return {"error": f"goldenpipe: unknown tool {name!r}"}
+        return h(args)
+
+    return _normalize_tools(list(gp.TOOLS)), dispatch
+
+
+def _adapt_infermap() -> tuple[list[Tool], Callable[[str, dict], dict]]:
+    from infermap.mcp import server as im
+
+    handlers = im.HANDLERS
+
+    def dispatch(name: str, args: dict) -> dict:
+        h = handlers.get(name)
+        if h is None:
+            return {"error": f"infermap: unknown tool {name!r}"}
+        return h(args)
+
+    return _normalize_tools(list(im.TOOLS)), dispatch
+
+
+# Order determines first-wins precedence on tool-name collisions.
+# Goldenmatch is the headline package, so its tools win; the others register
+# only their unshadowed names. Adjust this order to change precedence.
+_SUITE_ORDER: list[tuple[str, Callable[[], tuple[list[Tool], Callable[[str, dict], dict]]]]] = [
+    ("goldenmatch", _adapt_goldenmatch),
+    ("goldencheck", _adapt_goldencheck),
+    ("goldenflow", _adapt_goldenflow),
+    ("goldenpipe", _adapt_goldenpipe),
+    ("infermap", _adapt_infermap),
+]
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _aggregate() -> tuple[list[Tool], dict[str, Callable[[str, dict], dict]]]:
+    """Compose all sub-packages' tools + dispatchers under first-wins."""
+    all_tools: list[Tool] = []
+    name_to_dispatch: dict[str, Callable[[str, dict], dict]] = {}
+    seen: dict[str, str] = {}  # tool_name -> source pkg
+
+    for source_name, adapter in _SUITE_ORDER:
+        try:
+            tools, dispatch = adapter()
+        except Exception as exc:  # noqa: BLE001 — we want to keep going
+            logger.warning(
+                "Skipping %s in goldensuite-mcp: failed to load (%s: %s)",
+                source_name, type(exc).__name__, exc,
+            )
+            continue
+
+        added = 0
+        for tool in tools:
+            if tool.name in seen:
+                logger.warning(
+                    "tool collision: %r from %s shadowed by earlier %s (first-wins)",
+                    tool.name, source_name, seen[tool.name],
+                )
+                continue
+            seen[tool.name] = source_name
+            all_tools.append(tool)
+            name_to_dispatch[tool.name] = dispatch
+            added += 1
+        logger.info("goldensuite-mcp: registered %d tools from %s", added, source_name)
+
+    return all_tools, name_to_dispatch
+
+
+def create_server() -> Server:
+    """Build the aggregated Server."""
+    tools, dispatch_by_name = _aggregate()
+
+    server = Server("goldensuite-mcp")
+
+    @server.list_tools()
+    async def list_tools() -> list[Tool]:
+        return tools
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+        handler = dispatch_by_name.get(name)
+        if handler is None:
+            payload: Any = {"error": f"unknown tool: {name}"}
+        else:
+            try:
+                payload = handler(name, arguments or {})
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("tool %s failed", name)
+                payload = {"error": f"{type(exc).__name__}: {exc}"}
+        return [TextContent(type="text", text=json.dumps(payload, default=str, indent=2))]
+
+    return server
+
+
+__all__ = ["create_server"]

--- a/packages/python/goldensuite-mcp/pyproject.toml
+++ b/packages/python/goldensuite-mcp/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "goldensuite-mcp"
+version = "0.1.0"
+description = "One MCP server exposing every Golden Suite tool — goldenmatch, goldencheck, goldenflow, goldenpipe, infermap"
+readme = "README.md"
+requires-python = ">=3.11,<3.14"
+license = { text = "MIT" }
+authors = [{ name = "Ben Severn", email = "benzsevern@gmail.com" }]
+keywords = ["mcp", "data-quality", "entity-resolution", "golden-suite", "claude"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+dependencies = [
+    "mcp>=1.0",
+    "goldenmatch[mcp]",
+    "goldencheck[mcp]",
+    "goldenflow[mcp]",
+    "goldenpipe[mcp]",
+    "infermap[mcp]",
+    "uvicorn>=0.30",
+    "starlette>=0.37",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8", "ruff>=0.6"]
+
+[project.scripts]
+goldensuite-mcp = "goldensuite_mcp.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/benzsevern/goldenmatch"
+Repository = "https://github.com/benzsevern/goldenmatch"
+Issues = "https://github.com/benzsevern/goldenmatch/issues"
+
+[tool.uv.sources]
+goldenmatch = { workspace = true }
+goldencheck = { workspace = true }
+goldenflow = { workspace = true }
+goldenpipe = { workspace = true }
+infermap = { workspace = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["goldensuite_mcp"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ goldencheck = { workspace = true }
 goldenflow = { workspace = true }
 goldenpipe = { workspace = true }
 infermap = { workspace = true }
+goldensuite-mcp = { workspace = true }
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

Builds out the second item from the post-monorepo "address the empty Packages sidebar" thread: an in-process MCP aggregator package plus a multi-arch container publish workflow that fills `ghcr.io/benzsevern/*` with seven images.

### Three pieces

**1. Sub-package MCP refactor** (commit `ab15387`)
Each sub-package's MCP server needs to expose a module-level `TOOLS` list and a dispatcher so the aggregator can compose them without instantiating Servers. Three packages already had this (`goldencheck`, `goldenflow`, `infermap`); two needed a lift:
- `goldenmatch`: 332-line inline tool list moved to module-level `_BASE_TOOLS`; `TOOLS = AGENT_TOOLS + _BASE_TOOLS` is now public; new `dispatch(name, args) -> dict` routes agent tools through `agent_tools._dispatch` and base tools through `_handle_tool`. Existing paths still work — no breaking changes for Railway/Smithery.
- `goldenpipe`: lift `TOOLS` + `HANDLERS` dict to module level.

**2. New package: `packages/python/goldensuite-mcp/`**
- `goldensuite_mcp.server.create_server()` builds one Server aggregating all 5 sub-packages.
- Per-package adapter functions normalize tool format (goldenflow uses dicts, others use `Tool` objects) and dispatcher shape.
- **First-wins on tool-name collisions** (per the design call). Order: goldenmatch → goldencheck → goldenflow → goldenpipe → infermap. Collisions logged at WARNING.
- CLI: `goldensuite-mcp serve [--transport stdio|http] [--port 8300]`.
- Wired into workspace via root `pyproject.toml`; added to python CI matrix.

**3. New workflow: `.github/workflows/publish-containers.yml`**
- 7 multi-arch images (amd64 + arm64) to `ghcr.io/benzsevern/*`: `goldensuite-mcp` (master), `goldenmatch-mcp`, `goldencheck-mcp`, `goldenflow-mcp`, `goldenpipe-mcp`, `infermap-mcp`, `goldenmatch-extensions`.
- Triggers: push to `main` -> `:latest` + `:main-<sha7>` (all 7); tag `<name>-v<X.Y.Z>` -> only that image with `:v<X.Y.Z>` + `:v<X.Y>` + `:latest`.
- Auth via built-in `GITHUB_TOKEN`. Cache via GH Actions, scoped per image.

## Test plan

- [ ] CI green (python ruff matrix incl. new goldensuite-mcp job)
- [ ] After merge: publish-containers.yml succeeds on main push, 7 :latest tags appear on ghcr
- [ ] Packages sidebar fills with 7 entries
- [ ] Spot-check master container starts and serves `/.well-known/mcp/server-card.json`

## Notes / follow-ups

- First-wins is documented, not enforced — users can run standalone servers if a collision matters.
- Master container is heavier (bundles all 5 packages). Per-package containers stay lean.
- pgrx Postgres extension build on arm64 (QEMU) may be slow; if it times out, split to amd64-only.