### PR TITLE
fix(railway): pin goldenmatch-mcp config in railway.json after monorepo fold

### DIFF
--- a/packages/python/goldenmatch/railway.json
+++ b/packages/python/goldenmatch/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile.mcp"
+  },
+  "deploy": {
+    "startCommand": "goldenmatch mcp-serve --transport http --port 8200",
+    "healthcheckPath": "/mcp/",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
## Summary

Every Railway deployment of `goldenmatch-mcp` had failed since the 2026-05-01 monorepo fold (13 consecutive FAILED, last SUCCESS was 2026-04-15). The currently-serving production version was the pre-fold April 15 build — every git push since failed silently.

## Root cause

The Railway service was configured to find `Dockerfile.mcp` at the repo root. The fold moved it to `packages/python/goldenmatch/Dockerfile.mcp`. Build error:

```
couldn't locate the dockerfile at path Dockerfile.mcp in code archive
```

## Fix

1. **Set service `rootDirectory='packages/python/goldenmatch'`** via Railway's GraphQL API (one-time service config update — equivalent to changing it in the dashboard).
2. **Pin the build/deploy config in `packages/python/goldenmatch/railway.json`** (this PR) so the dockerfile path, start command, and healthcheck are reproducible from the repo and don't depend on dashboard-only state.

## Verification

Triggered redeploy `92e76ef4-764e-4ef6-bd76-f51d53cba70b` → **SUCCESS** (first green Railway deploy since April 15). Service is healthy, MCP endpoint serving traffic.

## Test plan

- [x] Service deploys cleanly from the new rootDirectory
- [x] MCP endpoint returns 200 (live traffic visible in `railway logs`)
- [ ] Next git push to main triggers a clean auto-deploy via the new config (will verify on first push after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)