### PR TITLE
perf(scorer): hoist matchkey transforms out of per-block loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,11 @@ jobs:
               IGNORE="--ignore=packages/python/infermap/benchmark"
               ;;
           esac
-          uv run pytest packages/python/${{ matrix.pkg }} -n auto $IGNORE
+          # --timeout=120 surfaces any hung test as a failure with a stack
+          # trace (vs the whole job timing out at 6h with zero diagnostics).
+          # PR #66 hit a goldencheck pytest hang on Linux that didn't
+          # reproduce locally — this converts that into actionable signal.
+          uv run pytest packages/python/${{ matrix.pkg }} -n auto --timeout=120 --timeout-method=thread $IGNORE
 
   typescript:
     runs-on: ubuntu-latest

--- a/docs/superpowers/plans/2026-05-04-hoist-matchkey-transforms.md
+++ b/docs/superpowers/plans/2026-05-04-hoist-matchkey-transforms.md
@@ -1,0 +1,725 @@
+# Hoist matchkey transforms — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate ~7000 redundant Polars `frame.select(...)` calls during dedupe scoring by precomputing each unique `(field, transforms)` pair once on the parent DataFrame; per-block scoring becomes an O(1) column lookup.
+
+**Architecture:** New helper `precompute_matchkey_transforms` in `core/matchkey.py` augments the working DataFrame with `__xform_<sig>__` columns (one per unique signature). Wired in once each into `_run_dedupe_pipeline` and `_run_match_pipeline`, immediately after `compute_matchkeys` so it runs before all `build_blocks` calls. `scorer._get_transformed_values` gets a fast-path lookup with the legacy path preserved as fallback for callers that bypass the pipeline.
+
+**Tech Stack:** Python 3.11+, Polars (lazy + eager APIs), pytest, hashlib (blake2b for stable signatures).
+
+**Spec:** `docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md`
+
+**Pre-existing state confirmed (2026-05-04):**
+- `_try_native_chain` lives at `packages/python/goldenmatch/goldenmatch/core/matchkey.py:13`
+- `_get_transformed_values` lives at `packages/python/goldenmatch/goldenmatch/core/scorer.py:113`
+- `_run_dedupe_pipeline` calls `compute_matchkeys` at `pipeline.py:371` and `build_blocks` at lines **407 AND 423** (weighted + probabilistic phases — single precompute covers both).
+- `_run_match_pipeline` calls `compute_matchkeys` at `pipeline.py:803` and `build_blocks` at lines **836 AND 850** (same pattern).
+- `combined_lf` is a `pl.LazyFrame` at the insertion points — the helper signature must accept LazyFrame OR materialize at call site. Plan adopts the latter (one explicit `.collect()` per pipeline) to keep the helper's API DataFrame-in/out as specified.
+- Test file already exists: `packages/python/goldenmatch/tests/test_matchkey.py` and `tests/test_scorer.py`.
+- Profile script already exists: `.profile_tmp/profile_dedupe.py` (`.profile_tmp/` is gitignored per package CLAUDE.md — do NOT commit).
+- Convention from `goldenmatch/CLAUDE.md`: TDD, test files at `tests/test_{module}.py`, internal columns use `__` prefix, conventional commits (`feat:`, `fix:`, `test:`, `chore:`).
+- GH auth: must `gh auth switch --user benzsevern` before push.
+
+**Branch:** `perf/hoist-matchkey-transforms`
+
+---
+
+## Task 1: Branch + write failing tests for the new helpers
+
+**Files:**
+- Modify: `packages/python/goldenmatch/tests/test_matchkey.py` (append)
+
+**Why:** TDD per CLAUDE.md. The new helper has 5 distinct test cases per the spec — write them all up front so the implementation has a fixed target.
+
+- [ ] **Step 1: Create branch**
+
+```bash
+git checkout main && git pull && git checkout -b perf/hoist-matchkey-transforms
+```
+
+- [ ] **Step 2: Append the 7 new tests to `tests/test_matchkey.py`**
+
+```python
+# --- Tests for precompute_matchkey_transforms (perf/hoist-matchkey-transforms) ---
+import polars as pl
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.matchkey import (
+    _xform_sig,
+    precompute_matchkey_transforms,
+)
+
+
+def _mk(name: str, fields: list[MatchkeyField], threshold: float = 0.7) -> MatchkeyConfig:
+    return MatchkeyConfig(name=name, type="weighted", threshold=threshold, fields=fields)
+
+
+def _field(field: str, transforms: list[str], scorer: str = "jaro_winkler",
+           weight: float = 1.0) -> MatchkeyField:
+    return MatchkeyField(field=field, transforms=transforms, scorer=scorer, weight=weight)
+
+
+def test_xform_sig_is_deterministic_across_processes():
+    # blake2b output is stable across processes (unlike Python's salted hash()).
+    f1 = _field("name", ["lowercase", "strip"])
+    f2 = _field("name", ["lowercase", "strip"])
+    assert _xform_sig(f1) == _xform_sig(f2)
+    # Hex digest: stable shape.
+    sig = _xform_sig(f1)
+    assert sig.startswith("__xform_name_") and sig.endswith("__")
+    assert len(sig) > len("__xform_name___")  # has digest body
+
+
+def test_precompute_matchkey_transforms_dedups_signatures():
+    # Same field+transforms across two matchkeys → ONE column, not two.
+    df = pl.DataFrame({"name": ["Alice", "BOB"]})
+    mk_a = _mk("a", [_field("name", ["lowercase"])])
+    mk_b = _mk("b", [_field("name", ["lowercase"])])
+    out = precompute_matchkey_transforms(df, [mk_a, mk_b])
+    xform_cols = [c for c in out.columns if c.startswith("__xform_")]
+    assert len(xform_cols) == 1
+
+
+def test_precompute_matchkey_transforms_distinct_transforms_same_field():
+    # Same field with two different transform chains → two distinct columns.
+    df = pl.DataFrame({"name": ["Alice"]})
+    mk = _mk("m", [
+        _field("name", ["lowercase"]),
+        _field("name", ["uppercase"]),
+    ])
+    out = precompute_matchkey_transforms(df, [mk])
+    xform_cols = sorted(c for c in out.columns if c.startswith("__xform_"))
+    assert len(xform_cols) == 2
+    assert out[xform_cols[0]].to_list() != out[xform_cols[1]].to_list()
+
+
+def test_precompute_matchkey_transforms_native_chain_path():
+    # lowercase + strip is in _NATIVE_TRANSFORMS — fast path runs.
+    df = pl.DataFrame({"name": ["  Alice  ", "BOB"]})
+    mk = _mk("m", [_field("name", ["lowercase", "strip"])])
+    out = precompute_matchkey_transforms(df, [mk])
+    sig = _xform_sig(_field("name", ["lowercase", "strip"]))
+    assert out[sig].to_list() == ["alice", "bob"]
+
+
+def test_precompute_matchkey_transforms_python_fallback_path():
+    # soundex is NOT in the native chain (per matchkey.py _try_native_transform);
+    # falls through to apply_transforms per-row.
+    df = pl.DataFrame({"name": ["Smith", "Smyth"]})
+    mk = _mk("m", [_field("name", ["soundex"])])
+    out = precompute_matchkey_transforms(df, [mk])
+    sig = _xform_sig(_field("name", ["soundex"]))
+    vals = out[sig].to_list()
+    # Smith and Smyth share a Soundex code (S530).
+    assert vals[0] == vals[1]
+
+
+def test_precompute_matchkey_transforms_skips_record_embedding():
+    # record_embedding fields use field.columns (plural), not field.field.
+    # Including them would crash on df["__record__"]. Helper must skip them.
+    df = pl.DataFrame({"name": ["a"], "desc": ["b"]})
+    mk = MatchkeyConfig(name="m", type="weighted", threshold=0.5, fields=[
+        MatchkeyField(field="__record__", transforms=[], scorer="record_embedding",
+                      weight=1.0, columns=["name", "desc"]),
+        _field("name", ["lowercase"]),  # this one should still be precomputed
+    ])
+    out = precompute_matchkey_transforms(df, [mk])
+    assert "__record__" not in out.columns
+    sig_name = _xform_sig(_field("name", ["lowercase"]))
+    assert sig_name in out.columns
+
+
+def test_precompute_matchkey_transforms_skips_empty_transforms():
+    # Empty transforms list → no precompute (legacy path is already a no-op).
+    df = pl.DataFrame({"name": ["Alice"]})
+    mk = _mk("m", [_field("name", [])])
+    out = precompute_matchkey_transforms(df, [mk])
+    xform_cols = [c for c in out.columns if c.startswith("__xform_")]
+    assert xform_cols == []
+```
+
+- [ ] **Step 3: Run tests — verify they all FAIL with `ImportError`**
+
+```bash
+cd /d/show_case/goldenmatch && uv run pytest packages/python/goldenmatch/tests/test_matchkey.py -v -k "xform_sig or precompute_matchkey"
+```
+
+Expected: 7 failures, all `ImportError: cannot import name '_xform_sig' / 'precompute_matchkey_transforms' from 'goldenmatch.core.matchkey'`
+
+- [ ] **Step 4: Commit failing tests**
+
+```bash
+git add packages/python/goldenmatch/tests/test_matchkey.py
+git commit -m "test: add failing tests for precompute_matchkey_transforms helper"
+```
+
+---
+
+## Task 2: Implement `_xform_sig` + `precompute_matchkey_transforms`
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/matchkey.py`
+
+**Why:** Make Task 1's tests pass. Implementation is verbatim from the spec.
+
+- [ ] **Step 1: Add the helper at the end of `matchkey.py`**
+
+Append after the existing `compute_matchkeys` function:
+
+```python
+import hashlib  # add at top of file with other stdlib imports if not present
+
+
+def _xform_sig(field: MatchkeyField) -> str:
+    """Stable, process-independent signature for a (field, transforms) pair.
+
+    Uses blake2b rather than Python's salted hash() so the resulting column
+    name is deterministic across processes — makes debugging dumps diffable
+    and avoids spooky cross-run differences in error messages.
+    """
+    digest = hashlib.blake2b(
+        repr(field.transforms).encode(), digest_size=8
+    ).hexdigest()
+    return f"__xform_{field.field}_{digest}__"
+
+
+def precompute_matchkey_transforms(
+    df: pl.DataFrame, matchkeys: list[MatchkeyConfig]
+) -> pl.DataFrame:
+    """Add one __xform_<sig>__ column per unique (field, transforms) signature.
+
+    Same field+transforms across multiple matchkeys reuses one column — dedup
+    is automatic via the signature. Native chains use _try_native_chain (Rust);
+    non-native chains fall back to Python per-row apply_transforms once.
+
+    Skips fields whose scorer is `record_embedding` (uses multi-column
+    `field.columns`, has its own scoring path that doesn't call
+    `_get_transformed_values`).
+
+    Skips fields with empty `transforms` list — nothing to precompute, and
+    `_get_transformed_values`' legacy path is already a single `to_list()`.
+
+    Returns the augmented DataFrame. Original columns are untouched.
+    """
+    seen: set[str] = set()
+    new_cols: list[pl.Series] = []
+    for mk in matchkeys:
+        for field in mk.fields:
+            if field.scorer == "record_embedding":
+                continue
+            if not field.transforms:
+                continue
+            sig = _xform_sig(field)
+            if sig in seen or sig in df.columns:
+                continue
+            seen.add(sig)
+
+            native_expr = _try_native_chain(field.field, field.transforms)
+            if native_expr is not None:
+                col = df.select(native_expr.alias(sig))[sig]
+            else:
+                values = df[field.field].to_list()
+                col = pl.Series(
+                    sig,
+                    [apply_transforms(v, field.transforms) if v is not None else None
+                     for v in values],
+                )
+            new_cols.append(col)
+
+    if not new_cols:
+        return df
+    return df.with_columns(new_cols)
+```
+
+- [ ] **Step 2: Verify the new tests pass**
+
+```bash
+uv run pytest packages/python/goldenmatch/tests/test_matchkey.py -v -k "xform_sig or precompute_matchkey"
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 3: Verify the rest of `test_matchkey.py` still passes (no regression)**
+
+```bash
+uv run pytest packages/python/goldenmatch/tests/test_matchkey.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit the helper**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/matchkey.py
+git commit -m "feat(matchkey): add precompute_matchkey_transforms helper
+
+Hoists each unique (field, transforms) signature to its own __xform_<sig>__
+column on the parent DataFrame. Setup for eliminating per-block redundant
+Polars .select() calls in scorer._get_transformed_values."
+```
+
+---
+
+## Task 3: Wire `_get_transformed_values` to use the precomputed columns
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/scorer.py:113-127`
+- Modify: `packages/python/goldenmatch/tests/test_scorer.py` (append 2 tests)
+
+**Why:** The hot path. Spec section 3.
+
+- [ ] **Step 1: Append 2 new tests to `tests/test_scorer.py`**
+
+```python
+# --- Tests for _get_transformed_values fast-path (perf/hoist-matchkey-transforms) ---
+import polars as pl
+from goldenmatch.config.schemas import MatchkeyField
+from goldenmatch.core.matchkey import _xform_sig, precompute_matchkey_transforms
+from goldenmatch.core.scorer import _get_transformed_values
+
+
+def test_get_transformed_values_uses_precomputed_column_when_present():
+    # If a __xform_*__ column matches the field signature, the fast path
+    # reads it directly — no Polars .select() round-trip.
+    field = MatchkeyField(field="name", transforms=["lowercase"],
+                          scorer="jaro_winkler", weight=1.0)
+    sig = _xform_sig(field)
+    block_df = pl.DataFrame({
+        "name": ["Alice", "BOB"],
+        sig: ["PRECOMPUTED_A", "PRECOMPUTED_B"],  # sentinel — proves we read this, not the raw column
+    })
+    assert _get_transformed_values(block_df, field) == ["PRECOMPUTED_A", "PRECOMPUTED_B"]
+
+
+def test_get_transformed_values_falls_back_when_column_absent():
+    # Without the precomputed column, behavior must be identical to the
+    # legacy path — regression pin for callers that bypass the pipeline
+    # (DataFrame entry points, tests calling find_fuzzy_matches directly).
+    field = MatchkeyField(field="name", transforms=["lowercase"],
+                          scorer="jaro_winkler", weight=1.0)
+    block_df = pl.DataFrame({"name": ["Alice", "BOB"]})
+    assert _get_transformed_values(block_df, field) == ["alice", "bob"]
+```
+
+- [ ] **Step 2: Run them — verify the first FAILS, second PASSES (legacy path already works)**
+
+```bash
+uv run pytest packages/python/goldenmatch/tests/test_scorer.py -v -k "get_transformed_values"
+```
+
+Expected: 1 fail (`assert ['alice', 'bob'] == ['PRECOMPUTED_A', 'PRECOMPUTED_B']`), 1 pass.
+
+- [ ] **Step 3: Update `_get_transformed_values` in `scorer.py:113`**
+
+Replace the function body (keep signature, keep docstring intent):
+
+```python
+def _get_transformed_values(block_df: pl.DataFrame, field: MatchkeyField) -> list:
+    """Get transformed values for a field as a list.
+
+    Fast path: read the precomputed __xform_*__ column populated by
+    precompute_matchkey_transforms (called once per pipeline run, eagerly,
+    before blocking). Avoids ~7000 redundant Polars .select() calls per
+    dedupe.
+
+    Fallback path: legacy per-block .select(_try_native_chain(...)) for
+    callers that bypass the pipeline (DataFrame entry points, tests calling
+    find_fuzzy_matches directly).
+    """
+    from goldenmatch.core.matchkey import _xform_sig, _try_native_chain
+
+    sig = _xform_sig(field)
+    if sig in block_df.columns:
+        return block_df[sig].to_list()
+
+    # Legacy path — preserved verbatim from before the perf change.
+    col = field.field
+    native_expr = _try_native_chain(col, field.transforms)
+    if native_expr is not None:
+        result_df = block_df.select(native_expr.alias("__tmp__"))
+        return result_df["__tmp__"].to_list()
+    values = block_df[col].to_list()
+    return [apply_transforms(v, field.transforms) if v is not None else None for v in values]
+```
+
+(The `apply_transforms` import was already present at the top of `scorer.py` — verify it's still imported. If not, add `from goldenmatch.utils.transforms import apply_transforms`.)
+
+- [ ] **Step 4: Verify both new scorer tests pass**
+
+```bash
+uv run pytest packages/python/goldenmatch/tests/test_scorer.py -v -k "get_transformed_values"
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Verify the rest of `test_scorer.py` still passes (regression check)**
+
+```bash
+uv run pytest packages/python/goldenmatch/tests/test_scorer.py -v
+```
+
+Expected: all green (modulo any pre-existing failures on this branch — record the baseline pass/fail count from `git stash` + run on main if any failures look surprising).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/scorer.py packages/python/goldenmatch/tests/test_scorer.py
+git commit -m "perf(scorer): fast-path _get_transformed_values via precomputed column
+
+Reads the __xform_<sig>__ column written by precompute_matchkey_transforms
+when present; falls back to the legacy Polars .select() path otherwise.
+No behavior change for callers that bypass the pipeline."
+```
+
+---
+
+## Task 4: Add an end-to-end equivalence test
+
+**Files:**
+- Modify: `packages/python/goldenmatch/tests/test_scorer.py` (append)
+
+**Why:** Pin that scoring with vs without precompute returns identical results on a small synthetic block. Catches any future drift in the fast-path lookup.
+
+- [ ] **Step 1: Append the equivalence test**
+
+```python
+def test_find_fuzzy_matches_identical_results_with_and_without_precompute():
+    # Score the same block twice — once with the precomputed __xform_*__ column,
+    # once without. Pair lists must match exactly.
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+    from goldenmatch.core.scorer import find_fuzzy_matches
+    from goldenmatch.core.matchkey import precompute_matchkey_transforms
+
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "name": ["Alice Smith", "Alice Smyth", "Bob Jones", "Robert Jones"],
+        "zip": ["10001", "10001", "20002", "20002"],
+    })
+    mk = MatchkeyConfig(
+        name="m", type="weighted", threshold=0.6,
+        fields=[
+            MatchkeyField(field="name", transforms=["lowercase", "strip"],
+                          scorer="jaro_winkler", weight=0.7),
+            MatchkeyField(field="zip", transforms=["strip"],
+                          scorer="exact", weight=0.3),
+        ],
+    )
+
+    pairs_legacy = sorted(find_fuzzy_matches(df, mk))
+    pairs_precomputed = sorted(find_fuzzy_matches(
+        precompute_matchkey_transforms(df, [mk]), mk
+    ))
+    assert pairs_legacy == pairs_precomputed
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+uv run pytest packages/python/goldenmatch/tests/test_scorer.py::test_find_fuzzy_matches_identical_results_with_and_without_precompute -v
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/python/goldenmatch/tests/test_scorer.py
+git commit -m "test(scorer): pin end-to-end equivalence of precompute vs legacy path"
+```
+
+---
+
+## Task 5: Wire precompute into both pipelines
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/pipeline.py`
+
+**Why:** Spec section 2. Inserts the actual perf win.
+
+- [ ] **Step 1: Add the import near the top of `pipeline.py`**
+
+Find the existing `from goldenmatch.core.matchkey import compute_matchkeys` import (around line 16). Replace with:
+
+```python
+from goldenmatch.core.matchkey import compute_matchkeys, precompute_matchkey_transforms
+```
+
+- [ ] **Step 2: Modify the existing `.collect()` in `_run_dedupe_pipeline`**
+
+The dedupe pipeline already collects the LazyFrame right after `compute_matchkeys` (currently line 374: `collected_df = combined_lf.collect()`). Augment that collect with the precompute and rebuild `combined_lf` so downstream `build_blocks` (lines 407, 423) sees the new columns AND `collected_df` (used for `_run_auto_suggest`, source_lookup) is kept in sync.
+
+Find this block in `_run_dedupe_pipeline`:
+
+```python
+    combined_lf = compute_matchkeys(combined_lf, matchkeys)
+
+    # ── Step 2.5: AUTO-SUGGEST blocking keys ──
+    collected_df = combined_lf.collect()
+```
+
+Replace with:
+
+```python
+    combined_lf = compute_matchkeys(combined_lf, matchkeys)
+
+    # ── Step 2.5: AUTO-SUGGEST blocking keys ──
+    # Hoist matchkey transforms onto the materialized df once — eliminates
+    # ~7000 redundant per-block .select() calls during scoring (folds into the
+    # existing collect; no extra materialization). See spec
+    # docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md.
+    collected_df = precompute_matchkey_transforms(combined_lf.collect(), matchkeys)
+    combined_lf = collected_df.lazy()
+```
+
+- [ ] **Step 3: Modify the existing `.collect()` in `_run_match_pipeline`**
+
+Same shape — the match pipeline also already collects right after `compute_matchkeys` (currently line 804: `combined_df = combined_lf.collect()`).
+
+Find this block in `_run_match_pipeline`:
+
+```python
+    # ── Step 3: Compute matchkeys ──
+    combined_lf = compute_matchkeys(combined_lf, matchkeys)
+    combined_df = combined_lf.collect()
+```
+
+Replace with:
+
+```python
+    # ── Step 3: Compute matchkeys ──
+    combined_lf = compute_matchkeys(combined_lf, matchkeys)
+    # Hoist matchkey transforms — see spec
+    # docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md.
+    combined_df = precompute_matchkey_transforms(combined_lf.collect(), matchkeys)
+    combined_lf = combined_df.lazy()
+```
+
+This keeps `combined_df` (used at line 811 for source_lookup) populated with the new `__xform_*__` columns and lets `build_blocks` at lines 836, 850 see them via `combined_lf`.
+
+- [ ] **Step 4: Run a small dedupe smoke test to verify pipeline integration**
+
+```bash
+uv run python -c "
+import goldenmatch as gm
+import csv, tempfile
+from pathlib import Path
+tmp = Path(tempfile.mkdtemp()) / 't.csv'
+with open(tmp, 'w', newline='') as f:
+    w = csv.writer(f); w.writerow(['id','name','email','zip'])
+    w.writerow([1,'Alice Smith','alice@x.com','10001'])
+    w.writerow([2,'Alice Smyth','alice@x.com','10001'])
+    w.writerow([3,'Bob Jones','bob@y.com','20002'])
+r = gm.dedupe(str(tmp), exact=['email'], fuzzy={'name': 0.8}, blocking=['zip'])
+print(f'OK: clusters={r.total_clusters} pairs={len(r.scored_pairs)}')
+"
+```
+
+Expected: `OK: clusters=...` (some non-zero number, no exception).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/pipeline.py
+git commit -m "perf(pipeline): hoist matchkey transforms before block scoring
+
+Calls precompute_matchkey_transforms once per pipeline (after compute_matchkeys,
+before build_blocks) so the per-block scorer reads precomputed columns instead
+of re-running native chains 7000+ times per dedupe.
+
+Wired into both _run_dedupe_pipeline and _run_match_pipeline."
+```
+
+---
+
+## Task 6: Run the full goldenmatch test suite
+
+**Why:** Drop-in compatibility check per spec acceptance. The 1319-test suite (per CLAUDE.md) must stay green modulo the pre-fold ignore list.
+
+- [ ] **Step 1: Run the suite with the ignore list from `goldencheck` package CLAUDE.md**
+
+```bash
+uv run pytest packages/python/goldenmatch -n auto \
+  --ignore=packages/python/goldenmatch/tests/test_db.py \
+  --ignore=packages/python/goldenmatch/tests/test_reconcile.py \
+  --ignore=packages/python/goldenmatch/tests/test_mcp_and_watch.py \
+  --ignore=packages/python/goldenmatch/tests/test_embedder.py \
+  --ignore=packages/python/goldenmatch/tests/test_llm_boost.py \
+  2>&1 | tail -20
+```
+
+Expected: all pass (or same baseline pass/fail count as `main`). Capture the final `N passed, M failed` line.
+
+- [ ] **Step 2: If new failures appear (failures NOT in the same set as `main`), STOP and triage**
+
+For each new failure: read the error, decide whether it's caused by the precompute change. The fast-path's signature-based lookup is the most likely suspect. If a test exercises a custom matchkey transform not covered by `_try_native_chain`, the fallback path should engage automatically — verify by adding a print of `sig in block_df.columns` to the failing test temporarily.
+
+If all new failures are unrelated (e.g., flaky integration tests), proceed.
+
+- [ ] **Step 3: No commit needed (verification only)**
+
+---
+
+## Task 7: Capture before/after performance numbers
+
+**Why:** Acceptance criterion from spec — `_get_transformed_values` cumulative time drops from ~8.97s to <1s on the 10k synthetic, end-to-end ≥2x.
+
+- [ ] **Step 1: Run the existing profile script on the branch (after-numbers)**
+
+```bash
+uv run python .profile_tmp/profile_dedupe.py 2>&1 | tail -50 > .profile_tmp/profile_after.txt
+cat .profile_tmp/profile_after.txt
+```
+
+Capture from the output:
+- `_get_transformed_values` cumtime
+- Total wall-clock (the `Total wall: X ms` line)
+- `frame.select` cumtime
+
+- [ ] **Step 2: Stash, switch to main, run again for the before-numbers**
+
+```bash
+git stash
+git checkout main
+uv run python .profile_tmp/profile_dedupe.py 2>&1 | tail -50 > .profile_tmp/profile_before.txt
+git checkout perf/hoist-matchkey-transforms
+git stash pop
+```
+
+(`.profile_tmp/` is gitignored, so the `before`/`after` text files are not committed — they only feed the PR description.)
+
+- [ ] **Step 3: Verify acceptance**
+
+The synthetic must show: `_get_transformed_values` cumtime < 1s AND total wall < 5.5s on the branch.
+
+If `_get_transformed_values` doesn't drop substantially: the fast path isn't being hit. Check that `precompute_matchkey_transforms` actually added columns (print `[c for c in combined_lf.collect_schema().names() if c.startswith('__xform_')]` from a debug branch).
+
+If `_get_transformed_values` drops to near-zero but total wall doesn't improve ≥2x: the bottleneck has shifted; report the new top-3 hot functions in the PR for the next item to look at.
+
+- [ ] **Step 4: No commit needed (numbers go in PR description)**
+
+---
+
+## Task 8: Update parent checklist with measured result
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-02-performance-audit-checklist.md`
+
+**Why:** Mirror the pattern_consistency entry — hypothesis → measured reality → decision. Keeps future work honest.
+
+- [ ] **Step 1: Replace the placeholder for the now-implemented item**
+
+Find the section under `## Runtime — Engine speed` near the entry currently noting the unmeasured items. Replace whatever bullet currently corresponds to "biggest single runtime win" / scoring path with:
+
+```markdown
+- [x] **Hoist matchkey transforms out of per-block scoring** — measured, shipped
+  - File: `packages/python/goldenmatch/goldenmatch/core/scorer.py:113` + `core/matchkey.py` + `core/pipeline.py`
+  - Hypothesis (cProfile, 2026-05-04): `_get_transformed_values` was 8.97s / 78% of an 11.4s 10k-row dedupe — 7028 redundant Polars `.select()` calls.
+  - Reality (measured 2026-05-04 on branch): `_get_transformed_values` <BEFORE>ms → <AFTER>ms (<MULT>x). End-to-end <BEFORE>ms → <AFTER>ms (<MULT>x). See PR #<N>.
+  - Decision: shipped. Per-spec `docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md`.
+```
+
+(Replace `<BEFORE>`/`<AFTER>`/`<MULT>`/`<N>` with the Task 7 numbers and the eventual PR number — easiest to do this AFTER the PR is open and update the file as a follow-up commit.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-02-performance-audit-checklist.md
+git commit -m "docs(perf-audit): mark hoist-matchkey-transforms shipped with measured numbers"
+```
+
+---
+
+## Task 9: Push, open PR, attach numbers
+
+- [ ] **Step 1: Switch gh auth to personal account (per CLAUDE.md)**
+
+```bash
+gh auth switch --user benzsevern
+gh auth status 2>&1 | grep "Active account"
+```
+
+Expected: shows `benzsevern` active.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin perf/hoist-matchkey-transforms
+```
+
+- [ ] **Step 3: Open the PR using the captured numbers**
+
+```bash
+gh pr create --title "perf(scorer): hoist matchkey transforms out of per-block loop" --body "$(cat <<'EOF'
+## Summary
+
+Eliminates ~7000 redundant Polars `frame.select(...)` calls per dedupe by precomputing each unique `(field, transforms)` pair once on the parent DataFrame. Per-block scoring becomes an O(1) column lookup.
+
+cProfile of a representative 10k-row dedupe (before this PR) showed `scorer._get_transformed_values` consuming **8.97s of 11.4s wall (78%)** with 7028 calls. Each call invoked `block_df.select(_try_native_chain(...))` even though the same value was being transformed the same way per block.
+
+This PR adds `precompute_matchkey_transforms` in `core/matchkey.py`, wires it into both pipelines (`_run_dedupe_pipeline`, `_run_match_pipeline`) right after `compute_matchkeys` so its output flows through every `build_blocks` call, and updates `scorer._get_transformed_values` to read precomputed `__xform_<sig>__` columns when present (with the legacy path preserved for callers that bypass the pipeline).
+
+## Numbers (10k synthetic dedupe, `.profile_tmp/profile_dedupe.py`)
+
+| Metric | Before | After | Speedup |
+|---|---|---|---|
+| `_get_transformed_values` cumtime | <BEFORE>ms | <AFTER>ms | <MULT>x |
+| `frame.select` cumtime | <BEFORE>ms | <AFTER>ms | <MULT>x |
+| End-to-end wall | <BEFORE>ms | <AFTER>ms | <MULT>x |
+
+## Spec + plan
+
+- Spec: `docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md`
+- Plan: `docs/superpowers/plans/2026-05-04-hoist-matchkey-transforms.md`
+
+## Test plan
+
+- [ ] CI green
+- [ ] All 1319 goldenmatch tests pass (modulo the pre-fold ignore list)
+- [ ] 9 new tests added covering: signature determinism, dedup, distinct transforms on same field, native + Python paths, record_embedding skip, empty-transforms skip, end-to-end equivalence, fast-path lookup, fallback path
+- [ ] Manual smoke: `gm.dedupe(small_csv, exact=['email'], fuzzy={'name': 0.8}, blocking=['zip'])` returns expected clusters
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Update PR body with the actual numbers from Task 7**
+
+If you couldn't substitute the numbers in the heredoc (Bash escaping issues), use:
+```bash
+gh pr edit <PR#> --body "$(cat new_body.md)"
+```
+
+- [ ] **Step 5: Switch gh auth back to work account**
+
+```bash
+gh auth switch --user benzsevern-mjh
+```
+
+---
+
+## Acceptance verification (run before requesting merge)
+
+- [ ] **A1:** All tasks completed; branch pushed; PR open.
+- [ ] **A2:** `_get_transformed_values` cumulative time drops from ~8.97s to **<1s** on the synthetic 10k workload.
+- [ ] **A3:** End-to-end wall improves by **≥2x** (≤5.5s vs 11.4s baseline). If <2x, ship anyway per spec — the structural cleanup is worth it independent of magnitude.
+- [ ] **A4:** Full goldenmatch suite passes with no regressions vs main (same baseline failure set, no new failures).
+- [ ] **A5:** PR body contains real before/after numbers (not the `<BEFORE>` placeholders).
+- [ ] **A6:** Parent checklist updated with the measured result.
+
+---
+
+## Risk reminders during execution
+
+- **`_xform_sig` collision** (theoretical): blake2b 64-bit. ~3e-14 collision probability for <1000 signatures. If anyone trips this, increase `digest_size` to 16. Don't worry about it preemptively.
+- **Lazy/eager boundary in pipeline** — the spec's helper takes `pl.DataFrame`. The pipeline call site does `combined_lf.collect()` then `.lazy()` to re-enter the lazy chain. This forces one materialization that wouldn't have happened on `main`. Acceptable cost (single-call op) and observable in the profile if it's not.
+- **Custom matchkey transforms** (plugin system, per `goldenmatch/CLAUDE.md`) — the Python fallback path handles these. If a plugin transform mutates external state (it shouldn't — transforms are documented as pure), precomputation could surface latent bugs. Existing test surface protects against this.
+
+---
+
+## Out of scope (explicit)
+
+- The 1.79s `_build_static_blocks` opportunity — separate item.
+- Cross-process caching / serialized transform output — adds invalidation surface; not worth it for single-call ops.
+- Refactoring the standardize step — different concept (global cleanup vs per-matchkey scoring prep).
+- Changing what gets transformed or how — pure plumbing change.

--- a/docs/superpowers/specs/2026-05-02-performance-audit-checklist.md
+++ b/docs/superpowers/specs/2026-05-02-performance-audit-checklist.md
@@ -28,9 +28,9 @@ Items are roughly ordered by ROI within each section. Check off as we go; we wil
   - Problem: `call_llm()` is one synchronous `messages.create()` per finding. 50 findings = 50 round-trips.
   - Fix: async parallelism with `asyncio.gather`, or use Anthropic's batch API for offline runs.
 
-- [x] **Verify the Rust core is actually on the hot path** — diagnosed, N/A
+- [~] **Verify the Rust core is actually on the hot path** — diagnosed, N/A
   - Diagnosis (2026-05-04): no Rust core exists for goldenmatch's Python path. `packages/rust/extensions/` is the *Postgres/DuckDB SQL surface* — Rust calls Python via PyO3, not the other way around. Audit's framing was a misread of the architecture.
-  - Decision: nothing to do. Item closed.
+  - Decision: nothing to do. Item closed (premise was wrong, not "shipped" — using `[~]` to match the pattern_consistency convention for non-shipped items).
 
 - [x] **Hoist matchkey transforms out of per-block scoring** — measured, shipped
   - File: `packages/python/goldenmatch/goldenmatch/core/scorer.py:113` + `core/matchkey.py` + `core/pipeline.py`

--- a/docs/superpowers/specs/2026-05-02-performance-audit-checklist.md
+++ b/docs/superpowers/specs/2026-05-02-performance-audit-checklist.md
@@ -10,10 +10,13 @@ Items are roughly ordered by ROI within each section. Check off as we go; we wil
 
 ## Runtime — Engine speed
 
-- [ ] **Vectorize `pattern_consistency` profiler**
-  - File: `packages/python/goldencheck/golenmatch/profilers/pattern_consistency.py:38,54-66`
-  - Problem: `_generalize()` runs as a Polars `map_elements()` Python UDF — one boundary crossing per row (~100k for a 100k sample).
-  - Fix: replace with a single vectorized regex pass / native Polars expressions.
+> **Lesson from the first attempt (2026-05-04):** the audit framed the runtime items as ROI-ranked, but framing was based on *static counts of "Python boundary crossings"*, not measured time. When we actually benchmarked the first item below, the speedup was 1.1x–1.4x, not the 10x+ the framing implied. **For every item in this section: measure before designing.** If the measured speedup is <2x, ship is optional, not assumed.
+
+- [~] **Vectorize `pattern_consistency` profiler** — measured, deferred
+  - File: `packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py:38`
+  - Hypothesis: `_generalize()` Python UDF in `map_elements` is the bottleneck.
+  - Reality (measured 2026-05-04): pure generalization step is **1.1x faster** at 100k rows (89ms → 82ms) and **1.4x faster** at 500k high-cardinality (549ms → 393ms). End-to-end profiler call on 100k rows is essentially flat (101ms → 100ms). Polars' `map_elements` releases the GIL and per-call overhead is small — the audit's "100k boundary crossings" framing overstated the cost.
+  - Decision: not worth the churn for a 10-40% speedup on a profiler that's already sub-100ms per column. Reconsider if a column ever measures >1s.
 
 - [ ] **Parallelize column profilers**
   - File: `packages/python/goldencheck/goldencheck/engine/scanner.py:35-53`
@@ -25,9 +28,15 @@ Items are roughly ordered by ROI within each section. Check off as we go; we wil
   - Problem: `call_llm()` is one synchronous `messages.create()` per finding. 50 findings = 50 round-trips.
   - Fix: async parallelism with `asyncio.gather`, or use Anthropic's batch API for offline runs.
 
-- [ ] **Verify the Rust core is actually on the hot path**
-  - Confirm PyO3 bindings are invoked for blocking/scoring/dedup rather than a Python fallback.
-  - Add a smoke benchmark to detect regressions if the fallback path silently re-engages.
+- [x] **Verify the Rust core is actually on the hot path** — diagnosed, N/A
+  - Diagnosis (2026-05-04): no Rust core exists for goldenmatch's Python path. `packages/rust/extensions/` is the *Postgres/DuckDB SQL surface* — Rust calls Python via PyO3, not the other way around. Audit's framing was a misread of the architecture.
+  - Decision: nothing to do. Item closed.
+
+- [x] **Hoist matchkey transforms out of per-block scoring** — measured, shipped
+  - File: `packages/python/goldenmatch/goldenmatch/core/scorer.py:113` + `core/matchkey.py` + `core/pipeline.py`
+  - Hypothesis (cProfile, 2026-05-04): `_get_transformed_values` was 8.97s / 78% of an 11.4s 10k-row dedupe — 7028 redundant Polars `.select()` calls.
+  - Reality (measured 2026-05-04 without cProfile overhead): 5-run median dedupe wall on 10k synthetic dropped from **3127ms → 2567ms (1.22x)**, best-case **2939ms → 2243ms (1.31x)**. cProfile's per-call overhead inflated the function's apparent share of wall — the underlying `select()` calls are individually fast enough that eliminating them yields a real but modest improvement.
+  - Decision: shipped per spec acceptance ("ship if structural cleanup is good even when speedup is smaller than expected"). Spec: `docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md`.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md
+++ b/docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md
@@ -1,0 +1,206 @@
+# Hoist matchkey transforms out of the per-block scoring loop
+
+**Date:** 2026-05-04
+**Status:** Design approved, awaiting implementation plan
+**Parent:** `2026-05-02-performance-audit-checklist.md` (replaces "vectorize pattern_consistency" as the actual #1 runtime win after profiling)
+
+## Goal
+
+Eliminate redundant Polars `frame.select(...)` calls during dedupe scoring by precomputing each unique `(field, transforms)` pair once on the parent DataFrame, then having per-block scoring read the precomputed column instead of re-transforming.
+
+## Background
+
+cProfile of a representative 10k-row dedupe workload (`.profile_tmp/profile_dedupe.py`, 2026-05-04):
+
+```
+Total wall:                          11,440 ms
+scorer._get_transformed_values        8,970 ms  (78%)  ← 7028 calls
+  └─ frame.select (Polars)            8,260 ms  (72%)  ← per-block, per-field selects
+score_blocks_parallel                 4,680 ms  (41%)  ← already threaded
+series.map_elements                   2,110 ms  (18%)  ← only 33 calls
+blocker._build_static_blocks          1,790 ms  (16%)  ← single call
+```
+
+**Why `_get_transformed_values` dominates:** `find_fuzzy_matches(block_df, mk)` runs once per block. Inside, for each matchkey field, it calls `_get_transformed_values(block_df, field)`, which invokes `block_df.select(_try_native_chain(...))`. With ~2350 blocks × 3 fields = ~7050 calls. Each `Polars.select` round-trips through `deprecation`/`opt_flags` wrappers, even though every block scores the same value through the same transform chain.
+
+Transforms are pure (`lowercase`, `strip`, `soundex`, `digits_only`, etc.). The same value transforms to the same output every call. The redundancy is structural, not semantic.
+
+The audit originally ranked "vectorize `pattern_consistency` profiler" as the biggest runtime win. Measurement disproved that (1.1–1.4x speedup, end-to-end flat). This spec is the *actually-measured* #1 win for goldenmatch dedupe.
+
+## Non-goals
+
+- Refactoring the standardize step (`_NATIVE_STANDARDIZERS`) — separate concept (global cleanup vs per-matchkey scoring prep).
+- Optimizing `_build_static_blocks` (1.79s, single call) — separate item.
+- Cross-process or cross-call caching — adds invalidation surface; not worth it for a single-call op.
+- Changing what gets transformed or how — pure plumbing change, semantics unchanged.
+
+## Design
+
+### 1. New helper: `precompute_matchkey_transforms`
+
+In `packages/python/goldenmatch/goldenmatch/core/matchkey.py` (alongside the existing `_try_native_chain`):
+
+```python
+import hashlib
+
+
+def _xform_sig(field: MatchkeyField) -> str:
+    """Stable, process-independent signature for a (field, transforms) pair.
+
+    Uses blake2b rather than Python's salted hash() so the resulting column
+    name is deterministic across processes — makes debugging dumps diffable
+    and avoids spooky cross-run differences in error messages.
+    """
+    digest = hashlib.blake2b(
+        repr(field.transforms).encode(), digest_size=8
+    ).hexdigest()
+    return f"__xform_{field.field}_{digest}__"
+
+
+def precompute_matchkey_transforms(
+    df: pl.DataFrame, matchkeys: list[MatchkeyConfig]
+) -> pl.DataFrame:
+    """Add one __xform_<sig>__ column per unique (field, transforms) signature.
+
+    Same field+transforms across multiple matchkeys reuses one column — dedup
+    is automatic via the signature. Native chains use _try_native_chain (Rust);
+    non-native chains fall back to Python per-row apply_transforms once.
+
+    Skips fields whose scorer is `record_embedding` — those use multi-column
+    `field.columns` (not a single `field.field`) and have a separate scoring
+    path (`_record_embedding_score_matrix`) that does NOT call
+    `_get_transformed_values`. Including them here would (a) collide on the
+    pseudo-field name "__record__" and (b) crash on `df[field.field]` because
+    the named single column doesn't exist for that scorer.
+
+    Skips fields whose `transforms` list is empty — there's nothing to
+    precompute, and `_get_transformed_values` falls through to the legacy
+    path which is already a single `to_list()` call (no Polars overhead to
+    eliminate).
+
+    Returns the augmented DataFrame. Original columns are untouched.
+    """
+    seen: set[str] = set()
+    new_cols: list[pl.Series] = []
+    for mk in matchkeys:
+        for field in mk.fields:
+            if field.scorer == "record_embedding":
+                continue
+            if not field.transforms:
+                continue
+            sig = _xform_sig(field)
+            if sig in seen or sig in df.columns:
+                continue
+            seen.add(sig)
+
+            native_expr = _try_native_chain(field.field, field.transforms)
+            if native_expr is not None:
+                col = df.select(native_expr.alias(sig))[sig]
+            else:
+                values = df[field.field].to_list()
+                col = pl.Series(
+                    sig,
+                    [apply_transforms(v, field.transforms) if v is not None else None
+                     for v in values],
+                )
+            new_cols.append(col)
+
+    if not new_cols:
+        return df
+    return df.with_columns(new_cols)
+```
+
+### 2. Pipeline wiring
+
+In `packages/python/goldenmatch/goldenmatch/core/pipeline.py`, insert one call to `precompute_matchkey_transforms(df, config.get_matchkeys())` **immediately before the `build_blocks(...)` call** in both:
+- `_run_dedupe_pipeline` (around line 407)
+- `_run_match_pipeline` (around line 802-836; the match pipeline calls `build_blocks` for the same reason and benefits identically)
+
+This placement runs *after* all upstream column-mutating steps:
+1. `standardize_columns(...)` — global cleanup
+2. `compute_matchkeys(...)` — adds `__mk_*__` columns
+3. Optional domain extraction / LLM extraction (lines 355-368) — may add `__brand__`, `__model__`, etc. that matchkey transforms reference
+
+The augmented df flows through blocking and scoring naturally — every block-construction strategy in `core/blocker.py` (static, sorted-neighborhood, ANN, canopy, multi-pass, learned) builds blocks via `df.filter`, `df.slice`, `df[member_list]`, or `lf.with_columns(...).collect()`, all of which preserve arbitrary added columns.
+
+Eager placement (rather than lazy inside `find_fuzzy_matches`) is the chosen design because:
+- Pipeline.py is the natural layer for "prepare data once for all blocks."
+- Keeps `find_fuzzy_matches` a pure scoring function with no side effects.
+- Makes the cost visible in the pipeline trace, not hidden in scoring.
+
+### 3. Lookup in scorer
+
+In `packages/python/goldenmatch/goldenmatch/core/scorer.py`, modify `_get_transformed_values`:
+
+```python
+def _get_transformed_values(block_df: pl.DataFrame, field: MatchkeyField) -> list:
+    """Get transformed values for a field as a list.
+
+    Fast path: read precomputed __xform_*__ column (eager precompute via
+    precompute_matchkey_transforms in pipeline). Fallback path preserves
+    backward compatibility for callers that bypass the pipeline (DataFrame
+    entry points, tests calling find_fuzzy_matches directly).
+    """
+    from goldenmatch.core.matchkey import _xform_sig, _try_native_chain
+
+    sig = _xform_sig(field)
+    if sig in block_df.columns:
+        return block_df[sig].to_list()
+
+    # Legacy path — preserved verbatim
+    col = field.field
+    native_expr = _try_native_chain(col, field.transforms)
+    if native_expr is not None:
+        result_df = block_df.select(native_expr.alias("__tmp__"))
+        return result_df["__tmp__"].to_list()
+    values = block_df[col].to_list()
+    return [apply_transforms(v, field.transforms) if v is not None else None for v in values]
+```
+
+### 4. Why this is safe
+
+- Transforms are deterministic functions of value: caching is correct by construction.
+- Native chains use the same `_try_native_chain` we already trust.
+- The `__xform_*__` columns use the project's existing internal-prefix convention (double underscore, per `goldenmatch/CLAUDE.md` "Internal columns prefixed with `__`").
+- Memory cost: one Series per unique `(field, transforms)` pair. 10k rows × 3 fields ≈ 30k strings ≈ ~3MB. Negligible.
+- Backward compatibility: the lookup path has a fallback so `DataFrame entry points` (`dedupe_df`, `match_df`) and tests that call `find_fuzzy_matches` directly continue to work — just at the old speed unless they precompute first.
+
+## Tests
+
+- **`test_precompute_matchkey_transforms_dedups_signatures`** — same field+transforms across two matchkeys produces one column.
+- **`test_precompute_matchkey_transforms_distinct_transforms_same_field`** — same field with two different transform chains produces two distinct columns (the deduplication only fires on identical signatures).
+- **`test_precompute_matchkey_transforms_native_chain_path`** — verifies fast path uses `_try_native_chain` output.
+- **`test_precompute_matchkey_transforms_python_fallback_path`** — verifies non-native chain (e.g., a hypothetical custom transform) falls through to per-row Python.
+- **`test_precompute_matchkey_transforms_skips_record_embedding`** — a matchkey with a `record_embedding` field does not raise, does not add a `__record__` column, and the rest of the matchkey's fields still get precomputed.
+- **`test_precompute_matchkey_transforms_skips_empty_transforms`** — a field with `transforms=[]` is not given a `__xform_*__` column (no-op precompute).
+- **`test_get_transformed_values_uses_precomputed_column_when_present`** — block_df with `__xform_*__` returns those values, doesn't re-select.
+- **`test_get_transformed_values_falls_back_when_column_absent`** — block_df without `__xform_*__` produces identical output to the legacy path (regression pin).
+- **`test_find_fuzzy_matches_identical_results_with_and_without_precompute`** — full end-to-end equivalence on a small synthetic dataset.
+- **`test_xform_sig_is_deterministic_across_processes`** — call `_xform_sig` twice on equivalent fields, assert identical output. Pins the blake2b choice against accidental reverts to `hash()`.
+- **Reuse the existing 1319-test goldenmatch suite untouched** — drop-in compatibility check.
+
+## Acceptance criteria
+
+**Verified locally before merge:**
+- All existing tests pass (1319-test suite, modulo the known pre-fold ignore list).
+- New tests above pass.
+- `.profile_tmp/profile_dedupe.py` re-run shows:
+  - `_get_transformed_values` cumulative time drops from ~8.97s to **<1s** on the 10k synthetic workload.
+  - End-to-end wall clock improves by **≥2x** (≤5.5s vs current 11.4s baseline).
+
+**Acceptance is conditional on the synthetic showing ≥3x on the hot function.** If the win is smaller than expected on real-shaped data, ship anyway — the per-block `select()` pattern is structurally wrong and the cleanup is worth it independent of magnitude.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `_xform_sig` collisions (two different `(field, transforms)` hash to the same column name) | Very low (blake2b 64-bit digest over `repr(transforms)`) | Resolved in the design by using `hashlib.blake2b` (process-independent). Collision probability for <1000 unique signatures is ~3e-14. |
+| `with_columns` on a wide DataFrame (200+ cols) is slow | Low — only at pipeline start, single call | Acceptable; the 7000 select() calls being eliminated dwarf this. |
+| A custom matchkey transform mutates state across calls | Low (transforms are documented as pure) | Existing test surface catches this; no new risk introduced. |
+| `dedupe_df` (DataFrame entry point) skips precompute and silently runs slow | Medium | Add `precompute_matchkey_transforms` call inside `_run_dedupe_pipeline` so all entry points using that pipeline benefit; document the legacy fallback path. |
+
+## Working agreement
+
+- Implementation goes through writing-plans next; this spec is the input.
+- Capture before/after wall clock + `_get_transformed_values` cumulative time in the PR description, both for the synthetic 10k workload and for one realistic shape if available.
+- Update parent checklist (`2026-05-02-performance-audit-checklist.md`) with the measured result, mirroring the pattern_consistency entry: hypothesis → measured reality → decision.

--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 
 import polars as pl
 
-from goldenmatch.config.schemas import MatchkeyConfig
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
 from goldenmatch.utils.transforms import apply_transforms
 
 
@@ -134,3 +135,64 @@ def compute_matchkeys(
     if exprs:
         lf = lf.with_columns(exprs)
     return lf
+
+
+def _xform_sig(field: MatchkeyField) -> str:
+    """Stable, process-independent signature for a (field, transforms) pair.
+
+    Uses blake2b rather than Python's salted hash() so the resulting column
+    name is deterministic across processes — makes debugging dumps diffable
+    and avoids spooky cross-run differences in error messages.
+    """
+    digest = hashlib.blake2b(
+        repr(field.transforms).encode(), digest_size=8
+    ).hexdigest()
+    return f"__xform_{field.field}_{digest}__"
+
+
+def precompute_matchkey_transforms(
+    df: pl.DataFrame, matchkeys: list[MatchkeyConfig]
+) -> pl.DataFrame:
+    """Add one __xform_<sig>__ column per unique (field, transforms) signature.
+
+    Same field+transforms across multiple matchkeys reuses one column — dedup
+    is automatic via the signature. Native chains use _try_native_chain (Rust);
+    non-native chains fall back to Python per-row apply_transforms once.
+
+    Skips fields whose scorer is `record_embedding` (uses multi-column
+    field.columns, has its own scoring path that doesn't call
+    _get_transformed_values).
+
+    Skips fields with empty transforms list — nothing to precompute, and
+    _get_transformed_values' legacy path is already a single to_list() call.
+
+    Returns the augmented DataFrame. Original columns are untouched.
+    """
+    seen: set[str] = set()
+    new_cols: list[pl.Series] = []
+    for mk in matchkeys:
+        for field in mk.fields:
+            if field.scorer == "record_embedding":
+                continue
+            if not field.transforms:
+                continue
+            sig = _xform_sig(field)
+            if sig in seen or sig in df.columns:
+                continue
+            seen.add(sig)
+
+            native_expr = _try_native_chain(field.field, field.transforms)
+            if native_expr is not None:
+                col = df.select(native_expr.alias(sig))[sig]
+            else:
+                values = df[field.field].to_list()
+                col = pl.Series(
+                    sig,
+                    [apply_transforms(v, field.transforms) if v is not None else None
+                     for v in values],
+                )
+            new_cols.append(col)
+
+    if not new_cols:
+        return df
+    return df.with_columns(new_cols)

--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -156,15 +156,25 @@ def precompute_matchkey_transforms(
     """Add one __xform_<sig>__ column per unique (field, transforms) signature.
 
     Same field+transforms across multiple matchkeys reuses one column — dedup
-    is automatic via the signature. Native chains use _try_native_chain (Rust);
-    non-native chains fall back to Python per-row apply_transforms once.
+    is automatic via the signature. Native chains use vectorized Polars
+    expressions via `_try_native_chain`; non-native chains fall back to Python
+    per-row `apply_transforms` once.
 
     Skips fields whose scorer is `record_embedding` (uses multi-column
-    field.columns, has its own scoring path that doesn't call
-    _get_transformed_values).
+    `field.columns`, has its own scoring path that doesn't call
+    `_get_transformed_values`).
 
     Skips fields with empty transforms list — nothing to precompute, and
-    _get_transformed_values' legacy path is already a single to_list() call.
+    `_get_transformed_values`' legacy path is already a single `to_list()`
+    call.
+
+    **Caller contract:** downstream code must NOT mutate the source columns
+    referenced by the matchkey fields after this function runs. The fast
+    path in `_get_transformed_values` trusts the precomputed column over
+    re-deriving from source — silently returning stale values if the source
+    is changed later. Today no in-tree caller does this (blocks are sliced
+    from the augmented df, not mutated), but adding a mid-pipeline column
+    rewrite step in the future would violate this assumption.
 
     Returns the augmented DataFrame. Original columns are untouched.
     """

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -13,7 +13,7 @@ from goldenmatch.core.autofix import auto_fix_dataframe
 from goldenmatch.core.ingest import load_file, validate_columns, apply_column_map
 from goldenmatch.core.standardize import apply_standardization
 from goldenmatch.core.validate import ValidationRule, validate_dataframe
-from goldenmatch.core.matchkey import compute_matchkeys
+from goldenmatch.core.matchkey import compute_matchkeys, precompute_matchkey_transforms
 from goldenmatch.core.block_analyzer import analyze_blocking
 from goldenmatch.core.blocker import build_blocks
 from goldenmatch.core.scorer import find_exact_matches, find_fuzzy_matches, score_blocks_parallel, rerank_top_pairs
@@ -371,7 +371,12 @@ def _run_dedupe_pipeline(
     combined_lf = compute_matchkeys(combined_lf, matchkeys)
 
     # ── Step 2.5: AUTO-SUGGEST blocking keys ──
-    collected_df = combined_lf.collect()
+    # Hoist matchkey transforms onto the materialized df once — eliminates
+    # ~7000 redundant per-block .select() calls during scoring (folds into the
+    # existing collect; no extra materialization). See spec
+    # docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md.
+    collected_df = precompute_matchkey_transforms(combined_lf.collect(), matchkeys)
+    combined_lf = collected_df.lazy()
     _run_auto_suggest(collected_df, config)
 
     # ── Step 3: BLOCK + COMPARE (cascading: exact first, then fuzzy) ──
@@ -801,7 +806,10 @@ def _run_match_pipeline(
 
     # ── Step 3: Compute matchkeys ──
     combined_lf = compute_matchkeys(combined_lf, matchkeys)
-    combined_df = combined_lf.collect()
+    # Hoist matchkey transforms — see spec
+    # docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md.
+    combined_df = precompute_matchkey_transforms(combined_lf.collect(), matchkeys)
+    combined_lf = combined_df.lazy()
 
     # ── Step 3.5: AUTO-SUGGEST blocking keys ──
     _run_auto_suggest(combined_df, config)

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -372,8 +372,8 @@ def _run_dedupe_pipeline(
 
     # ── Step 2.5: AUTO-SUGGEST blocking keys ──
     # Hoist matchkey transforms onto the materialized df once — eliminates
-    # ~7000 redundant per-block .select() calls during scoring (folds into the
-    # existing collect; no extra materialization). See spec
+    # one .select() per (block × matchkey field) during scoring (folds into
+    # the existing collect; no extra materialization). See spec
     # docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md.
     collected_df = precompute_matchkey_transforms(combined_lf.collect(), matchkeys)
     combined_lf = collected_df.lazy()
@@ -806,7 +806,8 @@ def _run_match_pipeline(
 
     # ── Step 3: Compute matchkeys ──
     combined_lf = compute_matchkeys(combined_lf, matchkeys)
-    # Hoist matchkey transforms — see spec
+    # Hoist matchkey transforms — eliminates one .select() per (block ×
+    # matchkey field) during scoring. See spec
     # docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md.
     combined_df = precompute_matchkey_transforms(combined_lf.collect(), matchkeys)
     combined_lf = combined_df.lazy()

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -111,17 +111,29 @@ def find_exact_matches(
 # ---------------------------------------------------------------------------
 
 def _get_transformed_values(block_df: pl.DataFrame, field: MatchkeyField) -> list:
-    """Get transformed values for a field as a list, using Polars expressions when possible."""
-    from goldenmatch.core.matchkey import _try_native_chain
-    col = field.field
+    """Get transformed values for a field as a list.
 
-    # Try native Polars transforms (fast path)
+    Fast path: read the precomputed __xform_<sig>__ column populated by
+    precompute_matchkey_transforms (called once per pipeline run, eagerly,
+    before blocking). Avoids ~7000 redundant Polars .select() calls per
+    dedupe.
+
+    Fallback path: legacy per-block .select(_try_native_chain(...)) for
+    callers that bypass the pipeline (DataFrame entry points, tests calling
+    find_fuzzy_matches directly).
+    """
+    from goldenmatch.core.matchkey import _xform_sig, _try_native_chain
+
+    sig = _xform_sig(field)
+    if sig in block_df.columns:
+        return block_df[sig].to_list()
+
+    col = field.field
     native_expr = _try_native_chain(col, field.transforms)
     if native_expr is not None:
         result_df = block_df.select(native_expr.alias("__tmp__"))
         return result_df["__tmp__"].to_list()
 
-    # Fallback: Python per-row
     values = block_df[col].to_list()
     return [apply_transforms(v, field.transforms) if v is not None else None for v in values]
 

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -115,8 +115,7 @@ def _get_transformed_values(block_df: pl.DataFrame, field: MatchkeyField) -> lis
 
     Fast path: read the precomputed __xform_<sig>__ column populated by
     precompute_matchkey_transforms (called once per pipeline run, eagerly,
-    before blocking). Avoids ~7000 redundant Polars .select() calls per
-    dedupe.
+    before blocking). Avoids one `.select()` per (block × matchkey field).
 
     Fallback path: legacy per-block .select(_try_native_chain(...)) for
     callers that bypass the pipeline (DataFrame entry points, tests calling

--- a/packages/python/goldenmatch/tests/test_matchkey.py
+++ b/packages/python/goldenmatch/tests/test_matchkey.py
@@ -103,3 +103,89 @@ class TestComputeMatchkeys:
         assert "__mk_zip_exact__" in result.columns
         assert result["__mk_name_sdx__"].to_list() == ["john", "jane"]
         assert result["__mk_zip_exact__"].to_list() == ["19382", "10001"]
+
+
+# --- Tests for precompute_matchkey_transforms (perf/hoist-matchkey-transforms) ---
+import polars as pl
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.matchkey import (
+    _xform_sig,
+    precompute_matchkey_transforms,
+)
+
+
+def _mk(name: str, fields: list[MatchkeyField], threshold: float = 0.7) -> MatchkeyConfig:
+    return MatchkeyConfig(name=name, type="weighted", threshold=threshold, fields=fields)
+
+
+def _field(field: str, transforms: list[str], scorer: str = "jaro_winkler",
+           weight: float = 1.0) -> MatchkeyField:
+    return MatchkeyField(field=field, transforms=transforms, scorer=scorer, weight=weight)
+
+
+def test_xform_sig_is_deterministic_across_processes():
+    f1 = _field("name", ["lowercase", "strip"])
+    f2 = _field("name", ["lowercase", "strip"])
+    assert _xform_sig(f1) == _xform_sig(f2)
+    sig = _xform_sig(f1)
+    assert sig.startswith("__xform_name_") and sig.endswith("__")
+    assert len(sig) > len("__xform_name___")
+
+
+def test_precompute_matchkey_transforms_dedups_signatures():
+    df = pl.DataFrame({"name": ["Alice", "BOB"]})
+    mk_a = _mk("a", [_field("name", ["lowercase"])])
+    mk_b = _mk("b", [_field("name", ["lowercase"])])
+    out = precompute_matchkey_transforms(df, [mk_a, mk_b])
+    xform_cols = [c for c in out.columns if c.startswith("__xform_")]
+    assert len(xform_cols) == 1
+
+
+def test_precompute_matchkey_transforms_distinct_transforms_same_field():
+    df = pl.DataFrame({"name": ["Alice"]})
+    mk = _mk("m", [
+        _field("name", ["lowercase"]),
+        _field("name", ["uppercase"]),
+    ])
+    out = precompute_matchkey_transforms(df, [mk])
+    xform_cols = sorted(c for c in out.columns if c.startswith("__xform_"))
+    assert len(xform_cols) == 2
+    assert out[xform_cols[0]].to_list() != out[xform_cols[1]].to_list()
+
+
+def test_precompute_matchkey_transforms_native_chain_path():
+    df = pl.DataFrame({"name": ["  Alice  ", "BOB"]})
+    mk = _mk("m", [_field("name", ["lowercase", "strip"])])
+    out = precompute_matchkey_transforms(df, [mk])
+    sig = _xform_sig(_field("name", ["lowercase", "strip"]))
+    assert out[sig].to_list() == ["alice", "bob"]
+
+
+def test_precompute_matchkey_transforms_python_fallback_path():
+    df = pl.DataFrame({"name": ["Smith", "Smyth"]})
+    mk = _mk("m", [_field("name", ["soundex"])])
+    out = precompute_matchkey_transforms(df, [mk])
+    sig = _xform_sig(_field("name", ["soundex"]))
+    vals = out[sig].to_list()
+    assert vals[0] == vals[1]
+
+
+def test_precompute_matchkey_transforms_skips_record_embedding():
+    df = pl.DataFrame({"name": ["a"], "desc": ["b"]})
+    mk = MatchkeyConfig(name="m", type="weighted", threshold=0.5, fields=[
+        MatchkeyField(field="__record__", transforms=[], scorer="record_embedding",
+                      weight=1.0, columns=["name", "desc"]),
+        _field("name", ["lowercase"]),
+    ])
+    out = precompute_matchkey_transforms(df, [mk])
+    assert "__record__" not in out.columns
+    sig_name = _xform_sig(_field("name", ["lowercase"]))
+    assert sig_name in out.columns
+
+
+def test_precompute_matchkey_transforms_skips_empty_transforms():
+    df = pl.DataFrame({"name": ["Alice"]})
+    mk = _mk("m", [_field("name", [])])
+    out = precompute_matchkey_transforms(df, [mk])
+    xform_cols = [c for c in out.columns if c.startswith("__xform_")]
+    assert xform_cols == []

--- a/packages/python/goldenmatch/tests/test_matchkey.py
+++ b/packages/python/goldenmatch/tests/test_matchkey.py
@@ -2,7 +2,12 @@
 
 import polars as pl
 
-from goldenmatch.core.matchkey import build_matchkey_expr, compute_matchkeys
+from goldenmatch.core.matchkey import (
+    _xform_sig,
+    build_matchkey_expr,
+    compute_matchkeys,
+    precompute_matchkey_transforms,
+)
 from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
 
 
@@ -106,12 +111,8 @@ class TestComputeMatchkeys:
 
 
 # --- Tests for precompute_matchkey_transforms (perf/hoist-matchkey-transforms) ---
-import polars as pl
-from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
-from goldenmatch.core.matchkey import (
-    _xform_sig,
-    precompute_matchkey_transforms,
-)
+# (Imports moved to top of file per CLAUDE.md guidance: ruff auto-fix can
+# cascade-delete test functions when removing mid-file imports.)
 
 
 def _mk(name: str, fields: list[MatchkeyField], threshold: float = 0.7) -> MatchkeyConfig:
@@ -189,3 +190,60 @@ def test_precompute_matchkey_transforms_skips_empty_transforms():
     out = precompute_matchkey_transforms(df, [mk])
     xform_cols = [c for c in out.columns if c.startswith("__xform_")]
     assert xform_cols == []
+
+
+def test_precompute_matchkey_transforms_is_idempotent():
+    # Calling the helper a second time on already-augmented output is a no-op
+    # (the `sig in df.columns` guard short-circuits). Pins this contract so a
+    # future "always recompute" change won't silently shadow the existing
+    # __xform_*__ columns.
+    df = pl.DataFrame({"name": ["Alice", "BOB"]})
+    mk = _mk("m", [_field("name", ["lowercase"])])
+    once = precompute_matchkey_transforms(df, [mk])
+    twice = precompute_matchkey_transforms(once, [mk])
+    assert once.columns == twice.columns
+    sig = _xform_sig(_field("name", ["lowercase"]))
+    assert once[sig].to_list() == twice[sig].to_list()
+
+
+def test_run_dedupe_pipeline_populates_xform_columns():
+    # End-to-end: the dedupe entry point actually wires precompute into the
+    # pipeline and the augmented columns reach the scorer. Without this test,
+    # someone could revert the pipeline.py change and only the helper-level
+    # tests would still pass.
+    import csv
+    import tempfile
+    from pathlib import Path
+    from goldenmatch import dedupe
+    from goldenmatch.config.schemas import (
+        BlockingConfig, BlockingKeyConfig, GoldenMatchConfig,
+        GoldenRulesConfig, OutputConfig,
+    )
+
+    tmp = Path(tempfile.mkdtemp()) / "t.csv"
+    with open(tmp, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["id", "name", "email", "zip"])
+        w.writerow([1, "Alice Smith", "alice@x.com", "10001"])
+        w.writerow([2, "Alice Smyth", "alice@x.com", "10001"])
+        w.writerow([3, "Bob Jones", "bob@y.com", "20002"])
+
+    config = GoldenMatchConfig(
+        matchkeys=[_mk("m", [
+            _field("name", ["lowercase", "strip"], scorer="jaro_winkler", weight=0.7),
+            _field("email", ["lowercase", "strip"], scorer="jaro_winkler", weight=0.3),
+        ], threshold=0.6)],
+        blocking=BlockingConfig(
+            max_block_size=100, skip_oversized=True,
+            keys=[BlockingKeyConfig(fields=["zip"], transforms=[])],
+        ),
+        standardization={"email": ["lowercase", "strip"], "name": ["strip"]},
+        golden_rules=GoldenRulesConfig(default_strategy="most_complete"),
+        output=OutputConfig(format="csv", directory=str(tmp.parent), run_name="r"),
+    )
+    result = dedupe(str(tmp), config=config)
+    # Alice Smith / Alice Smyth share the same email + zip — they should cluster.
+    assert result.total_records == 3
+    assert result.total_clusters >= 1
+    # And at least one scored pair was found (the Alice cluster).
+    assert len(result.scored_pairs) >= 1

--- a/packages/python/goldenmatch/tests/test_scorer.py
+++ b/packages/python/goldenmatch/tests/test_scorer.py
@@ -4,11 +4,13 @@ import polars as pl
 import pytest
 
 from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.matchkey import _xform_sig, precompute_matchkey_transforms
 from goldenmatch.core.scorer import (
-    score_field,
-    score_pair,
+    _get_transformed_values,
     find_exact_matches,
     find_fuzzy_matches,
+    score_field,
+    score_pair,
 )
 
 
@@ -724,10 +726,7 @@ class TestRerankTopPairs:
 
 
 # --- Tests for _get_transformed_values fast-path (perf/hoist-matchkey-transforms) ---
-import polars as pl
-from goldenmatch.config.schemas import MatchkeyField
-from goldenmatch.core.matchkey import _xform_sig, precompute_matchkey_transforms
-from goldenmatch.core.scorer import _get_transformed_values
+# (Imports moved to top of file per CLAUDE.md guidance.)
 
 
 def test_get_transformed_values_uses_precomputed_column_when_present():
@@ -749,10 +748,6 @@ def test_get_transformed_values_falls_back_when_column_absent():
 
 
 def test_find_fuzzy_matches_identical_results_with_and_without_precompute():
-    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField as _MF
-    from goldenmatch.core.scorer import find_fuzzy_matches
-    from goldenmatch.core.matchkey import precompute_matchkey_transforms as _pre
-
     df = pl.DataFrame({
         "__row_id__": [0, 1, 2, 3],
         "name": ["Alice Smith", "Alice Smyth", "Bob Jones", "Robert Jones"],
@@ -761,10 +756,12 @@ def test_find_fuzzy_matches_identical_results_with_and_without_precompute():
     mk = MatchkeyConfig(
         name="m", type="weighted", threshold=0.6,
         fields=[
-            _MF(field="name", transforms=["lowercase", "strip"], scorer="jaro_winkler", weight=0.7),
-            _MF(field="zip", transforms=["strip"], scorer="exact", weight=0.3),
+            MatchkeyField(field="name", transforms=["lowercase", "strip"],
+                          scorer="jaro_winkler", weight=0.7),
+            MatchkeyField(field="zip", transforms=["strip"],
+                          scorer="exact", weight=0.3),
         ],
     )
     pairs_legacy = sorted(find_fuzzy_matches(df, mk))
-    pairs_precomputed = sorted(find_fuzzy_matches(_pre(df, [mk]), mk))
+    pairs_precomputed = sorted(find_fuzzy_matches(precompute_matchkey_transforms(df, [mk]), mk))
     assert pairs_legacy == pairs_precomputed

--- a/packages/python/goldenmatch/tests/test_scorer.py
+++ b/packages/python/goldenmatch/tests/test_scorer.py
@@ -721,3 +721,28 @@ class TestRerankTopPairs:
         })
         result = rerank_top_pairs(pairs, df, mk)
         assert result == pairs
+
+
+# --- Tests for _get_transformed_values fast-path (perf/hoist-matchkey-transforms) ---
+import polars as pl
+from goldenmatch.config.schemas import MatchkeyField
+from goldenmatch.core.matchkey import _xform_sig, precompute_matchkey_transforms
+from goldenmatch.core.scorer import _get_transformed_values
+
+
+def test_get_transformed_values_uses_precomputed_column_when_present():
+    field = MatchkeyField(field="name", transforms=["lowercase"],
+                          scorer="jaro_winkler", weight=1.0)
+    sig = _xform_sig(field)
+    block_df = pl.DataFrame({
+        "name": ["Alice", "BOB"],
+        sig: ["PRECOMPUTED_A", "PRECOMPUTED_B"],
+    })
+    assert _get_transformed_values(block_df, field) == ["PRECOMPUTED_A", "PRECOMPUTED_B"]
+
+
+def test_get_transformed_values_falls_back_when_column_absent():
+    field = MatchkeyField(field="name", transforms=["lowercase"],
+                          scorer="jaro_winkler", weight=1.0)
+    block_df = pl.DataFrame({"name": ["Alice", "BOB"]})
+    assert _get_transformed_values(block_df, field) == ["alice", "bob"]

--- a/packages/python/goldenmatch/tests/test_scorer.py
+++ b/packages/python/goldenmatch/tests/test_scorer.py
@@ -746,3 +746,25 @@ def test_get_transformed_values_falls_back_when_column_absent():
                           scorer="jaro_winkler", weight=1.0)
     block_df = pl.DataFrame({"name": ["Alice", "BOB"]})
     assert _get_transformed_values(block_df, field) == ["alice", "bob"]
+
+
+def test_find_fuzzy_matches_identical_results_with_and_without_precompute():
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField as _MF
+    from goldenmatch.core.scorer import find_fuzzy_matches
+    from goldenmatch.core.matchkey import precompute_matchkey_transforms as _pre
+
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "name": ["Alice Smith", "Alice Smyth", "Bob Jones", "Robert Jones"],
+        "zip": ["10001", "10001", "20002", "20002"],
+    })
+    mk = MatchkeyConfig(
+        name="m", type="weighted", threshold=0.6,
+        fields=[
+            _MF(field="name", transforms=["lowercase", "strip"], scorer="jaro_winkler", weight=0.7),
+            _MF(field="zip", transforms=["strip"], scorer="exact", weight=0.3),
+        ],
+    )
+    pairs_legacy = sorted(find_fuzzy_matches(df, mk))
+    pairs_precomputed = sorted(find_fuzzy_matches(_pre(df, [mk]), mk))
+    assert pairs_legacy == pairs_precomputed

--- a/packages/typescript/goldenmatch/tests/unit/pprl-protocol.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/pprl-protocol.test.ts
@@ -163,7 +163,10 @@ describe("runPPRL", () => {
     return { a, b };
   }
 
-  it("finds most shared entities in two datasets with partial overlap", () => {
+  // 30s timeout: PPRL bloom filter generation + dice scoring is CPU-heavy.
+  // Default 5s passes locally and on dedicated runners but consistently times
+  // out under the post-monorepo-fold shared CI runner (per PR #66 CI history).
+  it("finds most shared entities in two datasets with partial overlap", { timeout: 30000 }, () => {
     const { a, b } = twoPartiesWithOverlap();
     const config: PPRLConfig = {
       fields: ["first_name", "last_name", "email"],
@@ -199,7 +202,10 @@ describe("runPPRL", () => {
     expect(hits).toBeGreaterThanOrEqual(7);
   });
 
-  it("runs end-to-end with security_level standard/high/paranoid and finds same true pairs", { timeout: 15000 }, () => {
+  // 45s (was 15s): the multi-level loop runs the full PPRL pipeline 3x. The
+  // 15s ceiling held on dedicated runners but consistently times out after
+  // the monorepo-fold CI consolidated TS + Python onto a shared runner.
+  it("runs end-to-end with security_level standard/high/paranoid and finds same true pairs", { timeout: 45000 }, () => {
     const { a, b } = twoPartiesWithOverlap();
     const baseFields: string[] = ["first_name", "last_name", "email"];
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest>=8",
     "pytest-xdist>=3.6",
     "pytest-asyncio>=0.23",  # required by goldenmatch + goldenflow async tests
+    "pytest-timeout>=2.3",  # surfaces hung tests in CI as failures w/ stack traces (vs job timeout)
     "ruff>=0.6",
     # transitive test deps surfaced across workspace packages:
     "httpx>=0.27",  # required by starlette.testclient (used by goldenpipe tests)

--- a/uv.lock
+++ b/uv.lock
@@ -1042,6 +1042,7 @@ dev = [
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -1053,6 +1054,7 @@ dev = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.6" },
 ]
@@ -2836,6 +2838,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Eliminates ~7000 redundant Polars `frame.select(...)` calls per dedupe by precomputing each unique `(field, transforms)` pair once on the parent DataFrame. Per-block scoring becomes a column lookup.

cProfile of a representative 10k-row dedupe (before this PR) initially showed `scorer._get_transformed_values` consuming ~78% of cumulative time with 7028 calls — but cumulative profile time inflates per-call overhead, so the wall-clock impact is more modest than the cProfile framing implied.

This PR adds `precompute_matchkey_transforms` in `core/matchkey.py`, wires it into both pipelines (`_run_dedupe_pipeline`, `_run_match_pipeline`) by folding into the existing `.collect()` after `compute_matchkeys`, and updates `scorer._get_transformed_values` to read precomputed `__xform_<sig>__` columns when present (with the legacy path preserved for callers that bypass the pipeline).

## Numbers (10k synthetic dedupe, 5-run wall, no cProfile overhead)

| Metric | main | branch | Speedup |
|---|---|---|---|
| Median dedupe wall | 3127 ms | **2567 ms** | **1.22x** |
| Best-case dedupe wall | 2939 ms | **2243 ms** | **1.31x** |

Modest but real. The structural cleanup (no more 7000 redundant `select()` round-trips per dedupe) is worth shipping independent of the magnitude — per the spec's own acceptance language. Documents the cProfile vs wall-clock framing lesson in the parent checklist for future audit items.

## Tests

- 9 new tests covering: signature determinism, dedup, distinct transforms on same field, native + Python paths, `record_embedding` skip, empty-transforms skip, end-to-end equivalence, fast-path lookup, fallback path
- Full goldenmatch suite (1302 passing) — zero new regressions vs main (same 6 pre-existing failures: 3 benchmark tests needing gitignored datasets, 3 excel tests).

## Spec + plan

- Spec: `docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md`
- Plan: `docs/superpowers/plans/2026-05-04-hoist-matchkey-transforms.md`
- Parent checklist: `docs/superpowers/specs/2026-05-02-performance-audit-checklist.md` (also closes the Rust-core diagnostic item — there is no Rust on the goldenmatch Python hot path).

## Test plan

- [ ] CI green
- [ ] All 1302 goldenmatch tests pass (modulo the pre-fold ignore list + 6 pre-existing failures)
- [ ] Manual: dedupe runs on real-shape data without exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)