### PR TITLE
fix(railway): point goldenmatch-mcp healthcheck at server-card

### DIFF
--- a/packages/python/goldenmatch/railway.json
+++ b/packages/python/goldenmatch/railway.json
@@ -6,7 +6,7 @@
   },
   "deploy": {
     "startCommand": "goldenmatch mcp-serve --transport http --port 8200",
-    "healthcheckPath": "/mcp/",
+    "healthcheckPath": "/.well-known/mcp/server-card.json",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3
   }


### PR DESCRIPTION
## Summary
- `healthcheckPath` was `/mcp/`, the streamable-HTTP MCP transport endpoint, which correctly returns **406 Not Acceptable** to a plain GET (the spec requires `Accept: application/json, text/event-stream`). Railway's healthcheck does not send those headers, so every deploy after #67 has failed healthcheck even though the container boots cleanly.
- Switched to `/.well-known/mcp/server-card.json` — returns 200, requires full app boot, cheap to serve.

## Verification
Live probe of currently-running replica:
- `GET /mcp/` → HTTP **406**
- `GET /.well-known/mcp/server-card.json` → HTTP **200**

Production isn't down — Railway kept the prior successful replica because of `restartPolicyType: ON_FAILURE`. This fix unblocks the next legitimate redeploy.

## Test plan
- [ ] Merge → Railway auto-deploy fires
- [ ] `railway deployment list` shows the new deploy as SUCCESS
- [ ] `curl https://goldenmatch-mcp-production.up.railway.app/.well-known/mcp/server-card.json` still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)