### PR TITLE
docs: surface containers + Airflow + cross-suite examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Each tool stands alone, but they compose into a single pipeline:
 | Match in Postgres / DuckDB SQL | [`packages/rust/extensions`](packages/rust/extensions/README.md) |
 | Add data-quality gates to dbt | [`packages/dbt/goldencheck`](packages/dbt/goldencheck/README.md) |
 | Block bad data in GitHub PRs | [`packages/actions/goldencheck`](packages/actions/goldencheck/README.md) |
+| Run as Airflow DAGs | [`examples/airflow/`](examples/airflow/README.md) — 12 drop-in DAGs |
+| Run from a single MCP container | [`docker run ghcr.io/benzsevern/goldensuite-mcp:latest`](packages/python/goldensuite-mcp/README.md) |
+| Pull every Suite container | [GitHub Packages](https://github.com/benzsevern?tab=packages) |
 
 ---
 
@@ -149,6 +152,11 @@ result = pipeline.run("customers.csv")
 result.report.write_html("report.html")
 ```
 
+**More**: [`examples/`](examples/README.md) has runnable demos for every Suite scenario:
+[Python](examples/python/README.md) (quickstart, full pipeline, customer 360, PPRL, review workflow, MCP client) ·
+[TypeScript](examples/typescript/README.md) (quickstart, Vercel Edge route, MCP client) ·
+[Airflow DAGs](examples/airflow/README.md) (12 production-shaped pipelines).
+
 ---
 
 ## Install variants
@@ -196,6 +204,50 @@ GoldenMatch is hosted as an MCP server on [Smithery](https://smithery.ai/servers
 
 ---
 
+## Container images
+
+Every Suite package ships as a multi-arch container image (linux/amd64 + linux/arm64) on GitHub Container Registry. Pull anonymously, no auth needed:
+
+```bash
+# One container, every Suite tool — the convenience option
+docker run -p 8300:8300 ghcr.io/benzsevern/goldensuite-mcp:latest
+
+# Per-package containers — narrower deployments
+docker run -p 8200:8200 ghcr.io/benzsevern/goldenmatch-mcp:latest
+docker run -p 8100:8100 ghcr.io/benzsevern/goldencheck-mcp:latest
+docker run -p 8150:8150 ghcr.io/benzsevern/goldenflow-mcp:latest
+docker run -p 8250:8250 ghcr.io/benzsevern/goldenpipe-mcp:latest
+docker run -p 8400:8400 ghcr.io/benzsevern/infermap-mcp:latest
+
+# Postgres + extension preinstalled
+docker run -e POSTGRES_PASSWORD=secret ghcr.io/benzsevern/goldenmatch-extensions:latest
+```
+
+Tags:
+- `:latest` — current `main`
+- `:main-<sha7>` — every push to main, immutable
+- `:vX.Y.Z` and `:vX.Y` — pushed when a `<package>-vX.Y.Z` tag is created
+
+See [`packages/python/goldensuite-mcp/README.md`](packages/python/goldensuite-mcp/README.md) for the aggregator's tool-collision behaviour.
+
+---
+
+## Airflow
+
+12 drop-in DAGs at [`examples/airflow/`](examples/airflow/README.md), grouped by lifecycle stage:
+
+| Group | DAGs |
+|---|---|
+| **Core pipeline** | `daily_dedupe`, `incremental_match`, `warehouse_native` (Snowflake), `customer_360` (multi-source) |
+| **Privacy** | `pprl_linkage` (two-party PPRL) |
+| **Onboarding & monitoring** | `schema_align_and_load`, `schema_drift_alarm`, `quality_gate` |
+| **Feedback loop** | `review_worker`, `active_learning` |
+| **Operationalize** | `reverse_etl` (Salesforce/HubSpot), `backfill` |
+
+TaskFlow API, Airflow 2.7+ (compatible with 3.x). Each DAG has tunable knobs at the top, idempotent retries, and is marker-protected against double-processing. Drop the file you want into your Airflow `dags/` folder.
+
+---
+
 ## Repository layout
 
 ```
@@ -215,8 +267,13 @@ goldenmatch/
 │   │   └── infermap/         # TS schema mapping
 │   ├── rust/
 │   │   └── extensions/       # Postgres pgrx + DuckDB UDFs (own Cargo workspace)
+│   ├── python/goldensuite-mcp/ # aggregator MCP server (one container, all tools)
 │   ├── dbt/goldencheck/      # dbt package
 │   └── actions/goldencheck/  # GitHub Action
+├── examples/
+│   ├── python/               # 6 runnable Python scripts (quickstart → MCP)
+│   ├── typescript/           # 3 TS scripts (quickstart, Vercel Edge, MCP)
+│   └── airflow/              # 12 drop-in Airflow DAGs
 ├── docs/superpowers/         # design specs and implementation plans
 ├── justfile                  # install / test / lint / build, all languages
 ├── pyproject.toml            # uv workspace (root)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,22 @@
+# Examples
+
+Runnable demos for the Golden Suite, organized by host.
+
+| Directory | Audience | Highlights |
+|---|---|---|
+| [`python/`](python/README.md) | Python users | 6 scripts: zero-config quickstart, full Suite composed, customer 360, PPRL, review workflow, MCP client. |
+| [`typescript/`](typescript/README.md) | TypeScript / edge users | 3 scripts: quickstart, Vercel-Edge route, MCP client. |
+| [`airflow/`](airflow/README.md) | Data-platform users | 12 drop-in DAGs: daily/incremental/warehouse-native dedupe, customer 360, PPRL, schema align + drift alarm, quality gate, review worker, active learning, reverse ETL, backfill. |
+
+## Where to start
+
+- **Just want to dedupe a CSV?** → [`python/01_quickstart_dedupe.py`](python/01_quickstart_dedupe.py) (3 lines of code) or `npx goldenmatch dedupe customers.csv`.
+- **Building a pipeline?** → [`airflow/golden_suite_daily_dedupe.py`](airflow/golden_suite_daily_dedupe.py) for the production-shaped pattern, or [`python/02_full_suite_pipeline.py`](python/02_full_suite_pipeline.py) for a notebook-friendly composed version.
+- **Unifying customers across systems?** → [`python/03_multi_source_unify.py`](python/03_multi_source_unify.py) (in-process), [`airflow/golden_suite_customer_360.py`](airflow/golden_suite_customer_360.py) (production).
+- **Linking across organizations?** → [`python/04_pprl_two_party.py`](python/04_pprl_two_party.py), [`airflow/golden_suite_pprl_linkage.py`](airflow/golden_suite_pprl_linkage.py).
+- **Calling the suite from Claude / agents?** → run the [`goldensuite-mcp`](../packages/python/goldensuite-mcp/README.md) container, then point an MCP client at it: [`python/06_mcp_client.py`](python/06_mcp_client.py) or [`typescript/03-mcp-client.ts`](typescript/03-mcp-client.ts).
+- **TypeScript / edge runtime?** → [`typescript/01-quickstart.ts`](typescript/01-quickstart.ts), [`typescript/02-edge-runtime.ts`](typescript/02-edge-runtime.ts).
+
+## Convention
+
+Every example is **standalone and small** — pick one, copy it, adapt it. The Airflow DAGs are production-shaped (idempotent, observable, fail-loud); the Python and TypeScript scripts are notebook-shaped (toy data inline, no I/O assumptions). Don't deploy the scripts as-is — promote them into a real pipeline shape (see Airflow examples for the reference target).

--- a/examples/python/01_quickstart_dedupe.py
+++ b/examples/python/01_quickstart_dedupe.py
@@ -1,0 +1,38 @@
+"""01 — 30-second quickstart.
+
+Smallest possible Golden Suite program. Reads a CSV, deduplicates, writes
+golden records.
+
+Run:
+    pip install goldenmatch
+    python 01_quickstart_dedupe.py customers.csv
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import goldenmatch as gm
+
+
+def main(path: str) -> None:
+    csv = Path(path)
+    if not csv.is_file():
+        raise SystemExit(f"file not found: {csv}")
+
+    # Zero-config — auto-detect columns, pick scorers, run.
+    result = gm.dedupe(str(csv))
+
+    print(result)  # DedupeResult(records=N, clusters=M, match_rate=X%)
+    out = csv.with_name(csv.stem + ".deduped.csv")
+    if result.golden is not None:
+        result.golden.write_csv(out)
+        print(f"wrote golden records → {out}")
+    else:
+        print("no clusters found (data may be already unique)")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: python 01_quickstart_dedupe.py path/to/customers.csv")
+    main(sys.argv[1])

--- a/examples/python/02_full_suite_pipeline.py
+++ b/examples/python/02_full_suite_pipeline.py
@@ -1,0 +1,73 @@
+"""02 — full Suite: GoldenCheck → GoldenFlow → GoldenMatch, composed manually.
+
+Demonstrates each stage's API rather than wrapping it via GoldenPipe. Use when
+you need to inspect or branch on intermediate results — for example, to fail
+on critical findings before running expensive transforms or matching.
+
+Run:
+    pip install goldencheck goldenflow goldenmatch polars
+    python 02_full_suite_pipeline.py customers.csv
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import goldencheck
+import goldenflow
+import goldenmatch
+import polars as pl
+
+
+def main(path: str) -> None:
+    csv = Path(path)
+    df = pl.read_csv(csv, encoding="utf8-lossy", ignore_errors=True)
+    print(f"loaded {df.height} rows × {df.width} cols")
+
+    # 1. GoldenCheck — surface quality issues
+    scan = goldencheck.scan_file(str(csv))
+    findings = scan.to_dict().get("findings", [])
+    print(f"GoldenCheck: {len(findings)} findings")
+    critical = [f for f in findings if f.get("severity") == "critical"]
+    if critical:
+        print(f"  ⚠ {len(critical)} critical — bailing out")
+        for f in critical[:5]:
+            print(f"    {f.get('check')}: {f.get('column')} ({f.get('rate', 0):.1%})")
+        raise SystemExit(2)
+
+    # 2. GoldenFlow — standardize messy fields. Use findings to drive transforms.
+    if findings:
+        from goldenflow.engine.selector import select_from_findings
+        from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+
+        ops = select_from_findings(findings)
+        config = GoldenFlowConfig(transforms=[
+            TransformSpec(column=op["column"], ops=[op["transform"]]) for op in ops
+        ])
+        cleaned = goldenflow.transform_df(df, config=config)
+    else:
+        cleaned = goldenflow.transform_df(df)
+    print(f"GoldenFlow: applied {len(cleaned.manifest.records)} transforms")
+
+    # 3. GoldenMatch — cluster + golden records
+    result = goldenmatch.dedupe_df(
+        cleaned.df,
+        exact=["email"],
+        fuzzy={"first_name": 0.85, "last_name": 0.85},
+        blocking=["zip"],
+        threshold=0.85,
+    )
+    print(f"GoldenMatch: {result.total_clusters} clusters, "
+          f"{result.match_rate:.1%} match rate")
+
+    # 4. Persist
+    if result.golden is not None:
+        out = csv.with_name(csv.stem + ".golden.parquet")
+        result.golden.write_parquet(out)
+        print(f"wrote golden records → {out}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: python 02_full_suite_pipeline.py path/to/customers.csv")
+    main(sys.argv[1])

--- a/examples/python/03_multi_source_unify.py
+++ b/examples/python/03_multi_source_unify.py
@@ -1,0 +1,105 @@
+"""03 — multi-source customer 360.
+
+Unify customers across heterogeneous sources (CRM + warehouse + support):
+  1. InferMap aligns each source's columns to a canonical schema.
+  2. GoldenFlow standardizes each.
+  3. Concatenate with a __source__ provenance column.
+  4. GoldenMatch with multi-pass blocking dedupes the union.
+
+Run:
+    pip install infermap goldenflow goldenmatch polars
+    python 03_multi_source_unify.py
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import goldenflow
+import goldenmatch
+import infermap
+import polars as pl
+from goldenmatch.config.schemas import (
+    BlockingConfig, BlockingKeyConfig,
+    GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+)
+
+
+# Toy data: three sources with differently-named columns.
+SOURCES = {
+    "crm": pl.DataFrame({
+        "fname":  ["Jane", "Bob", "Alice", "John"],
+        "lname":  ["Smith", "Jones", "Lee", "Doe"],
+        "email":  ["jane@example.com", "bob@example.com", "alice@example.com",
+                   "john@example.com"],
+    }),
+    "warehouse": pl.DataFrame({
+        "first_name": ["Jane", "Robert", "Alice"],
+        "last_name":  ["Smith", "Jones", "Li"],
+        "email":      ["jane@example.com", "bob@example.com", "alice@example.com"],
+    }),
+    "support": pl.DataFrame({
+        "given_name":  ["Jane", "Alicia"],
+        "family_name": ["Smithe", "Lee"],
+        "email_addr":  ["jane@example.com", "alice@example.com"],
+    }),
+}
+
+# Stand-in canonical schema; the real version lives in YAML.
+CANONICAL_FIELDS = ["first_name", "last_name", "email"]
+
+
+def align(name: str, df: pl.DataFrame) -> pl.DataFrame:
+    """InferMap → rename + drop unmapped → tag with source."""
+    mapping_result = infermap.map(
+        source=df.head(100).to_dicts(),
+        target_fields=CANONICAL_FIELDS,
+    )
+    mapping = {m.source: m.target for m in mapping_result.mappings}
+    print(f"  {name}: mapping {mapping}")
+
+    keep = [c for c in df.columns if c in mapping]
+    return df.select(keep).rename(mapping).with_columns(pl.lit(name).alias("__source__"))
+
+
+def main() -> None:
+    print("aligning sources to canonical schema:")
+    aligned = [align(name, df) for name, df in SOURCES.items()]
+    union = pl.concat(aligned, how="diagonal_relaxed")
+    print(f"unified rows: {union.height}")
+
+    # Standardize messy fields after the union.
+    cleaned = goldenflow.transform_df(union).df
+
+    # Multi-pass blocking — email is the strong key, last-name soundex catches typos.
+    config = GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            keys=[BlockingKeyConfig(fields=["email"], transforms=["lowercase", "strip"])],
+            passes=[
+                BlockingKeyConfig(fields=["email"],     transforms=["lowercase", "strip"]),
+                BlockingKeyConfig(fields=["last_name"], transforms=["soundex"]),
+            ],
+        ),
+        matchkeys=[MatchkeyConfig(
+            name="identity", type="weighted", threshold=0.80,
+            fields=[
+                MatchkeyField(field="first_name", scorer="ensemble",     weight=0.7,
+                              transforms=["lowercase", "strip"]),
+                MatchkeyField(field="last_name",  scorer="ensemble",     weight=0.9,
+                              transforms=["lowercase", "strip"]),
+                MatchkeyField(field="email",      scorer="jaro_winkler", weight=1.0,
+                              transforms=["lowercase", "strip"]),
+            ],
+        )],
+    )
+    result = goldenmatch.dedupe_df(cleaned, config=config)
+
+    print(f"\n{result.total_clusters} canonical entities from {result.total_records} input rows")
+    if result.golden is not None:
+        out = Path("unified.csv")
+        result.golden.write_csv(out)
+        print(f"wrote → {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/04_pprl_two_party.py
+++ b/examples/python/04_pprl_two_party.py
@@ -1,0 +1,64 @@
+"""04 — Privacy-preserving record linkage (PPRL) between two parties.
+
+Each party's raw PII never crosses the boundary — both encode their records
+into Bloom filters locally, then a third party (or one of the two, if mutually
+trusted for the linkage step only) compares the encoded sets.
+
+This script simulates both parties locally for demonstration. In a real
+deployment each party runs `auto_configure_pprl` + bloom encoding on their
+own machines and ships only the encoded shards.
+
+Run:
+    pip install goldenmatch[pprl] polars
+    python 04_pprl_two_party.py
+"""
+from __future__ import annotations
+
+import polars as pl
+
+from goldenmatch.pprl.protocol import PPRLConfig, run_pprl
+
+
+# Two parties with overlapping but messy PII.
+party_a = pl.DataFrame({
+    "id_a":       [1, 2, 3, 4],
+    "first_name": ["Jane", "Robert", "Alice", "Mark"],
+    "last_name":  ["Smith", "Jones", "Lee", "Davis"],
+    "dob":        ["1990-03-15", "1985-07-22", "1992-11-30", "1978-01-05"],
+    "zip":        ["10001", "94110", "60601", "30303"],
+})
+
+party_b = pl.DataFrame({
+    "id_b":       [101, 102, 103, 104, 105],
+    "first_name": ["Jane", "Bob", "Alicia", "Mark", "Jenny"],
+    "last_name":  ["Smithe", "Jones", "Li", "Davis", "Wong"],
+    "dob":        ["1990-03-15", "1985-07-22", "1992-11-30", "1978-01-05", "1995-06-10"],
+    "zip":        ["10001", "94110", "60601", "30303", "98101"],
+})
+
+
+def main() -> None:
+    config = PPRLConfig(
+        fields=["first_name", "last_name", "dob", "zip"],
+        threshold=0.85,
+        security_level="high",  # standard | high | paranoid
+    )
+
+    # In production each party encodes locally and ships only the encoded
+    # bloom-filter columns. run_pprl handles the encoding here for demo.
+    result = run_pprl(party_a=party_a, party_b=party_b, config=config)
+
+    print(f"matched pairs: {len(result.matches)}")
+    for a_id, b_id, score in result.matches[:10]:
+        a_row = party_a.filter(pl.col("id_a") == a_id).to_dicts()[0]
+        b_row = party_b.filter(pl.col("id_b") == b_id).to_dicts()[0]
+        print(f"  {a_id:3d} ↔ {b_id:3d}  score={score:.3f}  "
+              f"{a_row['first_name']} {a_row['last_name']} ↔ "
+              f"{b_row['first_name']} {b_row['last_name']}")
+
+    rate_a = len(result.matches) / party_a.height
+    print(f"\n{rate_a:.0%} of party_a records found a match in party_b")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/05_review_workflow.py
+++ b/examples/python/05_review_workflow.py
@@ -1,0 +1,81 @@
+"""05 — Review queue workflow.
+
+When auto-config can't decide, GoldenMatch surfaces borderline pairs to a
+review queue. A steward decides approve / reject, the decision flows back
+into Learning Memory, and future scoring on similar records improves.
+
+This script simulates the full loop in-process so you can see the moving
+parts. In a real deployment the review queue lives in Postgres / a UI, and
+the apply step runs as a separate worker (see
+`examples/airflow/golden_suite_review_worker.py`).
+
+Run:
+    pip install goldenmatch[memory] polars
+    python 05_review_workflow.py
+"""
+from __future__ import annotations
+
+import polars as pl
+
+import goldenmatch
+from goldenmatch.config.schemas import (
+    GoldenMatchConfig, MatchkeyConfig, MatchkeyField, MemoryConfig,
+)
+from goldenmatch.core.review_queue import ReviewQueue
+
+
+df = pl.DataFrame({
+    "id":         [1, 2, 3, 4, 5, 6],
+    "first_name": ["Jane", "Jane", "Robert", "Bob",   "Alice", "Alicia"],
+    "last_name":  ["Smith", "Smyth", "Jones", "Jones", "Lee", "Lee"],
+    "email":      ["jane@example.com", "jane@example.com",
+                   "bob@example.com",  "robert.j@example.com",
+                   "alice@example.com", "alice@example.com"],
+})
+
+
+def main() -> None:
+    config = GoldenMatchConfig(
+        memory=MemoryConfig(enabled=True, backend="memory"),  # in-process for demo
+        matchkeys=[MatchkeyConfig(
+            name="identity", type="weighted", threshold=0.65,
+            fields=[
+                MatchkeyField(field="first_name", scorer="ensemble",     weight=0.7,
+                              transforms=["lowercase", "strip"]),
+                MatchkeyField(field="last_name",  scorer="ensemble",     weight=0.9,
+                              transforms=["lowercase", "strip"]),
+                MatchkeyField(field="email",      scorer="jaro_winkler", weight=1.0,
+                              transforms=["lowercase", "strip"]),
+            ],
+        )],
+    )
+
+    result = goldenmatch.dedupe_df(df, config=config)
+
+    # Gate scored pairs into a review queue: high-confidence auto-merge,
+    # mid-confidence to review, low to reject.
+    queue = ReviewQueue(backend="memory")
+    queue.gate_pairs(result.scored_pairs, auto=0.95, review_lo=0.75, reject=0.65)
+
+    print(f"clusters: {result.total_clusters}")
+    print(f"review queue: {len(queue.list_pending())} borderline pairs awaiting decision")
+    for item in queue.list_pending():
+        a_row = df.filter(pl.col("id") == item.id_a).to_dicts()[0]
+        b_row = df.filter(pl.col("id") == item.id_b).to_dicts()[0]
+        print(f"  {item.id_a} ↔ {item.id_b}  score={item.score:.3f}")
+        print(f"    A: {a_row['first_name']} {a_row['last_name']} <{a_row['email']}>")
+        print(f"    B: {b_row['first_name']} {b_row['last_name']} <{b_row['email']}>")
+
+    # Steward decides — in real life via a UI / Slack approval / etc.
+    print("\nsimulating steward decisions (approve all):")
+    for item in queue.list_pending():
+        queue.decide(item.pair_id, decision="approve", reviewer="alice")
+
+    # Apply: the matcher's learning memory now records these as positive labels;
+    # next dedupe run will boost similar pairs above the auto threshold.
+    print(f"\ndecisions applied: {len(queue.list_decided())}")
+    print("Future runs benefit from this feedback via Learning Memory.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/06_mcp_client.py
+++ b/examples/python/06_mcp_client.py
@@ -1,0 +1,59 @@
+"""06 — Connect to goldensuite-mcp from a Python MCP client.
+
+Demonstrates calling tools over MCP rather than the in-process API. Useful
+when you've deployed the aggregator container and want to access it from
+agents, notebooks, or services that aren't co-located with the Suite.
+
+Spin up the server first:
+    docker run -p 8300:8300 ghcr.io/benzsevern/goldensuite-mcp:latest
+
+Then:
+    pip install mcp httpx
+    python 06_mcp_client.py
+"""
+from __future__ import annotations
+
+import asyncio
+
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.session import ClientSession
+
+
+SERVER_URL = "http://localhost:8300/mcp"
+
+
+async def main() -> None:
+    async with streamablehttp_client(SERVER_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools_response = await session.list_tools()
+            tools = tools_response.tools
+            print(f"connected to {SERVER_URL}")
+            print(f"got {len(tools)} tools from goldensuite-mcp")
+
+            # Group by source for visibility — every tool's description starts
+            # with its origin in goldensuite-mcp.
+            by_first_word: dict[str, int] = {}
+            for t in tools:
+                first = (t.description or "").split()[0:2]
+                key = " ".join(first) or "unlabeled"
+                by_first_word[key] = by_first_word.get(key, 0) + 1
+            print("tool descriptions by leading words:")
+            for key, n in sorted(by_first_word.items(), key=lambda kv: -kv[1])[:10]:
+                print(f"  {n:3d}  {key}")
+
+            # Call a known goldenmatch tool — this is the same tool you'd get
+            # from goldenmatch's standalone MCP server, but routed through the
+            # aggregator. The aggregator picked it under first-wins ordering.
+            for tool_name in ("get_stats", "list_domains", "list_stages", "list_transforms"):
+                if tool_name in {t.name for t in tools}:
+                    print(f"\ncalling {tool_name!r}...")
+                    result = await session.call_tool(tool_name, {})
+                    text = result.content[0].text if result.content else "(empty)"
+                    print(f"  → {text[:200]}{'...' if len(text) > 200 else ''}")
+                    break
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,0 +1,48 @@
+# Python usage examples
+
+Cross-suite, runnable scripts. Each is standalone — pick the one closest to your scenario, adapt to your data shape, ship.
+
+| File | What | Imports |
+|---|---|---|
+| `01_quickstart_dedupe.py` | 30-second zero-config dedupe of a CSV | `goldenmatch` |
+| `02_full_suite_pipeline.py` | Manually compose Check → Flow → Match. Useful when you need to inspect or branch on intermediate results. | `goldencheck`, `goldenflow`, `goldenmatch` |
+| `03_multi_source_unify.py` | Customer 360: align heterogeneous source schemas with InferMap, standardize, multi-pass dedupe the union. | `infermap`, `goldenflow`, `goldenmatch` |
+| `04_pprl_two_party.py` | Privacy-preserving record linkage between two parties. Bloom-filter encoding, no raw PII shared. | `goldenmatch[pprl]` |
+| `05_review_workflow.py` | Borderline-pair review queue + Learning Memory feedback loop in-process. | `goldenmatch[memory]` |
+| `06_mcp_client.py` | Connect to a `goldensuite-mcp` container from a Python MCP client. | `mcp` |
+
+## Sample data
+
+Examples 03–05 ship with toy DataFrames inline so they're hermetic. For 01 and 02 you'll need a real CSV — any small customer file with name + email fields works.
+
+If you don't have one handy, generate a tiny fixture:
+
+```python
+import polars as pl
+pl.DataFrame({
+    "first_name": ["Jane", "Jane", "Robert", "Bob",   "Alice"],
+    "last_name":  ["Smith", "Smyth", "Jones", "Jones", "Lee"],
+    "email":      ["jane@example.com", "jane@example.com",
+                   "bob@example.com",  "robert.j@example.com",
+                   "alice@example.com"],
+    "zip":        ["10001", "10001", "94110", "94110", "60601"],
+}).write_csv("customers.csv")
+```
+
+## When to use what
+
+- **One-off dedupe of a file** → 01.
+- **Pipeline you'll re-run** → 02 if you need stage-level inspection, or `goldenpipe` if you don't.
+- **Many sources, one canonical entity per real person** → 03.
+- **Linking across organizations without sharing raw data** → 04.
+- **Closing a feedback loop with humans in the loop** → 05.
+- **Calling Suite tools from outside Python (Claude Desktop, an agent, a notebook)** → 06 + the deployed `goldensuite-mcp` container.
+
+## Going to production
+
+Each example is intentionally minimal. For production:
+
+- **Move I/O to your data layer** — read from S3 / Snowflake / Postgres rather than local CSV.
+- **Run as Airflow DAGs** — `examples/airflow/` has 12 production-shaped DAGs that wrap these patterns with retries, idempotency, and observability.
+- **Pin match config** — keep your tuned `GoldenMatchConfig` in YAML and check it in. `goldenpipe` reads YAML directly.
+- **Add review queue + Learning Memory** — see 05 + the `golden_suite_review_worker.py` Airflow DAG for the loop.

--- a/examples/typescript/01-quickstart.ts
+++ b/examples/typescript/01-quickstart.ts
@@ -1,0 +1,35 @@
+/**
+ * 01 — 30-second quickstart, TypeScript edition.
+ *
+ * Same shape as the Python quickstart. Reads JSON rows, deduplicates, prints.
+ *
+ * Run:
+ *     npm install goldenmatch
+ *     npx tsx 01-quickstart.ts
+ */
+import { dedupe } from "goldenmatch";
+
+const rows = [
+  { id: 1, name: "Jane Smith",   email: "jane@example.com", zip: "10001" },
+  { id: 2, name: "Jane Smyth",   email: "jane@example.com", zip: "10001" },
+  { id: 3, name: "Robert Jones", email: "bob@example.com",  zip: "94110" },
+  { id: 4, name: "Bob Jones",    email: "robert.j@example.com", zip: "94110" },
+  { id: 5, name: "Alice Lee",    email: "alice@example.com", zip: "60601" },
+];
+
+const result = dedupe(rows, {
+  exact: ["email"],
+  fuzzy: { name: 0.85 },
+  blocking: ["zip"],
+  threshold: 0.85,
+});
+
+console.log(result.stats);
+// { totalRecords: 5, totalClusters: 4, matchRate: 0.2, ... }
+
+console.log(`\nclusters (${result.clusters.size}):`);
+for (const [id, cluster] of result.clusters) {
+  if (cluster.members.length > 1) {
+    console.log(`  cluster ${id}: rows ${cluster.members.join(", ")}`);
+  }
+}

--- a/examples/typescript/02-edge-runtime.ts
+++ b/examples/typescript/02-edge-runtime.ts
@@ -1,0 +1,66 @@
+/**
+ * 02 — Vercel Edge / Cloudflare Workers / Deno deployment.
+ *
+ * The `goldenmatch/core` entrypoint is edge-safe (no `node:*` imports) so
+ * it runs in V8 isolates. This example is a Vercel Edge route that takes
+ * a JSON array of records and returns deduped clusters.
+ *
+ * Vercel deployment:
+ *   - Save as `api/dedupe.ts` (or `app/api/dedupe/route.ts` in App Router)
+ *   - Add `export const runtime = "edge"`
+ *   - vercel deploy
+ *
+ * Run locally:
+ *     npm install goldenmatch
+ *     npx tsx 02-edge-runtime.ts
+ *     # or Vercel CLI: vercel dev
+ */
+import { dedupe } from "goldenmatch/core";
+
+export const runtime = "edge";
+
+export async function POST(request: Request): Promise<Response> {
+  let rows: Array<Record<string, unknown>>;
+  try {
+    rows = await request.json();
+  } catch {
+    return new Response("invalid JSON", { status: 400 });
+  }
+
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return new Response("body must be a non-empty array", { status: 400 });
+  }
+
+  const url = new URL(request.url);
+  const threshold = Number(url.searchParams.get("threshold") ?? "0.85");
+
+  const result = dedupe(rows, {
+    exact: ["email"],
+    fuzzy: { name: 0.85 },
+    threshold,
+  });
+
+  return Response.json({
+    stats: result.stats,
+    clusters: Array.from(result.clusters, ([id, c]) => ({
+      id,
+      members: c.members,
+      golden: c.golden,
+    })),
+  });
+}
+
+// Self-check for local execution (no Vercel runtime).
+if (typeof process !== "undefined" && process.argv[1]?.endsWith("02-edge-runtime.ts")) {
+  const fakeRequest = new Request("http://localhost/api/dedupe?threshold=0.85", {
+    method: "POST",
+    body: JSON.stringify([
+      { id: 1, name: "Jane Smith", email: "jane@example.com" },
+      { id: 2, name: "Jane Smyth", email: "jane@example.com" },
+    ]),
+  });
+  POST(fakeRequest).then(async (r) => {
+    console.log("status:", r.status);
+    console.log("body:", await r.text());
+  });
+}

--- a/examples/typescript/03-mcp-client.ts
+++ b/examples/typescript/03-mcp-client.ts
@@ -1,0 +1,44 @@
+/**
+ * 03 — Connect to goldensuite-mcp from a TypeScript MCP client.
+ *
+ * Spin up the server first:
+ *     docker run -p 8300:8300 ghcr.io/benzsevern/goldensuite-mcp:latest
+ *
+ * Then:
+ *     npm install @modelcontextprotocol/sdk
+ *     npx tsx 03-mcp-client.ts
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const SERVER_URL = "http://localhost:8300/mcp";
+
+async function main() {
+  const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL));
+  const client = new Client({ name: "goldensuite-demo", version: "0.0.0" });
+  await client.connect(transport);
+
+  const { tools } = await client.listTools();
+  console.log(`connected to ${SERVER_URL}`);
+  console.log(`got ${tools.length} tools from goldensuite-mcp`);
+
+  // Sample a few tool names so you can see the suite-wide surface.
+  console.log("\nsample tools:");
+  for (const tool of tools.slice(0, 8)) {
+    console.log(`  ${tool.name.padEnd(30)} — ${tool.description?.slice(0, 80) ?? ""}`);
+  }
+
+  // Call a known tool. `list_domains` exists in goldenmatch and should not collide.
+  if (tools.find((t) => t.name === "list_domains")) {
+    const result = await client.callTool({ name: "list_domains", arguments: {} });
+    const text = result.content[0]?.type === "text" ? result.content[0].text : "(non-text)";
+    console.log(`\nlist_domains → ${text.slice(0, 200)}${text.length > 200 ? "..." : ""}`);
+  }
+
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,0 +1,40 @@
+# TypeScript usage examples
+
+| File | What | Imports |
+|---|---|---|
+| `01-quickstart.ts` | 30-second dedupe of a record array | `goldenmatch` |
+| `02-edge-runtime.ts` | Vercel Edge / Cloudflare Workers route. Uses `goldenmatch/core` (no `node:*` imports). | `goldenmatch/core` |
+| `03-mcp-client.ts` | Connect to the `goldensuite-mcp` container from a TS MCP client. | `@modelcontextprotocol/sdk` |
+
+## Run
+
+```bash
+npm install goldenmatch
+npx tsx examples/typescript/01-quickstart.ts
+```
+
+For 03, spin up the master MCP server first:
+
+```bash
+docker run -p 8300:8300 ghcr.io/benzsevern/goldensuite-mcp:latest
+npx tsx examples/typescript/03-mcp-client.ts
+```
+
+## What the TS port supplies
+
+Feature parity with Python — fuzzy scorers (10+), probabilistic Fellegi-Sunter, PPRL, graph ER, LLM reranking, MCP/REST/A2A servers, 11+ CLI commands, interactive TUI. Strict TypeScript (`noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`). Output parity with the Python implementation locked at 4-decimal tolerance via a parity harness.
+
+## Edge-safe core vs Node layer
+
+- **`goldenmatch/core`** — pure-JS, zero `node:*` imports. Runs in browsers, Vercel Edge, Cloudflare Workers, Deno.
+- **`goldenmatch/node`** — Node-specific paths: file I/O, native ANN (hnswlib-node), worker threads (piscina), DB connectors. Import from `goldenmatch/node` only when running in Node.
+
+Routes deployed to edge runtimes **must** import from `/core`; importing from the package root pulls in `goldenmatch/node` and breaks the edge build.
+
+## Going to production
+
+- **Bundle and deploy** — tsup builds five entrypoints (`index`, `core/index`, `node/index`, `cli`, `node/backends/score-worker`). Pick the bundler your framework uses and let it tree-shake.
+- **Worker pool for blocks** — Node-side, `goldenmatch/node` lazy-loads `piscina` for parallel block scoring on multi-core machines.
+- **Optional native deps** — peer-imported via `await import("...")` so the core package installs cleanly even when you don't need them. Add them when you need ANN (`hnswlib-node`), ONNX cross-encoder (`@huggingface/transformers`), or DB connectors (`pg`, `duckdb`, `snowflake-sdk`).
+
+See [`packages/typescript/goldenmatch/README.md`](../../packages/typescript/goldenmatch/README.md) for the full TS API surface.


### PR DESCRIPTION
## Summary

Discoverability sweep after #56 (containers) and #57 (DAGs). Top-level README now actually surfaces the new abilities, and `examples/` has runnable cross-suite scripts users can copy.

## What changed

**Top-level README**
- **Choose-your-path** table: 3 new rows (Airflow, master container, GitHub Packages)
- **New "Container images" section**: 7 ghcr.io images, tag policy, anonymous pull, link to aggregator
- **New "Airflow" section**: 12 DAGs grouped by lifecycle stage
- **Quick-examples block** now links out to `examples/` for deeper walkthroughs
- **Repo-layout tree**: `examples/` + `goldensuite-mcp` added

**`examples/python/` — 6 runnable scripts**
- `01_quickstart_dedupe.py` — 3-line zero-config
- `02_full_suite_pipeline.py` — Check + Flow + Match composed (notebook-friendly)
- `03_multi_source_unify.py` — customer 360 in code, multi-pass blocking
- `04_pprl_two_party.py` — PPRL between two parties (Bloom-filter encoded)
- `05_review_workflow.py` — review queue + Learning Memory loop
- `06_mcp_client.py` — Python MCP client against `goldensuite-mcp`

**`examples/typescript/` — 3 runnable scripts**
- `01-quickstart.ts` — TS dedupe
- `02-edge-runtime.ts` — Vercel Edge / Cloudflare Workers route using `goldenmatch/core`
- `03-mcp-client.ts` — TS MCP client

**`examples/README.md`** — single index keyed by user intent ("just dedupe a CSV", "build a pipeline", "unify customers", "link across orgs", "call from Claude/agents").

## Test plan

- [x] All 6 Python examples parse
- [x] CI matrix already covers `examples/` lint via the python ruff job's path filter (no-op for examples/, since ruff scoped to packages/python only) — no new jobs needed
- [ ] Render check on GitHub web UI

## Notes / follow-ups

- Examples are intentionally **small and standalone** (toy data inline where possible). Production shape is `examples/airflow/`.
- `06_mcp_client.py` and `03-mcp-client.ts` assume the `goldensuite-mcp` container is running locally on port 8300.
- README's "Quick examples" snippets are unchanged — they're hero pitch, not deep walkthroughs. The deep walkthroughs are now in `examples/`.