### PR TITLE
seo(pages): canonical to bensevern.dev across the docs site

### DIFF
--- a/packages/python/goldenmatch/docs/_includes/head_custom.html
+++ b/packages/python/goldenmatch/docs/_includes/head_custom.html
@@ -1,0 +1,31 @@
+{%- comment -%}
+SEO: bensevern.dev is the canonical home for documentation. This Pages site
+serves the same content for discoverability (badges, package links, GitHub-
+indexed search), but tells search engines that bensevern.dev is the source
+of truth so link equity flows there.
+
+Mapping rule: drop the /goldenmatch baseurl prefix from page.url and append
+to https://bensevern.dev. Once bensevern.dev mirrors the same path layout,
+this resolves cleanly. If bensevern.dev hasn't published a given page yet
+the canonical 404s, but Google still treats bensevern.dev as the
+authoritative origin for the content here.
+{%- endcomment -%}
+{%- assign canonical_path = page.url | remove_first: "/goldenmatch" -%}
+{%- if canonical_path == "" -%}{%- assign canonical_path = "/" -%}{%- endif -%}
+<link rel="canonical" href="https://bensevern.dev{{ canonical_path }}">
+
+{%- comment -%}
+Open Graph / Twitter Card: point shares at bensevern.dev too. If a page is
+shared on social media, the preview links to bensevern.dev rather than
+github.io. Falls back to GoldenMatch's site title if page.title is empty.
+{%- endcomment -%}
+<meta property="og:url" content="https://bensevern.dev{{ canonical_path }}">
+<meta property="og:type" content="article">
+<meta property="og:title" content="{{ page.title | default: site.title }}">
+<meta property="og:site_name" content="bensevern.dev">
+<meta property="og:description" content="{{ page.description | default: site.description }}">
+
+<meta name="twitter:card" content="summary">
+<meta name="twitter:url" content="https://bensevern.dev{{ canonical_path }}">
+<meta name="twitter:title" content="{{ page.title | default: site.title }}">
+<meta name="twitter:description" content="{{ page.description | default: site.description }}">


### PR DESCRIPTION
## Summary

Resolves the duplicate-content concern flagged in PR #62's wrap-up: \`pages.yml\` made it onto \`main\` (via the squash-merge of #61 picking up its parent branch's changes), so the Pages site at \`benzsevern.github.io/goldenmatch\` is now active. Per the maintainer's \"unless it helps with SEO\" call, the right move is **(B)** — keep Pages live for discoverability, but route SEO credit to bensevern.dev via canonical tags.

## What this does

- New `packages/python/goldenmatch/docs/_includes/head_custom.html`
- Just-the-docs renders this into every page's `<head>`
- Adds:
  - `<link rel="canonical" href="https://bensevern.dev{{ path }}">`
  - Matching OpenGraph (`og:url`, `og:title`, `og:description`, `og:site_name=bensevern.dev`)
  - Matching Twitter Card meta

## Mapping

`{{ page.url | remove_first: "/goldenmatch" }}` so:

| Pages URL | Canonical |
|---|---|
| `/goldenmatch/` | `https://bensevern.dev/` |
| `/goldenmatch/installation/` | `https://bensevern.dev/installation/` |
| `/goldenmatch/python-api/` | `https://bensevern.dev/python-api/` |

If bensevern.dev hasn't published a given path yet, Google still treats it as the authoritative origin — the canonical resolves cleanly once the path goes live. No need to gate the Pages deploy on bensevern.dev being ready.

## SEO mechanics

- **Pages stays useful**: still indexed, still serves `:Docs` badge clicks, still aggregates GitHub-indexed search traffic.
- **bensevern.dev gets credit**: Google attributes content to the canonical URL (per [duplicate-content best practices](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)). Backlinks pointing at the github.io URL count toward bensevern.dev's authority.
- **No shadow SEO penalty**: without canonical tags, Pages and bensevern.dev would compete and split link equity.

## Test plan

- [x] Just-the-docs at v0.10.0 documents `_includes/head_custom.html` as the standard hook for `<head>` content
- [ ] After merge: `pages.yml` runs (path filter triggers on this change), site rebuilds, pages now have the canonical tag in source
- [ ] Spot-check via `curl -s https://benzsevern.github.io/goldenmatch/ | grep -i canonical` to confirm the tag emits

## Notes

If you ever want bensevern.dev to mirror these pages at a different path layout (e.g., everything under `bensevern.dev/docs/`), update the `canonical_path` assignment in `head_custom.html` accordingly. The current mapping assumes path parity with the Pages site after stripping the `/goldenmatch` baseurl.