### PR TITLE
ci(pages): restore https://benzsevern.github.io/goldenmatch/

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,63 @@
+name: pages
+
+# Builds the Jekyll docs site living at packages/python/goldenmatch/docs/
+# and deploys to https://benzsevern.github.io/goldenmatch/.
+#
+# The site existed pre-fold as a standalone Jekyll site; the fold-in moved
+# the source under packages/python/goldenmatch/docs/ but no Pages workflow
+# came along, so the URL has been broken. This restores it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/python/goldenmatch/docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, but don't cancel in-progress runs —
+# we want the queued build to land.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/python/goldenmatch/docs
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: packages/python/goldenmatch/docs
+
+      - uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "/goldenmatch"
+        env:
+          JEKYLL_ENV: production
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/python/goldenmatch/docs/_site/
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/packages/python/goldenmatch/docs/index.md
+++ b/packages/python/goldenmatch/docs/index.md
@@ -8,6 +8,8 @@ nav_order: 1
 
 **Entity resolution that finds duplicates in your data so you don't have to define the rules yourself.**
 
+> 🟡 **Now part of the Golden Suite monorepo.** This site documents GoldenMatch (entity resolution). The same repository hosts GoldenCheck (data quality), GoldenFlow (transforms), GoldenPipe (orchestrator), InferMap (schema mapping), the Rust SQL extensions, the dbt package, and the GitHub Action — plus a master MCP server (`goldensuite-mcp`), seven `ghcr.io` container images, and 12 drop-in Airflow DAGs. See the [repository README](https://github.com/benzsevern/goldenmatch#readme) and [`examples/`](https://github.com/benzsevern/goldenmatch/tree/main/examples) for the suite-wide picture.
+
 [![PyPI](https://img.shields.io/pypi/v/goldenmatch?color=d4a017)](https://pypi.org/project/goldenmatch/)
 [![Downloads](https://static.pepy.tech/badge/goldenmatch/month)](https://pepy.tech/projects/goldenmatch)
 [![Tests](https://github.com/benzsevern/goldenmatch/actions/workflows/ci.yml/badge.svg)](https://github.com/benzsevern/goldenmatch/actions)


### PR DESCRIPTION
## Summary

The Jekyll docs site lived at the repo root pre-fold. The fold-in moved its source under `packages/python/goldenmatch/docs/` but no Pages workflow came along, so [benzsevern.github.io/goldenmatch](https://benzsevern.github.io/goldenmatch/) has been broken since the monorepo migration. Pages config in repo settings still says \`build_type: workflow\`, just no workflow.

## What changed

- **`.github/workflows/pages.yml`** — new workflow:
  - Triggers on changes under \`packages/python/goldenmatch/docs/**\` or this workflow file, plus \`workflow_dispatch\` for manual rebuilds
  - Sets up Ruby 3.3 with \`bundler-cache: true\` scoped to the docs working directory
  - Runs \`bundle exec jekyll build --baseurl /goldenmatch\` against the existing \`_config.yml\` (just-the-docs remote theme)
  - Uploads \`_site/\` and deploys via \`actions/deploy-pages@v4\`
  - Concurrency group \`pages\`, \`cancel-in-progress: false\` so queued builds aren't dropped

- **`packages/python/goldenmatch/docs/index.md`** — adds a top-of-page banner pointing readers at the [repo README](https://github.com/benzsevern/goldenmatch#readme) and [`examples/`](https://github.com/benzsevern/goldenmatch/tree/main/examples) for the suite-wide picture.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: workflow runs successfully on \`main\` and \`benzsevern.github.io/goldenmatch\` returns 200
- [ ] Banner renders correctly on the home page
- [ ] No 404s on internal links (the existing nav structure should be unaffected)

## Notes / follow-ups

- This restores the **goldenmatch** docs only. A future PR could either build the per-package docs of the other Python packages too (each ships its own README; some have richer markdown trees) or reframe the top-level URL as a Suite landing page that links to per-package sub-paths. Out of scope for this PR.
- The Pages workflow does **not** depend on the python/typescript/rust CI jobs — it's intentionally cheap to retrigger via \`workflow_dispatch\` when content changes.