### PR TITLE
chore(deps): align third-party dependency floors

### DIFF
--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -49,7 +49,7 @@ goldencheck = "goldencheck.cli.main:app"
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
-    "ruff>=0.4",
+    "ruff>=0.6",
 ]
 llm = [
     "anthropic>=0.30",
@@ -65,11 +65,11 @@ agent = [
     "aiohttp>=3.9",
 ]
 baseline = [
-    "scipy>=1.10",
-    "numpy>=1.24",
+    "scipy>=1.11",
+    "numpy>=1.26",
 ]
 semantic = [
-    "sentence-transformers>=2.0",
+    "sentence-transformers>=2.2",
 ]
 
 [tool.ruff]

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "textual>=0.50",
     "fastapi>=0.110",
     "python-multipart>=0.0.20",
-    "uvicorn>=0.27",
+    "uvicorn>=0.30",
     "phonenumbers>=8.13",
     "python-dateutil>=2.9",
     "pyyaml>=6.0",
@@ -36,12 +36,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.3", "httpx>=0.27", "python-multipart>=0.0.20"]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.6", "httpx>=0.27", "python-multipart>=0.0.20"]
 check = ["goldencheck>=1.0"]
 excel = ["openpyxl>=3.1"]
 db = ["connectorx>=0.3"]
 mcp = ["mcp>=1.0"]
-llm = ["anthropic>=0.30", "openai>=1.0"]
+llm = ["anthropic>=0.30", "openai>=1.30"]
 s3 = ["boto3>=1.34"]
 gcs = ["google-cloud-storage>=2.14"]
 agent = ["aiohttp>=3.9"]

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "pytest-asyncio>=0.23",
-    "ruff>=0.4",
+    "ruff>=0.6",
 ]
 embeddings = [
     "sentence-transformers>=2.2",

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -30,11 +30,11 @@ flow = ["goldenflow>=0.1.0"]
 match = ["goldenmatch>=1.2.0"]
 golden-suite = ["goldencheck>=0.5.0", "goldenflow>=0.1.0", "goldenmatch>=1.2.0"]
 tui = ["textual>=1.0"]
-api = ["fastapi>=0.110", "uvicorn>=0.29"]
+api = ["fastapi>=0.110", "uvicorn>=0.30"]
 mcp = ["mcp>=1.0"]
 agent = ["aiohttp>=3.9"]
 all = ["goldenpipe[golden-suite,tui,api,mcp,agent]"]
-dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "pytest-aiohttp>=1.0", "httpx>=0.27", "ruff>=0.3", "pytest-cov>=5.0"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "pytest-aiohttp>=1.0", "httpx>=0.27", "ruff>=0.6", "pytest-cov>=5.0"]
 
 [project.scripts]
 goldenpipe = "goldenpipe.cli.main:app"

--- a/packages/python/infermap/pyproject.toml
+++ b/packages/python/infermap/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "rapidfuzz>=3.0",
     "scipy>=1.11",
     "pyyaml>=6.0",
-    "typer>=0.9",
+    "typer>=0.12",
 ]
 
 [project.optional-dependencies]
@@ -31,10 +31,10 @@ postgres = ["psycopg2-binary>=2.9"]
 mysql = ["mysql-connector-python>=8.0"]
 duckdb = ["duckdb>=0.9"]
 excel = ["openpyxl>=3.1"]
-llm = ["openai>=1.0", "anthropic>=0.20"]
+llm = ["openai>=1.30", "anthropic>=0.30"]
 all = ["infermap[postgres,mysql,duckdb,excel,llm]"]
 mcp = ["mcp>=1.0"]
-dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4"]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.6"]
 
 [project.scripts]
 infermap = "infermap.cli:app"

--- a/uv.lock
+++ b/uv.lock
@@ -810,7 +810,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.30" },
     { name = "connectorx", marker = "extra == 'db'", specifier = ">=0.3" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
-    { name = "numpy", marker = "extra == 'baseline'", specifier = ">=1.24" },
+    { name = "numpy", marker = "extra == 'baseline'", specifier = ">=1.26" },
     { name = "openai", marker = "extra == 'llm'", specifier = ">=1.30" },
     { name = "openpyxl", specifier = ">=3.1" },
     { name = "polars", specifier = ">=1.0" },
@@ -819,9 +819,9 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
-    { name = "scipy", marker = "extra == 'baseline'", specifier = ">=1.10" },
-    { name = "sentence-transformers", marker = "extra == 'semantic'", specifier = ">=2.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+    { name = "scipy", marker = "extra == 'baseline'", specifier = ">=1.11" },
+    { name = "sentence-transformers", marker = "extra == 'semantic'", specifier = ">=2.2" },
     { name = "textual", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.12" },
 ]
@@ -901,7 +901,7 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=2.14" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
-    { name = "openai", marker = "extra == 'llm'", specifier = ">=1.0" },
+    { name = "openai", marker = "extra == 'llm'", specifier = ">=1.30" },
     { name = "openpyxl", marker = "extra == 'excel'", specifier = ">=3.1" },
     { name = "phonenumbers", specifier = ">=8.13" },
     { name = "polars", specifier = ">=1.0" },
@@ -914,10 +914,10 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rapidfuzz", specifier = ">=3.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "textual", specifier = ">=0.50" },
     { name = "typer", specifier = ">=0.12" },
-    { name = "uvicorn", specifier = ">=0.27" },
+    { name = "uvicorn", specifier = ">=0.30" },
 ]
 provides-extras = ["dev", "check", "excel", "db", "mcp", "llm", "s3", "gcs", "agent", "all"]
 
@@ -1023,7 +1023,7 @@ requires-dist = [
     { name = "rapidfuzz", specifier = ">=3.0" },
     { name = "ray", marker = "extra == 'ray'", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=2.2" },
     { name = "simple-salesforce", marker = "extra == 'salesforce'", specifier = ">=1.12" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.0" },
@@ -1139,10 +1139,10 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.12" },
-    { name = "uvicorn", marker = "extra == 'api'", specifier = ">=0.29" },
+    { name = "uvicorn", marker = "extra == 'api'", specifier = ">=0.30" },
 ]
 provides-extras = ["check", "flow", "match", "golden-suite", "tui", "api", "mcp", "agent", "all", "dev"]
 
@@ -1516,12 +1516,12 @@ postgres = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.20" },
+    { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.30" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.9" },
     { name = "infermap", extras = ["postgres", "mysql", "duckdb", "excel", "llm"], marker = "extra == 'all'", editable = "packages/python/infermap" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
     { name = "mysql-connector-python", marker = "extra == 'mysql'", specifier = ">=8.0" },
-    { name = "openai", marker = "extra == 'llm'", specifier = ">=1.0" },
+    { name = "openai", marker = "extra == 'llm'", specifier = ">=1.30" },
     { name = "openpyxl", marker = "extra == 'excel'", specifier = ">=3.1" },
     { name = "polars", specifier = ">=1.0" },
     { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9" },
@@ -1529,9 +1529,9 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rapidfuzz", specifier = ">=3.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "scipy", specifier = ">=1.11" },
-    { name = "typer", specifier = ">=0.9" },
+    { name = "typer", specifier = ">=0.12" },
 ]
 provides-extras = ["postgres", "mysql", "duckdb", "excel", "llm", "all", "mcp", "dev"]
 


### PR DESCRIPTION
## Summary
Closes the last open item on the perf audit checklist: \"Audit duplicated dependencies across packages\".

12 of the 13 cross-package version-spec drift cases collapse to one floor each. Skipping:
- `textual` — goldenflow's CLAUDE.md note on Textual 8.x compat suggests the `>=0.50` floor is deliberate
- internal Golden Suite specs (goldencheck/goldenflow/goldenmatch as deps of each other) — uv resolves these via \`[tool.uv.sources] workspace = true\` regardless of the version string, so the spec is cosmetic

## Changes

| Dep | Old floors | New floor |
|---|---|---|
| ruff | 0.3 / 0.4 | 0.6 (matches goldensuite-mcp) |
| numpy | 1.24 | 1.26 |
| scipy | 1.10 | 1.11 |
| anthropic | 0.20 | 0.30 |
| openai | 1.0 | 1.30 |
| sentence-transformers | 2.0 | 2.2 |
| typer | 0.9 | 0.12 |
| uvicorn | 0.27 / 0.29 | 0.30 |

\`uv.lock\` updates only the \`requires-dist\` spec strings — resolved versions are unchanged because the existing lock already satisfied every new floor. So functionally, only standalone-PyPI consumers (Smithery, Railway, anyone installing one package outside the workspace) feel a difference.

## Test plan
- [ ] CI passes (proves the new floors don't break ruff/pytest)
- [ ] No lockfile churn beyond spec strings (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)