### PR TITLE
fix: address PR-review findings (review queue, PPRL, Airflow Jinja, MCP, workflow)

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -6,8 +6,9 @@ name: publish-containers
 #
 # Triggers:
 #   - push to main           -> all 7 images, tagged :latest and :main-<sha7>
-#   - tag <name>-v<X.Y.Z>    -> only that image, tagged :v<X.Y.Z>, :v<X.Y>, :latest
-#                              where <name> is one of: goldensuite-mcp, goldenmatch-mcp,
+#   - tag <name>-v<X.Y.Z>    -> only that image (matrix gated by tag prefix),
+#                              tagged :v<X.Y.Z>, :v<X.Y>, and :latest.
+#                              <name> is one of: goldensuite-mcp, goldenmatch-mcp,
 #                              goldencheck-mcp, goldenflow-mcp, goldenpipe-mcp,
 #                              infermap-mcp, goldenmatch-extensions
 #
@@ -41,24 +42,33 @@ jobs:
           - image: goldensuite-mcp
             dockerfile: packages/python/goldensuite-mcp/Dockerfile.mcp
             context: .
+            platforms: linux/amd64,linux/arm64
           - image: goldenmatch-mcp
             dockerfile: packages/python/goldenmatch/Dockerfile.mcp
             context: packages/python/goldenmatch
+            platforms: linux/amd64,linux/arm64
           - image: goldencheck-mcp
             dockerfile: packages/python/goldencheck/Dockerfile.mcp
             context: packages/python/goldencheck
+            platforms: linux/amd64,linux/arm64
           - image: goldenflow-mcp
             dockerfile: packages/python/goldenflow/Dockerfile.mcp
             context: packages/python/goldenflow
+            platforms: linux/amd64,linux/arm64
           - image: goldenpipe-mcp
             dockerfile: packages/python/goldenpipe/Dockerfile.mcp
             context: packages/python/goldenpipe
+            platforms: linux/amd64,linux/arm64
           - image: infermap-mcp
             dockerfile: packages/python/infermap/Dockerfile.mcp
             context: packages/python/infermap
+            platforms: linux/amd64,linux/arm64
           - image: goldenmatch-extensions
             dockerfile: packages/rust/extensions/Dockerfile
             context: packages/rust/extensions
+            # arm64 dropped: pgrx + Postgres + cargo build under QEMU emulation
+            # consistently OOMs / times out. Native arm64 runner would fix it.
+            platforms: linux/amd64
 
     steps:
       - uses: actions/checkout@v4
@@ -111,7 +121,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/') }}
             type=raw,value=main-{{sha}},enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
             type=match,pattern=^${{ matrix.image }}-v(.*)$,group=1
             type=match,pattern=^${{ matrix.image }}-v(\d+\.\d+)\.\d+$,group=1
@@ -126,7 +136,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           labels: ${{ steps.tags.outputs.labels }}

--- a/examples/airflow/golden_suite_active_learning.py
+++ b/examples/airflow/golden_suite_active_learning.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import pendulum
 from airflow.decorators import dag, task
+from airflow.models import Variable
 
 REVIEW_QUEUE_TABLE = "warehouse.customers_review_queue"
 
@@ -141,7 +142,7 @@ def golden_suite_active_learning():
         s3 = S3Hook(aws_conn_id="aws_default")
         try:
             current_yaml = s3.read_key(CURRENT_CONFIG_KEY,
-                                       bucket_name="{{ var.value.golden_suite_bucket }}")
+                                       bucket_name=Variable.get("golden_suite_bucket"))
             current_f1 = yaml.safe_load(current_yaml).get("training_metrics", {}).get("f1", 0.0)
         except Exception:  # noqa: BLE001
             current_f1 = 0.0
@@ -180,13 +181,13 @@ def golden_suite_active_learning():
         snapshot_key = f"{CONFIG_SNAPSHOT_PREFIX}{run_id}.yaml"
         s3.load_string(snapshot_yaml,
                        key=snapshot_key,
-                       bucket_name="{{ var.value.golden_suite_bucket }}",
+                       bucket_name=Variable.get("golden_suite_bucket"),
                        replace=True)
 
         if decision.get("promote"):
             s3.load_string(snapshot_yaml,
                            key=CURRENT_CONFIG_KEY,
-                           bucket_name="{{ var.value.golden_suite_bucket }}",
+                           bucket_name=Variable.get("golden_suite_bucket"),
                            replace=True)
             import logging
             logging.info(

--- a/examples/airflow/golden_suite_backfill.py
+++ b/examples/airflow/golden_suite_backfill.py
@@ -25,6 +25,7 @@ from typing import Any
 
 import pendulum
 from airflow.decorators import dag, task
+from airflow.models import Variable
 
 BACKFILL_PREFIX_TEMPLATE = "_backfill/{run_id}/customers/{ds}/golden.parquet"
 BACKFILL_METRICS_TABLE = "analytics.golden_suite_backfill_runs"
@@ -74,7 +75,7 @@ def golden_suite_backfill():
         import goldenmatch
         import polars as pl
 
-        bucket = "{{ var.value.golden_suite_bucket }}"
+        bucket = Variable.get("golden_suite_bucket")
         source_key = f"raw/customers/{ds}/customers.csv"
         local = Path(f"/tmp/golden_suite/backfill/{ds}/customers.csv")
         local.parent.mkdir(parents=True, exist_ok=True)

--- a/examples/airflow/golden_suite_customer_360.py
+++ b/examples/airflow/golden_suite_customer_360.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import pendulum
 from airflow.decorators import dag, task
+from airflow.models import Variable
 
 CANONICAL_SCHEMA_FILE = "/opt/airflow/dags/golden_suite/canonical_customers.yaml"
 MAPPINGS_TABLE = "warehouse.source_column_mappings"
@@ -58,7 +59,7 @@ def golden_suite_customer_360():
             local_csv = Path(f"/tmp/golden_suite/{source['name']}.csv")
             local_csv.parent.mkdir(parents=True, exist_ok=True)
             S3Hook(aws_conn_id="aws_default").get_key(
-                source["key"], "{{ var.value.golden_suite_bucket }}"
+                source["key"], Variable.get("golden_suite_bucket")
             ).download_file(Filename=str(local_csv))
             df = pl.read_csv(local_csv, encoding="utf8-lossy", ignore_errors=True)
         elif source["kind"] == "postgres":

--- a/examples/airflow/golden_suite_daily_dedupe.py
+++ b/examples/airflow/golden_suite_daily_dedupe.py
@@ -25,11 +25,12 @@ from typing import Any
 
 import pendulum
 from airflow.decorators import dag, task
+from airflow.models import Variable
 
 # -----------------------------------------------------------------------------
 # Knobs — adjust per environment
 # -----------------------------------------------------------------------------
-S3_BUCKET = "{{ var.value.golden_suite_bucket }}"  # Airflow Variable
+S3_BUCKET = Variable.get("golden_suite_bucket")  # Airflow Variable
 SOURCE_KEY_TEMPLATE = "raw/customers/{{ ds }}/customers.csv"
 GOLDEN_KEY_TEMPLATE = "golden/customers/{{ ds }}/golden.parquet"
 METRICS_TABLE = "analytics.golden_suite_runs"

--- a/examples/airflow/golden_suite_incremental_match.py
+++ b/examples/airflow/golden_suite_incremental_match.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import pendulum
 from airflow.decorators import dag, task
+from airflow.models import Variable
 
 NEW_RECORDS_PREFIX = "incoming/customers/"
 CANONICAL_TABLE = "warehouse.customers_canonical"
@@ -55,7 +56,7 @@ def golden_suite_incremental_match():
         from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
         hook = S3Hook(aws_conn_id="aws_default")
-        keys = hook.list_keys(bucket_name="{{ var.value.golden_suite_bucket }}",
+        keys = hook.list_keys(bucket_name=Variable.get("golden_suite_bucket"),
                               prefix=NEW_RECORDS_PREFIX) or []
         # Skip the prefix itself and any already-processed marker.
         return [k for k in keys if not k.endswith("/") and not k.endswith(".processed")]
@@ -93,7 +94,7 @@ def golden_suite_incremental_match():
         local_new = Path(f"/tmp/golden_suite/{new_key}")
         local_new.parent.mkdir(parents=True, exist_ok=True)
         S3Hook(aws_conn_id="aws_default").get_key(
-            new_key, "{{ var.value.golden_suite_bucket }}"
+            new_key, Variable.get("golden_suite_bucket")
         ).download_file(Filename=str(local_new))
 
         new_df = pl.read_csv(local_new, encoding="utf8-lossy", ignore_errors=True)
@@ -180,8 +181,8 @@ def golden_suite_incremental_match():
             s3.copy_object(
                 source_bucket_key=batch["key"],
                 dest_bucket_key=batch["key"] + ".processed",
-                source_bucket_name="{{ var.value.golden_suite_bucket }}",
-                dest_bucket_name="{{ var.value.golden_suite_bucket }}",
+                source_bucket_name=Variable.get("golden_suite_bucket"),
+                dest_bucket_name=Variable.get("golden_suite_bucket"),
             )
 
     new_keys = list_new_keys()

--- a/examples/airflow/golden_suite_pprl_linkage.py
+++ b/examples/airflow/golden_suite_pprl_linkage.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import pendulum
 from airflow.decorators import dag, task
+from airflow.models import Variable
 
 PARTY_A_PREFIX = "pprl/inbound/party_a/"
 PARTY_B_PREFIX = "pprl/inbound/party_b/"
@@ -59,14 +60,14 @@ def golden_suite_pprl_linkage():
         local_dir.mkdir(parents=True, exist_ok=True)
 
         hook = S3Hook(aws_conn_id="aws_default")
-        keys = hook.list_keys(bucket_name="{{ var.value.golden_suite_bucket }}",
+        keys = hook.list_keys(bucket_name=Variable.get("golden_suite_bucket"),
                               prefix=prefix) or []
         if not keys:
             raise ValueError(f"No encoded shards for {label} under {prefix}.")
 
         for key in keys:
             local = local_dir / Path(key).name
-            hook.get_key(key, "{{ var.value.golden_suite_bucket }}").download_file(
+            hook.get_key(key, Variable.get("golden_suite_bucket")).download_file(
                 Filename=str(local)
             )
         return str(local_dir)
@@ -119,9 +120,9 @@ def golden_suite_pprl_linkage():
         out_key = results_prefix.rstrip("/") + "/matches.parquet"
         s3.load_file(filename=str(local),
                      key=out_key,
-                     bucket_name="{{ var.value.golden_suite_bucket }}",
+                     bucket_name=Variable.get("golden_suite_bucket"),
                      replace=True)
-        return f"s3://{{ var.value.golden_suite_bucket }}/{out_key}"
+        return f"s3://{Variable.get("golden_suite_bucket")}/{out_key}"
 
     @task
     def audit(linkage: dict[str, Any], result_uri: str, **context) -> None:

--- a/examples/airflow/golden_suite_quality_gate.py
+++ b/examples/airflow/golden_suite_quality_gate.py
@@ -28,6 +28,7 @@ from typing import Any
 import pendulum
 from airflow.datasets import Dataset
 from airflow.decorators import dag, task
+from airflow.models import Variable
 
 WATCH_KEY_TEMPLATE = "raw/customers/{{ ds }}/customers.csv"
 
@@ -64,7 +65,7 @@ def golden_suite_quality_gate():
         local = Path(f"/tmp/golden_suite/gate/{key}")
         local.parent.mkdir(parents=True, exist_ok=True)
         S3Hook(aws_conn_id="aws_default").get_key(
-            key, "{{ var.value.golden_suite_bucket }}"
+            key, Variable.get("golden_suite_bucket")
         ).download_file(Filename=str(local))
         return str(local)
 

--- a/examples/airflow/golden_suite_schema_align_and_load.py
+++ b/examples/airflow/golden_suite_schema_align_and_load.py
@@ -24,6 +24,7 @@ from datetime import timedelta
 
 import pendulum
 from airflow.decorators import dag, task
+from airflow.models import Variable
 
 CANONICAL_SCHEMA_FILE = "/opt/airflow/dags/golden_suite/canonical_customers.yaml"
 MAPPINGS_TABLE = "warehouse.source_column_mappings"
@@ -63,7 +64,7 @@ def golden_suite_schema_align_and_load():
         local = Path(f"/tmp/golden_suite/{params['source_key']}")
         local.parent.mkdir(parents=True, exist_ok=True)
         S3Hook(aws_conn_id="aws_default").get_key(
-            params["source_key"], "{{ var.value.golden_suite_bucket }}"
+            params["source_key"], Variable.get("golden_suite_bucket")
         ).download_file(Filename=str(local))
         return str(local)
 

--- a/examples/airflow/golden_suite_schema_drift_alarm.py
+++ b/examples/airflow/golden_suite_schema_drift_alarm.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import pendulum
 from airflow.decorators import dag, task
+from airflow.models import Variable
 
 CANONICAL_SCHEMA_FILE = "/opt/airflow/dags/golden_suite/canonical_customers.yaml"
 MAPPINGS_TABLE = "warehouse.source_column_mappings"
@@ -73,7 +74,7 @@ def golden_suite_schema_drift_alarm():
         try:
             S3Hook(aws_conn_id="aws_default").get_key(
                 f"incoming/{source['name']}/_latest_sample.csv",
-                "{{ var.value.golden_suite_bucket }}",
+                Variable.get("golden_suite_bucket"),
             ).download_file(Filename=str(local))
         except Exception as exc:  # noqa: BLE001
             return {"source": source["name"], "skipped": True, "reason": str(exc)}

--- a/examples/python/04_pprl_two_party.py
+++ b/examples/python/04_pprl_two_party.py
@@ -5,8 +5,8 @@ into Bloom filters locally, then a third party (or one of the two, if mutually
 trusted for the linkage step only) compares the encoded sets.
 
 This script simulates both parties locally for demonstration. In a real
-deployment each party runs `auto_configure_pprl` + bloom encoding on their
-own machines and ships only the encoded shards.
+deployment each party runs encoding on their own machines and ships only the
+encoded shards.
 
 Run:
     pip install goldenmatch[pprl] polars
@@ -21,7 +21,7 @@ from goldenmatch.pprl.protocol import PPRLConfig, run_pprl
 
 # Two parties with overlapping but messy PII.
 party_a = pl.DataFrame({
-    "id_a":       [1, 2, 3, 4],
+    "id":         [1, 2, 3, 4],
     "first_name": ["Jane", "Robert", "Alice", "Mark"],
     "last_name":  ["Smith", "Jones", "Lee", "Davis"],
     "dob":        ["1990-03-15", "1985-07-22", "1992-11-30", "1978-01-05"],
@@ -29,7 +29,7 @@ party_a = pl.DataFrame({
 })
 
 party_b = pl.DataFrame({
-    "id_b":       [101, 102, 103, 104, 105],
+    "id":         [101, 102, 103, 104, 105],
     "first_name": ["Jane", "Bob", "Alicia", "Mark", "Jenny"],
     "last_name":  ["Smithe", "Jones", "Li", "Davis", "Wong"],
     "dob":        ["1990-03-15", "1985-07-22", "1992-11-30", "1978-01-05", "1995-06-10"],
@@ -44,20 +44,37 @@ def main() -> None:
         security_level="high",  # standard | high | paranoid
     )
 
-    # In production each party encodes locally and ships only the encoded
-    # bloom-filter columns. run_pprl handles the encoding here for demo.
-    result = run_pprl(party_a=party_a, party_b=party_b, config=config)
+    # Each party encodes locally; run_pprl handles encoding here for the demo.
+    result = run_pprl(
+        df_a=party_a, df_b=party_b, config=config,
+        party_a_id="hospital_a", party_b_id="hospital_b",
+    )
 
-    print(f"matched pairs: {len(result.matches)}")
-    for a_id, b_id, score in result.matches[:10]:
-        a_row = party_a.filter(pl.col("id_a") == a_id).to_dicts()[0]
-        b_row = party_b.filter(pl.col("id_b") == b_id).to_dicts()[0]
-        print(f"  {a_id:3d} ↔ {b_id:3d}  score={score:.3f}  "
-              f"{a_row['first_name']} {a_row['last_name']} ↔ "
-              f"{b_row['first_name']} {b_row['last_name']}")
+    print(f"linked clusters:   {len(result.clusters)}")
+    print(f"matched-pair count: {result.match_count}")
+    print(f"comparisons total:  {result.total_comparisons}")
+    print()
 
-    rate_a = len(result.matches) / party_a.height
-    print(f"\n{rate_a:.0%} of party_a records found a match in party_b")
+    # Each cluster is a list of (party_id, record_id) tuples.
+    # Show the first 10 cross-party clusters.
+    shown = 0
+    for cluster_id, members in result.clusters.items():
+        a_member = next((m for m in members if m[0] == "hospital_a"), None)
+        b_member = next((m for m in members if m[0] == "hospital_b"), None)
+        if not (a_member and b_member):
+            continue
+        a_rec = party_a.filter(pl.col("id") == a_member[1]).to_dicts()[0]
+        b_rec = party_b.filter(pl.col("id") == b_member[1]).to_dicts()[0]
+        print(f"  cluster {cluster_id}:  "
+              f"a:{a_member[1]} ↔ b:{b_member[1]}  "
+              f"{a_rec['first_name']} {a_rec['last_name']} ↔ "
+              f"{b_rec['first_name']} {b_rec['last_name']}")
+        shown += 1
+        if shown >= 10:
+            break
+
+    rate_a = result.match_count / max(party_a.height, 1)
+    print(f"\n{rate_a:.0%} of party_a records linked into a cross-party cluster")
 
 
 if __name__ == "__main__":

--- a/examples/python/05_review_workflow.py
+++ b/examples/python/05_review_workflow.py
@@ -1,16 +1,21 @@
 """05 — Review queue workflow.
 
-When auto-config can't decide, GoldenMatch surfaces borderline pairs to a
-review queue. A steward decides approve / reject, the decision flows back
-into Learning Memory, and future scoring on similar records improves.
+When matching surfaces borderline pairs, GoldenMatch's review queue captures
+them so a human can decide approve/reject. This script demonstrates the end-
+to-end loop in-process:
 
-This script simulates the full loop in-process so you can see the moving
-parts. In a real deployment the review queue lives in Postgres / a UI, and
-the apply step runs as a separate worker (see
-`examples/airflow/golden_suite_review_worker.py`).
+  1. dedupe a small dataset and collect scored pairs
+  2. partition them into auto-merge / review / auto-reject via gate_pairs()
+  3. enqueue the review-bucket pairs into a ReviewQueue
+  4. simulate a steward approving each pending item
+  5. inspect the queue's stats
+
+In production the queue lives in SQLite/Postgres (`ReviewQueue(backend="sqlite"|"postgres")`)
+and a separate worker applies decisions back to the canonical store — see
+`examples/airflow/golden_suite_review_worker.py`.
 
 Run:
-    pip install goldenmatch[memory] polars
+    pip install goldenmatch polars
     python 05_review_workflow.py
 """
 from __future__ import annotations
@@ -19,9 +24,9 @@ import polars as pl
 
 import goldenmatch
 from goldenmatch.config.schemas import (
-    GoldenMatchConfig, MatchkeyConfig, MatchkeyField, MemoryConfig,
+    GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
 )
-from goldenmatch.core.review_queue import ReviewQueue
+from goldenmatch.core.review_queue import ReviewQueue, gate_pairs
 
 
 df = pl.DataFrame({
@@ -33,16 +38,17 @@ df = pl.DataFrame({
                    "alice@example.com", "alice@example.com"],
 })
 
+JOB_NAME = "review-demo"
+
 
 def main() -> None:
     config = GoldenMatchConfig(
-        memory=MemoryConfig(enabled=True, backend="memory"),  # in-process for demo
         matchkeys=[MatchkeyConfig(
             name="identity", type="weighted", threshold=0.65,
             fields=[
-                MatchkeyField(field="first_name", scorer="ensemble",     weight=0.7,
+                MatchkeyField(field="first_name", scorer="ensemble", weight=0.7,
                               transforms=["lowercase", "strip"]),
-                MatchkeyField(field="last_name",  scorer="ensemble",     weight=0.9,
+                MatchkeyField(field="last_name",  scorer="ensemble", weight=0.9,
                               transforms=["lowercase", "strip"]),
                 MatchkeyField(field="email",      scorer="jaro_winkler", weight=1.0,
                               transforms=["lowercase", "strip"]),
@@ -52,29 +58,38 @@ def main() -> None:
 
     result = goldenmatch.dedupe_df(df, config=config)
 
-    # Gate scored pairs into a review queue: high-confidence auto-merge,
-    # mid-confidence to review, low to reject.
-    queue = ReviewQueue(backend="memory")
-    queue.gate_pairs(result.scored_pairs, auto=0.95, review_lo=0.75, reject=0.65)
-
+    # gate_pairs splits scored pairs into 3 buckets by score.
+    auto_merged, review, auto_rejected = gate_pairs(
+        result.scored_pairs,
+        merge_threshold=0.95,
+        review_threshold=0.75,
+    )
     print(f"clusters: {result.total_clusters}")
-    print(f"review queue: {len(queue.list_pending())} borderline pairs awaiting decision")
-    for item in queue.list_pending():
-        a_row = df.filter(pl.col("id") == item.id_a).to_dicts()[0]
-        b_row = df.filter(pl.col("id") == item.id_b).to_dicts()[0]
-        print(f"  {item.id_a} ↔ {item.id_b}  score={item.score:.3f}")
-        print(f"    A: {a_row['first_name']} {a_row['last_name']} <{a_row['email']}>")
-        print(f"    B: {b_row['first_name']} {b_row['last_name']} <{b_row['email']}>")
+    print(f"buckets — auto_merged={len(auto_merged)}  review={len(review)}  "
+          f"auto_rejected={len(auto_rejected)}")
+
+    # Enqueue review-bucket pairs for a human steward.
+    queue = ReviewQueue(backend="memory")
+    for id_a, id_b, score in review:
+        a = df.filter(pl.col("id") == id_a).to_dicts()[0]
+        b = df.filter(pl.col("id") == id_b).to_dicts()[0]
+        explanation = (
+            f"{a['first_name']} {a['last_name']} <{a['email']}> ↔ "
+            f"{b['first_name']} {b['last_name']} <{b['email']}> @ {score:.3f}"
+        )
+        queue.add(JOB_NAME, id_a, id_b, score, explanation)
+
+    pending = queue.list_pending(JOB_NAME)
+    print(f"\nreview queue: {len(pending)} pending")
+    for item in pending:
+        print(f"  [{item.score:.3f}] {item.explanation}")
 
     # Steward decides — in real life via a UI / Slack approval / etc.
     print("\nsimulating steward decisions (approve all):")
-    for item in queue.list_pending():
-        queue.decide(item.pair_id, decision="approve", reviewer="alice")
+    for item in pending:
+        queue.approve(JOB_NAME, item.id_a, item.id_b, decided_by="alice")
 
-    # Apply: the matcher's learning memory now records these as positive labels;
-    # next dedupe run will boost similar pairs above the auto threshold.
-    print(f"\ndecisions applied: {len(queue.list_decided())}")
-    print("Future runs benefit from this feedback via Learning Memory.")
+    print(f"\nstats: {queue.stats(JOB_NAME)}")
 
 
 if __name__ == "__main__":

--- a/examples/python/06_mcp_client.py
+++ b/examples/python/06_mcp_client.py
@@ -19,7 +19,7 @@ from mcp.client.streamable_http import streamablehttp_client
 from mcp.client.session import ClientSession
 
 
-SERVER_URL = "http://localhost:8300/mcp"
+SERVER_URL = "http://localhost:8300/mcp/"
 
 
 async def main() -> None:

--- a/examples/typescript/02-edge-runtime.ts
+++ b/examples/typescript/02-edge-runtime.ts
@@ -50,17 +50,12 @@ export async function POST(request: Request): Promise<Response> {
   });
 }
 
-// Self-check for local execution (no Vercel runtime).
-if (typeof process !== "undefined" && process.argv[1]?.endsWith("02-edge-runtime.ts")) {
-  const fakeRequest = new Request("http://localhost/api/dedupe?threshold=0.85", {
-    method: "POST",
-    body: JSON.stringify([
-      { id: 1, name: "Jane Smith", email: "jane@example.com" },
-      { id: 2, name: "Jane Smyth", email: "jane@example.com" },
-    ]),
-  });
-  POST(fakeRequest).then(async (r) => {
-    console.log("status:", r.status);
-    console.log("body:", await r.text());
-  });
-}
+// NOTE: the local-self-check that used `process.argv` lived here previously,
+// but `process` is a Node-only global and this file is meant to be edge-safe
+// (importing only from `goldenmatch/core`). Anyone copying the bottom of this
+// file into an actual edge route would hit a build error.
+//
+// To run this handler locally during development, point a tool that gives you
+// a Request-able runtime at it — e.g. `npx tsx --eval` with a small driver
+// script that imports POST and constructs a Request, or `vercel dev` against
+// the route after dropping this file at app/api/dedupe/route.ts.

--- a/examples/typescript/03-mcp-client.ts
+++ b/examples/typescript/03-mcp-client.ts
@@ -11,7 +11,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
-const SERVER_URL = "http://localhost:8300/mcp";
+const SERVER_URL = "http://localhost:8300/mcp/";
 
 async function main() {
   const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL));

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -580,7 +580,7 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
             focus = args.get("focus", "balanced")
             return [PromptMessage(
                 role="user",
-                content=PromptTextContent(
+                content=TextContent(
                     type="text",
                     text=(
                         f"I want to deduplicate my dataset with a '{focus}' focus. Walk me through it step by step:\n\n"
@@ -602,7 +602,7 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
             cluster_id = args.get("cluster_id", "0")
             return [PromptMessage(
                 role="user",
-                content=PromptTextContent(
+                content=TextContent(
                     type="text",
                     text=(
                         f"Investigate cluster {cluster_id} in detail:\n\n"
@@ -622,7 +622,7 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
             rec_b = args.get("record_b", "{}")
             return [PromptMessage(
                 role="user",
-                content=PromptTextContent(
+                content=TextContent(
                     type="text",
                     text=(
                         "Compare these two records and tell me if they're the same entity:\n\n"
@@ -638,7 +638,7 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
         elif name == "data-quality-audit":
             return [PromptMessage(
                 role="user",
-                content=PromptTextContent(
+                content=TextContent(
                     type="text",
                     text=(
                         "Run a full data quality audit on the loaded dataset:\n\n"
@@ -655,7 +655,7 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
             level = args.get("security_level", "high")
             return [PromptMessage(
                 role="user",
-                content=PromptTextContent(
+                content=TextContent(
                     type="text",
                     text=(
                         f"Help me set up privacy-preserving record linkage at '{level}' security:\n\n"
@@ -670,7 +670,7 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
 
         return [PromptMessage(
             role="user",
-            content=PromptTextContent(type="text", text=f"Unknown prompt: {name}"),
+            content=TextContent(type="text", text=f"Unknown prompt: {name}"),
         )]
 
     @server.call_tool()

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
@@ -151,7 +151,16 @@ def _aggregate() -> tuple[list[Tool], dict[str, Callable[[str, dict], dict]]]:
             all_tools.append(tool)
             name_to_dispatch[tool.name] = dispatch
             added += 1
-        logger.info("goldensuite-mcp: registered %d tools from %s", added, source_name)
+        if not tools:
+            # Sub-package import succeeded but its TOOLS list was empty. Most
+            # commonly this means the sub-package's optional [mcp] extra wasn't
+            # installed when it was imported (HAS_MCP=False -> TOOLS=[]).
+            logger.warning(
+                "goldensuite-mcp: %s registered 0 tools — is its [mcp] extra installed?",
+                source_name,
+            )
+        else:
+            logger.info("goldensuite-mcp: registered %d tools from %s", added, source_name)
 
     return all_tools, name_to_dispatch
 


### PR DESCRIPTION
## Summary

Addresses 8 of the 10 findings from the post-merge code review. (#9 was a non-issue once verified; #10 is the separate routing PR #61 the reviewer already approved.)

### Blockers — would have broken for users

**1. `examples/python/05_review_workflow.py` — full rewrite against real ReviewQueue API.** The previous version called `queue.gate_pairs(...)`, `queue.decide(...)`, `queue.list_decided()`, and `item.pair_id` — none of those exist. Real surface: module-level `gate_pairs(scored_pairs, merge_threshold, review_threshold)` returning a 3-tuple of buckets, plus `ReviewQueue.add(job_name, id_a, id_b, score, explanation)`, `.list_pending(job_name)`, `.approve(job_name, id_a, id_b, decided_by)`, `.reject(...)`. Anyone running the example would have hit `AttributeError` on the second line.

**2. `examples/python/04_pprl_two_party.py` — wrong `LinkageResult` fields.** Real shape: `.clusters` (dict[int, list[(party_id, record_id)]]), `.match_count`, `.total_comparisons`. Was iterating `.matches` as `(a_id, b_id, score)` tuples. Also fixed `run_pprl` kwargs (`df_a` / `df_b`, not `party_a` / `party_b`).

**3. 9 of 12 Airflow DAGs — Jinja inside `@task` bodies doesn't render.** TaskFlow only templates op_args/op_kwargs, not literals inside the function. Mechanical sweep across `active_learning`, `backfill`, `customer_360`, `daily_dedupe`, `incremental_match`, `pprl_linkage`, `quality_gate`, `schema_align_and_load`, `schema_drift_alarm`: replaced `\"{{ var.value.golden_suite_bucket }}\"` with `Variable.get(\"golden_suite_bucket\")` and added `from airflow.models import Variable`.

### Important

**4. `goldenmatch/mcp/server.py` — `PromptTextContent` undefined.** 6 occurrences replaced with `TextContent`. Pre-existing bug; any `get_prompt` call would `NameError`. The PR #56 refactor moved code around this without catching it.

**5. `examples/typescript/02-edge-runtime.ts` — Node `process` global in an edge-safe file.** Self-check was guarded with `typeof process !== \"undefined\"`, so it didn't crash, but it sat in a file that explicitly imports from `goldenmatch/core` (the edge-safe entrypoint). Anyone copying it into an actual edge route would hit a build error. Removed the self-check and added a comment pointing at correct local-dev paths.

**6. MCP client URLs — added trailing slash.** `http://localhost:8300/mcp` → `http://localhost:8300/mcp/`. Both `06_mcp_client.py` and `03-mcp-client.ts`. Avoids a 307 round-trip against the Starlette mount.

**7. `publish-containers.yml` — comment-vs-behavior mismatch + `goldenmatch-extensions` arm64 fix.** Header claimed tag pushes update `:latest`; they didn't. Fixed both ways: (a) the comment is now accurate, and (b) `:latest` now genuinely updates on tag pushes (gated by the existing per-step build gate, so only the targeted image is touched). Also dropped `linux/arm64` from the `goldenmatch-extensions` matrix entry — the post-merge run failed there because pgrx + Postgres + `cargo build` under QEMU consistently OOMs/times out. Native arm64 runner would fix it; that's a separate concern. `matrix.platforms` is now per-row.

**8. `goldensuite-mcp/server.py` — warn on empty TOOLS.** When a sub-package imports successfully but registers zero tools (most common cause: its `[mcp]` optional extra wasn't installed, so `HAS_MCP=False -> TOOLS=[]`), aggregator now logs a WARNING with a hint about the missing extra.

## Test plan

- [x] All 17 modified files parse cleanly (`ast.parse` on Python, `yaml.safe_load` on the workflow)
- [x] Mechanical sweep verified — no residual `\"{{ var.value.golden_suite_bucket }}\"` literals anywhere
- [x] PromptTextContent: 0 remaining occurrences
- [ ] CI run on this PR
- [ ] After merge: trigger publish-containers manually and confirm `goldenmatch-extensions` builds successfully on amd64 only
- [ ] After merge: spot-test `python examples/python/05_review_workflow.py` and `python examples/python/04_pprl_two_party.py` end-to-end

## Notes / follow-ups

- The active_learning DAG's S3 reads at module load (rendering Variable.get at parse time, not runtime) are now correct since `Variable.get(\"golden_suite_bucket\")` runs in Python directly. Airflow's parser will lookup the Variable on each DAG re-import (~periodic). If the variable isn't set, the DAG will fail to parse — fail-loud, which matches the rest of the DAG ethos.
- `goldenmatch-extensions` arm64 disabled. If you eventually want it back, options are: (a) self-hosted arm64 runner, (b) BuildKit cross-builds via pgrx's host-target separation, (c) re-enable QEMU with much higher timeout. Tracked as known follow-up.