### PR TITLE
feat(memory): Learning Memory completion (re-anchor, pipeline, surfaces)

### DIFF
--- a/docs/superpowers/plans/2026-05-04-learning-memory-completion.md
+++ b/docs/superpowers/plans/2026-05-04-learning-memory-completion.md
@@ -1,0 +1,1042 @@
+# Learning Memory Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the already-shipped Learning Memory primitives (PR #9 — store, corrections, learner) into the goldenmatch pipeline and surfaces (CLI, MCP, REST, TUI), add row-ID-stable re-anchoring via `record_hash`, and surface applied/stale counts in postflight.
+
+**Architecture:** Eight independently-mergeable phases following the spec's fixed implementation order. Re-anchoring lands first (foundational, localized, fully testable in isolation). Pipeline hook lands second (nothing observable works until it does). Collection points and surfaces stack on top. Each phase is one PR; each step inside a phase is 2–5 minutes of work.
+
+**Tech Stack:** Python 3.11+, polars (vectorized hashing), Pydantic (config), Typer (CLI), MCP SDK (tools), Textual (TUI), pytest + pytest-asyncio.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-learning-memory-completion.md` — read it first; this plan does not duplicate the spec's rationale or design rationale.
+
+**Foundation:** `_archive/goldenmatch-pre-fold/docs/superpowers/specs/2026-03-26-learning-memory-design.md` (approved 2026-03-26; Tasks 1–4 shipped via PR #9). Foundation plan at `_archive/goldenmatch-pre-fold/docs/superpowers/plans/2026-03-26-learning-memory-implementation.md` — Tasks 5–8 of that document inform but do not bind this plan; this plan supersedes them where they differ from the new spec.
+
+---
+
+## File Structure
+
+All paths relative to `packages/python/goldenmatch/` unless otherwise noted.
+
+**Create:**
+- `goldenmatch/mcp/memory_tools.py` — five MCP tools (Phase 7)
+- `goldenmatch/cli/memory.py` — Typer subgroup with five subcommands (Phase 6)
+- `tests/test_memory_e2e.py` — integration suite (Phase 8)
+- `tests/test_memory_reanchor.py` — re-anchor unit tests (Phase 1)
+- `tests/test_memory_pipeline.py` — pipeline-hook tests (Phase 2)
+- `tests/test_memory_postflight.py` — postflight rendering tests (Phase 3)
+- `tests/test_memory_collection.py` — collection-point tests (Phase 4)
+- `tests/test_memory_explainer.py` — explainer tests (Phase 5)
+- `tests/test_memory_cli.py` — CLI tests (Phase 6)
+- `tests/test_memory_tools.py` — MCP tool tests (Phase 7)
+
+**Modify:**
+- `goldenmatch/core/memory/corrections.py` — collision-safe vectorized re-anchor (Phase 1)
+- `goldenmatch/config/schemas.py` — add `MemoryConfig.reanchor: bool = True` (Phase 1)
+- `goldenmatch/core/pipeline.py:497` — insert memory hook between scoring and postflight; learner overlay near config materialization (Phase 2)
+- `goldenmatch/_api.py:36` — add `memory_stats: CorrectionStats | None` to `DedupeResult` (Phase 2)
+- `goldenmatch/_api.py:136` — add `memory_stats: CorrectionStats | None` to `MatchResult` (Phase 2)
+- `goldenmatch/_api.py` — add `get_memory`, `add_correction`, `learn`, `memory_stats` API functions (Phase 6)
+- `goldenmatch/__init__.py` — re-export the four new API functions (Phase 6)
+- `goldenmatch/core/postflight.py` (or wherever `_apply_postflight` lives) — render memory line when `memory_stats` is set (Phase 3)
+- `goldenmatch/core/review_queue.py:238,241` — `approve`/`reject` write to memory store (base class only) (Phase 4)
+- `goldenmatch/tui/tabs/boost_tab.py:276` — `on_button_pressed` (`btn-match`/`btn-nonmatch`/`btn-skip` branches) writes to memory store (Phase 4)
+- `goldenmatch/core/cluster.py:361,431` — `unmerge_record`/`unmerge_cluster` accept optional `memory_store`, write empty-hash corrections (Phase 4)
+- `goldenmatch/core/llm_scorer.py:33` — `llm_score_pairs` accepts optional `memory_store`, writes per-decision corrections (Phase 4)
+- `goldenmatch/mcp/agent_tools.py:104` — `agent_approve_reject` writes to memory store (Phase 4)
+- `goldenmatch/api/server.py:309` — `POST /reviews/decide` writes to memory store (Phase 4)
+- `goldenmatch/core/explain.py` — extend `explain_pair_nl` to accept correction context, optionally route to LLM (Phase 5)
+- `goldenmatch/cli/main.py:28,109` — register `memory_app` (Phase 6)
+- `goldenmatch/mcp/server.py:1266` — change description string from `"30 MCP tools"` to `"35 MCP tools"`; import + register `MEMORY_TOOLS` (Phase 7)
+
+---
+
+## Common patterns
+
+**Test directory.** All new tests live in `packages/python/goldenmatch/tests/`. Run from `packages/python/goldenmatch/` so pytest picks up the package conftest.
+
+**SQLite test isolation.** Use the existing pattern: `MemoryStore(backend="sqlite", path=str(tmp_path / "test.db"))`. The `tmp_path` fixture gives each test a fresh DB.
+
+**Polyrun command.** Single-test: `pytest packages/python/goldenmatch/tests/test_<file>.py::<name> -v`. Phase smoke: `pytest packages/python/goldenmatch/tests/test_memory*.py -v --tb=short`.
+
+**Commit message format.** `feat(memory): <description>` for new behavior, `test(memory): <description>` for test-only changes. Keep commits small — one TDD cycle per commit when practical.
+
+**Branch.** Per the goldenmatch SOP, all phases land on `feature/learning-memory-completion` (or per-phase branches if you prefer). Squash-merge each PR.
+
+---
+
+## Phase 1: Re-anchor (Addition 1)
+
+**Why first:** Fully testable in isolation against the existing 48 unit tests. Phases 2+ assume corrections survive row reordering; without this, pipeline-hook tests will pass but the feature won't be useful.
+
+**Files:**
+- Modify: `goldenmatch/config/schemas.py`
+- Modify: `goldenmatch/core/memory/corrections.py`
+- Test: `tests/test_memory_reanchor.py`
+
+### Steps
+
+- [ ] **Step 1.1: Add `reanchor` and `dataset` fields to `MemoryConfig`**
+
+`goldenmatch/config/schemas.py:402` — find the existing `MemoryConfig` class. Add:
+
+```python
+class MemoryConfig(BaseModel):
+    # ... existing fields ...
+    reanchor: bool = True
+    dataset: str | None = None
+```
+
+`dataset` is the scoping key referenced throughout the foundation spec but never schema-declared. Adding it now lets Phase 2 use `config.memory.dataset` as a real attribute instead of `hasattr` cargo-cult.
+
+- [ ] **Step 1.2: Run existing memory tests — confirm green baseline**
+
+```bash
+pytest packages/python/goldenmatch/tests/test_memory_store.py packages/python/goldenmatch/tests/test_corrections.py packages/python/goldenmatch/tests/test_learner.py packages/python/goldenmatch/tests/test_memory_integration.py -v
+```
+Expected: 48 passed.
+
+- [ ] **Step 1.3: Write the failing test — row reorder preserves correction**
+
+`tests/test_memory_reanchor.py`:
+
+```python
+import polars as pl
+import pytest
+from goldenmatch.core.memory.store import MemoryStore, Correction
+from goldenmatch.core.memory.corrections import (
+    apply_corrections,
+    compute_field_hash,
+    build_row_lookup,
+)
+from datetime import datetime
+import uuid
+
+
+def _make_df(rows):
+    """rows: list of (row_id, name, zip)"""
+    return pl.DataFrame(
+        {"__row_id__": [r[0] for r in rows],
+         "name": [r[1] for r in rows],
+         "zip": [r[2] for r in rows]}
+    )
+
+
+def _seed_correction(store, df, id_a, id_b, decision, *, fields=("name", "zip")):
+    """Helper: store a correction with full hashes computed from df."""
+    from goldenmatch.core.memory.corrections import compute_record_hash
+    lookup = build_row_lookup(df, list(fields))
+    fh = compute_field_hash(lookup[id_a], lookup[id_b])
+    rh = f"{compute_record_hash(df, id_a)}:{compute_record_hash(df, id_b)}"
+    store.add_correction(Correction(
+        id=str(uuid.uuid4()), id_a=id_a, id_b=id_b,
+        decision=decision, source="steward", trust=1.0,
+        field_hash=fh, record_hash=rh,
+        original_score=0.92, matchkey_name=None, reason=None,
+        dataset="t", created_at=datetime.now(),
+    ))
+
+
+def test_reanchor_after_row_reorder(tmp_path):
+    """Correction stays applied after rows are shuffled."""
+    df1 = _make_df([(1, "Acme Corp", "10001"),
+                    (2, "Acme LLC",  "10001"),
+                    (3, "Beta Inc",  "20002")])
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    _seed_correction(store, df1, 1, 2, "reject")  # Acme Corp != Acme LLC
+
+    # Same entities, different row IDs (sorted by name)
+    df2 = _make_df([(10, "Acme Corp", "10001"),
+                    (20, "Acme LLC",  "10001"),
+                    (30, "Beta Inc",  "20002")])
+    scored = [(10, 20, 0.92), (10, 30, 0.10), (20, 30, 0.10)]
+    adjusted, stats = apply_corrections(scored, store, df2,
+                                        ["name", "zip"], dataset="t")
+
+    # Pair (10, 20) corresponds to the corrected pair (1, 2).
+    pair_score = next(s for a, b, s in adjusted if (a, b) == (10, 20))
+    assert pair_score == 0.0, "rejected correction should re-anchor and apply"
+    assert stats.applied == 1
+    assert stats.stale == 0
+```
+
+- [ ] **Step 1.4: Run test — confirm it fails**
+
+Expected failure: `pair_score == 0.92` (correction not applied because row IDs no longer match).
+
+- [ ] **Step 1.5: Implement vectorized record_hash map + collision-safe re-anchor**
+
+In `goldenmatch/core/memory/corrections.py`, replace the body of `apply_corrections` with the algorithm from spec section "Addition 1". Key changes from current implementation:
+
+- Fetch all corrections once via `store.get_corrections(dataset=dataset)`
+- Build `hash_to_rids: dict[str, list[int]]` via vectorized `pl.concat_str` + `map_elements` (one O(N) pass over the df)
+- For each correction, prefer direct row-ID match; fall back to record_hash re-anchor only when both sides resolve uniquely; count ambiguous (`len(cands) > 1`) as stale-ambiguous
+- Existing dual-hash safety check runs unchanged on the resulting `active` map
+- Add new field `stale_ambiguous: int = 0` to `CorrectionStats`
+- Skip the re-anchor path entirely when `config.memory.reanchor is False` (the function takes `df` and `store` but not config; expose this via a new keyword arg `reanchor: bool = True` and have the pipeline hook pass `config.memory.reanchor`)
+
+Reference: spec Addition 1 Algorithm block — the sketched code is the contract.
+
+- [ ] **Step 1.6: Run the new test — confirm it passes**
+
+Expected: `pair_score == 0.0`, `stats.applied == 1`.
+
+- [ ] **Step 1.7: Run the full existing 48-test suite — confirm no regressions**
+
+```bash
+pytest packages/python/goldenmatch/tests/test_memory_store.py packages/python/goldenmatch/tests/test_corrections.py packages/python/goldenmatch/tests/test_learner.py packages/python/goldenmatch/tests/test_memory_integration.py -v
+```
+Expected: 48 passed.
+
+- [ ] **Step 1.8: Write the failing test — duplicate row collision**
+
+```python
+def test_reanchor_skips_ambiguous_duplicates(tmp_path):
+    """When two current rows share record_hash, refuse to re-anchor."""
+    df1 = _make_df([(1, "Acme Corp", "10001"),
+                    (2, "Acme LLC",  "10001")])
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    _seed_correction(store, df1, 1, 2, "reject")
+
+    # Now the input has a literal duplicate of "Acme Corp"
+    df2 = _make_df([(10, "Acme Corp", "10001"),
+                    (11, "Acme Corp", "10001"),  # duplicate
+                    (20, "Acme LLC",  "10001")])
+    scored = [(10, 20, 0.92), (11, 20, 0.92), (10, 11, 1.0)]
+    adjusted, stats = apply_corrections(scored, store, df2,
+                                        ["name", "zip"], dataset="t")
+
+    # Acme Corp side has 2 candidates → ambiguous → no application
+    assert all(s == orig for (_, _, s), (_, _, orig) in zip(adjusted, scored))
+    assert stats.applied == 0
+    assert stats.stale_ambiguous == 1
+```
+
+- [ ] **Step 1.9: Run; confirm passes**
+
+Expected: stats.applied == 0, stats.stale_ambiguous == 1.
+
+- [ ] **Step 1.10: Add edit-on-matchkey-field test**
+
+```python
+def test_edit_on_matchkey_field_marks_stale(tmp_path):
+    df1 = _make_df([(1, "Acme Corp", "10001"),
+                    (2, "Acme LLC",  "10001")])
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    _seed_correction(store, df1, 1, 2, "reject")
+
+    # Edit one of the matched fields
+    df2 = _make_df([(1, "ACME CORPORATION", "10001"),  # name changed
+                    (2, "Acme LLC",          "10001")])
+    scored = [(1, 2, 0.85)]
+    adjusted, stats = apply_corrections(scored, store, df2,
+                                        ["name", "zip"], dataset="t")
+    assert adjusted[0][2] == 0.85  # original score, not overridden
+    assert stats.applied == 0
+    assert stats.stale == 1
+```
+
+- [ ] **Step 1.11: Add edit-on-non-matchkey-field test (correction still applies)**
+
+```python
+def test_edit_on_non_matchkey_field_still_applies(tmp_path):
+    df1 = _make_df([(1, "Acme Corp", "10001"),
+                    (2, "Acme LLC",  "10001")])
+    # Add an extra column that is NOT a matchkey field
+    df1 = df1.with_columns(pl.lit("old_note").alias("note"))
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    _seed_correction(store, df1, 1, 2, "reject", fields=("name", "zip"))
+
+    df2 = df1.with_columns(pl.lit("new_note").alias("note"))
+    # ⚠ record_hash includes ALL columns, so changing `note` will mark stale.
+    # This is by design — the dual-hash captures full-row identity.
+    # Test verifies that the staleness detection is consistent with design.
+    scored = [(1, 2, 0.92)]
+    adjusted, stats = apply_corrections(scored, store, df2,
+                                        ["name", "zip"], dataset="t")
+    assert stats.stale == 1
+```
+
+(Note: this test confirms the *current* dual-hash semantics; if a future spec relaxes record_hash to matchkey-only, this test changes.)
+
+- [ ] **Step 1.12: Add `reanchor=False` opt-out test**
+
+```python
+def test_reanchor_disabled_falls_back_to_row_id_lookup(tmp_path):
+    df1 = _make_df([(1, "Acme Corp", "10001"),
+                    (2, "Acme LLC",  "10001")])
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    _seed_correction(store, df1, 1, 2, "reject")
+
+    df2 = _make_df([(10, "Acme Corp", "10001"),  # different row IDs
+                    (20, "Acme LLC",  "10001")])
+    scored = [(10, 20, 0.92)]
+    adjusted, stats = apply_corrections(scored, store, df2,
+                                        ["name", "zip"], dataset="t",
+                                        reanchor=False)
+    assert adjusted[0][2] == 0.92  # not applied
+    assert stats.applied == 0
+```
+
+- [ ] **Step 1.13: Run all phase-1 tests; confirm green**
+
+```bash
+pytest packages/python/goldenmatch/tests/test_memory_reanchor.py -v
+```
+
+- [ ] **Step 1.14: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/config/schemas.py \
+        packages/python/goldenmatch/goldenmatch/core/memory/corrections.py \
+        packages/python/goldenmatch/tests/test_memory_reanchor.py
+git commit -m "feat(memory): collision-safe vectorized re-anchor via record_hash"
+```
+
+---
+
+## Phase 2: Pipeline hook (Task 5)
+
+**Why second:** Nothing the user can observe works until this lands.
+
+**Ordering note:** Phase 3 (postflight rendering) consumes `result.memory_stats` set here; Phase 3 must merge after Phase 2. Phase 2 itself is independently shippable (its tests don't read postflight strings).
+
+**Files:**
+- Modify: `goldenmatch/core/pipeline.py` (around line 497)
+- Modify: `goldenmatch/_api.py:36` (DedupeResult), `:136` (MatchResult)
+- Test: `tests/test_memory_pipeline.py`
+
+### Steps
+
+- [ ] **Step 2.1: Add `memory_stats` field to both result dataclasses**
+
+`goldenmatch/_api.py` — at line 56 (after `postflight_report` in `DedupeResult`):
+
+```python
+    memory_stats: "CorrectionStats | None" = None
+```
+
+At line 148 (after `postflight_report` in `MatchResult`):
+
+```python
+    memory_stats: "CorrectionStats | None" = None
+```
+
+Add the import at top of file under TYPE_CHECKING:
+
+```python
+if TYPE_CHECKING:
+    from goldenmatch.core.memory.corrections import CorrectionStats
+```
+
+- [ ] **Step 2.2: Write the failing pipeline-hook test**
+
+`tests/test_memory_pipeline.py`:
+
+```python
+import polars as pl
+import pytest
+from datetime import datetime
+import uuid
+
+from goldenmatch import dedupe_df
+from goldenmatch.config.schemas import (
+    GoldenMatchConfig, MemoryConfig, MatchkeyConfig, MatchkeyField,
+    BlockingConfig, BlockingKeyConfig,
+)
+from goldenmatch.core.memory.store import MemoryStore, Correction
+
+
+def test_pipeline_applies_seeded_correction(tmp_path):
+    df = pl.DataFrame({
+        "name": ["Acme Corp", "Acme LLC", "Beta Inc"],
+        "zip":  ["10001",     "10001",    "20002"],
+    })
+
+    db_path = tmp_path / "mem.db"
+    # Seed: reject the (0, 1) pair
+    store = MemoryStore(backend="sqlite", path=str(db_path))
+    # Use the standard build_row_lookup / hash helpers
+    from goldenmatch.core.memory.corrections import (
+        build_row_lookup, compute_field_hash, compute_record_hash,
+    )
+    df_with_id = df.with_row_index(name="__row_id__")
+    lookup = build_row_lookup(df_with_id, ["name", "zip"])
+    fh = compute_field_hash(lookup[0], lookup[1])
+    rh = f"{compute_record_hash(df_with_id, 0)}:{compute_record_hash(df_with_id, 1)}"
+    store.add_correction(Correction(
+        id=str(uuid.uuid4()), id_a=0, id_b=1, decision="reject",
+        source="steward", trust=1.0, field_hash=fh, record_hash=rh,
+        original_score=0.95, matchkey_name=None, reason=None,
+        dataset=None, created_at=datetime.now(),
+    ))
+    store.close()
+
+    config = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="identity", type="weighted", threshold=0.75,
+            fields=[MatchkeyField(field="name", scorer="jaro_winkler",
+                                  transforms=["lowercase"], weight=1.0)],
+        )],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["zip"], transforms=["lowercase"])],
+            maxBlockSize=1000, skipOversized=True,
+        ),
+        memory=MemoryConfig(enabled=True, path=str(db_path)),
+    )
+
+    result = dedupe_df(df, config=config)
+
+    # Acme pair should NOT be in clusters — its score got overridden to 0.0
+    pairs_kept = {(a, b) for a, b, _ in result.scored_pairs}
+    assert (0, 1) not in pairs_kept or all(
+        s == 0.0 for a, b, s in result.scored_pairs if (a, b) == (0, 1)
+    )
+    assert result.memory_stats is not None
+    assert result.memory_stats.applied == 1
+```
+
+- [ ] **Step 2.3: Run; confirm fails**
+
+Expected failure: `result.memory_stats is None` (the hook isn't wired yet).
+
+- [ ] **Step 2.4: Add learner-overlay block at start of `_run_dedupe_pipeline`**
+
+`_run_dedupe_pipeline` already receives a `matchkeys` parameter from its caller (`dedupe()` at pipeline.py:206 and `match()` at :651/:691, threaded via `_run_dedupe_pipeline(... matchkeys, ...)`). The overlay must mutate **that parameter in place** — not rebind a fresh `list(config.get_matchkeys())`, which would create a shadow copy that the scoring loop (lines 393, 408, 422, 457) never reads.
+
+In `goldenmatch/core/pipeline.py`, after the config is fully materialized but before scoring (find the section before `# Step 3: SCORE`), add:
+
+```python
+    # ── Learning Memory: pre-scoring learner overlay ──
+    memory_store = None
+    if config.memory and config.memory.enabled:
+        try:
+            from goldenmatch.core.memory.store import MemoryStore
+            from goldenmatch.core.memory.learner import MemoryLearner
+            memory_store = MemoryStore(
+                backend=config.memory.backend,
+                path=config.memory.path,
+                connection=config.memory.connection,
+            )
+            learner = MemoryLearner(
+                memory_store,
+                threshold_min=config.memory.learning.threshold_min_corrections,
+                weights_min=config.memory.learning.weights_min_corrections,
+            )
+            if learner.has_new_corrections():
+                adjustments = learner.learn()
+                # Overlay onto the matchkeys PARAMETER in place — do NOT rebind
+                # to a new list, or the scoring loop downstream won't see it.
+                for adj in adjustments:
+                    if adj.threshold is None:
+                        continue
+                    for mk in matchkeys:  # mutate parameter, not a fresh copy
+                        if mk.threshold is not None and (
+                            not adj.matchkey_name or adj.matchkey_name == mk.name
+                            or adj.matchkey_name == "_default"
+                        ):
+                            mk.threshold = adj.threshold
+        except Exception as e:
+            logger.warning("Memory store init failed, continuing without memory: %s", e)
+            memory_store = None
+```
+
+Note: this mutates the `MatchkeyConfig` Pydantic objects on the in-memory matchkeys list. The original config's matchkeys are the *same objects* — be aware that calling the pipeline twice with the same config in the same Python process will see cumulative threshold overlay. If that becomes an issue, a deep-copy of the matchkeys parameter at function entry is the right fix; defer until/unless a test catches it.
+
+- [ ] **Step 2.5: Insert post-scoring `apply_corrections` call before `_apply_postflight`**
+
+At pipeline.py:497 (before the existing `all_pairs, postflight_report = _apply_postflight(...)` call), insert:
+
+```python
+    # ── Learning Memory: post-scoring corrections overlay ──
+    memory_stats = None
+    if memory_store is not None:
+        from goldenmatch.core.memory.corrections import apply_corrections
+        matchkey_field_names = [
+            f.field
+            for mk in config.get_matchkeys()
+            for f in mk.fields
+        ]
+        dataset = config.memory.dataset
+        all_pairs, memory_stats = apply_corrections(
+            all_pairs, memory_store, collected_df, matchkey_field_names,
+            dataset=dataset,
+            reanchor=config.memory.reanchor,
+        )
+```
+
+- [ ] **Step 2.6: Attach `memory_stats` and stale-pair enqueue at result-build time**
+
+Find where `DedupeResult(...)` is constructed at end of `_run_dedupe_pipeline()`. Add `memory_stats=memory_stats` to the constructor.
+
+After `DedupeResult` is built but before return, enqueue stale pairs:
+
+```python
+    if memory_stats is not None and memory_stats.stale_pairs:
+        try:
+            from goldenmatch.core.review_queue import ReviewQueue
+            rq = ReviewQueue()  # in-memory backend; users wire SQLite/PG via config
+            for (a, b) in memory_stats.stale_pairs:
+                # Find score from all_pairs if present, else 0.0
+                score = next(
+                    (s for ai, bi, s in all_pairs if (ai, bi) == (a, b)), 0.0
+                )
+                rq.add(item_a_id=a, item_b_id=b, score=score, source="memory_stale")
+        except Exception as e:
+            logger.warning("Failed to enqueue stale pairs: %s", e)
+```
+
+- [ ] **Step 2.7: Mirror the same hook in `_run_match_pipeline()`**
+
+Same pre-scoring overlay + post-scoring `apply_corrections` + result attach. `MatchResult` gains `memory_stats=memory_stats`.
+
+- [ ] **Step 2.8: Close `memory_store` in a `finally` block**
+
+Wrap the pipeline body so the SQLite connection always closes.
+
+- [ ] **Step 2.9: Run the test — confirm passes**
+
+```bash
+pytest packages/python/goldenmatch/tests/test_memory_pipeline.py -v
+```
+
+- [ ] **Step 2.10: Add no-memory baseline test (regression guard)**
+
+```python
+def test_pipeline_no_memory_stats_when_disabled():
+    df = pl.DataFrame({"name": ["A", "B"], "zip": ["1", "2"]})
+    result = dedupe_df(df)  # default config, no memory
+    assert result.memory_stats is None
+```
+
+- [ ] **Step 2.11: Add memory-disabled-but-config-present test**
+
+```python
+def test_pipeline_memory_disabled_does_not_open_store(tmp_path):
+    df = pl.DataFrame({"name": ["A", "B"], "zip": ["1", "2"]})
+    config = GoldenMatchConfig(
+        # ... minimal valid matchkeys ...
+        memory=MemoryConfig(enabled=False, path=str(tmp_path / "mem.db")),
+    )
+    result = dedupe_df(df, config=config)
+    assert result.memory_stats is None
+    # The DB file should not exist — store never opened
+    assert not (tmp_path / "mem.db").exists()
+```
+
+- [ ] **Step 2.12: Run full memory test suite; confirm 48 + new tests green**
+
+```bash
+pytest packages/python/goldenmatch/tests/test_memory_*.py -v
+```
+
+- [ ] **Step 2.13: Commit**
+
+```bash
+git commit -m "feat(memory): pipeline hook for learner overlay + correction apply"
+```
+
+---
+
+## Phase 3: Postflight wiring (Addition 3, postflight half)
+
+**Files:**
+- Modify: postflight rendering site (find via `grep -rn "_apply_postflight" packages/python/goldenmatch/goldenmatch/`)
+- Test: `tests/test_memory_postflight.py`
+
+### Steps
+
+- [ ] **Step 3.1: Open the postflight render path**
+
+The renderer lives at `core/autoconfig_verify.py:946` (function `postflight()`). It consumes a `PostflightReport` and emits a multi-line summary string. Open this file before drafting the test — the rendering site is the edit target for Step 3.4.
+
+- [ ] **Step 3.2: Failing test for memory line in postflight**
+
+```python
+def test_postflight_renders_memory_section(tmp_path):
+    # Use the same seeded fixture from Phase 2
+    # ... set up store with one approve correction ...
+    result = dedupe_df(df, config=config)
+    text = str(result.postflight_report) if result.postflight_report else ""
+    # Memory line is rendered into postflight summary
+    assert "Memory:" in text
+    assert "1 corrections applied" in text or "1 correction applied" in text
+```
+
+- [ ] **Step 3.3: Run; confirm fails**
+
+- [ ] **Step 3.4: Implement memory line in postflight rendering**
+
+Add a method to `PostflightReport` (or modify the renderer) that, when `memory_stats` is set on the parent `DedupeResult`/`MatchResult`, appends:
+
+```
+Memory: {applied} corrections applied, {stale} stale, {stale_ambiguous} stale-ambiguous
+        (run `goldenmatch review` to re-decide stale pairs)
+```
+
+If counts are zero across the board, omit the line entirely (don't clutter the report when memory is enabled but had nothing to do).
+
+The renderer needs access to `memory_stats`. Cleanest: pass `memory_stats` into the renderer alongside `postflight_report`, or attach `memory_stats` onto the `PostflightReport` object at result-build time.
+
+- [ ] **Step 3.5: Run test; confirm passes**
+
+- [ ] **Step 3.6: Stale-ambiguous test**
+
+Verify that when `stats.stale_ambiguous > 0`, the rendered string includes `"stale-ambiguous"`.
+
+- [ ] **Step 3.7: Zero-counts omission test**
+
+Verify that with memory enabled but `applied == stale == stale_ambiguous == 0`, the postflight does NOT contain "Memory:".
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+git commit -m "feat(memory): postflight surfaces applied/stale counts"
+```
+
+---
+
+## Phase 4: Collection points (Task 6)
+
+**Why fourth:** With phases 1–3 done, every `add_correction` call is observable end-to-end via re-run + postflight.
+
+**Files:**
+- Modify: `goldenmatch/core/review_queue.py` (base class only)
+- Modify: `goldenmatch/tui/tabs/boost_tab.py`
+- Modify: `goldenmatch/core/cluster.py` (`unmerge_record`, `unmerge_cluster`)
+- Modify: `goldenmatch/core/llm_scorer.py` (`llm_score_pairs`)
+- Modify: `goldenmatch/mcp/agent_tools.py` (`agent_approve_reject` handler)
+- Modify: `goldenmatch/api/server.py` (`POST /reviews/decide`)
+- Test: `tests/test_memory_collection.py`
+
+**Reference:** Foundation plan Task 6 has detailed code skeletons (review_queue, unmerge, llm_scorer). Reuse them with the spec-mandated changes:
+
+- ReviewQueue hook lands on the **base class only** (not per-backend); pass `memory_store` into `ReviewQueue.__init__`.
+- Unmerge functions write **empty hashes** (no df/matchkey_fields available; the empty-hash branch in `apply_corrections` already handles this).
+- Boost tab: file is `tui/tabs/boost_tab.py`, NOT `tui/app.py`. Hook in `on_button_pressed` at **line 276**, in the `btn-match` / `btn-nonmatch` branches (NOT `btn-skip`). Note: BoostTab labels also feed an LR classifier downstream (`_record_label`) — keep that wiring untouched; the memory write is purely additive at the same handler. Source = `"boost"`, trust = 1.0.
+- LLM scorer: at decision point, write `Correction` with `source="llm"`, `trust=0.5`, full hashes (df is in scope).
+- agent_approve_reject (agent_tools.py:104): trust=0.5, source="agent".
+- REST `POST /reviews/decide` (api/server.py:309): trust=1.0, source="steward". May not have df in scope — write empty hashes if so.
+
+### Steps (per surface — repeat the TDD cycle)
+
+For each surface, the cycle is:
+
+- [ ] **A: Failing test** — invoke the surface with `memory_store` set; assert the store has the expected `Correction` record.
+- [ ] **B: Run; confirm fails.**
+- [ ] **C: Implement** — add `memory_store` parameter, wire `add_correction` call after existing logic, with the spec-mandated trust/source/hashes for that surface.
+- [ ] **D: Run; confirm passes.**
+- [ ] **E: Run full memory test suite; confirm no regressions.**
+- [ ] **F: Commit per surface** — `feat(memory): wire <surface> as collection point`.
+
+**Surface order (in the same PR, separate commits):**
+
+- [ ] **4.1 ReviewQueue base class.**
+- [ ] **4.2 unmerge_record + unmerge_cluster** (single commit; same file).
+- [ ] **4.3 llm_score_pairs.**
+- [ ] **4.4 agent_approve_reject.**
+- [ ] **4.5 POST /reviews/decide.**
+- [ ] **4.6 BoostTab y/n handlers.** TUI testing uses `pytest-asyncio` with `app.run_test()`. Per CLAUDE.md guidance, assert at the `MemoryStore` layer — don't introspect rendered UI.
+
+- [ ] **4.7 Final commit covering all surfaces if not already split**
+
+---
+
+## Phase 5: Explainer integration (Addition 3, explainer half)
+
+**Files:**
+- Modify: `goldenmatch/core/explain.py`
+- Test: `tests/test_memory_explainer.py`
+
+### Steps
+
+- [ ] **Step 5.1: Failing test — review queue items carry a `why` field**
+
+`tests/test_memory_explainer.py`:
+
+```python
+from goldenmatch.core.review_queue import ReviewQueue
+from goldenmatch.core.memory.store import MemoryStore
+
+def test_review_queue_item_has_why_field(tmp_path):
+    # ... seed a few weak-cluster pairs ...
+    rq = ReviewQueue(memory_store=...)
+    items = rq.list()
+    assert all(hasattr(item, "why") and isinstance(item.why, str) and item.why for item in items)
+```
+
+- [ ] **Step 5.2: Implement default deterministic explainer path**
+
+Extend `core/explain.py::explain_pair_nl` (already exists) so it accepts the matchkey + scores and returns a one-sentence string. Plumb a `why` field onto `ReviewItem`.
+
+- [ ] **Step 5.3: Failing test — LLM upgrade path**
+
+```python
+def test_explainer_uses_llm_when_api_key_set(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    # ... mock the LLM call to return a known string ...
+    # assert that string appears in the why field
+```
+
+- [ ] **Step 5.4: Implement LLM upgrade path**
+
+When `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` is set AND `config.llm_scorer.enabled`, route through `core/llm_scorer.py` to generate richer prose. Reuse existing `BudgetTracker`. Fall back to deterministic on any error.
+
+- [ ] **Step 5.5: Run all phase-5 tests; confirm green**
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git commit -m "feat(memory): add why field to review queue + MCP results"
+```
+
+---
+
+## Phase 6: CLI surfaces (Task 7) + Python API
+
+**Files:**
+- Create: `goldenmatch/cli/memory.py`
+- Modify: `goldenmatch/cli/main.py:28,109`
+- Modify: `goldenmatch/_api.py` — add `get_memory`, `add_correction`, `learn`, `memory_stats` functions
+- Modify: `goldenmatch/__init__.py` — re-export the four new API functions
+- Test: `tests/test_memory_cli.py`
+
+### Steps
+
+- [ ] **Step 6.1: Add Python API functions**
+
+In `goldenmatch/_api.py`:
+
+```python
+def get_memory(path: str | None = None) -> "MemoryStore":
+    from goldenmatch.core.memory.store import MemoryStore
+    return MemoryStore(backend="sqlite", path=path or ".goldenmatch/memory.db")
+
+def add_correction(id_a: int, id_b: int, decision: str, *,
+                   source: str = "api", reason: str | None = None,
+                   dataset: str | None = None,
+                   matchkey_name: str | None = None,
+                   path: str | None = None) -> None:
+    import uuid
+    from datetime import datetime
+    from goldenmatch.core.memory.store import Correction
+    store = get_memory(path)
+    try:
+        # Trust mapping per spec table: steward/boost/unmerge=1.0, llm/agent=0.5.
+        # Default source "api" treated as agent-tier (0.5) — the Python API
+        # caller is conceptually a programmatic actor; users wanting human
+        # trust should pass source="steward" explicitly.
+        store.add_correction(Correction(
+            id=str(uuid.uuid4()), id_a=id_a, id_b=id_b,
+            decision=decision, source=source,
+            trust=1.0 if source in {"steward", "boost", "unmerge"} else 0.5,
+            field_hash="", record_hash="", original_score=0.0,
+            matchkey_name=matchkey_name, reason=reason,
+            dataset=dataset, created_at=datetime.now(),
+        ))
+    finally:
+        store.close()
+
+def learn(matchkey_name: str | None = None,
+          path: str | None = None) -> "list[LearnedAdjustment]":
+    from goldenmatch.core.memory.learner import MemoryLearner
+    store = get_memory(path)
+    try:
+        learner = MemoryLearner(store)
+        return learner.learn(matchkey_name=matchkey_name)
+    finally:
+        store.close()
+
+def memory_stats(path: str | None = None) -> dict:
+    store = get_memory(path)
+    try:
+        return {
+            "count": store.count_corrections(),
+            "last_learn_time": store.last_learn_time(),
+            "adjustments": [a.__dict__ for a in store.get_all_adjustments()],
+        }
+    finally:
+        store.close()
+```
+
+Re-export from `goldenmatch/__init__.py`.
+
+- [ ] **Step 6.2: Failing API tests**
+
+`tests/test_memory_cli.py` (Python API portion):
+
+```python
+def test_api_add_and_count(tmp_path):
+    import goldenmatch
+    p = str(tmp_path / "mem.db")
+    goldenmatch.add_correction(1, 2, "approve", source="steward", path=p)
+    stats = goldenmatch.memory_stats(path=p)
+    assert stats["count"] == 1
+```
+
+- [ ] **Step 6.3: Run; confirm passes** (functions exist after step 6.1)
+
+- [ ] **Step 6.4: Create `cli/memory.py` with five subcommands**
+
+Pattern from `cli/pprl.py` (look at it for reference). Each subcommand is a thin wrapper around the Python API. Use `rich.table.Table` for `stats` and `show` to match the rest of the CLI's output style.
+
+```python
+import typer
+from rich.console import Console
+from rich.table import Table
+import goldenmatch
+
+memory_app = typer.Typer(help="Inspect and manage Learning Memory.")
+
+@memory_app.command("stats")
+def stats_cmd(path: str = typer.Option(".goldenmatch/memory.db", "--path")):
+    s = goldenmatch.memory_stats(path=path)
+    # ... print table ...
+
+@memory_app.command("learn")
+def learn_cmd(...):
+    ...
+
+@memory_app.command("export")
+def export_cmd(out: str, path: str = typer.Option(".goldenmatch/memory.db", "--path")):
+    # write all corrections as CSV
+    ...
+
+@memory_app.command("import")
+def import_cmd(src: str, path: str = typer.Option(".goldenmatch/memory.db", "--path")):
+    # read CSV, validate columns, call store.add_correction per row
+    ...
+
+@memory_app.command("show")
+def show_cmd(id_a: int, id_b: int, path: str = typer.Option(".goldenmatch/memory.db", "--path")):
+    ...
+```
+
+- [ ] **Step 6.5: Register `memory_app` in `cli/main.py`**
+
+Match the `pprl_app` pattern at `cli/main.py:28,109`:
+
+```python
+from goldenmatch.cli.memory import memory_app
+# ...
+app.add_typer(memory_app, name="memory")
+```
+
+- [ ] **Step 6.6: Failing CLI test**
+
+```python
+def test_cli_memory_stats_runs(tmp_path):
+    from typer.testing import CliRunner
+    from goldenmatch.cli.main import app
+    runner = CliRunner()
+    p = str(tmp_path / "mem.db")
+    # Seed via API
+    import goldenmatch
+    goldenmatch.add_correction(1, 2, "approve", source="steward", path=p)
+    result = runner.invoke(app, ["memory", "stats", "--path", p])
+    assert result.exit_code == 0
+    assert "1" in result.stdout
+```
+
+- [ ] **Step 6.7: Run; confirm passes**
+
+- [ ] **Step 6.8: Round-trip export/import test**
+
+```python
+def test_cli_memory_export_import_roundtrip(tmp_path):
+    # add 3 corrections, export to CSV, clear store, import, verify count == 3
+```
+
+- [ ] **Step 6.9: Commit**
+
+```bash
+git commit -m "feat(memory): CLI subgroup + Python API"
+```
+
+---
+
+## Phase 7: MCP tools (Addition 2)
+
+**Files:**
+- Create: `goldenmatch/mcp/memory_tools.py`
+- Modify: `goldenmatch/mcp/server.py:1266` (description string + import + register)
+- Test: `tests/test_memory_tools.py`
+
+### Steps
+
+- [ ] **Step 7.1: Failing test — `list_corrections` tool registered**
+
+```python
+def test_memory_tools_registered():
+    from goldenmatch.mcp.memory_tools import MEMORY_TOOLS, _MEMORY_TOOL_NAMES
+    names = {t.name for t in MEMORY_TOOLS}
+    assert names == {
+        "list_corrections", "add_correction",
+        "learn_thresholds", "memory_stats", "memory_export",
+    }
+    assert names == _MEMORY_TOOL_NAMES
+```
+
+- [ ] **Step 7.2: Run; confirm fails (module doesn't exist).**
+
+- [ ] **Step 7.3: Create `mcp/memory_tools.py`**
+
+Pattern matches `mcp/agent_tools.py` exactly. Five `Tool` definitions with `inputSchema`. One `handle_memory_tool(name, arguments)` function (mirrors `handle_agent_tool`) that routes to per-tool handlers and returns `list[TextContent]`. Each handler instantiates its own `MemoryStore` (no shared global state) and traps `sqlite3.OperationalError` to return structured errors rather than crash MCP.
+
+Tools and required arguments (per spec Addition 2):
+
+| Tool | Required args | Optional args |
+|---|---|---|
+| `list_corrections` | — | `dataset` |
+| `add_correction` | `id_a`, `id_b`, `decision`, `dataset` | `reason`, `matchkey_name` |
+| `learn_thresholds` | — | `matchkey_name` |
+| `memory_stats` | — | `path` |
+| `memory_export` | — | `dataset`, `path` |
+
+`add_correction` writes with `source="agent"`, `trust=0.5`.
+
+- [ ] **Step 7.4: Run test; confirm passes**
+
+- [ ] **Step 7.5: Wire into `mcp/server.py`**
+
+Find the existing tool registration section in `server.py`:
+- Add `from goldenmatch.mcp.memory_tools import MEMORY_TOOLS, _MEMORY_TOOL_NAMES, handle_memory_tool` (name follows the existing `handle_agent_tool` symmetry in `agent_tools.py`)
+- Extend the tool list returned by `list_tools()` with `MEMORY_TOOLS`
+- In `call_tool()` dispatch, route to `handle_memory_tool` when `name in _MEMORY_TOOL_NAMES`
+- At line 1266, change description from `"30 MCP tools"` to `"35 MCP tools"`
+
+- [ ] **Step 7.6: Failing end-to-end MCP test**
+
+```python
+@pytest.mark.asyncio
+async def test_mcp_add_and_list_correction(tmp_path):
+    from goldenmatch.mcp.memory_tools import handle_memory_tool
+    # add via tool
+    res = await handle_memory_tool("add_correction", {
+        "id_a": 1, "id_b": 2, "decision": "approve", "dataset": "test",
+    })
+    # list via tool
+    res2 = await handle_memory_tool("list_corrections", {"dataset": "test"})
+    text = res2[0].text
+    assert "1" in text and "2" in text
+```
+
+- [ ] **Step 7.7: Run; confirm passes**
+
+- [ ] **Step 7.8: Server-card description test**
+
+```python
+def test_server_card_description_count():
+    import re
+    from pathlib import Path
+    src = Path("packages/python/goldenmatch/goldenmatch/mcp/server.py").read_text()
+    match = re.search(r"(\d+) MCP tools", src)
+    assert match and int(match.group(1)) == 35
+```
+
+- [ ] **Step 7.9: Commit**
+
+```bash
+git commit -m "feat(memory): five MCP tools (list/add/learn/stats/export)"
+```
+
+---
+
+## Phase 8: Integration tests (Task 8)
+
+**Files:**
+- Create: `tests/test_memory_e2e.py`
+
+### Test list (one test per scenario, end-to-end)
+
+- [ ] **8.1 Happy path:** dedupe → reject one cluster pair via Python API → re-run → assert pair score is 0.0.
+- [ ] **8.2 Re-anchor on reorder:** dedupe → reject pair → shuffle df → re-run → assert pair still rejected (`memory_stats.applied == 1`, `stats.stale == 0`).
+- [ ] **8.3 Re-anchor + edit on matchkey field:** edit one matched field on a corrected entity → re-run → `memory_stats.stale >= 1`, pair appears in review queue.
+- [ ] **8.4 Trust conflict:** LLM rejects pair (trust 0.5) → steward approves (trust 1.0) → assert steward's decision wins on next run.
+- [ ] **8.5 Threshold learning:** seed 12 corrections covering a score range → re-run → assert `MemoryLearner.learn()` ran (`last_learn_time` advanced) and matchkey threshold was overlaid.
+- [ ] **8.6 No API key, deterministic explainer:** unset `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` → assert review queue items still have non-empty `why` (deterministic fallback).
+- [ ] **8.7 Postflight surfaces stats:** run with seeded corrections → assert `memory_stats` populated and postflight string contains memory line.
+- [ ] **8.8 Stale-ambiguous reported separately:** seed correction → re-run with literal duplicate row → assert `memory_stats.stale_ambiguous == 1` and postflight string contains "stale-ambiguous".
+
+### Steps
+
+- [ ] **Step 8.1: Write all eight tests in `tests/test_memory_e2e.py`**
+
+Each test follows: build df → build config with memory enabled → seed correction(s) directly via `MemoryStore.add_correction` (in test setup, not via collection points — keeps tests fast) → run pipeline → assert result.
+
+- [ ] **Step 8.2: Run; confirm all eight pass**
+
+```bash
+pytest packages/python/goldenmatch/tests/test_memory_e2e.py -v
+```
+
+- [ ] **Step 8.3: Run full goldenmatch test suite — no regressions**
+
+```bash
+pytest packages/python/goldenmatch/tests/ --tb=short -q
+```
+
+Expected: pre-existing 1319 + ~34 new (count varies by surface coverage in Phase 4) = ~1353+ tests, all green. Don't tie the assertion to a precise number — confirm the pre-existing 1319 stays green and the new tests pass.
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git commit -m "test(memory): end-to-end integration suite"
+```
+
+- [ ] **Step 8.5: Bump version + changelog entry**
+
+In `packages/python/goldenmatch/pyproject.toml` and `goldenmatch/__init__.py`, bump to `1.6.0` (minor — new feature, additive, fully backward compatible).
+
+In `CHANGELOG.md`, add a "1.6.0" section describing Learning Memory wiring + re-anchor + MCP tools.
+
+- [ ] **Step 8.6: Commit + open PR**
+
+```bash
+git commit -m "chore: bump goldenmatch 1.5.0 -> 1.6.0"
+gh auth switch --user benzsevern
+gh pr create --title "feat: Learning Memory completion (re-anchor, pipeline, surfaces)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Pipeline integration for Learning Memory (per spec 2026-05-04)
+- Collision-safe vectorized re-anchor via record_hash
+- Postflight surfaces applied/stale/stale-ambiguous counts
+- Five MCP tools (list/add/learn/stats/export)
+- Five CLI subcommands under `goldenmatch memory`
+- Seven collection-point wirings across six files (review queue, boost, unmerge_record + unmerge_cluster in cluster.py, llm, agent, REST)
+- Explainer integration (deterministic + LLM fallback)
+- 58 new tests, 0 regressions on the existing 1319
+
+## Spec
+docs/superpowers/specs/2026-05-04-learning-memory-completion.md
+
+## Test plan
+- [x] All new tests pass
+- [x] Pre-existing 1319 tests pass
+- [ ] Manual smoke: `goldenmatch dedupe customers.csv` with seeded correction → applied
+- [ ] Manual smoke: MCP `add_correction` from Claude Desktop → re-run → applied
+EOF
+)"
+```
+
+---
+
+## Out of plan (deferred per spec)
+
+- Rules layer (b) — separate brainstorm/spec.
+- Web review surface — converges with browser-playground spec.
+- MCP-sampling host-LLM explainer path.
+- Identity Store extraction (Phase 2 of suite roadmap).
+- Field-weight learning beyond the existing stub (requires schema addition).
+- Postgres-backend parity testing for memory store (Postgres works today; full integration tests are SQLite-only).
+
+---
+
+## Risk register
+
+- **Pipeline.py is 1024 LOC.** Phase 2's two insertions add ~30 LOC each. Avoid further growth — if Phase 2 + Phase 3 push it over 1100 LOC, consider extracting a `_pipeline_memory.py` helper module before merging.
+- **Boost tab tests are slow.** Phase 4.6 must assert at the `MemoryStore` layer, not the rendered UI, or test runtime will balloon.
+- **MCP server.py is 1281 LOC.** Phase 7's `memory_tools.py` keeps new tools out of `server.py`; only ~5 LOC of registration lands in server.py.
+- **Test fixture seeding for Phase 2.** Until Phase 4 lands, pipeline-hook tests must seed `MemoryStore` directly. Document this in test docstrings.
+- **Postgres backend.** The shipped code accepts a Postgres backend but only SQLite is fully exercised. Integration tests in Phase 8 are SQLite-only; if a user reports a Postgres issue, it's a follow-up — not a launch blocker.

--- a/docs/superpowers/specs/2026-05-04-learning-memory-completion.md
+++ b/docs/superpowers/specs/2026-05-04-learning-memory-completion.md
@@ -70,7 +70,11 @@ def apply_corrections(
 
     # 2. Build vectorized record_hash → [row_ids] map ONCE.
     #    Use polars-native concat_str + hash to avoid O(N) per-row filters.
-    sorted_cols = sorted(df.columns)
+    #    EXCLUDE __row_id__ — it is the positional key that changes across runs;
+    #    including it would make record_hash non-durable, defeating re-anchoring.
+    #    The shipped compute_record_hash() also excludes __row_id__ (corrections
+    #    of v1.6.0+ — earlier persisted hashes that included it appear as stale).
+    sorted_cols = sorted(c for c in df.columns if c != "__row_id__")
     hashed = (
         df.select(
             pl.col("__row_id__"),

--- a/docs/superpowers/specs/2026-05-04-learning-memory-completion.md
+++ b/docs/superpowers/specs/2026-05-04-learning-memory-completion.md
@@ -1,0 +1,303 @@
+# Design: Learning Memory completion (slice-1)
+
+**Date:** 2026-05-04
+**Author:** Ben Severn (with Claude)
+**Status:** Draft
+**Foundation:** [`_archive/goldenmatch-pre-fold/docs/superpowers/specs/2026-03-26-learning-memory-design.md`](../../../_archive/goldenmatch-pre-fold/docs/superpowers/specs/2026-03-26-learning-memory-design.md) (Approved 2026-03-26; Tasks 1–4 shipped)
+
+## Context
+
+The 2026-03-26 Learning Memory spec was approved and Tasks 1–4 (config, store, corrections, learner) were shipped under PR #9. Tasks 5–8 (pipeline integration, collection-point wiring, surfaces, integration tests) remain unchecked. Since the pre-fold work, three gaps have surfaced that the original spec does not address:
+
+1. **Row-ID stability under input refresh.** Today, `apply_corrections()` looks up corrections by `(id_a, id_b)` (the positional `__row_id__`). If the input data is refreshed and rows reorder, stored corrections never match — they go silently unapplied. The dual-hash check protects safety (no false positives) but loses durability (false negatives on every refresh).
+2. **MCP tool surface.** The original spec lists Python API + CLI; MCP is not covered, despite goldenmatch having 30+ MCP tools elsewhere.
+3. **Explainer + postflight reporting.** The original spec does not describe how corrections are narrated in the review queue, nor how applied/stale counts surface in `DedupeResult`.
+
+This spec closes the unchecked tasks **and** addresses these three gaps. The rules layer (LLM-generalized IF-THEN principles from corrections) is explicitly **out of scope** and will be a separate brainstorm/spec.
+
+## Goals
+
+- All collection points in the original spec write to `MemoryStore`.
+- Pipeline applies corrections after scoring, applies learned threshold/weight adjustments before scoring, and surfaces `CorrectionStats` on `DedupeResult`.
+- Corrections survive input refresh (row reorder, row insertion/deletion) without becoming stale, *as long as* the entity rows themselves are unchanged.
+- Surfaces: Python API, CLI, MCP tools.
+- Integration tests cover end-to-end correct → re-run → apply, refresh → re-anchor, trust conflict, no-API-key fallback.
+- Zero-config posture preserved: nothing about auto-config or default behavior changes for users who don't enable memory.
+
+## Non-goals
+
+- Rules layer (LLM generalization of corrections into IF-THEN principles).
+- Web review surface.
+- MCP-sampling for explainer (host-LLM-driven explanation).
+- Identity Store extraction (the schema is forward-compatible; migration is deferred).
+- Team sync, multi-user backends beyond the existing Postgres option.
+- Field-weight learning beyond what `MemoryLearner` already produces (per-field scores not yet stored on corrections; learner stub returns `None` and that stays for slice-1).
+
+## Foundation summary (from 2026-03-26 spec, shipped)
+
+For reference. None of this is changing.
+
+- `MemoryStore` — SQLite (default `.goldenmatch/memory.db`) and Postgres backends; trust-based upsert; canonical `(min, max)` pair ordering; `UNIQUE(id_a, id_b, dataset)`.
+- `Correction` — id_a, id_b, decision (approve/reject), source, trust (1.0 human / 0.5 agent), field_hash, record_hash, original_score, matchkey_name, reason, dataset, created_at.
+- `apply_corrections()` — bulk fetch by row IDs, dual-hash staleness check (field_hash for matched fields, record_hash for full row), hard override (1.0 / 0.0) when both hashes match.
+- `MemoryLearner` — threshold tuning at 10+ corrections via grid search weighted by trust; field-weight learning stubbed (returns `None`).
+- `MemoryConfig`, `LearningConfig` — Pydantic models in `config/schemas.py`. `GoldenMatchConfig.memory: MemoryConfig | None`.
+- 48 tests in `tests/test_memory_store.py`, `test_corrections.py`, `test_learner.py`, `test_memory_integration.py`.
+
+## Addition 1: Re-anchoring via record_hash
+
+**Problem.** `apply_corrections()` looks up by `(id_a, id_b)`. When input rows reorder (e.g., resorted CSV, refreshed warehouse table), the same entities now have different row IDs, so lookups miss and corrections silently fail to apply. Users perceive this as "the system forgot."
+
+**Insight.** `record_hash` is already stored on every correction and is durable — it identifies the entity by content rather than position.
+
+**Fix.** Augment `apply_corrections()` with a record-hash-keyed re-anchoring path. No schema migration; uses existing fields.
+
+**Algorithm:**
+
+```python
+def apply_corrections(
+    scored_pairs: list[tuple[int, int, float]],
+    store: MemoryStore,
+    df: pl.DataFrame,
+    matchkey_fields: list[str],
+    dataset: str | None = None,
+) -> tuple[list[tuple[int, int, float]], CorrectionStats]:
+    # 1. Single fetch (replaces both the existing get_pair_corrections_bulk
+    #    and the re-anchor pass; bulk already loads all dataset corrections).
+    all_corrections = store.get_corrections(dataset=dataset)
+    if not all_corrections:
+        return scored_pairs, stats
+
+    # 2. Build vectorized record_hash → [row_ids] map ONCE.
+    #    Use polars-native concat_str + hash to avoid O(N) per-row filters.
+    sorted_cols = sorted(df.columns)
+    hashed = (
+        df.select(
+            pl.col("__row_id__"),
+            pl.concat_str([pl.col(c).cast(pl.Utf8) for c in sorted_cols], separator="|")
+              .map_elements(lambda s: hashlib.sha256(s.encode()).hexdigest()[:16],
+                            return_dtype=pl.Utf8)
+              .alias("__rec_hash__"),
+        )
+    )
+    hash_to_rids: dict[str, list[int]] = {}
+    for rid, h in zip(hashed["__row_id__"].to_list(), hashed["__rec_hash__"].to_list()):
+        hash_to_rids.setdefault(h, []).append(int(rid))
+
+    # 3. Build the active correction map. Direct match (id_a/id_b still valid)
+    #    takes precedence; only fall back to re-anchor when direct row IDs are
+    #    not present in the current df.
+    current_rids = {rid for rids in hash_to_rids.values() for rid in rids}
+    active: dict[tuple[int, int], Correction] = {}
+    stats_skipped_ambiguous = 0
+    for c in all_corrections:
+        if c.id_a in current_rids and c.id_b in current_rids:
+            active[_canon_pair(c.id_a, c.id_b)] = c
+            continue
+        # Re-anchor via record_hash. Stored as "<hash_a>:<hash_b>".
+        ha, hb = (c.record_hash.split(":", 1) + [""])[:2]
+        cands_a = hash_to_rids.get(ha, [])
+        cands_b = hash_to_rids.get(hb, [])
+        # Collision-safe: only re-anchor when each side resolves uniquely.
+        # Ambiguous resolutions (duplicate rows) are counted as stale and surfaced.
+        if len(cands_a) == 1 and len(cands_b) == 1:
+            active[_canon_pair(cands_a[0], cands_b[0])] = c
+        elif cands_a and cands_b:
+            stats_skipped_ambiguous += 1
+            stats.stale_pairs.append((c.id_a, c.id_b))
+        # else: entity no longer present → silently dropped (existing stale path)
+
+    # 4. Apply with existing dual-hash safety check (unchanged behavior).
+    # For each scored pair: look up active[canon_pair(a,b)]; if found, run the
+    # existing field_hash + record_hash check; on match, override score (1.0/0.0).
+    # ... existing apply logic ...
+```
+
+**Invariants preserved:**
+- Dual-hash staleness check still runs before applying any correction; re-anchored corrections referencing now-stale entity content still fail safely.
+- No schema change; existing tests stay green.
+- **Collision safety:** when two current rows share an identical `record_hash` (real case: actual duplicate rows in input), the re-anchor refuses to guess and counts the correction as stale-ambiguous. No false-positive applications.
+
+**Cost:**
+- One vectorized O(N) hash pass over the df via `pl.concat_str` + `map_elements`. Single Python function call across all rows; no O(N) filter per row.
+- O(C) work for C stored corrections (lookups in `hash_to_rids`).
+- Skipped entirely on cold runs (no corrections in store).
+- Opt-out: `config.memory.reanchor: bool = True` (added to `MemoryConfig`, see Surfaces).
+
+**New tests:**
+- Row reorder: shuffle df between runs, verify corrections still apply.
+- Row insert/delete: insert new rows; verify corrections on unchanged entities still apply, corrections on deleted entities are reported as stale via the existing path.
+- Edit on non-matchkey field: verify correction still applies (field_hash unchanged) — captures intent of the original dual-hash design.
+- Edit on matchkey field: verify correction goes stale (field_hash changes) — captures intent.
+
+## Addition 2: MCP tool surface
+
+Pattern follows `mcp/agent_tools.py` (additive Tool list + dispatch handler + server-card count update).
+
+**New tools** in `mcp/memory_tools.py`:
+
+| Tool | Purpose |
+|---|---|
+| `list_corrections` | Returns all corrections (optionally filtered by `dataset`). Includes `why` field from explainer. |
+| `add_correction` | Adds a pair correction. Required: `id_a`, `id_b`, `decision`, `dataset`. Optional: `reason`, `matchkey_name`. Trust = 0.5 (agent source). |
+| `learn_thresholds` | Forces `MemoryLearner.learn()`. Returns list of `LearnedAdjustment`. |
+| `memory_stats` | Returns counts, last learn time, current adjustments. Cheap; safe for status checks. |
+| `memory_export` | Returns corrections as a list of dicts (CSV-shaped). Caller writes the file. |
+
+Each handler instantiates its own `MemoryStore` (matches the AgentSession pattern — no shared global state). All handlers validate `dataset` is non-empty and trap `sqlite3.OperationalError` to return a structured error rather than crash the MCP session.
+
+**Module exports** in `mcp/memory_tools.py`:
+- `MEMORY_TOOLS: list[Tool]` — the five tool definitions
+- `_MEMORY_TOOL_NAMES: frozenset[str]` — for fast membership checks
+- `handle_memory_tool(name: str, arguments: dict) -> list[TextContent]` — routes to per-tool handlers (mirrors `handle_agent_tool` in agent_tools.py)
+
+`mcp/server.py` imports these and extends its tool list + dispatch chain — pattern matches `agent_tools.py` (`AGENT_TOOLS`, `_AGENT_TOOL_NAMES`, `handle_agent_tool`).
+
+**Server-card update:** edit the literal description string in `mcp/server.py:1266` from `"30 MCP tools"` to `"35 MCP tools"`. (The count is hardcoded in the server-card description, not dynamically computed.) Add `test_memory_tools_registered` to `tests/test_mcp_and_watch.py`.
+
+## Addition 3: Explainer + postflight
+
+**Explainer.** Every correction surfaced through MCP `list_corrections`, the review queue, and the TUI boost tab carries a `why` field — a one-sentence explanation of the original match decision.
+
+- Default: `core/explain.py::explain_pair_nl()` — deterministic, template-based, zero cost. Already shipped.
+- Upgrade: when `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` is set AND `config.llm_scorer.enabled`, route through `core/llm_scorer.py` for richer prose. Reuses existing `BudgetTracker`; respects existing budget caps. No new API surface.
+- MCP-sampling path (host LLM does the prose) is explicitly **deferred** to a later spec.
+
+**Postflight.** Both `DedupeResult` and `MatchResult` (in `_api.py`) gain:
+
+```python
+@dataclass
+class DedupeResult:  # also MatchResult
+    # ... existing fields ...
+    memory_stats: CorrectionStats | None = None  # populated when memory enabled
+```
+
+The existing v1.5.0 postflight report (`postflight_report` field, present on both result types) gains a one-line memory section when `memory_stats` is set, rendered by the same code that renders the rest of postflight:
+
+```
+Memory: 23 corrections applied, 4 stale, 1 stale-ambiguous (run `goldenmatch review` to re-decide stale pairs)
+```
+
+`memory_stats.stale_pairs` is automatically enqueued into `ReviewQueue` so the next `goldenmatch review` invocation surfaces them. Stale-ambiguous pairs (collision-safe re-anchor refused — see Addition 1) are reported separately because they need user attention to resolve which of the duplicate rows the original correction was about.
+
+## Pipeline integration (Task 5 acceptance criteria)
+
+In `core/pipeline.py`, both `_run_dedupe_pipeline()` and `_run_match_pipeline()`:
+
+1. **Pre-scoring (learning overlay):** if `config.memory and config.memory.enabled`, open `MemoryStore`, instantiate `MemoryLearner`, call `learner.has_new_corrections()` → `learner.learn()`. Overlay each `LearnedAdjustment.threshold` onto the matching matchkey's `threshold` field on the **in-memory config copy only** (original YAML/Pydantic config never mutated).
+2. **Post-scoring (correction overlay):** call `apply_corrections(scored_pairs, store, df, matchkey_fields, dataset=dataset)` between scoring and clustering. Replace `scored_pairs` with the returned adjusted list. Attach returned `CorrectionStats` to `DedupeResult.memory_stats`.
+3. **Stale enqueue:** push `stats.stale_pairs` to `ReviewQueue` for next-run review.
+4. **Dataset scoping:** default to input file path (or `"<DataFrame>"` for df entry points); honor `config.memory.dataset` override.
+
+Failure mode: if `MemoryStore` open fails (corrupt DB, permission error), log a warning and continue without memory. Never block the pipeline.
+
+## Collection points (Task 6 acceptance criteria)
+
+All additive — existing behavior unchanged when memory disabled. Each surface accepts an optional `MemoryStore` parameter; if provided, calls `store.add_correction()` alongside its existing logic.
+
+| Surface | File | Source | Trust | Trigger |
+|---|---|---|---|---|
+| Review Queue | `core/review_queue.py` (base class `ReviewQueue.approve()`/`.reject()`) | `"steward"` | 1.0 | hook lands once on the base class so memory/SQLite/Postgres backends inherit it; do not duplicate per-backend |
+| Boost Tab | `tui/tabs/boost_tab.py` (`BoostTab` class, around the y/n button handlers) | `"boost"` | 1.0 | y/n keypress |
+| Unmerge record | `core/cluster.py::unmerge_record()` | `"unmerge"` | 1.0 | reject correction for every pair `(record_id, other)` in cluster's `pair_scores`; **empty hashes** (function takes no df) — see hash-collection note below |
+| Unmerge cluster | `core/cluster.py::unmerge_cluster()` | `"unmerge"` | 1.0 | reject correction for every pair in `pair_scores`; **empty hashes** — see hash-collection note below |
+| LLM Scorer | `core/llm_scorer.py::llm_score_pairs()` | `"llm"` | 0.5 | LLM returns approve/reject decision (only when `store` provided) |
+| Agent Tools | `mcp/agent_tools.py::agent_approve_reject` (line 104) | `"agent"` | 0.5 | tool invocation |
+| REST API | `api/server.py::POST /reviews/decide` (line 309) | `"steward"` | 1.0 | endpoint call |
+
+**Hash collection.** Where the df is in scope, `field_hash` and `record_hash` are computed at correction time. Where it isn't (`unmerge_record`, `unmerge_cluster`, possibly REST API receiving raw decisions), corrections are written with **empty hashes**. The shipped `apply_corrections()` already handles this branch (`hashes_empty = (not correction.field_hash and not correction.record_hash)` at corrections.py:107) — empty-hash corrections always apply when the row IDs match, with no staleness gate. This is a deliberate trade-off: unmerge corrections cannot detect data drift, but they will always reflect the user's "these don't belong together" intent. Re-anchoring still works for empty-hash corrections via the row-ID-presence path; it cannot work via record_hash because none was stored.
+
+**Trust same-tier semantics.** `MemoryStore.add_correction()` (store.py:108-111) only ignores incoming corrections of *strictly lower* trust than the existing one. Same-tier writes overwrite (latest wins). Document this in the user-facing CLI help and MCP tool descriptions so users aren't surprised when a second `add_correction` from the same source replaces the first.
+
+## Surfaces (Task 7 acceptance criteria)
+
+**Python API** (additions to `_api.py`, re-exported via `__init__.py`):
+- `get_memory(path: str | None = None) -> MemoryStore`
+- `add_correction(id_a: int, id_b: int, decision: str, *, source: str = "api", reason: str | None = None, dataset: str | None = None, matchkey_name: str | None = None) -> None`
+- `learn(matchkey_name: str | None = None) -> list[LearnedAdjustment]`
+- `memory_stats() -> dict`
+
+**CLI** (new file `cli/memory.py` exposing a `memory_app: typer.Typer` object, registered via `app.add_typer(memory_app, name="memory")` in `cli/main.py` — pattern matches `pprl_app` at cli/main.py:28/109):
+- `goldenmatch memory stats` — counts, last learn time, current adjustments
+- `goldenmatch memory learn` — force learning pass; print results
+- `goldenmatch memory export <path>` — dump corrections as CSV
+- `goldenmatch memory import <path>` — load corrections from CSV (validates schema, respects trust upsert)
+- `goldenmatch memory show <id_a> <id_b>` — pretty-print a single correction
+
+**Config schema** addition to `MemoryConfig` (already in `config/schemas.py`):
+```python
+class MemoryConfig(BaseModel):
+    # ... existing fields ...
+    reanchor: bool = True              # NEW: enable record_hash re-anchoring (Addition 1)
+    dataset: str | None = None          # NEW: scope corrections to a named dataset (referenced
+                                        # but not previously schema-declared in the 2026-03-26 spec)
+```
+`reanchor` defaults to `True` so re-anchoring is on by default; `False` disables and falls back to row-ID-only lookup. `dataset` is the scoping key for `MemoryStore`; defaults to `None`, in which case the pipeline derives a default (input file path, or `"<DataFrame>"` for df entry points).
+
+**MCP** — five tools per Addition 2.
+
+## Integration tests (Task 8 acceptance criteria)
+
+New file `tests/test_memory_e2e.py`:
+
+1. **Happy path:** dedupe → reject one cluster pair via TUI → re-run → verify pair score is now 0.0.
+2. **Re-anchor on reorder:** dedupe customers.csv → reject a pair → shuffle df → re-run → verify pair still rejected.
+3. **Re-anchor + edit on matchkey field:** edit one matched field on a corrected entity → re-run → verify correction goes stale, pair shows up in review queue.
+4. **Trust conflict:** LLM rejects a pair (trust 0.5), then steward approves (trust 1.0) → verify steward's decision wins.
+5. **Threshold learning:** seed 12 corrections covering a range of scores → re-run → verify `MemoryLearner.learn()` ran, threshold overlay applied to matchkey, `last_learn_time` updated.
+6. **No API key, no LLM:** unset env vars → verify deterministic explainer fallback for review queue and MCP `list_corrections`.
+7. **Postflight surfaces stats:** run with corrections present → verify `DedupeResult.memory_stats` populated and postflight string contains the one-line memory section.
+
+Existing 48 unit tests must remain green. Test count target: 48 + ~10 = ~58.
+
+## Out of scope (deferred to later specs)
+
+- **Rules layer** — LLM-generalized IF-THEN principles from corrections.
+- **Web review surface** — converges with the standalone "browser playground" idea; separate effort.
+- **MCP-sampling explainer path** — host LLM does prose generation via MCP `sampling`. Requires host support that's still uneven.
+- **Identity Store extraction** — the schema is forward-compatible (entities, aliases, assertions, provenance, dataset scoping) but extracting it as a separate package and wiring reverse-ETL is Phase 2 work.
+- **Field-weight learning beyond stub** — requires storing per-field scores on corrections; schema addition.
+- **Team sync / external backend beyond existing Postgres** — multi-user/multi-machine semantics.
+
+## Implementation order
+
+Each phase mergeable on its own behind feature flag (`config.memory.enabled` already gates everything).
+
+1. **Re-anchoring (Addition 1).** Localized change to `core/memory/corrections.py`; new tests for reorder/edit/duplicate-row cases. Foundational because everything else depends on corrections actually persisting across runs.
+2. **Pipeline hook (Task 5).** Nothing observable works until this lands. Includes `DedupeResult.memory_stats` and `MatchResult.memory_stats` fields, stale-pair enqueue, `MemoryConfig.reanchor` flag plumbing. **Test note:** until phase 4 (collection points) lands, pipeline-hook tests must seed the store via fixtures (write `Correction` objects directly through `MemoryStore.add_correction()` in test setup).
+3. **Postflight wiring (Addition 3, postflight half).** One-line memory section in postflight report on both result types.
+4. **Collection points (Task 6).** Corrections start flowing into the store from real surfaces. ReviewQueue hook on the base class only (not per-backend).
+5. **Explainer integration (Addition 3, explainer half).** `why` field on review queue items and MCP results.
+6. **CLI surfaces (Task 7).** `goldenmatch memory stats|learn|export|import|show` via `memory_app` Typer subgroup.
+7. **MCP tools (Addition 2).** Five new tools in `mcp/memory_tools.py`, server-card string update at server.py:1266, registration test.
+8. **Integration tests (Task 8).** End-to-end coverage gates the release.
+
+Each phase is its own PR. Estimated effort: 1–2 days per phase for phases 1–6, 0.5 days for phase 7, 1 day for phase 8.
+
+## Risks
+
+- **Re-anchoring cost on large inputs.** Building `{record_hash → row_id}` is O(N). On a 1M-row input with 100 corrections, this is one O(N) pass plus 100 O(1) lookups — well under existing pipeline costs. Validated by an opt-out flag (`config.memory.reanchor: bool = True`) in case a pathological case appears.
+- **Postgres backend drift.** Original spec mentions Postgres support but the shipped code only fully exercises SQLite. Slice-1 keeps Postgres as a documented option but does not gate on it; integration tests use SQLite. Postgres parity is a follow-up if/when a user needs it.
+- **Boost tab and TUI tests are slow.** Existing `tests/test_tui.py` uses `pytest-asyncio` with `app.run_test()` pilot — adding correction-write assertions will slow this further. Mitigation: assert at the `MemoryStore` layer in TUI tests, not the rendered UI.
+- **MCP server.py is 1,281 LOC.** Adding tools inline would worsen this. Per pattern in `mcp/agent_tools.py`, new tools live in `mcp/memory_tools.py` and are imported into `server.py` with a single registration call.
+
+## Open questions resolved
+
+- **Q4 row-ID stability:** re-anchor via existing `record_hash`; no schema migration; collision-safe (ambiguous re-anchors counted stale, never silently misapplied); single `reanchor` config flag for opt-out.
+- **Gap-fill spec vs new full design:** gap-fill, referencing 2026-03-26 spec.
+- **Rules layer (b):** deferred to a separate spec.
+
+## Review notes (2026-05-04)
+
+This spec was reviewed against the shipped code (PR #9 modules + foundation pipeline/api/cluster/tui code) before plan generation. Findings folded into the spec rather than left as a separate review log:
+
+- Boost tab path corrected (`tui/tabs/boost_tab.py`, not `tui/app.py`).
+- Unmerge collection points cannot compute hashes; documented as deliberate empty-hash writes.
+- `MatchResult` parity with `DedupeResult` for `memory_stats`.
+- Server-card edit is a literal-string change at server.py:1266, not a dynamic count.
+- Re-anchor algorithm rewritten to be collision-safe and vectorized (was O(N²) per call as originally drafted).
+- ReviewQueue hook lands on the base class to cover all three backends.
+- `MemoryConfig.reanchor` flag added explicitly.
+- Trust same-tier (latest-wins) semantics documented.
+
+48 unit tests confirmed across the four memory test files; pipeline hook insertion point at pipeline.py:497-514 (between scoring and `_apply_postflight`) is sensible and uncontested.

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased] / TypeScript port
 
+## [1.6.0] - 2026-05-04
+
+### Added
+- **Learning Memory completion** — corrections now flow end-to-end from collection points through pipeline application to postflight surfaces.
+  - **Re-anchor via record_hash**: corrections survive row reorder and input refresh through a collision-safe vectorized record-hash lookup. Ambiguous re-anchors (duplicate rows) report as `stale_ambiguous` rather than silently misapplying. New `MemoryConfig.reanchor` flag (default `True`) gates the behavior.
+  - **Pipeline hook**: `dedupe_df` and `match_df` apply stored corrections after scoring and overlay learned thresholds before scoring. `DedupeResult.memory_stats` and `MatchResult.memory_stats` surface applied/stale/stale-ambiguous counts.
+  - **Seven collection points** capture corrections automatically: review queue (`steward`, trust 1.0), boost tab y/n (`boost`, 1.0), `unmerge_record`/`unmerge_cluster` (`unmerge`, 1.0, empty hashes), LLM scorer decisions (`llm`, 0.5), MCP `agent_approve_reject` (`agent`, 0.5), and REST `POST /reviews/decide` (`steward`, 1.0).
+  - **Postflight section**: rendered postflight string adds a `Memory: N corrections applied, M stale, K stale-ambiguous` line when memory is active.
+  - **Explainer integration**: review queue items carry a `why` field. Deterministic template by default; routes to `core/llm_scorer.llm_explain_pair` when `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` is set.
+  - **CLI subgroup**: `goldenmatch memory stats|learn|export|import|show`.
+  - **Five MCP tools**: `list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`. Server card description updated to "35 MCP tools".
+  - **Python API**: `goldenmatch.get_memory()`, `goldenmatch.add_correction()`, `goldenmatch.learn()`, `goldenmatch.memory_stats()`.
+  - **Stale persistence**: stale corrections are enqueued to a sibling SQLite review queue (`.goldenmatch/review_queue.db`) so the next `goldenmatch review` invocation surfaces them.
+  - **8 end-to-end integration tests** in `test_memory_e2e.py` covering happy path, re-anchor on reorder, stale-on-edit, trust conflict, threshold learning, deterministic explainer fallback, postflight rendering, and stale-ambiguous reporting.
+
+### Changed
+- Zero-config posture preserved: nothing changes for users who don't enable memory (`config.memory.enabled = False` by default; absent config section means no memory work).
+
 - **NEW**: TypeScript / Node.js port published as `goldenmatch` on npm
   - Full feature parity with Python: scorers, clustering, golden records, LLM, PPRL, probabilistic, graph ER, streaming, MCP/REST/A2A servers
   - Edge-safe core (browsers, Workers, Edge Runtime) + Node-only file/DB layer

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -44,6 +44,10 @@ from goldenmatch._api import (
     load_config,
     DedupeResult,
     MatchResult,
+    get_memory,
+    add_correction,
+    learn,
+    memory_stats,
 )
 
 # ── Config schemas (for building configs programmatically) ────────────────
@@ -286,4 +290,6 @@ __all__ = [
     # Learning Memory
     "MemoryStore", "Correction", "LearnedAdjustment", "CorrectionStats",
     "MemoryLearner", "apply_corrections",
+    # Learning Memory API
+    "get_memory", "add_correction", "learn", "memory_stats",
 ]

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 # ── High-level API (convenience functions) ────────────────────────────────
 from goldenmatch._api import (

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -870,6 +870,102 @@ def _extract_stats(result: dict) -> dict:
     }
 
 
+# ── Learning Memory API ──
+
+
+def get_memory(path: str | None = None) -> Any:
+    """Open (or create) a Learning Memory store.
+
+    Args:
+        path: Path to the SQLite DB file. Defaults to ``.goldenmatch/memory.db``.
+
+    Returns:
+        A ``MemoryStore`` instance. Caller is responsible for ``close()``.
+    """
+    from goldenmatch.core.memory.store import MemoryStore
+    return MemoryStore(backend="sqlite", path=path or ".goldenmatch/memory.db")
+
+
+def add_correction(
+    id_a: int,
+    id_b: int,
+    decision: str,
+    *,
+    source: str = "api",
+    reason: str | None = None,
+    dataset: str | None = None,
+    matchkey_name: str | None = None,
+    path: str | None = None,
+) -> None:
+    """Add a correction to the Learning Memory store.
+
+    Trust is derived from ``source``: 1.0 for ``steward``/``boost``/``unmerge``,
+    0.5 otherwise. Default ``source="api"`` is treated as a programmatic
+    (agent-tier) actor; pass ``source="steward"`` explicitly for human trust.
+
+    Hashes are written empty — apply_corrections handles empty-hash entries
+    via the row-ID-presence path.
+    """
+    import uuid
+    from datetime import datetime
+    from goldenmatch.core.memory.store import Correction
+
+    trust = 1.0 if source in {"steward", "boost", "unmerge"} else 0.5
+    store = get_memory(path)
+    try:
+        store.add_correction(Correction(
+            id=str(uuid.uuid4()),
+            id_a=id_a, id_b=id_b,
+            decision=decision, source=source, trust=trust,
+            field_hash="", record_hash="",
+            original_score=0.0,
+            matchkey_name=matchkey_name,
+            reason=reason,
+            dataset=dataset,
+            created_at=datetime.now(),
+        ))
+    finally:
+        store.close()
+
+
+def learn(
+    matchkey_name: str | None = None,
+    path: str | None = None,
+) -> list:
+    """Force a learning pass over stored corrections.
+
+    Args:
+        matchkey_name: Optional filter; only learn for this matchkey.
+        path: Path to the memory DB file.
+
+    Returns:
+        List of ``LearnedAdjustment`` objects produced this pass.
+    """
+    from goldenmatch.core.memory.learner import MemoryLearner
+    store = get_memory(path)
+    try:
+        learner = MemoryLearner(store)
+        return learner.learn(matchkey_name=matchkey_name)
+    finally:
+        store.close()
+
+
+def memory_stats(path: str | None = None) -> dict:
+    """Return summary stats about the memory store.
+
+    Returns a dict with ``count``, ``last_learn_time``, and ``adjustments``.
+    """
+    store = get_memory(path)
+    try:
+        return {
+            "count": store.count_corrections(),
+            "last_learn_time": store.last_learn_time(),
+            "adjustments": [a.__dict__ for a in store.get_all_adjustments()],
+        }
+    finally:
+        store.close()
+
+
 def _extract_pairs(result: dict) -> list:
     """Extract scored pairs from cluster pair_scores."""
     pairs = []

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -27,6 +27,25 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _attach_memory_to_postflight(
+    postflight_report: PostflightReport | None,
+    memory_stats: "CorrectionStats | None",
+) -> PostflightReport | None:
+    """Attach memory_stats onto the postflight report so str(report) renders
+    a 'Memory:' line. Creates an empty report when memory ran but no
+    postflight ran (explicit-config path), so the rendering is always
+    reachable via ``result.postflight_report``.
+
+    Returns None only when both the report and memory_stats are absent.
+    """
+    if memory_stats is None:
+        return postflight_report
+    if postflight_report is None:
+        postflight_report = PostflightReport()
+    postflight_report.memory_stats = memory_stats
+    return postflight_report
+
+
 def _detect_llm_provider() -> str | None:
     """Auto-detect LLM provider from environment variables."""
     if os.environ.get("ANTHROPIC_API_KEY"):
@@ -261,6 +280,7 @@ def dedupe(
     # Run pipeline
     result = run_dedupe(file_specs, cfg)
 
+    _mem = result.get("memory_stats")
     return DedupeResult(
         golden=result.get("golden"),
         clusters=result.get("clusters", {}),
@@ -269,8 +289,10 @@ def dedupe(
         stats=_extract_stats(result),
         scored_pairs=_extract_pairs(result),
         config=cfg,
-        postflight_report=result.get("postflight_report"),
-        memory_stats=result.get("memory_stats"),
+        postflight_report=_attach_memory_to_postflight(
+            result.get("postflight_report"), _mem
+        ),
+        memory_stats=_mem,
     )
 
 
@@ -347,6 +369,7 @@ def dedupe_df(
         auto_config_llm_provider=_auto_config_provider,
     )
 
+    _mem = result.get("memory_stats")
     return DedupeResult(
         golden=result.get("golden"),
         clusters=result.get("clusters", {}),
@@ -355,8 +378,10 @@ def dedupe_df(
         stats=_extract_stats(result),
         scored_pairs=_extract_pairs(result),
         config=config,
-        postflight_report=result.get("postflight_report"),
-        memory_stats=result.get("memory_stats"),
+        postflight_report=_attach_memory_to_postflight(
+            result.get("postflight_report"), _mem
+        ),
+        memory_stats=_mem,
     )
 
 
@@ -419,12 +444,15 @@ def match_df(
 
     result = run_match_df(target, reference, config, auto_config=_auto_config)
 
+    _mem = result.get("memory_stats")
     return MatchResult(
         matched=result.get("matched"),
         unmatched=result.get("unmatched"),
         stats=_extract_stats(result),
-        postflight_report=result.get("postflight_report"),
-        memory_stats=result.get("memory_stats"),
+        postflight_report=_attach_memory_to_postflight(
+            result.get("postflight_report"), _mem
+        ),
+        memory_stats=_mem,
     )
 
 
@@ -599,11 +627,15 @@ def match(
 
     result = run_match(target_spec, ref_specs, cfg)
 
+    _mem = result.get("memory_stats")
     return MatchResult(
         matched=result.get("matched"),
         unmatched=result.get("unmatched"),
         stats=_extract_stats(result),
-        memory_stats=result.get("memory_stats"),
+        postflight_report=_attach_memory_to_postflight(
+            result.get("postflight_report"), _mem
+        ),
+        memory_stats=_mem,
     )
 
 

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -76,6 +76,11 @@ class DedupeResult:
     scored_pairs: list[tuple[int, int, float]] = field(default_factory=list)
     config: Any = None
     postflight_report: PostflightReport | None = None
+    # Note: memory_stats is also attached to postflight_report.memory_stats by
+    # _attach_memory_to_postflight. The duplication is intentional — converting
+    # this field to a property delegating to postflight_report would break the
+    # pipeline's direct field assignment pattern. Single source of truth would
+    # require refactoring _attach_memory_to_postflight; tracked as follow-up.
     memory_stats: "CorrectionStats | None" = None
 
     def to_csv(self, path: str, which: str = "golden") -> Path:
@@ -169,6 +174,7 @@ class MatchResult:
     unmatched: pl.DataFrame | None = None
     stats: dict = field(default_factory=dict)
     postflight_report: PostflightReport | None = None
+    # See DedupeResult.memory_stats note — same intentional duplication.
     memory_stats: "CorrectionStats | None" = None
 
     def to_csv(self, path: str) -> Path:
@@ -910,8 +916,8 @@ def add_correction(
     from datetime import datetime
     from goldenmatch.core.memory.store import Correction
 
-    from goldenmatch.core.memory.store import HIGH_TRUST_SOURCES
-    trust = 1.0 if source in HIGH_TRUST_SOURCES else 0.5
+    from goldenmatch.core.memory.store import trust_for_source
+    trust = trust_for_source(source)
     store = get_memory(path)
     try:
         store.add_correction(Correction(

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -910,7 +910,8 @@ def add_correction(
     from datetime import datetime
     from goldenmatch.core.memory.store import Correction
 
-    trust = 1.0 if source in {"steward", "boost", "unmerge"} else 0.5
+    from goldenmatch.core.memory.store import HIGH_TRUST_SOURCES
+    trust = 1.0 if source in HIGH_TRUST_SOURCES else 0.5
     store = get_memory(path)
     try:
         store.add_correction(Correction(

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -15,11 +15,14 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
 from goldenmatch.core.autoconfig_verify import PostflightReport
+
+if TYPE_CHECKING:
+    from goldenmatch.core.memory.corrections import CorrectionStats
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +57,7 @@ class DedupeResult:
     scored_pairs: list[tuple[int, int, float]] = field(default_factory=list)
     config: Any = None
     postflight_report: PostflightReport | None = None
+    memory_stats: "CorrectionStats | None" = None
 
     def to_csv(self, path: str, which: str = "golden") -> Path:
         """Write results to CSV.
@@ -146,6 +150,7 @@ class MatchResult:
     unmatched: pl.DataFrame | None = None
     stats: dict = field(default_factory=dict)
     postflight_report: PostflightReport | None = None
+    memory_stats: "CorrectionStats | None" = None
 
     def to_csv(self, path: str) -> Path:
         """Write matched results to CSV."""
@@ -265,6 +270,7 @@ def dedupe(
         scored_pairs=_extract_pairs(result),
         config=cfg,
         postflight_report=result.get("postflight_report"),
+        memory_stats=result.get("memory_stats"),
     )
 
 
@@ -350,6 +356,7 @@ def dedupe_df(
         scored_pairs=_extract_pairs(result),
         config=config,
         postflight_report=result.get("postflight_report"),
+        memory_stats=result.get("memory_stats"),
     )
 
 
@@ -417,6 +424,7 @@ def match_df(
         unmatched=result.get("unmatched"),
         stats=_extract_stats(result),
         postflight_report=result.get("postflight_report"),
+        memory_stats=result.get("memory_stats"),
     )
 
 
@@ -595,6 +603,7 @@ def match(
         matched=result.get("matched"),
         unmatched=result.get("unmatched"),
         stats=_extract_stats(result),
+        memory_stats=result.get("memory_stats"),
     )
 
 

--- a/packages/python/goldenmatch/goldenmatch/api/server.py
+++ b/packages/python/goldenmatch/goldenmatch/api/server.py
@@ -42,6 +42,10 @@ class MatchServer:
         self._id_to_idx: dict[int, int] = {}
         self._review_queue: list[dict] = []  # pending reviews
         self._review_decisions: list[dict] = []  # completed reviews
+        # Optional learning memory plumbing — when set, /reviews/decide writes a
+        # Correction with empty hashes (REST receives raw decisions, no df).
+        self._memory_store: Any = None
+        self._memory_dataset: str | None = None
 
     def initialize(self) -> None:
         """Run initial matching and cache results."""
@@ -228,9 +232,39 @@ class MatchServer:
                     self.engine.unmerge_record(item["row_id_a"])
                     self.result = self.engine._last_result
 
+                self._record_memory_correction(item, decision)
+
                 return {"status": "recorded", "pair_id": pair_id, "decision": decision}
 
         return {"error": f"Pair {pair_id} not found in review queue"}
+
+    def _record_memory_correction(self, item: dict, decision: str) -> None:
+        """Persist a Correction with source='steward', trust=1.0, empty hashes."""
+        if self._memory_store is None:
+            return
+        try:
+            import uuid
+            from datetime import datetime as _dt
+
+            from goldenmatch.core.memory.store import Correction
+
+            self._memory_store.add_correction(Correction(
+                id=str(uuid.uuid4()),
+                id_a=int(item["row_id_a"]),
+                id_b=int(item["row_id_b"]),
+                decision=decision,
+                source="steward",
+                trust=1.0,
+                field_hash="",
+                record_hash="",
+                original_score=float(item.get("score", 0.0)),
+                matchkey_name=None,
+                reason=None,
+                dataset=self._memory_dataset,
+                created_at=_dt.now(),
+            ))
+        except Exception as e:
+            logger.warning("REST /reviews/decide memory write failed: %s", e)
 
 
 # Global server instance

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -26,6 +26,7 @@ from goldenmatch.cli.schedule import schedule_cmd
 from goldenmatch.cli.evaluate import evaluate_cmd
 from goldenmatch.cli.incremental import incremental_cmd
 from goldenmatch.cli.pprl import pprl_app
+from goldenmatch.cli.memory import memory_app
 from goldenmatch.cli.label import label_cmd
 from goldenmatch.cli.agent_serve import agent_serve_cmd
 from goldenmatch.cli.compare import compare_clusters_cmd
@@ -107,6 +108,7 @@ app.command("unmerge", help="Remove a record from its cluster (per-entity unmerg
 app.command("schedule", help="Run deduplication on a schedule.")(schedule_cmd)
 app.command("evaluate", help="Evaluate matching quality against ground truth pairs.")(evaluate_cmd)
 app.add_typer(pprl_app, name="pprl")
+app.add_typer(memory_app, name="memory")
 app.command("label", help="Build ground truth by labeling record pairs interactively.")(label_cmd)
 app.command("agent-serve", help="Start the A2A agent server for AI-to-AI discovery.")(agent_serve_cmd)
 app.command("incremental", help="Match new records against an existing base dataset.")(incremental_cmd)

--- a/packages/python/goldenmatch/goldenmatch/cli/memory.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/memory.py
@@ -161,15 +161,18 @@ def import_cmd(
                 f"{sorted(missing)}[/red]"
             )
             raise typer.Exit(code=1)
+        skipped = 0
         for i, row in enumerate(reader, start=2):  # line 1 is header
             try:
                 row["id_a"] = int(row["id_a"])
                 row["id_b"] = int(row["id_b"])
             except (KeyError, ValueError, TypeError) as e:
                 err_console.print(
-                    f"[red]Malformed CSV at row {i}: cannot parse id_a/id_b ({e})[/red]"
+                    f"[yellow]Skipping malformed row {i}: cannot parse "
+                    f"id_a/id_b ({e})[/yellow]"
                 )
-                raise typer.Exit(code=1)
+                skipped += 1
+                continue
             rows.append(row)
 
     store = goldenmatch.get_memory(path)
@@ -205,7 +208,10 @@ def import_cmd(
     finally:
         store.close()
 
-    console.print(f"[green]Imported {len(rows)} corrections from {src_path}[/green]")
+    msg = f"[green]Imported {len(rows)} corrections from {src_path}[/green]"
+    if skipped:
+        msg += f" [yellow](skipped {skipped} malformed row(s))[/yellow]"
+    console.print(msg)
 
 
 @memory_app.command("show")

--- a/packages/python/goldenmatch/goldenmatch/cli/memory.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/memory.py
@@ -1,0 +1,246 @@
+"""CLI memory commands for GoldenMatch.
+
+Inspect and manage the Learning Memory store: stats, force-learn, export
+corrections to CSV, import from CSV, show a single correction.
+"""
+from __future__ import annotations
+
+import csv
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+import goldenmatch
+
+console = Console()
+err_console = Console(stderr=True)
+
+DEFAULT_PATH = ".goldenmatch/memory.db"
+
+# CSV schema for export/import. Matches MemoryStore.Correction fields.
+_CSV_FIELDS = [
+    "id", "id_a", "id_b", "decision", "source", "trust",
+    "field_hash", "record_hash", "original_score",
+    "matchkey_name", "reason", "dataset", "created_at",
+]
+
+memory_app = typer.Typer(
+    name="memory",
+    help="Inspect and manage Learning Memory.",
+    no_args_is_help=True,
+)
+
+
+@memory_app.command("stats")
+def stats_cmd(
+    path: str = typer.Option(DEFAULT_PATH, "--path", help="Memory DB path"),
+) -> None:
+    """Show counts, last learn time, and current adjustments."""
+    s = goldenmatch.memory_stats(path=path)
+
+    table = Table(title="Memory Stats")
+    table.add_column("Metric", style="bold cyan")
+    table.add_column("Value", justify="right")
+    table.add_row("Corrections", str(s["count"]))
+    last = s["last_learn_time"]
+    table.add_row("Last learn", last.isoformat() if last else "(never)")
+    table.add_row("Adjustments", str(len(s["adjustments"])))
+    console.print(table)
+
+    if s["adjustments"]:
+        adj_table = Table(title="Learned Adjustments")
+        adj_table.add_column("Matchkey", style="bold")
+        adj_table.add_column("Threshold", justify="right")
+        adj_table.add_column("Samples", justify="right")
+        adj_table.add_column("Learned at")
+        for a in s["adjustments"]:
+            thr = a.get("threshold")
+            learned = a.get("learned_at")
+            adj_table.add_row(
+                str(a.get("matchkey_name", "")),
+                f"{thr:.3f}" if isinstance(thr, (int, float)) else "-",
+                str(a.get("sample_size", 0)),
+                learned.isoformat() if hasattr(learned, "isoformat") else str(learned or ""),
+            )
+        console.print(adj_table)
+
+
+@memory_app.command("learn")
+def learn_cmd(
+    matchkey_name: Optional[str] = typer.Option(
+        None, "--matchkey-name", help="Limit learning to this matchkey",
+    ),
+    path: str = typer.Option(DEFAULT_PATH, "--path", help="Memory DB path"),
+) -> None:
+    """Force a learning pass over stored corrections."""
+    adjustments = goldenmatch.learn(matchkey_name=matchkey_name, path=path)
+    if not adjustments:
+        console.print("[dim]No adjustments produced (need >=10 corrections "
+                      "with both approve and reject decisions).[/dim]")
+        return
+
+    table = Table(title="Learning Pass Results")
+    table.add_column("Matchkey", style="bold")
+    table.add_column("Threshold", justify="right")
+    table.add_column("Samples", justify="right")
+    for a in adjustments:
+        thr = a.threshold
+        table.add_row(
+            str(a.matchkey_name),
+            f"{thr:.3f}" if isinstance(thr, (int, float)) else "-",
+            str(a.sample_size),
+        )
+    console.print(table)
+
+
+@memory_app.command("export")
+def export_cmd(
+    out: str = typer.Argument(..., help="Output CSV path"),
+    path: str = typer.Option(DEFAULT_PATH, "--path", help="Memory DB path"),
+) -> None:
+    """Dump all corrections as CSV."""
+    store = goldenmatch.get_memory(path)
+    try:
+        corrections = store.get_corrections()
+    finally:
+        store.close()
+
+    out_path = Path(out)
+    if out_path.parent and str(out_path.parent) != ".":
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with out_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=_CSV_FIELDS)
+        writer.writeheader()
+        for c in corrections:
+            writer.writerow({
+                "id": c.id,
+                "id_a": c.id_a,
+                "id_b": c.id_b,
+                "decision": c.decision,
+                "source": c.source,
+                "trust": c.trust,
+                "field_hash": c.field_hash or "",
+                "record_hash": c.record_hash or "",
+                "original_score": c.original_score,
+                "matchkey_name": c.matchkey_name or "",
+                "reason": c.reason or "",
+                "dataset": c.dataset or "",
+                "created_at": c.created_at.isoformat(),
+            })
+
+    console.print(f"[green]Exported {len(corrections)} corrections to {out_path}[/green]")
+
+
+@memory_app.command("import")
+def import_cmd(
+    src: str = typer.Argument(..., help="Source CSV path"),
+    path: str = typer.Option(DEFAULT_PATH, "--path", help="Memory DB path"),
+) -> None:
+    """Load corrections from CSV. Validates schema before writing."""
+    src_path = Path(src)
+    if not src_path.exists():
+        err_console.print(f"[red]File not found: {src_path}[/red]")
+        raise typer.Exit(code=1)
+
+    from goldenmatch.core.memory.store import Correction
+
+    required = {"id_a", "id_b", "decision", "source"}
+    rows: list[dict] = []
+    with src_path.open("r", newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        if reader.fieldnames is None or not required.issubset(set(reader.fieldnames)):
+            missing = required - set(reader.fieldnames or [])
+            err_console.print(
+                f"[red]Malformed CSV: missing required columns: "
+                f"{sorted(missing)}[/red]"
+            )
+            raise typer.Exit(code=1)
+        for i, row in enumerate(reader, start=2):  # line 1 is header
+            try:
+                row["id_a"] = int(row["id_a"])
+                row["id_b"] = int(row["id_b"])
+            except (KeyError, ValueError, TypeError) as e:
+                err_console.print(
+                    f"[red]Malformed CSV at row {i}: cannot parse id_a/id_b ({e})[/red]"
+                )
+                raise typer.Exit(code=1)
+            rows.append(row)
+
+    store = goldenmatch.get_memory(path)
+    try:
+        for row in rows:
+            try:
+                trust = float(row.get("trust") or 0.5)
+            except (ValueError, TypeError):
+                trust = 0.5
+            try:
+                original_score = float(row.get("original_score") or 0.0)
+            except (ValueError, TypeError):
+                original_score = 0.0
+            created_raw = row.get("created_at") or ""
+            try:
+                created_at = datetime.fromisoformat(created_raw) if created_raw else datetime.now()
+            except ValueError:
+                created_at = datetime.now()
+            store.add_correction(Correction(
+                id=row.get("id") or str(uuid.uuid4()),
+                id_a=row["id_a"], id_b=row["id_b"],
+                decision=row["decision"],
+                source=row["source"],
+                trust=trust,
+                field_hash=row.get("field_hash") or "",
+                record_hash=row.get("record_hash") or "",
+                original_score=original_score,
+                matchkey_name=row.get("matchkey_name") or None,
+                reason=row.get("reason") or None,
+                dataset=row.get("dataset") or None,
+                created_at=created_at,
+            ))
+    finally:
+        store.close()
+
+    console.print(f"[green]Imported {len(rows)} corrections from {src_path}[/green]")
+
+
+@memory_app.command("show")
+def show_cmd(
+    id_a: int = typer.Argument(..., help="First record ID"),
+    id_b: int = typer.Argument(..., help="Second record ID"),
+    path: str = typer.Option(DEFAULT_PATH, "--path", help="Memory DB path"),
+) -> None:
+    """Pretty-print a single stored correction."""
+    store = goldenmatch.get_memory(path)
+    try:
+        c = store.get_pair_correction(id_a, id_b)
+    finally:
+        store.close()
+
+    if c is None:
+        err_console.print(
+            f"[yellow]No correction found for pair ({id_a}, {id_b}).[/yellow]"
+        )
+        raise typer.Exit(code=1)
+
+    table = Table(title=f"Correction ({c.id_a}, {c.id_b})")
+    table.add_column("Field", style="bold cyan")
+    table.add_column("Value")
+    table.add_row("id", c.id)
+    table.add_row("id_a", str(c.id_a))
+    table.add_row("id_b", str(c.id_b))
+    table.add_row("decision", c.decision)
+    table.add_row("source", c.source)
+    table.add_row("trust", f"{c.trust:.2f}")
+    table.add_row("matchkey_name", c.matchkey_name or "")
+    table.add_row("reason", c.reason or "")
+    table.add_row("dataset", c.dataset or "")
+    table.add_row("original_score", f"{c.original_score:.3f}")
+    table.add_row("field_hash", c.field_hash or "")
+    table.add_row("record_hash", c.record_hash or "")
+    table.add_row("created_at", c.created_at.isoformat())
+    console.print(table)

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -407,6 +407,8 @@ class MemoryConfig(BaseModel):
     connection: str | None = None
     trust: dict[str, float] = Field(default_factory=lambda: {"human": 1.0, "agent": 0.5})
     learning: LearningConfig = Field(default_factory=LearningConfig)
+    reanchor: bool = True
+    dataset: str | None = None
 
 
 # ── MatchSettingsConfig ─────────────────────────────────────────────────────

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -415,9 +415,10 @@ class MemoryConfig(BaseModel):
     def _reject_empty_dataset(cls, v: str | None) -> str | None:
         if v is None:
             return v
-        if not v.strip():
+        stripped = v.strip()
+        if not stripped:
             raise ValueError("MemoryConfig.dataset must be non-empty (or None)")
-        return v
+        return stripped
 
 
 # ── MatchSettingsConfig ─────────────────────────────────────────────────────

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 
 if TYPE_CHECKING:
     from goldenmatch.core.autoconfig_verify import PreflightReport
@@ -409,6 +409,15 @@ class MemoryConfig(BaseModel):
     learning: LearningConfig = Field(default_factory=LearningConfig)
     reanchor: bool = True
     dataset: str | None = None
+
+    @field_validator("dataset")
+    @classmethod
+    def _reject_empty_dataset(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not v.strip():
+            raise ValueError("MemoryConfig.dataset must be non-empty (or None)")
+        return v
 
 
 # ── MatchSettingsConfig ─────────────────────────────────────────────────────

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
@@ -214,12 +214,65 @@ class PostflightReport:
     ``signals`` is the stable schema documented in ``PostflightSignals``.
     ``adjustments`` is the list of auto-applied config tweaks (suppressed in
     strict mode). ``advisories`` are human-readable hints (e.g. "consider
-    --llm-auto").
+    --llm-auto"). ``memory_stats`` is set by the result-build layer when the
+    Learning Memory hook produced a ``CorrectionStats`` for this run; the
+    string render surfaces it as a single ``Memory: ...`` line.
     """
 
     signals: "PostflightSignals" = field(default_factory=_empty_signals)
     adjustments: list[PostflightAdjustment] = field(default_factory=list)
     advisories: list[str] = field(default_factory=list)
+    # Set at result-build time when Learning Memory ran. Kept loosely typed
+    # to avoid an import cycle (corrections.py imports nothing from this
+    # module today, but we don't want to invert that).
+    memory_stats: Any = None
+
+    def __str__(self) -> str:
+        """Human-readable rendering used by CLI/postflight summaries.
+
+        Includes signals, adjustments, advisories and -- when set -- a
+        single Memory line. Returns ASCII only (Windows cp1252-safe).
+        """
+        parts: list[str] = ["PostflightReport:"]
+        if self.signals:
+            parts.append(f"  signals: {dict(self.signals)}")
+        if self.adjustments:
+            parts.append("  adjustments:")
+            for adj in self.adjustments:
+                parts.append(
+                    f"    - {adj.field}: {adj.from_value} -> {adj.to_value} "
+                    f"({adj.signal}) {adj.reason}"
+                )
+        if self.advisories:
+            parts.append("  advisories:")
+            for adv in self.advisories:
+                parts.append(f"    - {adv}")
+        mem_line = _render_memory_line(self.memory_stats)
+        if mem_line:
+            parts.append(f"  {mem_line}")
+        return "\n".join(parts)
+
+
+def _render_memory_line(stats: Any) -> str:
+    """Render the one-line memory section, or '' when nothing to show.
+
+    Returns empty string when ``stats`` is None or every relevant counter
+    (applied/stale/stale_ambiguous/stale_unanchorable) is zero. ASCII only.
+    """
+    if stats is None:
+        return ""
+    applied = int(getattr(stats, "applied", 0) or 0)
+    stale = int(getattr(stats, "stale", 0) or 0)
+    stale_ambig = int(getattr(stats, "stale_ambiguous", 0) or 0)
+    stale_unanch = int(getattr(stats, "stale_unanchorable", 0) or 0)
+    if applied == 0 and stale == 0 and stale_ambig == 0 and stale_unanch == 0:
+        return ""
+    noun = "correction applied" if applied == 1 else "corrections applied"
+    return (
+        f"Memory: {applied} {noun}, {stale} stale, "
+        f"{stale_ambig} stale-ambiguous, {stale_unanch} unanchorable "
+        "(run `goldenmatch review` to re-decide stale pairs)"
+    )
 
 
 class ConfigValidationError(Exception):

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
@@ -261,6 +261,9 @@ def _render_memory_line(stats: Any) -> str:
     """
     if stats is None:
         return ""
+    if getattr(stats, "failed", False):
+        err = getattr(stats, "error", None) or "unknown error"
+        return f"Memory: failed ({err})"
     applied = int(getattr(stats, "applied", 0) or 0)
     stale = int(getattr(stats, "stale", 0) or 0)
     stale_ambig = int(getattr(stats, "stale_ambiguous", 0) or 0)

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -2,7 +2,47 @@
 
 from __future__ import annotations
 
+import logging
+import uuid
 from collections import defaultdict
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from goldenmatch.core.memory.store import MemoryStore
+
+_log = logging.getLogger("goldenmatch.memory")
+
+
+def _record_unmerge_corrections(
+    pairs: list[tuple[int, int]],
+    memory_store: "MemoryStore | None",
+    dataset: str | None,
+) -> None:
+    """Write reject corrections with empty hashes for each unmerged pair."""
+    if memory_store is None or not pairs:
+        return
+    try:
+        from goldenmatch.core.memory.store import Correction
+
+        for a, b in pairs:
+            memory_store.add_correction(Correction(
+                id=str(uuid.uuid4()),
+                id_a=a,
+                id_b=b,
+                decision="reject",
+                source="unmerge",
+                trust=1.0,
+                field_hash="",
+                record_hash="",
+                original_score=0.0,
+                matchkey_name=None,
+                reason=None,
+                dataset=dataset,
+                created_at=datetime.now(),
+            ))
+    except Exception as e:
+        _log.warning("Unmerge memory write failed: %s", e)
 
 
 class UnionFind:
@@ -362,6 +402,9 @@ def unmerge_record(
     record_id: int,
     clusters: dict[int, dict],
     threshold: float = 0.0,
+    *,
+    memory_store: "MemoryStore | None" = None,
+    dataset: str | None = None,
 ) -> dict[int, dict]:
     """Remove a record from its cluster and re-cluster remaining members.
 
@@ -390,6 +433,19 @@ def unmerge_record(
     cinfo = clusters[source_cid]
     if cinfo["size"] <= 1:
         return clusters  # Already a singleton
+
+    # Memory: reject correction for every pair (record_id, other) in this cluster.
+    if memory_store is not None:
+        unmerge_pairs: list[tuple[int, int]] = []
+        for (a, b) in cinfo.get("pair_scores", {}).keys():
+            if a == record_id and b != record_id:
+                unmerge_pairs.append((a, b))
+            elif b == record_id and a != record_id:
+                unmerge_pairs.append((a, b))
+        # Fall back to (record_id, other_member) if pair_scores missing this edge.
+        if not unmerge_pairs:
+            unmerge_pairs = [(record_id, m) for m in cinfo["members"] if m != record_id]
+        _record_unmerge_corrections(unmerge_pairs, memory_store, dataset)
 
     # Extract pair_scores excluding the removed record
     remaining_members = [m for m in cinfo["members"] if m != record_id]
@@ -431,6 +487,9 @@ def unmerge_record(
 def unmerge_cluster(
     cluster_id: int,
     clusters: dict[int, dict],
+    *,
+    memory_store: "MemoryStore | None" = None,
+    dataset: str | None = None,
 ) -> dict[int, dict]:
     """Shatter a cluster back into individual singletons.
 
@@ -448,6 +507,18 @@ def unmerge_cluster(
 
     cinfo = clusters[cluster_id]
     members = cinfo["members"]
+
+    # Memory: reject correction for every pair in this cluster.
+    if memory_store is not None:
+        unmerge_pairs = list(cinfo.get("pair_scores", {}).keys())
+        if not unmerge_pairs:
+            unmerge_pairs = [
+                (members[i], members[j])
+                for i in range(len(members))
+                for j in range(i + 1, len(members))
+            ]
+        _record_unmerge_corrections(unmerge_pairs, memory_store, dataset)
+
     del clusters[cluster_id]
 
     next_cid = max(clusters.keys(), default=0) + 1

--- a/packages/python/goldenmatch/goldenmatch/core/llm_scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/llm_scorer.py
@@ -311,6 +311,86 @@ def llm_score_pairs(
     return _return(result)
 
 
+def llm_explain_pair(
+    row_a: dict,
+    row_b: dict,
+    score: float,
+    *,
+    provider: str | None = None,
+    api_key: str | None = None,
+    model: str | None = None,
+    budget: "BudgetTracker | None" = None,
+    max_chars: int = 240,
+) -> str:
+    """Generate a one-sentence prose explanation for a record pair.
+
+    Routes through the configured LLM provider when an API key is available.
+    On ANY error (no key, network failure, budget exhausted, parse failure),
+    returns a short deterministic fallback string. Never raises.
+
+    The output is clipped to ``max_chars`` characters; long LLM responses are
+    truncated to the first sentence (or hard-cut) so the result stays
+    suitable for a UI ``why`` field.
+    """
+    def _fallback() -> str:
+        # Deterministic, no network.
+        cols = sorted(set((row_a or {}).keys()) | set((row_b or {}).keys()))
+        cols = [c for c in cols if not c.startswith("__")]
+        head = ", ".join(cols[:3]) if cols else "the available fields"
+        return f"Pair score {score:.2f} based on {head}."
+
+    try:
+        if not provider or not api_key:
+            detected_provider, detected_key = _detect_provider()
+            provider = provider or detected_provider
+            api_key = api_key or detected_key
+        if not provider or not api_key:
+            return _fallback()
+
+        if budget is not None and budget.budget_exhausted:
+            return _fallback()
+
+        if not model:
+            model = "gpt-4o-mini" if provider == "openai" else "claude-haiku-4-5-20251001"
+
+        cols = sorted(set((row_a or {}).keys()) | set((row_b or {}).keys()))
+        cols = [c for c in cols if not c.startswith("__")]
+        text_a = " | ".join(f"{c}: {row_a.get(c, '')}" for c in cols if row_a.get(c) is not None)[:300]
+        text_b = " | ".join(f"{c}: {row_b.get(c, '')}" for c in cols if row_b.get(c) is not None)[:300]
+        prompt = (
+            "In ONE short sentence (max 25 words), explain why these two records "
+            "could refer to the same entity, citing the most informative field(s). "
+            "Do not restate the question.\n"
+            f"A: {text_a}\nB: {text_b}\nFuzzy score: {score:.2f}"
+        )
+
+        if provider == "openai":
+            text, in_tok, out_tok = _call_openai(prompt, api_key, model, max_tokens=80)
+        else:
+            text, in_tok, out_tok = _call_anthropic(prompt, api_key, model, max_tokens=80)
+
+        if budget is not None:
+            try:
+                budget.record_usage(input_tokens=in_tok, output_tokens=out_tok, model=model)
+            except Exception:
+                pass
+
+        text = (text or "").strip().replace("\n", " ").replace("  ", " ")
+        if not text:
+            return _fallback()
+        # First sentence only.
+        for sep in (". ", "! ", "? "):
+            if sep in text:
+                text = text.split(sep, 1)[0] + sep.strip()
+                break
+        if len(text) > max_chars:
+            text = text[: max_chars - 3].rstrip() + "..."
+        return text
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("llm_explain_pair failed: %s", e)
+        return _fallback()
+
+
 def _detect_provider() -> tuple[str | None, str | None]:
     """Auto-detect LLM provider from environment variables."""
     key = os.environ.get("OPENAI_API_KEY")

--- a/packages/python/goldenmatch/goldenmatch/core/llm_scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/llm_scorer.py
@@ -25,9 +25,72 @@ import time
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+from typing import TYPE_CHECKING
+
 import polars as pl
 
+if TYPE_CHECKING:
+    from goldenmatch.core.memory.store import MemoryStore
+
 logger = logging.getLogger(__name__)
+
+
+def _record_llm_corrections(
+    llm_results: dict[int, bool],
+    pairs: list[tuple[int, int, float]],
+    df: pl.DataFrame,
+    memory_store: "MemoryStore | None",
+    matchkey_fields: list[str] | None,
+    matchkey_name: str | None,
+    dataset: str | None,
+    cols: list[str],
+) -> None:
+    """Write Correction rows for each LLM decision (approve/reject)."""
+    if memory_store is None or not llm_results:
+        return
+    try:
+        import uuid
+        from datetime import datetime
+
+        from goldenmatch.core.memory.store import Correction, _canon_pair
+        from goldenmatch.core.memory.corrections import (
+            build_row_lookup,
+            compute_field_hash,
+            compute_record_hash,
+        )
+
+        fields = matchkey_fields or cols
+        lookup = build_row_lookup(df, fields)
+
+        for idx, is_match in llm_results.items():
+            a, b, score = pairs[idx]
+            ca, cb = _canon_pair(a, b)
+            field_hash = ""
+            record_hash = ""
+            if ca in lookup and cb in lookup:
+                field_hash = compute_field_hash(lookup[ca], lookup[cb])
+            ra = compute_record_hash(df, ca)
+            rb = compute_record_hash(df, cb)
+            if ra and rb:
+                record_hash = f"{ra}:{rb}"
+
+            memory_store.add_correction(Correction(
+                id=str(uuid.uuid4()),
+                id_a=a,
+                id_b=b,
+                decision="approve" if is_match else "reject",
+                source="llm",
+                trust=0.5,
+                field_hash=field_hash,
+                record_hash=record_hash,
+                original_score=score,
+                matchkey_name=matchkey_name,
+                reason=None,
+                dataset=dataset,
+                created_at=datetime.now(),
+            ))
+    except Exception as e:
+        logger.warning("LLM scorer memory write failed: %s", e)
 
 
 def llm_score_pairs(
@@ -44,6 +107,10 @@ def llm_score_pairs(
     display_columns: list[str] | None = None,
     config: "LLMScorerConfig | None" = None,
     return_budget: bool = False,
+    memory_store: "MemoryStore | None" = None,
+    matchkey_fields: list[str] | None = None,
+    matchkey_name: str | None = None,
+    dataset: str | None = None,
 ) -> "list[tuple[int, int, float]] | tuple[list[tuple[int, int, float]], dict | None]":
     """Score borderline pairs with an LLM.
 
@@ -206,6 +273,10 @@ def llm_score_pairs(
             "LLM calibration applied in %.1fs: %d promoted, %d unchanged",
             elapsed, n_promoted + sum(1 for m in llm_results.values() if m), n_unchanged,
         )
+        _record_llm_corrections(
+            llm_results, pairs, df, memory_store,
+            matchkey_fields, matchkey_name, dataset, cols,
+        )
     else:
         # Direct scoring path: few candidates, score them all
         llm_results = _batch_score(
@@ -231,6 +302,11 @@ def llm_score_pairs(
                 a, b, _ = result[i]
                 result[i] = (a, b, 1.0)
             # else: keep original fuzzy score (never demote)
+
+        _record_llm_corrections(
+            llm_results, pairs, df, memory_store,
+            matchkey_fields, matchkey_name, dataset, cols,
+        )
 
     return _return(result)
 

--- a/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
@@ -28,6 +28,29 @@ class CorrectionStats:
     failed: bool = False
     error: str | None = None
 
+    def validate(self) -> bool:
+        """Sanity check the count invariant after apply_corrections finishes.
+
+        Returns True when applied + stale + stale_ambiguous +
+        stale_unanchorable <= total_pairs. On violation logs a warning and
+        returns False — callers should NOT crash on a counting bug, but a
+        violation does indicate something accidentally double-counted a pair.
+        """
+        total_classified = (
+            self.applied + self.stale + self.stale_ambiguous
+            + self.stale_unanchorable
+        )
+        if self.total_pairs > 0 and total_classified > self.total_pairs:
+            log.warning(
+                "CorrectionStats invariant violated: applied=%d stale=%d "
+                "stale_ambiguous=%d stale_unanchorable=%d (sum=%d) > "
+                "total_pairs=%d",
+                self.applied, self.stale, self.stale_ambiguous,
+                self.stale_unanchorable, total_classified, self.total_pairs,
+            )
+            return False
+        return True
+
 
 def build_row_lookup(df: pl.DataFrame, fields: list[str]) -> dict[int, tuple]:
     """Build row ID to field values lookup once for all pairs."""
@@ -51,8 +74,8 @@ def compute_field_hash(row_a_vals: tuple, row_b_vals: tuple) -> str:
 def compute_record_hash(df: pl.DataFrame, row_id: int) -> str:
     """Hash content fields (sorted by name) for entity identity check.
 
-    Excludes __row_id__ so the hash is durable across input refreshes that
-    reorder rows.
+    Excludes ``__row_id__`` so two runs over the same content produce the
+    same hash even if row order changes.
     """
     filtered = df.filter(pl.col("__row_id__") == row_id)
     if filtered.is_empty():
@@ -64,8 +87,7 @@ def compute_record_hash(df: pl.DataFrame, row_id: int) -> str:
 
 
 def _build_hash_to_rids(df: pl.DataFrame) -> dict[str, list[int]]:
-    """Vectorized record_hash → [row_ids] map. Excludes __row_id__ so hash is
-    content-keyed and durable across row reordering."""
+    """Vectorized record_hash to [row_ids] map."""
     sorted_cols = sorted(c for c in df.columns if c != "__row_id__")
     hashed = df.select(
         pl.col("__row_id__"),
@@ -115,8 +137,6 @@ def apply_corrections(
     hash_to_rids = _build_hash_to_rids(df)
     current_rids = {rid for rids in hash_to_rids.values() for rid in rids}
 
-    # active maps canonical (id_a, id_b) — keyed by NEW row IDs after re-anchor —
-    # to the originating Correction.
     active: dict[tuple[int, int], Correction] = {}
     for c in all_corrections:
         if c.id_a in current_rids and c.id_b in current_rids:
@@ -148,7 +168,6 @@ def apply_corrections(
             stats.stale_ambiguous += 1
             stats.stale_pairs.append((c.id_a, c.id_b))
         else:
-            # One or both hash sides have NO match — entity gone.
             stats.stale_unanchorable += 1
             stats.stale_pairs.append((c.id_a, c.id_b))
             log.debug(
@@ -211,4 +230,5 @@ def apply_corrections(
         stats.applied, stats.stale, stats.stale_ambiguous,
         stats.stale_unanchorable, stats.total_pairs,
     )
+    stats.validate()
     return adjusted, stats

--- a/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
@@ -24,6 +24,7 @@ class CorrectionStats:
     total_pairs: int = 0
     stale_pairs: list[tuple[int, int]] = field(default_factory=list)
     stale_ambiguous: int = 0
+    stale_unanchorable: int = 0
 
 
 def build_row_lookup(df: pl.DataFrame, fields: list[str]) -> dict[int, tuple]:
@@ -120,10 +121,23 @@ def apply_corrections(
             active[_canon_pair(c.id_a, c.id_b)] = c
             continue
         if not reanchor:
+            stats.stale_unanchorable += 1
+            stats.stale_pairs.append((c.id_a, c.id_b))
+            log.debug(
+                "Correction unanchorable (row IDs gone, no usable record_hash): (%d, %d)",
+                c.id_a, c.id_b,
+            )
             continue
-        parts = (c.record_hash or "").split(":", 1)
-        ha = parts[0] if parts else ""
-        hb = parts[1] if len(parts) > 1 else ""
+        rh = c.record_hash or ""
+        if ":" not in rh:
+            stats.stale_unanchorable += 1
+            stats.stale_pairs.append((c.id_a, c.id_b))
+            log.debug(
+                "Correction unanchorable (row IDs gone, no usable record_hash): (%d, %d)",
+                c.id_a, c.id_b,
+            )
+            continue
+        ha, hb = rh.split(":", 1)
         cands_a = hash_to_rids.get(ha, []) if ha else []
         cands_b = hash_to_rids.get(hb, []) if hb else []
         if len(cands_a) == 1 and len(cands_b) == 1:
@@ -131,6 +145,14 @@ def apply_corrections(
         elif cands_a and cands_b:
             stats.stale_ambiguous += 1
             stats.stale_pairs.append((c.id_a, c.id_b))
+        else:
+            # One or both hash sides have NO match — entity gone.
+            stats.stale_unanchorable += 1
+            stats.stale_pairs.append((c.id_a, c.id_b))
+            log.debug(
+                "Correction unanchorable (row IDs gone, no usable record_hash): (%d, %d)",
+                c.id_a, c.id_b,
+            )
 
     if not active:
         return scored_pairs, stats
@@ -182,6 +204,9 @@ def apply_corrections(
             stats.stale += 1
             stats.stale_pairs.append((id_a, id_b))
 
-    log.info("Corrections: %d applied, %d stale, %d ambiguous, %d total pairs",
-             stats.applied, stats.stale, stats.stale_ambiguous, stats.total_pairs)
+    log.info(
+        "Corrections: %d applied, %d stale, %d ambiguous, %d unanchorable, %d total pairs",
+        stats.applied, stats.stale, stats.stale_ambiguous,
+        stats.stale_unanchorable, stats.total_pairs,
+    )
     return adjusted, stats

--- a/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
+from goldenmatch.core.memory.store import Correction, _canon_pair
+
 if TYPE_CHECKING:
     from goldenmatch.core.memory.store import MemoryStore
 
@@ -21,6 +23,7 @@ class CorrectionStats:
     stale: int = 0
     total_pairs: int = 0
     stale_pairs: list[tuple[int, int]] = field(default_factory=list)
+    stale_ambiguous: int = 0
 
 
 def build_row_lookup(df: pl.DataFrame, fields: list[str]) -> dict[int, tuple]:
@@ -43,39 +46,99 @@ def compute_field_hash(row_a_vals: tuple, row_b_vals: tuple) -> str:
 
 
 def compute_record_hash(df: pl.DataFrame, row_id: int) -> str:
-    """Hash ALL fields (sorted by name) for entity identity check."""
+    """Hash content fields (sorted by name) for entity identity check.
+
+    Excludes __row_id__ so the hash is durable across input refreshes that
+    reorder rows.
+    """
     filtered = df.filter(pl.col("__row_id__") == row_id)
     if filtered.is_empty():
         log.warning("Row ID %d not found in DataFrame, returning empty hash", row_id)
         return ""
-    row = filtered.select(sorted(df.columns)).row(0)
+    content_cols = sorted(c for c in df.columns if c != "__row_id__")
+    row = filtered.select(content_cols).row(0)
     return hashlib.sha256("|".join(str(v) for v in row).encode()).hexdigest()[:16]
+
+
+def _build_hash_to_rids(df: pl.DataFrame) -> dict[str, list[int]]:
+    """Vectorized record_hash → [row_ids] map. Excludes __row_id__ so hash is
+    content-keyed and durable across row reordering."""
+    sorted_cols = sorted(c for c in df.columns if c != "__row_id__")
+    hashed = df.select(
+        pl.col("__row_id__"),
+        pl.concat_str(
+            [pl.col(c).cast(pl.Utf8) for c in sorted_cols],
+            separator="|",
+        )
+        .map_elements(
+            lambda s: hashlib.sha256(s.encode()).hexdigest()[:16],
+            return_dtype=pl.Utf8,
+        )
+        .alias("__rec_hash__"),
+    )
+    out: dict[str, list[int]] = {}
+    for rid, h in zip(
+        hashed["__row_id__"].to_list(), hashed["__rec_hash__"].to_list()
+    ):
+        out.setdefault(h, []).append(int(rid))
+    return out
 
 
 def apply_corrections(
     scored_pairs: list[tuple[int, int, float]],
-    store: MemoryStore,
+    store: "MemoryStore",
     df: pl.DataFrame,
     matchkey_fields: list[str],
     dataset: str | None = None,
+    reanchor: bool = True,
 ) -> tuple[list[tuple[int, int, float]], CorrectionStats]:
     """Apply pair-level corrections to scored pairs.
 
-    Returns adjusted pairs and correction stats.
+    Direct row-ID match takes precedence; falls back to record_hash re-anchor
+    when the original IDs are no longer present. Ambiguous re-anchors (current
+    df has duplicate rows for either side) refuse to apply and surface as
+    stale_ambiguous.
     """
     stats = CorrectionStats(total_pairs=len(scored_pairs))
 
-    pair_keys = [(a, b) for a, b, _ in scored_pairs]
-    corrections = store.get_pair_corrections_bulk(pair_keys, dataset=dataset)
+    all_corrections = store.get_corrections(dataset=dataset)
+    if not all_corrections:
+        return scored_pairs, stats
 
-    if not corrections:
+    if "__row_id__" not in df.columns:
+        log.warning("DataFrame missing __row_id__ column, corrections cannot be applied")
+        return scored_pairs, stats
+
+    hash_to_rids = _build_hash_to_rids(df)
+    current_rids = {rid for rids in hash_to_rids.values() for rid in rids}
+
+    # active maps canonical (id_a, id_b) — keyed by NEW row IDs after re-anchor —
+    # to the originating Correction.
+    active: dict[tuple[int, int], Correction] = {}
+    for c in all_corrections:
+        if c.id_a in current_rids and c.id_b in current_rids:
+            active[_canon_pair(c.id_a, c.id_b)] = c
+            continue
+        if not reanchor:
+            continue
+        parts = (c.record_hash or "").split(":", 1)
+        ha = parts[0] if parts else ""
+        hb = parts[1] if len(parts) > 1 else ""
+        cands_a = hash_to_rids.get(ha, []) if ha else []
+        cands_b = hash_to_rids.get(hb, []) if hb else []
+        if len(cands_a) == 1 and len(cands_b) == 1:
+            active[_canon_pair(cands_a[0], cands_b[0])] = c
+        elif cands_a and cands_b:
+            stats.stale_ambiguous += 1
+            stats.stale_pairs.append((c.id_a, c.id_b))
+
+    if not active:
         return scored_pairs, stats
 
     field_lookup = build_row_lookup(df, matchkey_fields)
 
-    # Pre-compute record hashes for correction-involved rows
     record_hashes: dict[int, str] = {}
-    for (id_a, id_b) in corrections:
+    for (id_a, id_b) in active.keys():
         if id_a not in record_hashes:
             record_hashes[id_a] = compute_record_hash(df, id_a)
         if id_b not in record_hashes:
@@ -83,14 +146,14 @@ def apply_corrections(
 
     adjusted = []
     for id_a, id_b, score in scored_pairs:
-        correction = corrections.get((id_a, id_b))
+        correction = active.get(_canon_pair(id_a, id_b))
         if correction is None:
             adjusted.append((id_a, id_b, score))
             continue
 
-        # Check if row IDs are in lookup
         if id_a not in field_lookup or id_b not in field_lookup:
-            log.warning("Row ID(s) not in lookup for correction (%d, %d), marking stale", id_a, id_b)
+            log.warning("Row ID(s) not in lookup for correction (%d, %d), marking stale",
+                       id_a, id_b)
             adjusted.append((id_a, id_b, score))
             stats.stale += 1
             stats.stale_pairs.append((id_a, id_b))
@@ -99,11 +162,11 @@ def apply_corrections(
         current_field_hash = compute_field_hash(
             field_lookup[id_a], field_lookup[id_b],
         )
+        ca, cb = _canon_pair(id_a, id_b)
         current_record_hash = (
-            f"{record_hashes.get(id_a, '')}:{record_hashes.get(id_b, '')}"
+            f"{record_hashes.get(ca, '')}:{record_hashes.get(cb, '')}"
         )
 
-        # Empty hashes = collected without DataFrame access, skip staleness check
         hashes_empty = (not correction.field_hash and not correction.record_hash)
         hashes_match = (
             current_field_hash == correction.field_hash
@@ -119,6 +182,6 @@ def apply_corrections(
             stats.stale += 1
             stats.stale_pairs.append((id_a, id_b))
 
-    log.info("Corrections: %d applied, %d stale, %d total pairs",
-             stats.applied, stats.stale, stats.total_pairs)
+    log.info("Corrections: %d applied, %d stale, %d ambiguous, %d total pairs",
+             stats.applied, stats.stale, stats.stale_ambiguous, stats.total_pairs)
     return adjusted, stats

--- a/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
@@ -25,6 +25,8 @@ class CorrectionStats:
     stale_pairs: list[tuple[int, int]] = field(default_factory=list)
     stale_ambiguous: int = 0
     stale_unanchorable: int = 0
+    failed: bool = False
+    error: str | None = None
 
 
 def build_row_lookup(df: pl.DataFrame, fields: list[str]) -> dict[int, tuple]:

--- a/packages/python/goldenmatch/goldenmatch/core/memory/store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/store.py
@@ -40,6 +40,15 @@ HIGH_TRUST_SOURCES: frozenset[CorrectionSource] = frozenset({
 })
 
 
+def trust_for_source(source: str | CorrectionSource) -> float:
+    """Return 1.0 for human-trust sources (steward/boost/unmerge), 0.5 else.
+
+    Accepts a raw string OR a CorrectionSource member. Centralizes the trust
+    mapping so call sites cannot drift.
+    """
+    return 1.0 if source in HIGH_TRUST_SOURCES else 0.5
+
+
 @dataclass
 class Correction:
     """A single pair decision stored in memory."""

--- a/packages/python/goldenmatch/goldenmatch/core/memory/store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/store.py
@@ -6,9 +6,38 @@ import logging
 import sqlite3
 from dataclasses import dataclass, field
 from datetime import datetime
+from enum import StrEnum
 from typing import Any
 
 log = logging.getLogger("goldenmatch.memory")
+
+
+class CorrectionSource(StrEnum):
+    """Canonical correction source identifiers.
+
+    StrEnum members ARE strings, so existing call sites that pass raw
+    "steward"/"boost"/etc. continue to work. These enums are reference
+    values for callers/tests/lookups, not field type changes.
+    """
+    STEWARD = "steward"
+    BOOST = "boost"
+    UNMERGE = "unmerge"
+    AGENT = "agent"
+    LLM = "llm"
+    API = "api"
+
+
+class Decision(StrEnum):
+    """Canonical correction decisions."""
+    APPROVE = "approve"
+    REJECT = "reject"
+
+
+HIGH_TRUST_SOURCES: frozenset[CorrectionSource] = frozenset({
+    CorrectionSource.STEWARD,
+    CorrectionSource.BOOST,
+    CorrectionSource.UNMERGE,
+})
 
 
 @dataclass
@@ -17,9 +46,9 @@ class Correction:
     id: str
     id_a: int
     id_b: int
-    decision: str                # "approve" | "reject"
-    source: str                  # "steward" | "boost" | "unmerge" | "agent" | "llm"
-    trust: float                 # 1.0 (human) or 0.5 (agent)
+    decision: str                # Decision value (StrEnum members serialize as str)
+    source: str                  # CorrectionSource value
+    trust: float                 # 1.0 (HIGH_TRUST_SOURCES) or 0.5 (else)
     field_hash: str
     record_hash: str
     original_score: float

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -60,6 +60,97 @@ def _propagate_autoconfig_markers(
         dst._strict_autoconfig = True
 
 
+def _open_memory_store(config: GoldenMatchConfig):
+    """Open the MemoryStore configured on `config`. Returns None on failure or
+    when memory is disabled — pipeline must continue regardless."""
+    if not config.memory or not config.memory.enabled:
+        return None
+    try:
+        from goldenmatch.core.memory.store import MemoryStore
+        return MemoryStore(
+            backend=config.memory.backend,
+            path=config.memory.path,
+            connection=config.memory.connection,
+        )
+    except Exception as e:
+        logger.warning("Memory store init failed, continuing without memory: %s", e)
+        return None
+
+
+def _apply_memory_pre(memory_store, config: GoldenMatchConfig, matchkeys: list) -> None:
+    """Overlay learned threshold adjustments onto the matchkeys parameter.
+
+    Mutates `matchkeys` in place — rebinding to a fresh list would shadow the
+    parameter and the scoring loop would never see the overlay.
+    """
+    if memory_store is None:
+        return
+    try:
+        from goldenmatch.core.memory.learner import MemoryLearner
+        learner = MemoryLearner(
+            memory_store,
+            threshold_min=config.memory.learning.threshold_min_corrections,
+            weights_min=config.memory.learning.weights_min_corrections,
+        )
+        if not learner.has_new_corrections():
+            return
+        adjustments = learner.learn()
+        for adj in adjustments:
+            if adj.threshold is None:
+                continue
+            for mk in matchkeys:
+                if mk.threshold is None:
+                    continue
+                if (not adj.matchkey_name
+                        or adj.matchkey_name == mk.name
+                        or adj.matchkey_name == "_default"):
+                    mk.threshold = adj.threshold
+    except Exception as e:
+        logger.warning("Memory learner overlay failed: %s", e)
+
+
+def _apply_memory_post(
+    memory_store,
+    config: GoldenMatchConfig,
+    df: pl.DataFrame,
+    all_pairs: list[tuple[int, int, float]],
+):
+    """Apply stored corrections to scored pairs. Returns (pairs, stats|None)."""
+    if memory_store is None:
+        return all_pairs, None
+    try:
+        from goldenmatch.core.memory.corrections import apply_corrections
+        matchkey_field_names = sorted({
+            f.field for mk in config.get_matchkeys() for f in mk.fields
+        })
+        return apply_corrections(
+            all_pairs, memory_store, df, matchkey_field_names,
+            dataset=config.memory.dataset,
+            reanchor=config.memory.reanchor,
+        )
+    except Exception as e:
+        logger.warning("Memory apply_corrections failed: %s", e)
+        return all_pairs, None
+
+
+def _enqueue_stale_pairs(memory_stats, all_pairs: list[tuple[int, int, float]]) -> None:
+    """Push stale pairs onto an in-memory ReviewQueue for steward triage."""
+    if memory_stats is None or not memory_stats.stale_pairs:
+        return
+    try:
+        from goldenmatch.core.review_queue import ReviewQueue
+        rq = ReviewQueue()
+        score_lookup = {(a, b): s for a, b, s in all_pairs}
+        for (a, b) in memory_stats.stale_pairs:
+            score = score_lookup.get((a, b), score_lookup.get((b, a), 0.0))
+            rq.add(
+                job_name="memory_stale", id_a=a, id_b=b, score=score,
+                explanation="correction stale: re-decide",
+            )
+    except Exception as e:
+        logger.warning("Failed to enqueue stale pairs: %s", e)
+
+
 def _apply_postflight(
     df: pl.DataFrame,
     config: GoldenMatchConfig,
@@ -256,6 +347,7 @@ def _run_dedupe_pipeline(
     This function contains all pipeline steps from auto-fix/validation through
     output. Both run_dedupe() and run_dedupe_df() delegate to this function.
     """
+    memory_store = _open_memory_store(config)
     # ── Step 1.4: GOLDENCHECK QUALITY SCAN (if available) ──
     if config.quality is None or config.quality.mode != "disabled":
         from goldenmatch.core.quality import run_quality_check
@@ -366,6 +458,12 @@ def _run_dedupe_pipeline(
                 logger.info("LLM validated %d/%d low-confidence extractions", len(extractions), len(low_conf_ids))
 
             combined_lf = combined_df_tmp.lazy()
+
+    # ── Learning Memory: pre-scoring learner overlay ──
+    # Threshold adjustments are mutated onto the matchkeys parameter in place;
+    # rebinding to a fresh list would shadow the parameter that the scoring
+    # loop below reads.
+    _apply_memory_pre(memory_store, config, matchkeys)
 
     # ── Step 2: TRANSFORM ──
     combined_lf = compute_matchkeys(combined_lf, matchkeys)
@@ -487,6 +585,11 @@ def _run_dedupe_pipeline(
             )
         except ImportError as e:
             logger.warning("LLM boost unavailable: %s", e)
+
+    # ── Learning Memory: post-scoring corrections overlay ──
+    all_pairs, memory_stats = _apply_memory_post(
+        memory_store, config, collected_df, all_pairs
+    )
 
     # ── Step 3.6: POSTFLIGHT (auto-config only) ──
     # Postflight verification. Signals are computed from the unadjusted pair
@@ -626,8 +729,14 @@ def _run_dedupe_pipeline(
         "report": report,
         "quarantine": quarantine_df,
         "postflight_report": postflight_report,
+        "memory_stats": memory_stats,
     }
 
+    try:
+        _enqueue_stale_pairs(memory_stats, all_pairs)
+    finally:
+        if memory_store is not None:
+            memory_store.close()
     return results
 
 
@@ -754,6 +863,7 @@ def _run_match_pipeline(
     This function contains all pipeline steps from auto-fix/validation through
     output. Both run_match() and run_match_df() delegate to this function.
     """
+    memory_store = _open_memory_store(config)
     # ── Step 2.5a: AUTO-FIX + VALIDATION ──
     if config.validation and config.validation.auto_fix:
         combined_df_tmp = combined_lf.collect()
@@ -803,6 +913,9 @@ def _run_match_pipeline(
     # ── Step 2.5b: STANDARDIZE ──
     if config.standardization and config.standardization.rules:
         combined_lf = apply_standardization(combined_lf, config.standardization.rules)
+
+    # ── Learning Memory: pre-scoring learner overlay ──
+    _apply_memory_pre(memory_store, config, matchkeys)
 
     # ── Step 3: Compute matchkeys ──
     combined_lf = compute_matchkeys(combined_lf, matchkeys)
@@ -892,6 +1005,11 @@ def _run_match_pipeline(
             all_pairs = llm_score_pairs(all_pairs, combined_df, config=config.llm_scorer)
         all_pairs = [(a, b, s) for a, b, s in all_pairs if s > 0.5]
 
+    # ── Learning Memory: post-scoring corrections overlay ──
+    all_pairs, memory_stats = _apply_memory_post(
+        memory_store, config, combined_df, all_pairs
+    )
+
     # ── Step 4.7: POSTFLIGHT (auto-config only) ──
     # Postflight verification. Signals are computed from the unadjusted pair
     # list; threshold adjustments (if any, non-strict only) are then applied
@@ -971,12 +1089,19 @@ def _run_match_pipeline(
     if output_scores and matched_df is not None:
         write_output(matched_df, directory, run_name, "scores", fmt)
 
+    try:
+        _enqueue_stale_pairs(memory_stats, all_pairs)
+    finally:
+        if memory_store is not None:
+            memory_store.close()
+
     return {
         "matched": matched_df,
         "unmatched": unmatched_df,
         "report": report,
         "quarantine": quarantine_df_match,
         "postflight_report": postflight_report,
+        "memory_stats": memory_stats,
     }
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -131,7 +131,10 @@ def _apply_memory_post(
         )
     except Exception as e:
         logger.warning("Memory apply_corrections failed: %s", e)
-        return all_pairs, None
+        from goldenmatch.core.memory.corrections import CorrectionStats
+        return all_pairs, CorrectionStats(
+            total_pairs=len(all_pairs), failed=True, error=str(e),
+        )
 
 
 def _derive_review_queue_path(config: GoldenMatchConfig) -> str | None:

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -497,9 +497,6 @@ def _run_dedupe_pipeline(
             combined_lf = combined_df_tmp.lazy()
 
     # ── Learning Memory: pre-scoring learner overlay ──
-    # Threshold adjustments are mutated onto the matchkeys parameter in place;
-    # rebinding to a fresh list would shadow the parameter that the scoring
-    # loop below reads.
     _apply_memory_pre(memory_store, config, matchkeys)
 
     # ── Step 2: TRANSFORM ──

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from datetime import datetime
+from pathlib import Path
 
 import polars as pl
 
@@ -133,13 +134,40 @@ def _apply_memory_post(
         return all_pairs, None
 
 
-def _enqueue_stale_pairs(memory_stats, all_pairs: list[tuple[int, int, float]]) -> None:
-    """Push stale pairs onto an in-memory ReviewQueue for steward triage."""
+def _derive_review_queue_path(config: GoldenMatchConfig) -> str | None:
+    """Derive review-queue SQLite path as sibling of the memory store path.
+
+    Returns None if memory is disabled or no path is configured.
+    """
+    if not config.memory or not config.memory.enabled:
+        return None
+    mem_path = getattr(config.memory, "path", None)
+    if not mem_path:
+        return None
+    p = Path(mem_path)
+    return str(p.with_name("review_queue.db"))
+
+
+def _enqueue_stale_pairs(
+    memory_stats,
+    all_pairs: list[tuple[int, int, float]],
+    config: GoldenMatchConfig,
+) -> None:
+    """Push stale pairs onto a SQLite-backed ReviewQueue for steward triage.
+
+    The queue is colocated with the memory store (sibling SQLite file) so the
+    next `goldenmatch review` invocation surfaces these pairs across processes.
+    """
     if memory_stats is None or not memory_stats.stale_pairs:
         return
+    rq = None
     try:
         from goldenmatch.core.review_queue import ReviewQueue
-        rq = ReviewQueue()
+        queue_path = _derive_review_queue_path(config)
+        if queue_path is not None:
+            rq = ReviewQueue(backend="sqlite", path=queue_path)
+        else:
+            rq = ReviewQueue()
         score_lookup = {(a, b): s for a, b, s in all_pairs}
         for (a, b) in memory_stats.stale_pairs:
             score = score_lookup.get((a, b), score_lookup.get((b, a), 0.0))
@@ -149,6 +177,12 @@ def _enqueue_stale_pairs(memory_stats, all_pairs: list[tuple[int, int, float]]) 
             )
     except Exception as e:
         logger.warning("Failed to enqueue stale pairs: %s", e)
+    finally:
+        if rq is not None:
+            try:
+                rq.close()
+            except Exception:
+                pass
 
 
 def _apply_postflight(
@@ -733,7 +767,7 @@ def _run_dedupe_pipeline(
     }
 
     try:
-        _enqueue_stale_pairs(memory_stats, all_pairs)
+        _enqueue_stale_pairs(memory_stats, all_pairs, config)
     finally:
         if memory_store is not None:
             memory_store.close()
@@ -1090,7 +1124,7 @@ def _run_match_pipeline(
         write_output(matched_df, directory, run_name, "scores", fmt)
 
     try:
-        _enqueue_stale_pairs(memory_stats, all_pairs)
+        _enqueue_stale_pairs(memory_stats, all_pairs, config)
     finally:
         if memory_store is not None:
             memory_store.close()

--- a/packages/python/goldenmatch/goldenmatch/core/review_queue.py
+++ b/packages/python/goldenmatch/goldenmatch/core/review_queue.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import logging
 import sqlite3
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    import polars as pl
+
+    from goldenmatch.core.memory.store import MemoryStore
+
+log = logging.getLogger("goldenmatch.memory")
 
 
 @dataclass
@@ -221,7 +230,16 @@ class ReviewQueue:
         "memory" (default) or "sqlite"
     """
 
-    def __init__(self, backend: str = "memory", path: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        backend: str = "memory",
+        path: Optional[str] = None,
+        *,
+        memory_store: "MemoryStore | None" = None,
+        df: "pl.DataFrame | None" = None,
+        matchkey_fields: Optional[List[str]] = None,
+        dataset: Optional[str] = None,
+    ) -> None:
         if backend == "memory":
             self._backend = _MemoryBackend()
         elif backend == "sqlite":
@@ -229,6 +247,10 @@ class ReviewQueue:
         else:
             raise ValueError(f"Unknown backend: {backend!r}. Use 'memory' or 'sqlite'.")
         self._backend_name = backend
+        self._memory_store = memory_store
+        self._memory_df = df
+        self._memory_matchkey_fields = list(matchkey_fields) if matchkey_fields else None
+        self._memory_dataset = dataset
 
     def close(self) -> None:
         """Close any backend resources. SQLite uses per-call connections, so this is a no-op."""
@@ -247,9 +269,61 @@ class ReviewQueue:
 
     def approve(self, job_name: str, id_a: int, id_b: int, decided_by: str) -> None:
         self._backend.approve(job_name, id_a, id_b, decided_by)
+        self._record_correction(id_a, id_b, "approve", reason=None)
 
     def reject(self, job_name: str, id_a: int, id_b: int, decided_by: str, reason: str = "") -> None:
         self._backend.reject(job_name, id_a, id_b, decided_by, reason)
+        self._record_correction(id_a, id_b, "reject", reason=reason or None)
 
     def stats(self, job_name: str) -> dict[str, int]:
         return self._backend.stats(job_name)
+
+    def _record_correction(
+        self,
+        id_a: int,
+        id_b: int,
+        decision: str,
+        reason: Optional[str],
+    ) -> None:
+        """Write a Correction to the optional memory store; never raises."""
+        if self._memory_store is None:
+            return
+        try:
+            from goldenmatch.core.memory.store import Correction
+            from goldenmatch.core.memory.corrections import (
+                build_row_lookup,
+                compute_field_hash,
+                compute_record_hash,
+            )
+
+            from goldenmatch.core.memory.store import _canon_pair
+
+            ca, cb = _canon_pair(id_a, id_b)
+            field_hash = ""
+            record_hash = ""
+            if self._memory_df is not None and self._memory_matchkey_fields:
+                lookup = build_row_lookup(self._memory_df, self._memory_matchkey_fields)
+                if ca in lookup and cb in lookup:
+                    field_hash = compute_field_hash(lookup[ca], lookup[cb])
+                ra = compute_record_hash(self._memory_df, ca)
+                rb = compute_record_hash(self._memory_df, cb)
+                if ra and rb:
+                    record_hash = f"{ra}:{rb}"
+
+            self._memory_store.add_correction(Correction(
+                id=str(uuid.uuid4()),
+                id_a=id_a,
+                id_b=id_b,
+                decision=decision,
+                source="steward",
+                trust=1.0,
+                field_hash=field_hash,
+                record_hash=record_hash,
+                original_score=0.0,
+                matchkey_name=None,
+                reason=reason,
+                dataset=self._memory_dataset,
+                created_at=datetime.now(),
+            ))
+        except Exception as e:
+            log.warning("ReviewQueue memory write failed: %s", e)

--- a/packages/python/goldenmatch/goldenmatch/core/review_queue.py
+++ b/packages/python/goldenmatch/goldenmatch/core/review_queue.py
@@ -31,6 +31,7 @@ class ReviewItem:
     decided_by: Optional[str] = None
     decided_at: Optional[str] = None
     reason: Optional[str] = None
+    why: Optional[str] = None
 
     def approve(self, decided_by: str) -> None:
         self.status = "approved"
@@ -42,6 +43,95 @@ class ReviewItem:
         self.decided_by = decided_by
         self.decided_at = datetime.now(timezone.utc).isoformat()
         self.reason = reason
+
+
+_MAX_WHY_CHARS = 240
+
+
+def _row_to_dict(df: "pl.DataFrame", row_id: int, fields: List[str]) -> dict:
+    """Pluck a row's matchkey-field values into a dict; empty if not found."""
+    try:
+        cols = [f for f in fields if f in df.columns]
+        if "__row_id__" not in df.columns or not cols:
+            return {}
+        sub = df.filter(df["__row_id__"] == row_id).select(cols)
+        if sub.is_empty():
+            return {}
+        return sub.row(0, named=True)
+    except Exception:
+        return {}
+
+
+def _llm_enabled() -> bool:
+    import os
+    return bool(os.environ.get("OPENAI_API_KEY") or os.environ.get("ANTHROPIC_API_KEY"))
+
+
+def why_for_correction(
+    id_a: int,
+    id_b: int,
+    df: "pl.DataFrame | None",
+    matchkey_fields: Optional[List[str]],
+    *,
+    score: float = 0.0,
+    use_llm: bool = False,
+) -> str:
+    """Compute a short ``why`` string for a (id_a, id_b) correction.
+
+    Default path is deterministic (zero cost). When ``use_llm=True`` AND an
+    LLM API key is present in the environment, routes through
+    :func:`goldenmatch.core.llm_scorer.llm_explain_pair`. Falls back to the
+    deterministic path on any error so callers never have to handle
+    exceptions. Output is always non-empty and clipped to one short sentence.
+    """
+    row_a: dict = {}
+    row_b: dict = {}
+    fields = list(matchkey_fields) if matchkey_fields else []
+    if df is not None and fields:
+        row_a = _row_to_dict(df, id_a, fields)
+        row_b = _row_to_dict(df, id_b, fields)
+
+    if use_llm and _llm_enabled():
+        try:
+            from goldenmatch.core.llm_scorer import llm_explain_pair
+            out = llm_explain_pair(row_a or {}, row_b or {}, score)
+            if out:
+                if len(out) > _MAX_WHY_CHARS:
+                    out = out[: _MAX_WHY_CHARS - 3].rstrip() + "..."
+                return out
+        except Exception as e:  # pragma: no cover - defensive
+            log.warning("why_for_correction LLM path failed: %s", e)
+
+    # Deterministic path.
+    try:
+        if row_a and row_b and fields:
+            field_scores = []
+            for f in fields:
+                va = row_a.get(f)
+                vb = row_b.get(f)
+                if va is None and vb is None:
+                    continue
+                # Cheap exact-or-not signal; explain_pair_nl knows how to
+                # phrase it. We don't compute fuzzy scores here -- this stays
+                # zero-cost.
+                s = 1.0 if (va is not None and str(va) == str(vb)) else 0.4
+                field_scores.append({
+                    "field": f, "scorer": "exact",
+                    "value_a": va, "value_b": vb,
+                    "score": s, "weight": 1.0,
+                })
+            if field_scores:
+                from goldenmatch.core.explain import explain_pair_nl
+                out = explain_pair_nl(row_a, row_b, field_scores, score)
+                out = (out or "").strip().replace("\n", " ")
+                if out:
+                    if len(out) > _MAX_WHY_CHARS:
+                        out = out[: _MAX_WHY_CHARS - 3].rstrip() + "..."
+                    return out
+    except Exception as e:  # pragma: no cover - defensive
+        log.warning("why_for_correction deterministic path failed: %s", e)
+
+    return f"Pair ({id_a}, {id_b}) flagged at score {score:.2f}."
 
 
 def gate_pairs(
@@ -239,6 +329,7 @@ class ReviewQueue:
         df: "pl.DataFrame | None" = None,
         matchkey_fields: Optional[List[str]] = None,
         dataset: Optional[str] = None,
+        use_llm_explainer: bool = False,
     ) -> None:
         if backend == "memory":
             self._backend = _MemoryBackend()
@@ -251,6 +342,7 @@ class ReviewQueue:
         self._memory_df = df
         self._memory_matchkey_fields = list(matchkey_fields) if matchkey_fields else None
         self._memory_dataset = dataset
+        self._use_llm_explainer = use_llm_explainer
 
     def close(self) -> None:
         """Close any backend resources. SQLite uses per-call connections, so this is a no-op."""
@@ -262,6 +354,15 @@ class ReviewQueue:
 
     def add(self, job_name: str, id_a: int, id_b: int, score: float, explanation: str) -> None:
         item = ReviewItem(job_name=job_name, id_a=id_a, id_b=id_b, score=score, explanation=explanation)
+        # Populate `why` when we have enough context. Never raises.
+        if self._memory_df is not None and self._memory_matchkey_fields:
+            try:
+                item.why = why_for_correction(
+                    id_a, id_b, self._memory_df, self._memory_matchkey_fields,
+                    score=score, use_llm=self._use_llm_explainer,
+                )
+            except Exception as e:  # pragma: no cover - defensive
+                log.warning("ReviewQueue why computation failed: %s", e)
         self._backend.add(item)
 
     def list_pending(self, job_name: str) -> list[ReviewItem]:

--- a/packages/python/goldenmatch/goldenmatch/core/review_queue.py
+++ b/packages/python/goldenmatch/goldenmatch/core/review_queue.py
@@ -107,10 +107,16 @@ class _MemoryBackend:
 class _SQLiteBackend:
     """SQLite-backed persistent storage for review items."""
 
-    def __init__(self) -> None:
-        db_dir = Path(".goldenmatch")
-        db_dir.mkdir(exist_ok=True)
-        self._db_path = db_dir / "reviews.db"
+    def __init__(self, path: Optional[str] = None) -> None:
+        if path is None:
+            db_dir = Path(".goldenmatch")
+            db_dir.mkdir(exist_ok=True)
+            self._db_path = db_dir / "reviews.db"
+        else:
+            self._db_path = Path(path)
+            parent = self._db_path.parent
+            if str(parent) and parent != Path(""):
+                parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
 
     def _connect(self) -> sqlite3.Connection:
@@ -215,14 +221,18 @@ class ReviewQueue:
         "memory" (default) or "sqlite"
     """
 
-    def __init__(self, backend: str = "memory") -> None:
+    def __init__(self, backend: str = "memory", path: Optional[str] = None) -> None:
         if backend == "memory":
             self._backend = _MemoryBackend()
         elif backend == "sqlite":
-            self._backend = _SQLiteBackend()
+            self._backend = _SQLiteBackend(path=path)
         else:
             raise ValueError(f"Unknown backend: {backend!r}. Use 'memory' or 'sqlite'.")
         self._backend_name = backend
+
+    def close(self) -> None:
+        """Close any backend resources. SQLite uses per-call connections, so this is a no-op."""
+        return None
 
     @property
     def storage_tier(self) -> str:

--- a/packages/python/goldenmatch/goldenmatch/core/review_queue.py
+++ b/packages/python/goldenmatch/goldenmatch/core/review_queue.py
@@ -8,7 +8,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Literal, Optional, Tuple
 
 if TYPE_CHECKING:
     import polars as pl
@@ -27,11 +27,18 @@ class ReviewItem:
     id_b: int
     score: float
     explanation: str
-    status: str = "pending"
+    status: Literal["pending", "approved", "rejected"] = "pending"
     decided_by: Optional[str] = None
     decided_at: Optional[str] = None
     reason: Optional[str] = None
     why: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        # Normalize empty `why` to None so callers don't have to special-case
+        # the difference between "no explanation" and "explainer ran but
+        # produced an empty string".
+        if not self.why:
+            self.why = None
 
     def approve(self, decided_by: str) -> None:
         self.status = "approved"

--- a/packages/python/goldenmatch/goldenmatch/core/review_queue.py
+++ b/packages/python/goldenmatch/goldenmatch/core/review_queue.py
@@ -58,7 +58,8 @@ def _row_to_dict(df: "pl.DataFrame", row_id: int, fields: List[str]) -> dict:
         if sub.is_empty():
             return {}
         return sub.row(0, named=True)
-    except Exception:
+    except Exception as e:
+        log.debug("row lookup for id=%s failed: %s", row_id, e)
         return {}
 
 

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -60,8 +60,12 @@ def _write_agent_correction(
                 rb = compute_record_hash(df, cb)
                 if ra and rb:
                     record_hash = f"{ra}:{rb}"
-            except Exception:
-                # Hash computation failures fall back to empty hashes.
+            except Exception as e:
+                logger.warning(
+                    "agent correction hash computation failed for pair (%s,%s); "
+                    "writing empty hashes - staleness detection degraded: %s",
+                    ca, cb, e,
+                )
                 field_hash, record_hash = "", ""
 
         memory_store.add_correction(Correction(

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -9,11 +9,79 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mcp.types import Tool, TextContent
 
+if TYPE_CHECKING:
+    from goldenmatch.core.memory.store import MemoryStore
+
 logger = logging.getLogger(__name__)
+
+
+def _write_agent_correction(
+    *,
+    memory_store: "MemoryStore",
+    session: Any,
+    id_a: int,
+    id_b: int,
+    decision: str,
+    reason: str | None,
+    dataset: str | None,
+) -> None:
+    """Write a Correction with source='agent', trust=0.5.
+
+    Hashes are computed from `session.data` when present; otherwise empty.
+    """
+    try:
+        import uuid
+        from datetime import datetime
+
+        from goldenmatch.core.memory.store import Correction, _canon_pair
+
+        ca, cb = _canon_pair(id_a, id_b)
+        field_hash = ""
+        record_hash = ""
+        df = getattr(session, "data", None)
+        if df is not None:
+            try:
+                from goldenmatch.core.memory.corrections import (
+                    build_row_lookup,
+                    compute_field_hash,
+                    compute_record_hash,
+                )
+
+                cols = [c for c in df.columns if not c.startswith("__")]
+                if cols:
+                    lookup = build_row_lookup(df, cols)
+                    if ca in lookup and cb in lookup:
+                        field_hash = compute_field_hash(lookup[ca], lookup[cb])
+                ra = compute_record_hash(df, ca)
+                rb = compute_record_hash(df, cb)
+                if ra and rb:
+                    record_hash = f"{ra}:{rb}"
+            except Exception:
+                # Hash computation failures fall back to empty hashes.
+                field_hash, record_hash = "", ""
+
+        memory_store.add_correction(Correction(
+            id=str(uuid.uuid4()),
+            id_a=id_a,
+            id_b=id_b,
+            decision=decision,
+            source="agent",
+            trust=0.5,
+            field_hash=field_hash,
+            record_hash=record_hash,
+            original_score=0.0,
+            matchkey_name=None,
+            reason=reason,
+            dataset=dataset,
+            created_at=datetime.now(),
+        ))
+    except Exception as e:
+        logger.warning("agent_approve_reject memory write failed: %s", e)
+
 
 AGENT_TOOLS = [
     Tool(
@@ -265,7 +333,14 @@ def handle_agent_tool(name: str, arguments: dict) -> list[TextContent]:
         )]
 
 
-def _dispatch(name: str, args: dict, session_cls: type) -> dict:
+def _dispatch(
+    name: str,
+    args: dict,
+    session_cls: type,
+    *,
+    memory_store: "MemoryStore | None" = None,
+    dataset: str | None = None,
+) -> dict:
     """Dispatch to the appropriate handler by tool name."""
 
     if name == "analyze_data":
@@ -367,6 +442,17 @@ def _dispatch(name: str, args: dict, session_cls: type) -> dict:
             )
         else:
             return {"error": f"Invalid decision: {decision!r}. Use 'approve' or 'reject'."}
+
+        if memory_store is not None:
+            _write_agent_correction(
+                memory_store=memory_store,
+                session=session,
+                id_a=int(args["id_a"]),
+                id_b=int(args["id_b"]),
+                decision=decision,
+                reason=reason or None,
+                dataset=dataset,
+            )
 
         return {
             "status": "ok",

--- a/packages/python/goldenmatch/goldenmatch/mcp/memory_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/memory_tools.py
@@ -1,0 +1,287 @@
+"""MCP tool surface for Learning Memory.
+
+Five tools wrap MemoryStore + MemoryLearner operations:
+  list_corrections, add_correction, learn_thresholds, memory_stats, memory_export.
+
+Each handler instantiates its own MemoryStore (matches AgentSession pattern in
+agent_tools.py -- no shared global state). All handlers trap
+sqlite3.OperationalError and return a structured JSON error in TextContent
+rather than raising, so a failed memory call cannot crash an MCP session.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import uuid
+from datetime import datetime
+from typing import Any
+
+from mcp.types import Tool, TextContent
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_PATH = ".goldenmatch/memory.db"
+
+
+MEMORY_TOOLS: list[Tool] = [
+    Tool(
+        name="list_corrections",
+        description=(
+            "List stored Learning Memory corrections, optionally filtered by "
+            "dataset. Returns id_a, id_b, decision, source, trust, reason, "
+            "matchkey_name, dataset, original_score, created_at."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "dataset": {
+                    "type": "string",
+                    "description": "Optional dataset filter (e.g. file path).",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "SQLite memory DB path. Default: .goldenmatch/memory.db",
+                },
+            },
+        },
+    ),
+    Tool(
+        name="add_correction",
+        description=(
+            "Add a pair correction to Learning Memory. Source is set to 'agent' "
+            "with trust=0.5 (lower than human steward decisions which are 1.0). "
+            "Pair (id_a, id_b) is canonicalized to (min, max) before storage."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "id_a": {"type": "integer"},
+                "id_b": {"type": "integer"},
+                "decision": {
+                    "type": "string",
+                    "enum": ["approve", "reject"],
+                },
+                "dataset": {
+                    "type": "string",
+                    "description": "Dataset identifier (e.g. file path). Required, non-empty.",
+                },
+                "reason": {"type": "string"},
+                "matchkey_name": {"type": "string"},
+                "path": {
+                    "type": "string",
+                    "description": "SQLite memory DB path. Default: .goldenmatch/memory.db",
+                },
+            },
+            "required": ["id_a", "id_b", "decision", "dataset"],
+        },
+    ),
+    Tool(
+        name="learn_thresholds",
+        description=(
+            "Force a MemoryLearner pass over accumulated corrections. Returns "
+            "the list of LearnedAdjustments produced (matchkey_name, threshold, "
+            "sample_size, learned_at). Requires >= 10 corrections per matchkey "
+            "before threshold tuning fires; otherwise returns an empty list."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "matchkey_name": {
+                    "type": "string",
+                    "description": "Optional: learn only for this matchkey.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "SQLite memory DB path. Default: .goldenmatch/memory.db",
+                },
+            },
+        },
+    ),
+    Tool(
+        name="memory_stats",
+        description=(
+            "Return Learning Memory status: total correction count, last learn "
+            "time, and current learned adjustments. Cheap; safe for status checks."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "SQLite memory DB path. Default: .goldenmatch/memory.db",
+                },
+            },
+        },
+    ),
+    Tool(
+        name="memory_export",
+        description=(
+            "Return all corrections as a list of dicts (CSV-shaped). Caller is "
+            "responsible for writing the file. Optionally filter by dataset."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "dataset": {"type": "string"},
+                "path": {
+                    "type": "string",
+                    "description": "SQLite memory DB path. Default: .goldenmatch/memory.db",
+                },
+            },
+        },
+    ),
+]
+
+
+_MEMORY_TOOL_NAMES: frozenset[str] = frozenset(t.name for t in MEMORY_TOOLS)
+
+
+def _correction_to_dict(c: Any) -> dict:
+    return {
+        "id": c.id,
+        "id_a": c.id_a,
+        "id_b": c.id_b,
+        "decision": c.decision,
+        "source": c.source,
+        "trust": c.trust,
+        "field_hash": c.field_hash,
+        "record_hash": c.record_hash,
+        "original_score": c.original_score,
+        "matchkey_name": c.matchkey_name,
+        "reason": c.reason,
+        "dataset": c.dataset,
+        "created_at": c.created_at.isoformat() if c.created_at else None,
+    }
+
+
+def _adjustment_to_dict(a: Any) -> dict:
+    return {
+        "matchkey_name": a.matchkey_name,
+        "threshold": a.threshold,
+        "field_weights": a.field_weights,
+        "sample_size": a.sample_size,
+        "learned_at": a.learned_at.isoformat() if a.learned_at else None,
+    }
+
+
+# Re-export point for tests/monkeypatching: the dispatcher reads MemoryStore
+# from this module so tests can swap it out.
+from goldenmatch.core.memory.store import MemoryStore as MemoryStore  # noqa: E402,F401
+
+
+def handle_memory_tool(name: str, arguments: dict) -> list[TextContent]:
+    """Route a memory-tool MCP call to its handler.
+
+    Each handler opens its own MemoryStore. Returns JSON in TextContent.
+    sqlite3.OperationalError (and other exceptions) are trapped and returned
+    as a structured error rather than raised.
+    """
+    try:
+        result = _dispatch(name, arguments)
+    except sqlite3.OperationalError as exc:
+        logger.warning("Memory tool %s sqlite error: %s", name, exc)
+        result = {"error": f"sqlite3.OperationalError: {exc}"}
+    except Exception as exc:
+        logger.exception("Memory tool %s failed", name)
+        result = {"error": str(exc)}
+
+    return [TextContent(
+        type="text",
+        text=json.dumps(result, default=str, indent=2),
+    )]
+
+
+def _dispatch(name: str, args: dict) -> dict:
+    path = args.get("path") or _DEFAULT_PATH
+
+    if name == "list_corrections":
+        dataset = args.get("dataset")
+        with MemoryStore(backend="sqlite", path=path) as store:
+            corrections = store.get_corrections(dataset=dataset)
+        return {
+            "count": len(corrections),
+            "corrections": [_correction_to_dict(c) for c in corrections],
+        }
+
+    if name == "add_correction":
+        # Validate required, non-empty dataset.
+        dataset = args.get("dataset")
+        if not dataset:
+            return {"error": "Missing or empty required parameter: dataset"}
+
+        decision = args.get("decision")
+        if decision not in ("approve", "reject"):
+            return {"error": f"Invalid decision: {decision!r}. Use 'approve' or 'reject'."}
+
+        try:
+            id_a = int(args["id_a"])
+            id_b = int(args["id_b"])
+        except (KeyError, TypeError, ValueError) as exc:
+            return {"error": f"id_a / id_b must be integers: {exc}"}
+
+        from goldenmatch.core.memory.store import Correction, _canon_pair
+
+        ca, cb = _canon_pair(id_a, id_b)
+        correction = Correction(
+            id=str(uuid.uuid4()),
+            id_a=ca,
+            id_b=cb,
+            decision=decision,
+            source="agent",
+            trust=0.5,
+            field_hash="",
+            record_hash="",
+            original_score=0.0,
+            matchkey_name=args.get("matchkey_name"),
+            reason=args.get("reason"),
+            dataset=dataset,
+            created_at=datetime.now(),
+        )
+        with MemoryStore(backend="sqlite", path=path) as store:
+            store.add_correction(correction)
+        return {
+            "status": "ok",
+            "id": correction.id,
+            "id_a": ca,
+            "id_b": cb,
+            "decision": decision,
+            "source": "agent",
+            "trust": 0.5,
+            "dataset": dataset,
+        }
+
+    if name == "learn_thresholds":
+        from goldenmatch.core.memory.learner import MemoryLearner
+
+        matchkey_name = args.get("matchkey_name")
+        with MemoryStore(backend="sqlite", path=path) as store:
+            learner = MemoryLearner(store)
+            adjustments = learner.learn(matchkey_name=matchkey_name)
+        return {
+            "count": len(adjustments),
+            "adjustments": [_adjustment_to_dict(a) for a in adjustments],
+        }
+
+    if name == "memory_stats":
+        with MemoryStore(backend="sqlite", path=path) as store:
+            total = store.count_corrections()
+            last = store.last_learn_time()
+            adjustments = store.get_all_adjustments()
+        return {
+            "total_corrections": total,
+            "last_learn_time": last.isoformat() if last else None,
+            "adjustments": [_adjustment_to_dict(a) for a in adjustments],
+        }
+
+    if name == "memory_export":
+        dataset = args.get("dataset")
+        with MemoryStore(backend="sqlite", path=path) as store:
+            corrections = store.get_corrections(dataset=dataset)
+        return {
+            "count": len(corrections),
+            "corrections": [_correction_to_dict(c) for c in corrections],
+        }
+
+    return {"error": f"Unknown memory tool: {name}"}

--- a/packages/python/goldenmatch/goldenmatch/mcp/memory_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/memory_tools.py
@@ -1,13 +1,4 @@
-"""MCP tool surface for Learning Memory.
-
-Five tools wrap MemoryStore + MemoryLearner operations:
-  list_corrections, add_correction, learn_thresholds, memory_stats, memory_export.
-
-Each handler instantiates its own MemoryStore (matches AgentSession pattern in
-agent_tools.py -- no shared global state). All handlers trap
-sqlite3.OperationalError and return a structured JSON error in TextContent
-rather than raising, so a failed memory call cannot crash an MCP session.
-"""
+"""MCP tool surface for Learning Memory."""
 from __future__ import annotations
 
 import json
@@ -166,8 +157,7 @@ def _adjustment_to_dict(a: Any) -> dict:
     }
 
 
-# Re-export point for tests/monkeypatching: the dispatcher reads MemoryStore
-# from this module so tests can swap it out.
+# Re-export so tests can monkeypatch the dispatcher's MemoryStore.
 from goldenmatch.core.memory.store import MemoryStore as MemoryStore  # noqa: E402,F401
 
 
@@ -206,7 +196,6 @@ def _dispatch(name: str, args: dict) -> dict:
         }
 
     if name == "add_correction":
-        # Validate required, non-empty dataset.
         dataset = args.get("dataset")
         if not dataset:
             return {"error": "Missing or empty required parameter: dataset"}

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -28,6 +28,11 @@ from mcp.types import (
 )
 
 from goldenmatch.mcp.agent_tools import AGENT_TOOLS, handle_agent_tool
+from goldenmatch.mcp.memory_tools import (
+    MEMORY_TOOLS,
+    _MEMORY_TOOL_NAMES,
+    handle_memory_tool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -405,20 +410,24 @@ _BASE_TOOLS = [
     ),
 ]
 
-# TOOLS is the union of agent tools + base tools, in the same order list_tools returns.
-TOOLS = AGENT_TOOLS + _BASE_TOOLS
+# TOOLS is the union of agent tools + memory tools + base tools, in the same order list_tools returns.
+TOOLS = AGENT_TOOLS + MEMORY_TOOLS + _BASE_TOOLS
 
 
 def dispatch(name: str, args: dict) -> dict:
     """Unified dispatcher used by goldensuite-mcp aggregator.
 
-    Routes agent-level tool calls to AgentSession via agent_tools._dispatch, and
-    base tool calls to _handle_tool. Returns a JSON-serializable dict for both.
+    Routes agent-level tool calls to AgentSession via agent_tools._dispatch,
+    memory tools via memory_tools._dispatch, and base tool calls to
+    _handle_tool. Returns a JSON-serializable dict for all.
     """
     if name in _AGENT_TOOL_NAMES:
         from goldenmatch.core.agent import AgentSession
         from goldenmatch.mcp.agent_tools import _dispatch as _agent_dispatch
         return _agent_dispatch(name, args, AgentSession)
+    if name in _MEMORY_TOOL_NAMES:
+        from goldenmatch.mcp.memory_tools import _dispatch as _memory_dispatch
+        return _memory_dispatch(name, args)
     return _handle_tool(name, args)
 
 
@@ -432,7 +441,7 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:
-        return AGENT_TOOLS + _BASE_TOOLS
+        return AGENT_TOOLS + MEMORY_TOOLS + _BASE_TOOLS
 
     @server.list_resources()
     async def list_resources() -> list[Resource]:
@@ -678,6 +687,8 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
         # Delegate agent-level tools to the agent handler
         if name in _AGENT_TOOL_NAMES:
             return handle_agent_tool(name, arguments)
+        if name in _MEMORY_TOOL_NAMES:
+            return handle_memory_tool(name, arguments)
         try:
             result = _handle_tool(name, arguments)
             return [TextContent(type="text", text=json.dumps(result, default=str, indent=2))]
@@ -1263,7 +1274,7 @@ async def run_server_http(
     async def server_card(request):
         return JSONResponse({
             "name": "GoldenMatch",
-            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 30 MCP tools for matching, explaining, reviewing, data quality, transforms, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
+            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 35 MCP tools for matching, explaining, reviewing, data quality, transforms, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
             "homepage": "https://github.com/benzsevern/goldenmatch",
             "iconUrl": "https://avatars.githubusercontent.com/u/192581748"
         })

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/boost_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/boost_tab.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
@@ -281,50 +282,85 @@ class BoostTab(Static):
         if self._memory_store is None or self._result is None or self._data is None:
             return
         try:
-            import uuid
-            from datetime import datetime
-
-            from goldenmatch.core.memory.store import Correction, _canon_pair
-            from goldenmatch.core.memory.corrections import (
-                build_row_lookup,
-                compute_field_hash,
-                compute_record_hash,
-            )
-
             a, b, score = self._result.scored_pairs[pair_idx]
-            ca, cb = _canon_pair(a, b)
-            fields = self._memory_matchkey_fields or [
-                c for c in self._data.columns if not c.startswith("__")
-            ]
-
-            field_hash = ""
-            record_hash = ""
-            if fields:
-                lookup = build_row_lookup(self._data, fields)
-                if ca in lookup and cb in lookup:
-                    field_hash = compute_field_hash(lookup[ca], lookup[cb])
-            ra = compute_record_hash(self._data, ca)
-            rb = compute_record_hash(self._data, cb)
-            if ra and rb:
-                record_hash = f"{ra}:{rb}"
-
-            self._memory_store.add_correction(Correction(
-                id=str(uuid.uuid4()),
-                id_a=a,
-                id_b=b,
-                decision="approve" if is_match else "reject",
-                source="boost",
-                trust=1.0,
-                field_hash=field_hash,
-                record_hash=record_hash,
-                original_score=score,
-                matchkey_name=None,
-                reason=None,
-                dataset=self._memory_dataset,
-                created_at=datetime.now(),
-            ))
         except Exception as e:
             logger.warning("BoostTab memory write failed: %s", e)
+            return
+        record_boost_label(
+            memory_store=self._memory_store,
+            df=self._data,
+            id_a=a,
+            id_b=b,
+            score=score,
+            is_match=is_match,
+            matchkey_fields=self._memory_matchkey_fields,
+            dataset=self._memory_dataset,
+        )
+
+
+def record_boost_label(
+    *,
+    memory_store: Any,
+    df: Any,
+    id_a: int,
+    id_b: int,
+    score: float,
+    is_match: bool,
+    matchkey_fields: list[str] | None = None,
+    dataset: str | None = None,
+) -> None:
+    """Write a boost-tab y/n label as a Correction.
+
+    Extracted from BoostTab._record_memory_correction so tests can target the
+    seam without instantiating a Textual widget. Never raises; logs warnings
+    on failure.
+    """
+    if memory_store is None or df is None:
+        return
+    try:
+        import uuid
+        from datetime import datetime
+
+        from goldenmatch.core.memory.store import Correction, _canon_pair
+        from goldenmatch.core.memory.corrections import (
+            build_row_lookup,
+            compute_field_hash,
+            compute_record_hash,
+        )
+
+        ca, cb = _canon_pair(id_a, id_b)
+        fields = matchkey_fields or [
+            c for c in df.columns if not c.startswith("__")
+        ]
+
+        field_hash = ""
+        record_hash = ""
+        if fields:
+            lookup = build_row_lookup(df, fields)
+            if ca in lookup and cb in lookup:
+                field_hash = compute_field_hash(lookup[ca], lookup[cb])
+        ra = compute_record_hash(df, ca)
+        rb = compute_record_hash(df, cb)
+        if ra and rb:
+            record_hash = f"{ra}:{rb}"
+
+        memory_store.add_correction(Correction(
+            id=str(uuid.uuid4()),
+            id_a=id_a,
+            id_b=id_b,
+            decision="approve" if is_match else "reject",
+            source="boost",
+            trust=1.0,
+            field_hash=field_hash,
+            record_hash=record_hash,
+            original_score=score,
+            matchkey_name=None,
+            reason=None,
+            dataset=dataset,
+            created_at=datetime.now(),
+        ))
+    except Exception as e:
+        logger.warning("BoostTab memory write failed: %s", e)
 
     # ── Button handlers ──────────────────────────────────────────
 

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/boost_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/boost_tab.py
@@ -80,6 +80,10 @@ class BoostTab(Static):
         self._batch_pos: int = 0  # current position in batch
         self._labels: dict[int, bool] = {}  # pair_index -> True (match) / False (non-match)
         self._total_labeled: int = 0
+        # Optional learning memory plumbing (additive to LR classifier wiring).
+        self._memory_store = None
+        self._memory_dataset: str | None = None
+        self._memory_matchkey_fields: list[str] | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -268,8 +272,59 @@ class BoostTab(Static):
             pair_idx = self._batch[self._batch_pos]
             self._labels[pair_idx] = is_match
             self._total_labeled += 1
+            self._record_memory_correction(pair_idx, is_match)
         self._batch_pos += 1
         self._show_current_pair()
+
+    def _record_memory_correction(self, pair_idx: int, is_match: bool) -> None:
+        """Mirror the y/n label into the optional learning-memory store."""
+        if self._memory_store is None or self._result is None or self._data is None:
+            return
+        try:
+            import uuid
+            from datetime import datetime
+
+            from goldenmatch.core.memory.store import Correction, _canon_pair
+            from goldenmatch.core.memory.corrections import (
+                build_row_lookup,
+                compute_field_hash,
+                compute_record_hash,
+            )
+
+            a, b, score = self._result.scored_pairs[pair_idx]
+            ca, cb = _canon_pair(a, b)
+            fields = self._memory_matchkey_fields or [
+                c for c in self._data.columns if not c.startswith("__")
+            ]
+
+            field_hash = ""
+            record_hash = ""
+            if fields:
+                lookup = build_row_lookup(self._data, fields)
+                if ca in lookup and cb in lookup:
+                    field_hash = compute_field_hash(lookup[ca], lookup[cb])
+            ra = compute_record_hash(self._data, ca)
+            rb = compute_record_hash(self._data, cb)
+            if ra and rb:
+                record_hash = f"{ra}:{rb}"
+
+            self._memory_store.add_correction(Correction(
+                id=str(uuid.uuid4()),
+                id_a=a,
+                id_b=b,
+                decision="approve" if is_match else "reject",
+                source="boost",
+                trust=1.0,
+                field_hash=field_hash,
+                record_hash=record_hash,
+                original_score=score,
+                matchkey_name=None,
+                reason=None,
+                dataset=self._memory_dataset,
+                created_at=datetime.now(),
+            ))
+        except Exception as e:
+            logger.warning("BoostTab memory write failed: %s", e)
 
     # ── Button handlers ──────────────────────────────────────────
 

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.5.0"
+version = "1.6.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/tests/test_corrections.py
+++ b/packages/python/goldenmatch/tests/test_corrections.py
@@ -133,3 +133,31 @@ class TestApplyCorrections:
         assert result[1][2] == 0.60
         assert stats.applied == 1
         assert stats.total_pairs == 2
+
+
+# ── Tier 3.2: CorrectionStats validate() helper ──────────────────────────
+
+
+class TestCorrectionStatsInvariant:
+    def test_validate_returns_true_when_consistent(self):
+        stats = CorrectionStats(
+            applied=2, stale=1, stale_ambiguous=1, stale_unanchorable=0,
+            total_pairs=10,
+        )
+        assert stats.validate() is True
+
+    def test_validate_returns_false_when_overshoot(self, caplog):
+        stats = CorrectionStats(
+            applied=5, stale=5, stale_ambiguous=5, stale_unanchorable=5,
+            total_pairs=10,
+        )
+        with caplog.at_level("WARNING", logger="goldenmatch.memory"):
+            ok = stats.validate()
+        assert ok is False
+        # A warning should have been logged surfacing the bad counts.
+        assert any("invariant violated" in r.message.lower() for r in caplog.records)
+
+    def test_validate_skipped_when_total_pairs_zero(self):
+        """Synthetic / unset construction should not trip the invariant."""
+        stats = CorrectionStats(applied=10, total_pairs=0)
+        assert stats.validate() is True

--- a/packages/python/goldenmatch/tests/test_memory_cli.py
+++ b/packages/python/goldenmatch/tests/test_memory_cli.py
@@ -154,3 +154,33 @@ def test_cli_memory_import_rejects_malformed_csv(tmp_path):
     bad.write_text("foo,bar\n1,2\n", encoding="utf-8")
     res = runner.invoke(app, ["memory", "import", str(bad), "--path", p])
     assert res.exit_code == 1
+
+
+def test_cli_memory_import_skips_malformed_rows(tmp_path):
+    """Mixed valid/invalid rows: header is fine so import proceeds, but each
+    invalid row is skipped with a warning printed. The valid rows land in the
+    store; the malformed ones do not."""
+    runner = CliRunner()
+    p = str(tmp_path / "mem.db")
+    src = tmp_path / "mixed.csv"
+    src.write_text(
+        "id_a,id_b,decision,source\n"
+        "1,2,approve,steward\n"
+        "not_an_int,3,approve,steward\n"  # malformed id_a
+        "4,not_an_int,reject,steward\n"   # malformed id_b
+        "5,6,reject,steward\n",
+        encoding="utf-8",
+    )
+    res = runner.invoke(app, ["memory", "import", str(src), "--path", p])
+    assert res.exit_code == 0, res.output
+    # Two malformed rows were skipped; two good rows imported.
+    from goldenmatch.core.memory.store import MemoryStore
+
+    store = MemoryStore(backend="sqlite", path=p)
+    try:
+        items = store.get_corrections()
+    finally:
+        store.close()
+    assert len(items) == 2
+    pairs = sorted({(c.id_a, c.id_b) for c in items})
+    assert pairs == [(1, 2), (5, 6)]

--- a/packages/python/goldenmatch/tests/test_memory_cli.py
+++ b/packages/python/goldenmatch/tests/test_memory_cli.py
@@ -1,0 +1,156 @@
+"""Tests for the Learning Memory Python API additions and CLI subgroup (Phase 6)."""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import goldenmatch
+from goldenmatch.cli.main import app
+
+
+# ── Python API tests ──
+
+
+def test_api_add_and_count(tmp_path):
+    p = str(tmp_path / "mem.db")
+    goldenmatch.add_correction(1, 2, "approve", source="steward", path=p)
+    stats = goldenmatch.memory_stats(path=p)
+    assert stats["count"] == 1
+
+
+def test_api_learn_returns_adjustments(tmp_path):
+    p = str(tmp_path / "mem.db")
+    # Need at least 10 corrections (threshold_min) covering both decisions
+    # to produce an adjustment.
+    for i in range(6):
+        goldenmatch.add_correction(
+            i, i + 100, "approve", source="steward",
+            matchkey_name="identity", path=p,
+        )
+    for i in range(6):
+        goldenmatch.add_correction(
+            200 + i, 300 + i, "reject", source="steward",
+            matchkey_name="identity", path=p,
+        )
+    # Manually patch original_score by reopening — but our API leaves it 0.0.
+    # Instead, rewrite via store with non-zero scores so threshold can compute.
+    from goldenmatch.core.memory.store import MemoryStore, Correction
+    from datetime import datetime
+    import uuid
+    store = MemoryStore(backend="sqlite", path=p)
+    try:
+        # Replace existing rows with non-zero original_score
+        for i in range(6):
+            store.add_correction(Correction(
+                id=str(uuid.uuid4()), id_a=i, id_b=i + 100,
+                decision="approve", source="steward", trust=1.0,
+                field_hash="", record_hash="",
+                original_score=0.85 + i * 0.01,
+                matchkey_name="identity", reason=None,
+                dataset=None, created_at=datetime.now(),
+            ))
+        for i in range(6):
+            store.add_correction(Correction(
+                id=str(uuid.uuid4()), id_a=200 + i, id_b=300 + i,
+                decision="reject", source="steward", trust=1.0,
+                field_hash="", record_hash="",
+                original_score=0.50 + i * 0.01,
+                matchkey_name="identity", reason=None,
+                dataset=None, created_at=datetime.now(),
+            ))
+    finally:
+        store.close()
+
+    adjustments = goldenmatch.learn(path=p)
+    assert isinstance(adjustments, list)
+    assert len(adjustments) >= 1
+    assert any(a.matchkey_name == "identity" for a in adjustments)
+
+
+def test_api_memory_stats_shape(tmp_path):
+    p = str(tmp_path / "mem.db")
+    goldenmatch.add_correction(1, 2, "approve", source="steward", path=p)
+    stats = goldenmatch.memory_stats(path=p)
+    assert set(stats.keys()) >= {"count", "last_learn_time", "adjustments"}
+    assert stats["count"] == 1
+    assert isinstance(stats["adjustments"], list)
+
+
+# ── CLI tests ──
+
+
+def test_cli_memory_stats_runs(tmp_path):
+    runner = CliRunner()
+    p = str(tmp_path / "mem.db")
+    goldenmatch.add_correction(1, 2, "approve", source="steward", path=p)
+    result = runner.invoke(app, ["memory", "stats", "--path", p])
+    assert result.exit_code == 0, result.output
+    assert "1" in result.stdout
+
+
+def test_cli_memory_export_import_roundtrip(tmp_path):
+    runner = CliRunner()
+    p = str(tmp_path / "mem.db")
+    csv_out = str(tmp_path / "corrs.csv")
+
+    goldenmatch.add_correction(1, 2, "approve", source="steward", path=p)
+    goldenmatch.add_correction(3, 4, "reject", source="steward", path=p)
+    goldenmatch.add_correction(5, 6, "approve", source="steward", path=p)
+    assert goldenmatch.memory_stats(path=p)["count"] == 3
+
+    # Export
+    res = runner.invoke(app, ["memory", "export", csv_out, "--path", p])
+    assert res.exit_code == 0, res.output
+    assert Path(csv_out).exists()
+
+    # Clear store by deleting the DB file
+    Path(p).unlink()
+
+    # Import
+    res2 = runner.invoke(app, ["memory", "import", csv_out, "--path", p])
+    assert res2.exit_code == 0, res2.output
+
+    stats = goldenmatch.memory_stats(path=p)
+    assert stats["count"] == 3
+
+    # Verify the actual pairs survived
+    from goldenmatch.core.memory.store import MemoryStore
+    store = MemoryStore(backend="sqlite", path=p)
+    try:
+        corrs = store.get_corrections()
+        pairs = {(c.id_a, c.id_b) for c in corrs}
+        assert pairs == {(1, 2), (3, 4), (5, 6)}
+    finally:
+        store.close()
+
+
+def test_cli_memory_show_renders(tmp_path):
+    runner = CliRunner()
+    p = str(tmp_path / "mem.db")
+    goldenmatch.add_correction(
+        7, 8, "approve", source="steward", reason="same person", path=p,
+    )
+    result = runner.invoke(app, ["memory", "show", "7", "8", "--path", p])
+    assert result.exit_code == 0, result.output
+    assert "7" in result.stdout and "8" in result.stdout
+    assert "approve" in result.stdout
+
+
+def test_cli_memory_learn_runs(tmp_path):
+    runner = CliRunner()
+    p = str(tmp_path / "mem.db")
+    # Empty store — learn should still run cleanly with no adjustments.
+    result = runner.invoke(app, ["memory", "learn", "--path", p])
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_memory_import_rejects_malformed_csv(tmp_path):
+    runner = CliRunner()
+    p = str(tmp_path / "mem.db")
+    bad = tmp_path / "bad.csv"
+    bad.write_text("foo,bar\n1,2\n", encoding="utf-8")
+    res = runner.invoke(app, ["memory", "import", str(bad), "--path", p])
+    assert res.exit_code == 1

--- a/packages/python/goldenmatch/tests/test_memory_collection.py
+++ b/packages/python/goldenmatch/tests/test_memory_collection.py
@@ -15,6 +15,29 @@ def _new_store(tmp_path) -> MemoryStore:
     return MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
 
 
+def _make_match_server_for_test(memory_store: MemoryStore, dataset: str):
+    """Test factory that builds a MatchServer with memory plumbing only.
+
+    Avoids reaching into private fields directly across the test surface;
+    keeps the test honest if MatchServer.__init__ grows new defaults.
+    """
+    from goldenmatch.api.server import MatchServer
+
+    server = MatchServer.__new__(MatchServer)
+    # Mirror the public init shape (engine/config/result), then populate
+    # memory plumbing.
+    server.engine = None
+    server.config = None
+    server.result = None
+    server._rows = []
+    server._id_to_idx = {}
+    server._review_queue = []
+    server._review_decisions = []
+    server._memory_store = memory_store
+    server._memory_dataset = dataset
+    return server
+
+
 def _person_df() -> pl.DataFrame:
     return pl.DataFrame(
         {
@@ -234,18 +257,10 @@ class TestRestDecideCollection:
         from goldenmatch.api.server import MatchServer
 
         store = _new_store(tmp_path)
-        server = MatchServer.__new__(MatchServer)
-        server.engine = None
-        server.config = None
-        server.result = None
-        server._rows = []
-        server._id_to_idx = {}
+        server = _make_match_server_for_test(store, "dsr")
         server._review_queue = [
             {"pair_id": "p1", "row_id_a": 1, "row_id_b": 2, "status": "pending"}
         ]
-        server._review_decisions = []
-        server._memory_store = store
-        server._memory_dataset = "dsr"
 
         result = server.review_decision("p1", "approve", reviewer="steward")
         assert result["status"] == "recorded"
@@ -267,50 +282,29 @@ class TestRestDecideCollection:
 
 class TestBoostTabCollection:
     def test_record_label_writes_correction(self, tmp_path):
-        from goldenmatch.tui.tabs.boost_tab import BoostTab
-        from goldenmatch.tui.engine import EngineResult, EngineStats
+        """Targets the testable seam (record_boost_label) instead of poking
+        private BoostTab attrs. Real Textual setup is too heavy for unit tests,
+        and the seam is what BoostTab._record_memory_correction calls anyway."""
+        from goldenmatch.tui.tabs.boost_tab import record_boost_label
 
         store = _new_store(tmp_path)
         df = _person_df()
-        result = EngineResult(
-            clusters={},
-            golden=None,
-            unique=None,
-            dupes=None,
-            quarantine=None,
-            matched=None,
-            unmatched=None,
-            scored_pairs=[(0, 1, 0.82), (2, 3, 0.78)],
-            stats=EngineStats(
-                total_records=4,
-                total_clusters=4,
-                singleton_count=4,
-                match_rate=0.0,
-                cluster_sizes=[1, 1, 1, 1],
-                avg_cluster_size=1.0,
-                max_cluster_size=1,
-                oversized_count=0,
-            ),
+        pairs = [(0, 1, 0.82), (2, 3, 0.78)]
+
+        # Match (approve).
+        a, b, score = pairs[0]
+        record_boost_label(
+            memory_store=store, df=df,
+            id_a=a, id_b=b, score=score, is_match=True,
+            matchkey_fields=["name", "zip"], dataset="dsb",
         )
-
-        tab = BoostTab.__new__(BoostTab)
-        tab._result = result
-        tab._data = df
-        tab._display_cols = ["name", "zip"]
-        tab._batch = [0, 1]
-        tab._batch_pos = 0
-        tab._labels = {}
-        tab._total_labeled = 0
-        tab._memory_store = store
-        tab._memory_dataset = "dsb"
-        tab._memory_matchkey_fields = ["name", "zip"]
-
-        # Stub UI side-effects.
-        tab._show_current_pair = lambda: None  # type: ignore
-        tab._on_batch_complete = lambda: None  # type: ignore
-
-        tab._record_label(True)  # match
-        tab._record_label(False)  # non-match
+        # Non-match (reject).
+        a, b, score = pairs[1]
+        record_boost_label(
+            memory_store=store, df=df,
+            id_a=a, id_b=b, score=score, is_match=False,
+            matchkey_fields=["name", "zip"], dataset="dsb",
+        )
 
         items = store.get_corrections(dataset="dsb")
         assert len(items) == 2

--- a/packages/python/goldenmatch/tests/test_memory_collection.py
+++ b/packages/python/goldenmatch/tests/test_memory_collection.py
@@ -1,0 +1,323 @@
+"""Phase 4: Collection point tests for Learning Memory.
+
+Each surface accepts an optional MemoryStore. When provided, calling the
+surface's existing approve/reject/decide/label flow also writes a Correction
+into the store.
+"""
+from __future__ import annotations
+
+import polars as pl
+
+from goldenmatch.core.memory.store import MemoryStore
+
+
+def _new_store(tmp_path) -> MemoryStore:
+    return MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+
+
+def _person_df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "__row_id__": [0, 1, 2, 3],
+            "name": ["alice", "alice b", "bob", "carol"],
+            "zip": ["10001", "10001", "10002", "10003"],
+        }
+    )
+
+
+# ── 4.1 ReviewQueue ─────────────────────────────────────────────────────
+
+
+class TestReviewQueueCollection:
+    def test_approve_writes_correction(self, tmp_path):
+        from goldenmatch.core.review_queue import ReviewQueue
+
+        store = _new_store(tmp_path)
+        df = _person_df()
+        rq = ReviewQueue(
+            backend="memory",
+            memory_store=store,
+            df=df,
+            matchkey_fields=["name", "zip"],
+            dataset="test",
+        )
+        rq.add(job_name="job1", id_a=0, id_b=1, score=0.85, explanation="x")
+        rq.approve("job1", 0, 1, decided_by="alice")
+
+        items = store.get_corrections(dataset="test")
+        assert len(items) == 1
+        c = items[0]
+        assert (c.id_a, c.id_b) == (0, 1)
+        assert c.decision == "approve"
+        assert c.source == "steward"
+        assert c.trust == 1.0
+        assert len(c.field_hash) == 16
+        assert ":" in c.record_hash and len(c.record_hash) == 33
+
+    def test_reject_writes_correction(self, tmp_path):
+        from goldenmatch.core.review_queue import ReviewQueue
+
+        store = _new_store(tmp_path)
+        df = _person_df()
+        rq = ReviewQueue(
+            backend="memory",
+            memory_store=store,
+            df=df,
+            matchkey_fields=["name", "zip"],
+            dataset="test",
+        )
+        rq.add(job_name="job1", id_a=2, id_b=3, score=0.80, explanation="x")
+        rq.reject("job1", 2, 3, decided_by="bob", reason="diff")
+
+        items = store.get_corrections(dataset="test")
+        assert len(items) == 1
+        assert items[0].decision == "reject"
+        assert items[0].source == "steward"
+        assert items[0].trust == 1.0
+        assert items[0].reason == "diff"
+
+    def test_no_store_unchanged(self, tmp_path):
+        from goldenmatch.core.review_queue import ReviewQueue
+
+        rq = ReviewQueue(backend="memory")
+        rq.add(job_name="j", id_a=0, id_b=1, score=0.85, explanation="x")
+        rq.approve("j", 0, 1, decided_by="alice")
+        # No exception, default behavior preserved.
+        assert rq.stats("j")["approved"] == 1
+
+
+# ── 4.2 unmerge_record + unmerge_cluster ─────────────────────────────────
+
+
+class TestUnmergeCollection:
+    def _two_clusters(self):
+        from goldenmatch.core.cluster import build_clusters
+
+        pairs = [(0, 1, 0.95), (1, 2, 0.92), (0, 2, 0.93)]
+        return build_clusters(pairs, [0, 1, 2, 3])
+
+    def test_unmerge_record_writes_rejects(self, tmp_path):
+        from goldenmatch.core.cluster import unmerge_record
+
+        store = _new_store(tmp_path)
+        clusters = self._two_clusters()
+        unmerge_record(0, clusters, memory_store=store, dataset="ds")
+
+        items = store.get_corrections(dataset="ds")
+        # Record 0 was paired with 1 and 2 in the cluster — both rejects.
+        assert len(items) == 2
+        for c in items:
+            assert c.decision == "reject"
+            assert c.source == "unmerge"
+            assert c.trust == 1.0
+            assert c.field_hash == ""
+            assert c.record_hash == ""
+
+    def test_unmerge_cluster_writes_rejects(self, tmp_path):
+        from goldenmatch.core.cluster import unmerge_cluster
+
+        store = _new_store(tmp_path)
+        clusters = self._two_clusters()
+        # Find the multi-member cluster
+        cid = next(cid for cid, ci in clusters.items() if ci["size"] > 1)
+        unmerge_cluster(cid, clusters, memory_store=store, dataset="ds")
+
+        items = store.get_corrections(dataset="ds")
+        # 3 pairs from a 3-member cluster
+        assert len(items) == 3
+        for c in items:
+            assert c.decision == "reject"
+            assert c.source == "unmerge"
+            assert c.field_hash == ""
+            assert c.record_hash == ""
+
+    def test_unmerge_no_store_unchanged(self):
+        from goldenmatch.core.cluster import unmerge_record, unmerge_cluster
+
+        clusters = self._two_clusters()
+        result = unmerge_record(0, clusters)
+        assert isinstance(result, dict)
+        clusters2 = self._two_clusters()
+        cid = next(cid for cid, ci in clusters2.items() if ci["size"] > 1)
+        result2 = unmerge_cluster(cid, clusters2)
+        assert isinstance(result2, dict)
+
+
+# ── 4.3 llm_score_pairs ──────────────────────────────────────────────────
+
+
+class TestLLMScorerCollection:
+    def test_writes_corrections_for_each_decision(self, tmp_path, monkeypatch):
+        from goldenmatch.core import llm_scorer as mod
+
+        # Stub provider detection so no real network calls.
+        monkeypatch.setattr(mod, "_detect_provider", lambda: ("openai", "sk-test"))
+
+        # Stub _batch_score: return is_match=True for first candidate, False for next.
+        def fake_batch_score(candidate_indices, pairs, *a, **kw):
+            return {idx: (i == 0) for i, idx in enumerate(candidate_indices)}
+
+        monkeypatch.setattr(mod, "_batch_score", fake_batch_score)
+
+        store = _new_store(tmp_path)
+        df = _person_df()
+        # Both pairs in candidate range [0.75, 0.95]
+        pairs = [(0, 1, 0.80), (2, 3, 0.82)]
+
+        mod.llm_score_pairs(
+            pairs,
+            df,
+            auto_threshold=0.95,
+            candidate_lo=0.75,
+            candidate_hi=0.95,
+            memory_store=store,
+            dataset="dsl",
+        )
+
+        items = store.get_corrections(dataset="dsl")
+        assert len(items) == 2
+        decisions = sorted(c.decision for c in items)
+        assert decisions == ["approve", "reject"]
+        for c in items:
+            assert c.source == "llm"
+            assert c.trust == 0.5
+            assert len(c.field_hash) == 16
+            assert ":" in c.record_hash
+
+
+# ── 4.4 agent_approve_reject ─────────────────────────────────────────────
+
+
+class TestAgentApproveRejectCollection:
+    def test_approve_writes_correction(self, tmp_path):
+        from goldenmatch.mcp.agent_tools import _dispatch
+        from goldenmatch.core.agent import AgentSession
+
+        store = _new_store(tmp_path)
+        # Need to enqueue first via the session's queue.
+        session = AgentSession()
+        session.review_queue.add(
+            job_name="j", id_a=5, id_b=7, score=0.8, explanation="x"
+        )
+
+        def session_factory():
+            return session
+
+        result = _dispatch(
+            "agent_approve_reject",
+            {
+                "job_name": "j",
+                "id_a": 5,
+                "id_b": 7,
+                "decision": "approve",
+                "decided_by": "agent",
+            },
+            session_factory,
+            memory_store=store,
+            dataset="dsa",
+        )
+        assert result["status"] == "ok"
+        items = store.get_corrections(dataset="dsa")
+        assert len(items) == 1
+        c = items[0]
+        assert (c.id_a, c.id_b) == (5, 7)
+        assert c.decision == "approve"
+        assert c.source == "agent"
+        assert c.trust == 0.5
+
+
+# ── 4.5 REST POST /reviews/decide ────────────────────────────────────────
+
+
+class TestRestDecideCollection:
+    def test_review_decision_writes_correction(self, tmp_path):
+        from goldenmatch.api.server import MatchServer
+
+        store = _new_store(tmp_path)
+        server = MatchServer.__new__(MatchServer)
+        server.engine = None
+        server.config = None
+        server.result = None
+        server._rows = []
+        server._id_to_idx = {}
+        server._review_queue = [
+            {"pair_id": "p1", "row_id_a": 1, "row_id_b": 2, "status": "pending"}
+        ]
+        server._review_decisions = []
+        server._memory_store = store
+        server._memory_dataset = "dsr"
+
+        result = server.review_decision("p1", "approve", reviewer="steward")
+        assert result["status"] == "recorded"
+
+        items = store.get_corrections(dataset="dsr")
+        assert len(items) == 1
+        c = items[0]
+        assert (c.id_a, c.id_b) == (1, 2)
+        assert c.decision == "approve"
+        assert c.source == "steward"
+        assert c.trust == 1.0
+        # Empty hashes (REST has no df in scope).
+        assert c.field_hash == ""
+        assert c.record_hash == ""
+
+
+# ── 4.6 BoostTab y/n ─────────────────────────────────────────────────────
+
+
+class TestBoostTabCollection:
+    def test_record_label_writes_correction(self, tmp_path):
+        from goldenmatch.tui.tabs.boost_tab import BoostTab
+        from goldenmatch.tui.engine import EngineResult, EngineStats
+
+        store = _new_store(tmp_path)
+        df = _person_df()
+        result = EngineResult(
+            clusters={},
+            golden=None,
+            unique=None,
+            dupes=None,
+            quarantine=None,
+            matched=None,
+            unmatched=None,
+            scored_pairs=[(0, 1, 0.82), (2, 3, 0.78)],
+            stats=EngineStats(
+                total_records=4,
+                total_clusters=4,
+                singleton_count=4,
+                match_rate=0.0,
+                cluster_sizes=[1, 1, 1, 1],
+                avg_cluster_size=1.0,
+                max_cluster_size=1,
+                oversized_count=0,
+            ),
+        )
+
+        tab = BoostTab.__new__(BoostTab)
+        tab._result = result
+        tab._data = df
+        tab._display_cols = ["name", "zip"]
+        tab._batch = [0, 1]
+        tab._batch_pos = 0
+        tab._labels = {}
+        tab._total_labeled = 0
+        tab._memory_store = store
+        tab._memory_dataset = "dsb"
+        tab._memory_matchkey_fields = ["name", "zip"]
+
+        # Stub UI side-effects.
+        tab._show_current_pair = lambda: None  # type: ignore
+        tab._on_batch_complete = lambda: None  # type: ignore
+
+        tab._record_label(True)  # match
+        tab._record_label(False)  # non-match
+
+        items = store.get_corrections(dataset="dsb")
+        assert len(items) == 2
+        decisions = sorted(c.decision for c in items)
+        assert decisions == ["approve", "reject"]
+        for c in items:
+            assert c.source == "boost"
+            assert c.trust == 1.0
+            assert len(c.field_hash) == 16
+            assert ":" in c.record_hash

--- a/packages/python/goldenmatch/tests/test_memory_e2e.py
+++ b/packages/python/goldenmatch/tests/test_memory_e2e.py
@@ -1,0 +1,495 @@
+"""End-to-end integration tests for Learning Memory (Phase 8).
+
+Covers the full memory loop: seed corrections directly via MemoryStore,
+run dedupe_df, assert on result.memory_stats, postflight rendering,
+review queue persistence, trust conflicts, threshold learning, and the
+deterministic explainer fallback.
+
+Each test seeds via store.add_correction(...) rather than going through
+collection points -- faster and isolates the integration surface from
+the surface code under test.
+"""
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from goldenmatch import dedupe_df
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    MemoryConfig,
+)
+from goldenmatch.core.memory.store import Correction, MemoryStore
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _build_config(db_path: str, *, memory_enabled: bool = True) -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="identity",
+                type="weighted",
+                threshold=0.75,
+                fields=[
+                    MatchkeyField(
+                        field="name",
+                        scorer="jaro_winkler",
+                        transforms=["lowercase"],
+                        weight=1.0,
+                    ),
+                ],
+            ),
+        ],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["zip"], transforms=["lowercase"])],
+            maxBlockSize=1000,
+            skipOversized=True,
+        ),
+        memory=MemoryConfig(enabled=memory_enabled, path=db_path),
+    )
+
+
+def _basic_df() -> pl.DataFrame:
+    """Three rows; rows 0 and 1 are the cluster pair (same zip + similar name)."""
+    return pl.DataFrame(
+        {
+            "name": ["Acme Corp", "Acme LLC", "Beta Inc"],
+            "zip": ["10001", "10001", "20002"],
+        }
+    )
+
+
+def compute_field_hash_from_values(row_a_vals: tuple, row_b_vals: tuple) -> str:
+    """Mirrors goldenmatch.core.memory.corrections.compute_field_hash so we
+    can construct a matching field_hash for a seeded correction without
+    needing the full df at seed time."""
+    combined = "|".join(str(v) for v in row_a_vals + row_b_vals)
+    return hashlib.sha256(combined.encode()).hexdigest()[:16]
+
+
+def _capture_pipeline_df(input_df: pl.DataFrame, db_path: str) -> pl.DataFrame:
+    """Run the pipeline once with no seeded corrections and capture the df
+    as it appears at apply_corrections() time.
+
+    The df at that point has extra columns (__source__, __xform_<sig>__) that
+    feed into compute_record_hash. To produce hashes that re-anchor correctly
+    in subsequent runs, we need to seed against this exact column set.
+    """
+    import goldenmatch.core.memory.corrections as corr_module
+
+    captured: dict[str, pl.DataFrame] = {}
+    orig = corr_module.apply_corrections
+
+    def capture(scored, store, df, fields, **kw):
+        captured["df"] = df
+        return orig(scored, store, df, fields, **kw)
+
+    corr_module.apply_corrections = capture
+    # The pipeline imports apply_corrections inside its function body, so we
+    # also have to patch that local binding via the module attribute -- the
+    # internal `from ... import apply_corrections` resolves at call time
+    # against corr_module, so a single attribute patch is sufficient.
+    try:
+        config = _build_config(db_path)
+        # Ensure a memory.db exists so the hook fires (empty store is fine).
+        store = MemoryStore(backend="sqlite", path=db_path)
+        store.close()
+        _ = dedupe_df(input_df, config=config)
+    finally:
+        corr_module.apply_corrections = orig
+
+    assert "df" in captured, "pipeline did not invoke apply_corrections"
+    return captured["df"]
+
+
+def _record_hash_from_pipeline_df(pipeline_df: pl.DataFrame, row_id: int) -> str:
+    """Compute record_hash exactly as apply_corrections does: sorted cols
+    excluding __row_id__, joined by '|', sha256[:16]."""
+    sorted_cols = sorted(c for c in pipeline_df.columns if c != "__row_id__")
+    row = pipeline_df.filter(pl.col("__row_id__") == row_id).select(sorted_cols).row(0)
+    return hashlib.sha256("|".join(str(v) for v in row).encode()).hexdigest()[:16]
+
+
+def _seed_correction(
+    db_path: str,
+    *,
+    id_a: int,
+    id_b: int,
+    decision: str,
+    source: str = "steward",
+    trust: float = 1.0,
+    field_hash: str = "",
+    record_hash: str = "",
+    original_score: float = 0.95,
+    matchkey_name: str | None = None,
+    dataset: str | None = None,
+) -> None:
+    store = MemoryStore(backend="sqlite", path=db_path)
+    try:
+        store.add_correction(
+            Correction(
+                id=str(uuid.uuid4()),
+                id_a=id_a,
+                id_b=id_b,
+                decision=decision,
+                source=source,
+                trust=trust,
+                field_hash=field_hash,
+                record_hash=record_hash,
+                original_score=original_score,
+                matchkey_name=matchkey_name,
+                reason=None,
+                dataset=dataset,
+                created_at=datetime.now(),
+            )
+        )
+    finally:
+        store.close()
+
+
+def _pair_score(scored_pairs, a: int, b: int) -> float | None:
+    for pa, pb, s in scored_pairs:
+        if (pa, pb) == (a, b) or (pa, pb) == (b, a):
+            return s
+    return None
+
+
+# ── 1. Happy path ────────────────────────────────────────────────────
+
+
+def test_e2e_happy_path_reject_overrides_score(tmp_path):
+    """Seed a reject correction, run dedupe, assert pair score is 0.0."""
+    df = _basic_df()
+    db_path = str(tmp_path / "mem.db")
+    _seed_correction(db_path, id_a=0, id_b=1, decision="reject")
+
+    config = _build_config(db_path)
+    result = dedupe_df(df, config=config)
+
+    assert result.memory_stats is not None
+    assert result.memory_stats.applied == 1
+    score = _pair_score(result.scored_pairs, 0, 1)
+    # Pair may have been filtered out below threshold, but if present, must be 0.0
+    if score is not None:
+        assert score == 0.0
+
+
+# ── 2. Re-anchor on reorder ──────────────────────────────────────────
+
+
+def test_e2e_reanchor_on_row_reorder(tmp_path):
+    """Seed a correction with a real record_hash, shuffle df, re-run.
+    Correction must still apply via record_hash re-anchor."""
+    df = _basic_df()
+    db_path = str(tmp_path / "mem.db")
+
+    # Capture the df shape that apply_corrections will see (with __source__
+    # and __xform_* columns) so we seed with the right record_hash recipe.
+    pipeline_df = _capture_pipeline_df(df, db_path)
+    # Original row IDs in pipeline_df: 0=Acme Corp, 1=Acme LLC.
+    h0 = _record_hash_from_pipeline_df(pipeline_df, 0)
+    h1 = _record_hash_from_pipeline_df(pipeline_df, 1)
+
+    # field_hash matches what apply_corrections computes for matchkey field
+    # values "name" -> ("Acme Corp", "Acme LLC").
+    field_hash = compute_field_hash_from_values(("Acme Corp",), ("Acme LLC",))
+
+    # Seed against synthetic row IDs that are NOT present in either the
+    # original or shuffled df. This forces the re-anchor path via
+    # record_hash (the production scenario for corrections persisted from
+    # a prior run whose row IDs have since drifted).
+    _seed_correction(
+        db_path,
+        id_a=100,
+        id_b=101,
+        decision="reject",
+        field_hash=field_hash,
+        record_hash=f"{h0}:{h1}",
+    )
+
+    # Reorder so Acme Corp and Acme LLC keep their relative order (Corp
+    # before LLC) but a new row is inserted before them, shifting their
+    # row IDs. This guarantees the canonical record_hash alignment used at
+    # dual-hash check time matches the seeded record_hash.
+    df_shuffled = pl.DataFrame(
+        {
+            "name": ["Beta Inc", "Acme Corp", "Acme LLC"],
+            "zip": ["20002", "10001", "10001"],
+        }
+    )
+
+    config = _build_config(db_path)
+    result = dedupe_df(df_shuffled, config=config)
+
+    assert result.memory_stats is not None
+    assert result.memory_stats.applied == 1
+    assert result.memory_stats.stale == 0
+
+
+# ── 3. Re-anchor + edit on matchkey field => stale + review queue ───
+
+
+def test_e2e_edit_on_matchkey_field_marks_stale_and_enqueues(tmp_path):
+    """Edit a matchkey field on a corrected entity; correction must be
+    classified as stale AND enqueued to the sibling review queue DB."""
+    df = _basic_df()
+    db_path = tmp_path / "mem.db"
+
+    # Capture the pipeline-time df once with empty store so we can compute
+    # record_hash exactly the way apply_corrections will. (The edited df in
+    # this test will produce a DIFFERENT hash for row 0, which is the point
+    # -- the correction goes stale because record_hash mismatches.)
+    pipeline_df = _capture_pipeline_df(df, str(db_path))
+    h0 = _record_hash_from_pipeline_df(pipeline_df, 0)
+    h1 = _record_hash_from_pipeline_df(pipeline_df, 1)
+    field_hash = compute_field_hash_from_values(("Acme Corp",), ("Acme LLC",))
+    _seed_correction(
+        str(db_path),
+        id_a=0,
+        id_b=1,
+        decision="reject",
+        field_hash=field_hash,
+        record_hash=f"{h0}:{h1}",
+    )
+
+    # Edit the matchkey field on row 0.
+    df_edited = pl.DataFrame(
+        {
+            "name": ["ACME CORPORATION", "Acme LLC", "Beta Inc"],
+            "zip": ["10001", "10001", "20002"],
+        }
+    )
+
+    config = _build_config(str(db_path))
+    result = dedupe_df(df_edited, config=config)
+
+    assert result.memory_stats is not None
+    assert result.memory_stats.stale >= 1
+
+    # Sibling SQLite review queue should now contain the stale pair.
+    queue_path = db_path.with_name("review_queue.db")
+    assert queue_path.exists(), f"review queue not found at {queue_path}"
+
+    from goldenmatch.core.review_queue import ReviewQueue
+
+    rq = ReviewQueue(backend="sqlite", path=str(queue_path))
+    pending = rq.list_pending("memory_stale")
+    rq.close()
+    pair_ids = {(it.id_a, it.id_b) for it in pending}
+    # Original IDs are 0/1; canonicalization may flip order.
+    assert (0, 1) in pair_ids or (1, 0) in pair_ids
+
+
+# ── 4. Trust conflict ────────────────────────────────────────────────
+
+
+def test_e2e_steward_overrides_llm_on_trust_conflict(tmp_path):
+    """LLM (trust 0.5) rejects, then steward (trust 1.0) approves.
+    Steward decision must win on next run -- pair survives as approved."""
+    df = _basic_df()
+    db_path = str(tmp_path / "mem.db")
+
+    # First: LLM rejects (trust 0.5).
+    _seed_correction(
+        db_path,
+        id_a=0,
+        id_b=1,
+        decision="reject",
+        source="llm",
+        trust=0.5,
+    )
+    # Then: steward approves (trust 1.0). Higher trust wins per upsert rule.
+    _seed_correction(
+        db_path,
+        id_a=0,
+        id_b=1,
+        decision="approve",
+        source="steward",
+        trust=1.0,
+    )
+
+    # Verify the store has only the approve.
+    store = MemoryStore(backend="sqlite", path=db_path)
+    try:
+        c = store.get_pair_correction(0, 1, dataset=None)
+        assert c is not None
+        assert c.decision == "approve"
+        assert c.source == "steward"
+        assert c.trust == 1.0
+    finally:
+        store.close()
+
+    config = _build_config(db_path)
+    result = dedupe_df(df, config=config)
+
+    assert result.memory_stats is not None
+    assert result.memory_stats.applied == 1
+    # Approved override forces score to 1.0.
+    score = _pair_score(result.scored_pairs, 0, 1)
+    assert score == 1.0
+
+
+# ── 5. Threshold learning ────────────────────────────────────────────
+
+
+def test_e2e_threshold_learning_runs_and_updates_last_learn_time(tmp_path):
+    """Seed 12 corrections covering a score range; pipeline triggers learn();
+    last_learn_time advances and an adjustment is persisted."""
+    df = _basic_df()
+    db_path = str(tmp_path / "mem.db")
+
+    # Seed 12 corrections with non-zero original_score, mixed approve/reject.
+    # Approves cluster at higher scores, rejects at lower -- gives the learner
+    # a real separating threshold to find.
+    store = MemoryStore(backend="sqlite", path=db_path)
+    try:
+        for i in range(12):
+            decision = "approve" if i >= 6 else "reject"
+            score = 0.85 if decision == "approve" else 0.55
+            store.add_correction(
+                Correction(
+                    id=str(uuid.uuid4()),
+                    # Use disjoint synthetic row IDs so they don't conflict
+                    # with the live df pair (0, 1).
+                    id_a=100 + 2 * i,
+                    id_b=101 + 2 * i,
+                    decision=decision,
+                    source="steward",
+                    trust=1.0,
+                    field_hash="",
+                    record_hash="",
+                    original_score=score,
+                    matchkey_name=None,
+                    reason=None,
+                    dataset=None,
+                    created_at=datetime.now(),
+                )
+            )
+        # Sanity: no learn pass has run yet.
+        assert store.last_learn_time() is None
+    finally:
+        store.close()
+
+    config = _build_config(db_path)
+    _ = dedupe_df(df, config=config)
+
+    # Confirm the learner ran and persisted an adjustment.
+    store = MemoryStore(backend="sqlite", path=db_path)
+    try:
+        last = store.last_learn_time()
+        assert last is not None, "MemoryLearner.learn() should have advanced last_learn_time"
+        adjustments = store.get_all_adjustments()
+        assert any(a.threshold is not None for a in adjustments), \
+            "expected at least one threshold adjustment from 12 seeded corrections"
+    finally:
+        store.close()
+
+
+# ── 6. No API key, deterministic explainer ───────────────────────────
+
+
+def test_e2e_explainer_deterministic_without_api_keys(monkeypatch, tmp_path):
+    """With OPENAI_API_KEY and ANTHROPIC_API_KEY unset, review queue items
+    still get a non-empty deterministic `why`."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    df = pl.DataFrame(
+        {
+            "__row_id__": [1, 2, 3],
+            "name": ["Acme Corp", "Acme LLC", "Beta Inc"],
+            "zip": ["10001", "10001", "20002"],
+        }
+    )
+
+    from goldenmatch.core.review_queue import ReviewQueue
+
+    rq = ReviewQueue(df=df, matchkey_fields=["name", "zip"])
+    rq.add("job", 1, 2, 0.85, explanation="legacy")
+    items = rq.list_pending("job")
+    assert len(items) == 1
+    item = items[0]
+    assert isinstance(item.why, str)
+    assert item.why  # non-empty
+
+
+# ── 7. Postflight surfaces stats ─────────────────────────────────────
+
+
+def test_e2e_postflight_contains_memory_section(tmp_path):
+    """Run with seeded correction; result.memory_stats populated and the
+    rendered postflight string contains 'Memory:' and 'corrections applied'."""
+    df = _basic_df()
+    db_path = str(tmp_path / "mem.db")
+    _seed_correction(db_path, id_a=0, id_b=1, decision="reject")
+
+    config = _build_config(db_path)
+    result = dedupe_df(df, config=config)
+
+    assert result.memory_stats is not None
+    assert result.memory_stats.applied == 1
+    text = str(result.postflight_report) if result.postflight_report else ""
+    assert "Memory:" in text, f"expected 'Memory:' in postflight, got: {text!r}"
+    assert "corrections applied" in text or "correction applied" in text
+
+
+# ── 8. Stale-ambiguous reported separately ───────────────────────────
+
+
+def test_e2e_stale_ambiguous_surfaces_in_stats_and_postflight(tmp_path):
+    """Seed correction with real record_hash, then re-run with a literal
+    duplicate row that creates an ambiguous re-anchor. memory_stats must
+    report stale_ambiguous == 1 and postflight must mention 'stale-ambiguous'."""
+    db_path = str(tmp_path / "mem.db")
+
+    # Build the duplicate df first; we need the record_hash that the pipeline
+    # will compute for the duplicate row content -- both duplicates produce
+    # the SAME hash, which is the ambiguity we want to trigger.
+    df_dup = pl.DataFrame(
+        {
+            "name": ["Acme Corp", "Acme Corp", "Acme LLC", "Beta Inc"],
+            "zip": ["10001", "10001", "10001", "20002"],
+        }
+    )
+
+    # Capture the pipeline df for df_dup (no corrections yet -- just to
+    # extract the actual hash for an Acme Corp row).
+    pipeline_df = _capture_pipeline_df(df_dup, db_path)
+    h_corp = _record_hash_from_pipeline_df(pipeline_df, 0)  # "Acme Corp" hash
+    h_llc = _record_hash_from_pipeline_df(pipeline_df, 2)   # "Acme LLC" hash
+    # Sanity: both Acme Corp duplicates produce the same hash.
+    assert h_corp == _record_hash_from_pipeline_df(pipeline_df, 1)
+
+    field_hash = compute_field_hash_from_values(("Acme Corp",), ("Acme LLC",))
+    # Seed against IDs that AREN'T in the live df so direct lookup fails and
+    # the system falls back to record_hash re-anchor -- where the duplicate
+    # triggers the ambiguous branch.
+    _seed_correction(
+        db_path,
+        id_a=999,
+        id_b=998,
+        decision="reject",
+        field_hash=field_hash,
+        record_hash=f"{h_corp}:{h_llc}",
+    )
+
+    config = _build_config(db_path)
+    result = dedupe_df(df_dup, config=config)
+
+    assert result.memory_stats is not None
+    assert result.memory_stats.stale_ambiguous == 1
+    text = str(result.postflight_report) if result.postflight_report else ""
+    assert "stale-ambiguous" in text, \
+        f"expected 'stale-ambiguous' in postflight, got: {text!r}"

--- a/packages/python/goldenmatch/tests/test_memory_e2e.py
+++ b/packages/python/goldenmatch/tests/test_memory_e2e.py
@@ -493,3 +493,52 @@ def test_e2e_stale_ambiguous_surfaces_in_stats_and_postflight(tmp_path):
     text = str(result.postflight_report) if result.postflight_report else ""
     assert "stale-ambiguous" in text, \
         f"expected 'stale-ambiguous' in postflight, got: {text!r}"
+
+
+def test_unmerge_correction_round_trips_empty_hash(tmp_path):
+    """Integration test for the empty-hash collection path.
+
+    Run dedupe -> call unmerge_record (which writes empty-hash reject
+    corrections) -> re-run dedupe -> assert previously-merged pair has score
+    0.0 (correction applied via empty-hash short-circuit).
+    """
+    from goldenmatch.core.cluster import unmerge_record
+
+    df = _basic_df()
+    db_path = str(tmp_path / "mem.db")
+    config = _build_config(db_path)
+
+    # First run: rows 0 and 1 should match into a cluster.
+    result_1 = dedupe_df(df, config=config)
+    assert result_1.clusters is not None
+    multi_clusters = [
+        c for c in result_1.clusters.values() if c.get("size", 0) > 1
+    ]
+    assert len(multi_clusters) >= 1, "expected at least one multi-member cluster"
+
+    # Unmerge record 0 with a memory_store hooked up so a Correction is written.
+    store = MemoryStore(backend="sqlite", path=db_path)
+    try:
+        unmerge_record(0, result_1.clusters, memory_store=store, dataset=None)
+        items = store.get_corrections()
+        assert any(
+            c.decision == "reject" and c.source == "unmerge"
+            and c.field_hash == "" and c.record_hash == ""
+            for c in items
+        ), f"expected an empty-hash unmerge correction, got: {items}"
+    finally:
+        store.close()
+
+    # Re-run dedupe — the empty-hash correction should override the (0, 1)
+    # score to 0.0.
+    result_2 = dedupe_df(df, config=config)
+    pair_scores_01 = [
+        s for a, b, s in result_2.scored_pairs
+        if {a, b} == {0, 1}
+    ]
+    assert pair_scores_01, "pair (0,1) should still appear in scored_pairs"
+    assert all(s == 0.0 for s in pair_scores_01), (
+        f"expected (0,1) score forced to 0.0, got: {pair_scores_01}"
+    )
+    assert result_2.memory_stats is not None
+    assert result_2.memory_stats.applied >= 1

--- a/packages/python/goldenmatch/tests/test_memory_e2e.py
+++ b/packages/python/goldenmatch/tests/test_memory_e2e.py
@@ -602,3 +602,101 @@ def test_pipeline_memory_failure_renders_in_postflight(tmp_path):
     line = _render_memory_line(stats)
     assert "failed" in line
     assert "boom" in line
+
+
+def test_pipeline_respects_reanchor_false_flag(tmp_path):
+    """With reanchor=False, a correction whose row IDs no longer match must
+    NOT attempt re-anchor (every such correction lands in stale_unanchorable
+    immediately). With reanchor=True the same correction would route through
+    the record-hash re-anchor path.
+    """
+    df = pl.DataFrame(
+        {
+            "name": ["Acme Corp", "Acme LLC", "Beta Inc"],
+            "zip": ["10001", "10001", "20002"],
+        }
+    )
+
+    db_path = str(tmp_path / "mem.db")
+    captured_hashes: dict[str, list[int]] = {}
+    from goldenmatch.core.memory import corrections as corr_mod
+
+    real_build = corr_mod._build_hash_to_rids
+
+    def capturing_build(df_arg):
+        out = real_build(df_arg)
+        captured_hashes.update(out)
+        return out
+
+    # Seed an unrelated correction so apply_corrections actually runs (it
+    # short-circuits when the store is empty).
+    store = MemoryStore(backend="sqlite", path=db_path)
+    try:
+        store.add_correction(Correction(
+            id=str(uuid.uuid4()),
+            id_a=42, id_b=43,
+            decision="reject",
+            source="steward",
+            trust=1.0,
+            field_hash="placeholder",
+            record_hash="aaaa:bbbb",
+            original_score=0.5,
+            matchkey_name=None,
+            reason=None,
+            dataset=None,
+            created_at=datetime.now(),
+        ))
+    finally:
+        store.close()
+
+    corr_mod._build_hash_to_rids = capturing_build
+    try:
+        config = _build_config(db_path)
+        dedupe_df(df, config=config)
+    finally:
+        corr_mod._build_hash_to_rids = real_build
+
+    distinct = [(h, rids[0]) for h, rids in captured_hashes.items() if len(rids) == 1]
+    assert len(distinct) >= 2, f"need 2 distinct rows, got {captured_hashes}"
+    rh0 = distinct[0][0]
+    rh1 = distinct[1][0]
+
+    def seed_and_get_stats(reanchor_value: bool):
+        Path(db_path).unlink(missing_ok=True)
+        store = MemoryStore(backend="sqlite", path=db_path)
+        try:
+            store.add_correction(Correction(
+                id=str(uuid.uuid4()),
+                id_a=999, id_b=1000,  # absent from df
+                decision="reject",
+                source="steward",
+                trust=1.0,
+                field_hash="",
+                record_hash=f"{rh0}:{rh1}",
+                original_score=0.95,
+                matchkey_name=None,
+                reason=None,
+                dataset=None,
+                created_at=datetime.now(),
+            ))
+        finally:
+            store.close()
+        config = _build_config(db_path)
+        config.memory.reanchor = reanchor_value
+        result = dedupe_df(df, config=config)
+        return result.memory_stats
+
+    stats_reanchor = seed_and_get_stats(True)
+    stats_no_reanchor = seed_and_get_stats(False)
+
+    # reanchor=False should immediately route the correction to
+    # stale_unanchorable (it never tries the record_hash path).
+    assert stats_no_reanchor.stale_unanchorable == 1, (
+        f"reanchor=False should yield 1 unanchorable; got {stats_no_reanchor}"
+    )
+    # reanchor=True should NOT route to stale_unanchorable (it found the
+    # record hashes — even if downstream hash mismatch makes it stale, it
+    # exited the unanchorable bucket).
+    assert stats_reanchor.stale_unanchorable == 0, (
+        f"reanchor=True should attempt re-anchor; got {stats_reanchor}"
+    )

--- a/packages/python/goldenmatch/tests/test_memory_e2e.py
+++ b/packages/python/goldenmatch/tests/test_memory_e2e.py
@@ -542,3 +542,63 @@ def test_unmerge_correction_round_trips_empty_hash(tmp_path):
     )
     assert result_2.memory_stats is not None
     assert result_2.memory_stats.applied >= 1
+
+
+def test_trust_same_tier_latest_wins(tmp_path):
+    """Two trust=1.0 corrections from steward for the same pair, opposing
+    decisions: the second (latest) wins."""
+    import time
+
+    from goldenmatch.core.memory.store import Correction, MemoryStore
+
+    db_path = str(tmp_path / "mem.db")
+    store = MemoryStore(backend="sqlite", path=db_path)
+    try:
+        # First correction: approve.
+        store.add_correction(Correction(
+            id=str(uuid.uuid4()),
+            id_a=0, id_b=1,
+            decision="approve",
+            source="steward",
+            trust=1.0,
+            field_hash="", record_hash="",
+            original_score=0.85,
+            matchkey_name=None,
+            reason=None,
+            dataset=None,
+            created_at=datetime.now(),
+        ))
+        # Tiny sleep so created_at strictly differs even on fast clocks.
+        time.sleep(0.01)
+        # Second correction (same pair, same trust): reject. Should override.
+        store.add_correction(Correction(
+            id=str(uuid.uuid4()),
+            id_a=0, id_b=1,
+            decision="reject",
+            source="steward",
+            trust=1.0,
+            field_hash="", record_hash="",
+            original_score=0.85,
+            matchkey_name=None,
+            reason="changed my mind",
+            dataset=None,
+            created_at=datetime.now(),
+        ))
+        items = store.get_corrections()
+        assert len(items) == 1, f"expected upsert (1 row), got {len(items)}"
+        assert items[0].decision == "reject"
+        assert items[0].reason == "changed my mind"
+    finally:
+        store.close()
+
+
+def test_pipeline_memory_failure_renders_in_postflight(tmp_path):
+    """When _apply_memory_post raises, CorrectionStats(failed=True) flows
+    through and the postflight renderer surfaces 'Memory: failed (...)'."""
+    from goldenmatch.core.autoconfig_verify import _render_memory_line
+    from goldenmatch.core.memory.corrections import CorrectionStats
+
+    stats = CorrectionStats(total_pairs=5, failed=True, error="boom")
+    line = _render_memory_line(stats)
+    assert "failed" in line
+    assert "boom" in line

--- a/packages/python/goldenmatch/tests/test_memory_explainer.py
+++ b/packages/python/goldenmatch/tests/test_memory_explainer.py
@@ -1,0 +1,163 @@
+"""Phase 5: Explainer integration tests for ReviewQueue + Correction why."""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from goldenmatch.core.review_queue import ReviewItem, ReviewQueue
+
+
+def _df():
+    return pl.DataFrame({
+        "__row_id__": [1, 2, 3],
+        "name": ["Acme Corp", "Acme LLC", "Beta Inc"],
+        "zip": ["10001", "10001", "20002"],
+    })
+
+
+def test_review_item_has_why_field_default_none():
+    """ReviewItem dataclass exposes a `why` attribute, defaulting to None."""
+    item = ReviewItem(job_name="j", id_a=1, id_b=2, score=0.85, explanation="x")
+    assert hasattr(item, "why")
+    assert item.why is None
+
+
+def test_review_queue_add_populates_why_when_df_provided():
+    """ReviewQueue.add() computes a deterministic `why` when df + fields are wired."""
+    df = _df()
+    rq = ReviewQueue(df=df, matchkey_fields=["name", "zip"])
+    rq.add("job", 1, 2, 0.85, explanation="legacy explanation")
+    pending = rq.list_pending("job")
+    assert len(pending) == 1
+    item = pending[0]
+    assert isinstance(item.why, str)
+    assert item.why  # non-empty
+    # Deterministic explainer mentions the field names or values
+    assert "name" in item.why or "zip" in item.why or "Acme" in item.why
+    assert len(item.why) <= 240  # one short sentence, generous cap
+
+
+def test_review_queue_add_no_df_leaves_why_none():
+    """Without df/matchkey_fields the queue gracefully leaves why=None."""
+    rq = ReviewQueue()
+    rq.add("job", 1, 2, 0.85, explanation="x")
+    item = rq.list_pending("job")[0]
+    assert item.why is None
+
+
+def test_why_for_correction_helper_returns_string():
+    """The shared helper produces a non-empty string from a Correction-like input."""
+    from goldenmatch.core.review_queue import why_for_correction
+
+    df = _df()
+    out = why_for_correction(1, 2, df, ["name", "zip"], score=0.85)
+    assert isinstance(out, str)
+    assert out
+    assert len(out) <= 240
+
+
+def test_why_for_correction_handles_missing_rows():
+    """Helper falls back to a non-empty string even for unknown row IDs."""
+    from goldenmatch.core.review_queue import why_for_correction
+
+    df = _df()
+    out = why_for_correction(999, 998, df, ["name", "zip"], score=0.5)
+    assert isinstance(out, str)
+    assert out
+
+
+def test_why_for_correction_handles_no_df():
+    from goldenmatch.core.review_queue import why_for_correction
+
+    out = why_for_correction(1, 2, None, None, score=0.85)
+    assert isinstance(out, str)
+    assert out  # generic fallback
+
+
+# ── LLM upgrade path ─────────────────────────────────────────────────────
+
+
+def test_llm_explain_pair_uses_provider_when_key_set(monkeypatch):
+    """When OPENAI_API_KEY is set, llm_explain_pair calls the provider."""
+    from goldenmatch.core import llm_scorer
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    captured = {}
+
+    def fake_openai(prompt, api_key, model, max_tokens=100):
+        captured["prompt"] = prompt
+        captured["model"] = model
+        return ("These records share a name and zip code.", 30, 12)
+
+    monkeypatch.setattr(llm_scorer, "_call_openai", fake_openai)
+
+    out = llm_scorer.llm_explain_pair(
+        row_a={"name": "Acme Corp", "zip": "10001"},
+        row_b={"name": "Acme LLC",  "zip": "10001"},
+        score=0.85,
+    )
+    assert isinstance(out, str)
+    assert out
+    assert "name" in captured["prompt"].lower() or "entity" in captured["prompt"].lower()
+    # Output gets clipped to single short sentence (<= 240 chars)
+    assert len(out) <= 240
+
+
+def test_llm_explain_pair_falls_back_on_error(monkeypatch):
+    """Any exception in the LLM path returns a deterministic fallback (never raises)."""
+    from goldenmatch.core import llm_scorer
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(llm_scorer, "_call_openai", boom)
+
+    out = llm_scorer.llm_explain_pair(
+        row_a={"name": "Acme"}, row_b={"name": "Beta"}, score=0.6,
+    )
+    assert isinstance(out, str)
+    assert out  # fallback string
+
+
+def test_llm_explain_pair_no_key_returns_deterministic(monkeypatch):
+    """No API key -> deterministic path, no network attempt."""
+    from goldenmatch.core import llm_scorer
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    # If _call_openai is touched, raise to fail the test.
+    def fail(*a, **kw):
+        raise AssertionError("LLM should not be called without an API key")
+
+    monkeypatch.setattr(llm_scorer, "_call_openai", fail)
+
+    out = llm_scorer.llm_explain_pair(
+        row_a={"name": "Acme"}, row_b={"name": "Beta"}, score=0.6,
+    )
+    assert isinstance(out, str) and out
+
+
+def test_review_queue_uses_llm_when_enabled(monkeypatch):
+    """ReviewQueue with use_llm_explainer=True routes through llm_explain_pair."""
+    from goldenmatch.core import llm_scorer
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(
+        llm_scorer, "_call_openai",
+        lambda prompt, api_key, model, max_tokens=100: ("LLM_SENTINEL_PROSE", 10, 5),
+    )
+
+    df = _df()
+    rq = ReviewQueue(
+        df=df,
+        matchkey_fields=["name", "zip"],
+        use_llm_explainer=True,
+    )
+    rq.add("job", 1, 2, 0.85, explanation="x")
+    item = rq.list_pending("job")[0]
+    assert "LLM_SENTINEL_PROSE" in item.why

--- a/packages/python/goldenmatch/tests/test_memory_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_memory_pipeline.py
@@ -129,6 +129,65 @@ def test_pipeline_no_memory_stats_when_disabled():
     assert result.memory_stats is None
 
 
+def test_pipeline_persists_stale_pairs_to_review_queue(tmp_path):
+    """Stale corrections must be enqueued to a SQLite review queue colocated
+    with the memory store, so the next `goldenmatch review` invocation
+    surfaces them across processes."""
+    import uuid as _uuid
+    from pathlib import Path
+
+    from goldenmatch.core.memory.store import Correction, MemoryStore
+    from goldenmatch.core.review_queue import ReviewQueue
+
+    df = pl.DataFrame(
+        {
+            "name": ["Acme Corp", "Acme LLC", "Beta Inc"],
+            "zip": ["10001", "10001", "20002"],
+        }
+    )
+    db_path = tmp_path / "mem.db"
+    # Seed a correction with non-empty hashes that won't match the test df,
+    # forcing it to be classified as stale.
+    store = MemoryStore(backend="sqlite", path=str(db_path))
+    try:
+        store.add_correction(
+            Correction(
+                id=str(_uuid.uuid4()),
+                id_a=0,
+                id_b=1,
+                decision="reject",
+                source="steward",
+                trust=1.0,
+                field_hash="bogus_field_hash_will_not_match",
+                record_hash="bogus_record_hash_will_not_match",
+                original_score=0.95,
+                matchkey_name=None,
+                reason=None,
+                dataset=None,
+                created_at=datetime.now(),
+            )
+        )
+    finally:
+        store.close()
+
+    config = _build_config(str(db_path))
+    result = dedupe_df(df, config=config)
+
+    assert result.memory_stats is not None
+    assert len(result.memory_stats.stale_pairs) >= 1
+
+    # Sibling SQLite file should appear next to the memory store.
+    queue_path = db_path.with_name("review_queue.db")
+    assert Path(queue_path).exists(), f"queue file not at {queue_path}"
+
+    # Querying the same backend should surface the stale pair.
+    rq = ReviewQueue(backend="sqlite", path=str(queue_path))
+    pending = rq.list_pending("memory_stale")
+    rq.close()
+    pair_ids = {(it.id_a, it.id_b) for it in pending}
+    assert (0, 1) in pair_ids or (1, 0) in pair_ids
+
+
 def test_pipeline_memory_disabled_does_not_open_store(tmp_path):
     df = pl.DataFrame({"name": ["Acme Corp", "Beta Inc"], "zip": ["10001", "20002"]})
     db_path = tmp_path / "mem.db"

--- a/packages/python/goldenmatch/tests/test_memory_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_memory_pipeline.py
@@ -1,0 +1,139 @@
+"""Pipeline-hook tests for Learning Memory (Phase 2).
+
+Phase 4 (collection points) hasn't landed yet — these tests seed the
+MemoryStore directly via store.add_correction(...) rather than going through
+production code paths that capture corrections.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import polars as pl
+
+from goldenmatch import dedupe_df
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    MemoryConfig,
+)
+from goldenmatch.core.memory.store import Correction, MemoryStore
+
+
+def _build_config(db_path: str, *, memory_enabled: bool = True) -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="identity",
+                type="weighted",
+                threshold=0.75,
+                fields=[
+                    MatchkeyField(
+                        field="name",
+                        scorer="jaro_winkler",
+                        transforms=["lowercase"],
+                        weight=1.0,
+                    ),
+                ],
+            ),
+        ],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["zip"], transforms=["lowercase"])],
+            maxBlockSize=1000,
+            skipOversized=True,
+        ),
+        memory=MemoryConfig(enabled=memory_enabled, path=db_path),
+    )
+
+
+def _seed_reject(db_path: str, df: pl.DataFrame, id_a: int, id_b: int) -> None:
+    """Seed a reject correction with empty hashes (row-ID match path).
+
+    Empty hashes short-circuit the dual-hash staleness check — equivalent to
+    the unmerge / REST collection points which lack df context.
+    """
+    store = MemoryStore(backend="sqlite", path=db_path)
+    try:
+        store.add_correction(
+            Correction(
+                id=str(uuid.uuid4()),
+                id_a=id_a,
+                id_b=id_b,
+                decision="reject",
+                source="steward",
+                trust=1.0,
+                field_hash="",
+                record_hash="",
+                original_score=0.95,
+                matchkey_name=None,
+                reason=None,
+                dataset=None,
+                created_at=datetime.now(),
+            )
+        )
+    finally:
+        store.close()
+
+
+def test_pipeline_applies_seeded_correction(tmp_path):
+    df = pl.DataFrame(
+        {
+            "name": ["Acme Corp", "Acme LLC", "Beta Inc"],
+            "zip": ["10001", "10001", "20002"],
+        }
+    )
+    db_path = str(tmp_path / "mem.db")
+    _seed_reject(db_path, df, 0, 1)
+
+    config = _build_config(db_path)
+    result = dedupe_df(df, config=config)
+
+    # The (0, 1) pair was rejected — score must be overridden to 0.0.
+    rejected_scores = [s for a, b, s in result.scored_pairs if (a, b) == (0, 1)]
+    assert all(s == 0.0 for s in rejected_scores)
+    assert result.memory_stats is not None
+    assert result.memory_stats.applied == 1
+
+
+def test_pipeline_no_memory_stats_when_disabled():
+    """Default config has no memory section — memory_stats should be None."""
+    df = pl.DataFrame({"name": ["Acme Corp", "Beta Inc"], "zip": ["10001", "20002"]})
+    config = GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="identity",
+                type="weighted",
+                threshold=0.75,
+                fields=[
+                    MatchkeyField(
+                        field="name",
+                        scorer="jaro_winkler",
+                        transforms=["lowercase"],
+                        weight=1.0,
+                    ),
+                ],
+            ),
+        ],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["zip"], transforms=["lowercase"])],
+            maxBlockSize=1000,
+            skipOversized=True,
+        ),
+    )
+    result = dedupe_df(df, config=config)
+    assert result.memory_stats is None
+
+
+def test_pipeline_memory_disabled_does_not_open_store(tmp_path):
+    df = pl.DataFrame({"name": ["Acme Corp", "Beta Inc"], "zip": ["10001", "20002"]})
+    db_path = tmp_path / "mem.db"
+    config = _build_config(str(db_path), memory_enabled=False)
+    result = dedupe_df(df, config=config)
+    assert result.memory_stats is None
+    # MemoryConfig.enabled=False — the pipeline should never open the store.
+    assert not db_path.exists()

--- a/packages/python/goldenmatch/tests/test_memory_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_memory_pipeline.py
@@ -10,6 +10,7 @@ import uuid
 from datetime import datetime
 
 import polars as pl
+import pytest
 
 from goldenmatch import dedupe_df
 from goldenmatch.config.schemas import (
@@ -232,3 +233,32 @@ def test_pipeline_continues_when_store_open_fails(tmp_path, caplog):
         for rec in caplog.records
         if rec.levelname == "WARNING"
     )
+
+
+# ── Tier 3.1: MemoryConfig.dataset validator ────────────────────────────
+
+
+def test_memory_config_rejects_empty_dataset():
+    """Empty string dataset is rejected at validation time."""
+    import pydantic
+    with pytest.raises(pydantic.ValidationError, match="non-empty"):
+        MemoryConfig(dataset="")
+
+
+def test_memory_config_rejects_whitespace_dataset():
+    """Whitespace-only dataset is rejected (would silently fail downstream)."""
+    import pydantic
+    with pytest.raises(pydantic.ValidationError, match="non-empty"):
+        MemoryConfig(dataset="   ")
+
+
+def test_memory_config_accepts_none_dataset():
+    """None remains valid (means: dataset filtering off)."""
+    cfg = MemoryConfig(dataset=None)
+    assert cfg.dataset is None
+
+
+def test_memory_config_strips_dataset():
+    """Padding whitespace is trimmed but real value preserved."""
+    cfg = MemoryConfig(dataset="  prod  ")
+    assert cfg.dataset == "prod"

--- a/packages/python/goldenmatch/tests/test_memory_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_memory_pipeline.py
@@ -196,3 +196,39 @@ def test_pipeline_memory_disabled_does_not_open_store(tmp_path):
     assert result.memory_stats is None
     # MemoryConfig.enabled=False — the pipeline should never open the store.
     assert not db_path.exists()
+
+
+def test_pipeline_continues_when_store_open_fails(tmp_path, caplog):
+    """Garbage bytes at memory.db path: pipeline still returns valid DedupeResult.
+
+    memory_stats is None (or marked failed) and the regular clusters are
+    populated. A warning is logged describing the failure.
+    """
+    import logging
+
+    df = pl.DataFrame(
+        {
+            "name": ["Acme Corp", "Acme LLC", "Beta Inc"],
+            "zip": ["10001", "10001", "20002"],
+        }
+    )
+    db_path = tmp_path / "mem.db"
+    # Write garbage so sqlite3.connect succeeds but executescript fails.
+    db_path.write_bytes(b"this is not a sqlite database file at all" * 100)
+
+    config = _build_config(str(db_path))
+    with caplog.at_level(logging.WARNING):
+        result = dedupe_df(df, config=config)
+
+    assert result is not None
+    assert result.clusters is not None
+    # memory_stats should be None or marked as failed (commit 2 adds the
+    # failure sentinel).
+    if result.memory_stats is not None:
+        assert getattr(result.memory_stats, "failed", False) is True
+    # A warning should have been logged about the memory failure.
+    assert any(
+        "memory" in rec.message.lower() or "memorystore" in rec.message.lower()
+        for rec in caplog.records
+        if rec.levelname == "WARNING"
+    )

--- a/packages/python/goldenmatch/tests/test_memory_postflight.py
+++ b/packages/python/goldenmatch/tests/test_memory_postflight.py
@@ -1,0 +1,137 @@
+"""Postflight rendering tests for Learning Memory (Phase 3).
+
+These tests verify that when memory is enabled and corrections are applied,
+the postflight report's rendered string surfaces a one-line memory section.
+Empty/zero memory_stats omit the section entirely.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import polars as pl
+
+from goldenmatch import dedupe_df
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    MemoryConfig,
+)
+from goldenmatch.core.autoconfig_verify import PostflightReport
+from goldenmatch.core.memory.corrections import CorrectionStats
+from goldenmatch.core.memory.store import Correction, MemoryStore
+
+
+def _build_config(db_path: str, *, memory_enabled: bool = True) -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="identity",
+                type="weighted",
+                threshold=0.75,
+                fields=[
+                    MatchkeyField(
+                        field="name",
+                        scorer="jaro_winkler",
+                        transforms=["lowercase"],
+                        weight=1.0,
+                    ),
+                ],
+            ),
+        ],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["zip"], transforms=["lowercase"])],
+            maxBlockSize=1000,
+            skipOversized=True,
+        ),
+        memory=MemoryConfig(enabled=memory_enabled, path=db_path),
+    )
+
+
+def _seed_reject(db_path: str, id_a: int, id_b: int) -> None:
+    """Seed an empty-hash reject correction (always-applies path)."""
+    store = MemoryStore(backend="sqlite", path=db_path)
+    try:
+        store.add_correction(
+            Correction(
+                id=str(uuid.uuid4()),
+                id_a=id_a,
+                id_b=id_b,
+                decision="reject",
+                source="steward",
+                trust=1.0,
+                field_hash="",
+                record_hash="",
+                original_score=0.95,
+                matchkey_name=None,
+                reason=None,
+                dataset=None,
+                created_at=datetime.now(),
+            )
+        )
+    finally:
+        store.close()
+
+
+def test_postflight_renders_memory_section(tmp_path):
+    """A correction was applied; postflight string surfaces 'Memory:' line."""
+    df = pl.DataFrame(
+        {
+            "name": ["Acme Corp", "Acme LLC", "Beta Inc"],
+            "zip": ["10001", "10001", "20002"],
+        }
+    )
+    db_path = str(tmp_path / "mem.db")
+    _seed_reject(db_path, 0, 1)
+
+    config = _build_config(db_path)
+    result = dedupe_df(df, config=config)
+
+    assert result.memory_stats is not None
+    assert result.memory_stats.applied == 1
+    text = str(result.postflight_report) if result.postflight_report else ""
+    assert "Memory:" in text, f"expected 'Memory:' in postflight, got: {text!r}"
+    # Plural-form is fine; accept either for robustness
+    assert "1 correction applied" in text or "1 corrections applied" in text
+
+
+def test_postflight_renders_stale_ambiguous():
+    """Direct render check: a fake CorrectionStats with stale_ambiguous>0
+    surfaces the 'stale-ambiguous' label."""
+    report = PostflightReport()
+    report.memory_stats = CorrectionStats(
+        applied=2, stale=1, stale_ambiguous=1, stale_unanchorable=0,
+    )
+    text = str(report)
+    assert "Memory:" in text
+    assert "stale-ambiguous" in text
+
+
+def test_postflight_omits_memory_when_zero_counts(tmp_path):
+    """Memory enabled, no corrections in store -> no 'Memory:' line."""
+    df = pl.DataFrame(
+        {
+            "name": ["Acme Corp", "Acme LLC", "Beta Inc"],
+            "zip": ["10001", "10001", "20002"],
+        }
+    )
+    db_path = str(tmp_path / "mem.db")
+    # Note: no _seed_reject call. Store is empty.
+    config = _build_config(db_path)
+    result = dedupe_df(df, config=config)
+
+    # memory_stats may be present (memory enabled) but with zero counts.
+    text = str(result.postflight_report) if result.postflight_report else ""
+    assert "Memory:" not in text
+
+
+def test_postflight_omits_memory_when_stats_none():
+    """Direct render check: report without memory_stats has no 'Memory:'."""
+    report = PostflightReport()
+    # No memory_stats attached
+    text = str(report)
+    assert "Memory:" not in text

--- a/packages/python/goldenmatch/tests/test_memory_postflight.py
+++ b/packages/python/goldenmatch/tests/test_memory_postflight.py
@@ -111,6 +111,31 @@ def test_postflight_renders_stale_ambiguous():
     assert "stale-ambiguous" in text
 
 
+def test_postflight_renders_stale_unanchorable():
+    """A fake CorrectionStats with stale_unanchorable>0 surfaces the
+    'unanchorable' label so stewards can spot row-IDs-gone-no-record-hash
+    cases distinctly from generic stale counts."""
+    report = PostflightReport()
+    report.memory_stats = CorrectionStats(
+        applied=0, stale=0, stale_ambiguous=0, stale_unanchorable=3,
+    )
+    text = str(report)
+    assert "Memory:" in text
+    assert "unanchorable" in text
+
+
+def test_postflight_renders_failure_sentinel():
+    """When CorrectionStats.failed=True the renderer surfaces a 'failed'
+    line carrying the error string (added in tier-2 review feedback)."""
+    report = PostflightReport()
+    report.memory_stats = CorrectionStats(
+        total_pairs=10, failed=True, error="garbage memory.db",
+    )
+    text = str(report)
+    assert "Memory: failed" in text
+    assert "garbage memory.db" in text
+
+
 def test_postflight_omits_memory_when_zero_counts(tmp_path):
     """Memory enabled, no corrections in store -> no 'Memory:' line."""
     df = pl.DataFrame(

--- a/packages/python/goldenmatch/tests/test_memory_reanchor.py
+++ b/packages/python/goldenmatch/tests/test_memory_reanchor.py
@@ -151,6 +151,84 @@ def test_edit_on_non_matchkey_field_still_applies(tmp_path):
     assert stats.stale == 1
 
 
+def test_apply_corrections_empty_store_returns_unchanged(tmp_path):
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    df = _make_df(
+        [
+            (1, "Acme Corp", "10001"),
+            (2, "Acme LLC", "10001"),
+        ]
+    )
+    scored = [(1, 2, 0.92), (1, 1, 0.5)]
+    adjusted, stats = apply_corrections(
+        scored, store, df, ["name", "zip"], dataset="t"
+    )
+    assert adjusted == scored
+    assert stats.applied == 0
+    assert stats.stale == 0
+    assert stats.total_pairs == len(scored)
+
+
+def test_apply_corrections_missing_row_id_column(tmp_path, caplog):
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    df_with_row_id = _make_df(
+        [
+            (1, "Acme Corp", "10001"),
+            (2, "Acme LLC", "10001"),
+        ]
+    )
+    _seed_correction(store, df_with_row_id, 1, 2, "reject")
+
+    df_no_row_id = pl.DataFrame(
+        {
+            "name": ["Acme Corp", "Acme LLC"],
+            "zip": ["10001", "10001"],
+        }
+    )
+    scored = [(1, 2, 0.92)]
+    with caplog.at_level("WARNING", logger="goldenmatch.memory"):
+        adjusted, stats = apply_corrections(
+            scored, store, df_no_row_id, ["name", "zip"], dataset="t"
+        )
+    assert adjusted == scored
+    assert stats.applied == 0
+    assert any("__row_id__" in rec.message for rec in caplog.records)
+
+
+def test_unanchorable_corrections_counted(tmp_path):
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    # Seed correction with empty record_hash (simulating unmerge-collected correction)
+    store.add_correction(
+        Correction(
+            id=str(uuid.uuid4()),
+            id_a=999,
+            id_b=1000,
+            decision="reject",
+            source="unmerge",
+            trust=1.0,
+            field_hash="",
+            record_hash="",
+            original_score=0.92,
+            matchkey_name=None,
+            reason=None,
+            dataset="t",
+            created_at=datetime.now(),
+        )
+    )
+    df = _make_df(
+        [
+            (1, "Acme Corp", "10001"),
+            (2, "Acme LLC", "10001"),
+        ]
+    )
+    scored = [(1, 2, 0.5)]
+    adjusted, stats = apply_corrections(
+        scored, store, df, ["name", "zip"], dataset="t"
+    )
+    assert stats.stale_unanchorable >= 1
+    assert (999, 1000) in stats.stale_pairs
+
+
 def test_reanchor_disabled_falls_back_to_row_id_lookup(tmp_path):
     df1 = _make_df(
         [

--- a/packages/python/goldenmatch/tests/test_memory_reanchor.py
+++ b/packages/python/goldenmatch/tests/test_memory_reanchor.py
@@ -1,0 +1,180 @@
+"""Tests for collision-safe vectorized re-anchor via record_hash."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import polars as pl
+
+from goldenmatch.core.memory.corrections import (
+    apply_corrections,
+    build_row_lookup,
+    compute_field_hash,
+    compute_record_hash,
+)
+from goldenmatch.core.memory.store import Correction, MemoryStore
+
+
+def _make_df(rows):
+    """rows: list of (row_id, name, zip)"""
+    return pl.DataFrame(
+        {
+            "__row_id__": [r[0] for r in rows],
+            "name": [r[1] for r in rows],
+            "zip": [r[2] for r in rows],
+        }
+    )
+
+
+def _seed_correction(store, df, id_a, id_b, decision, *, fields=("name", "zip")):
+    lookup = build_row_lookup(df, list(fields))
+    fh = compute_field_hash(lookup[id_a], lookup[id_b])
+    rh = f"{compute_record_hash(df, id_a)}:{compute_record_hash(df, id_b)}"
+    store.add_correction(
+        Correction(
+            id=str(uuid.uuid4()),
+            id_a=id_a,
+            id_b=id_b,
+            decision=decision,
+            source="steward",
+            trust=1.0,
+            field_hash=fh,
+            record_hash=rh,
+            original_score=0.92,
+            matchkey_name=None,
+            reason=None,
+            dataset="t",
+            created_at=datetime.now(),
+        )
+    )
+
+
+def test_reanchor_after_row_reorder(tmp_path):
+    df1 = _make_df(
+        [
+            (1, "Acme Corp", "10001"),
+            (2, "Acme LLC", "10001"),
+            (3, "Beta Inc", "20002"),
+        ]
+    )
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    _seed_correction(store, df1, 1, 2, "reject")
+
+    df2 = _make_df(
+        [
+            (10, "Acme Corp", "10001"),
+            (20, "Acme LLC", "10001"),
+            (30, "Beta Inc", "20002"),
+        ]
+    )
+    scored = [(10, 20, 0.92), (10, 30, 0.10), (20, 30, 0.10)]
+    adjusted, stats = apply_corrections(
+        scored, store, df2, ["name", "zip"], dataset="t"
+    )
+
+    pair_score = next(s for a, b, s in adjusted if (a, b) == (10, 20))
+    assert pair_score == 0.0
+    assert stats.applied == 1
+    assert stats.stale == 0
+
+
+def test_reanchor_skips_ambiguous_duplicates(tmp_path):
+    df1 = _make_df(
+        [
+            (1, "Acme Corp", "10001"),
+            (2, "Acme LLC", "10001"),
+        ]
+    )
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    _seed_correction(store, df1, 1, 2, "reject")
+
+    df2 = _make_df(
+        [
+            (10, "Acme Corp", "10001"),
+            (11, "Acme Corp", "10001"),
+            (20, "Acme LLC", "10001"),
+        ]
+    )
+    scored = [(10, 20, 0.92), (11, 20, 0.92), (10, 11, 1.0)]
+    adjusted, stats = apply_corrections(
+        scored, store, df2, ["name", "zip"], dataset="t"
+    )
+
+    assert all(
+        s == orig for (_, _, s), (_, _, orig) in zip(adjusted, scored)
+    )
+    assert stats.applied == 0
+    assert stats.stale_ambiguous == 1
+
+
+def test_edit_on_matchkey_field_marks_stale(tmp_path):
+    df1 = _make_df(
+        [
+            (1, "Acme Corp", "10001"),
+            (2, "Acme LLC", "10001"),
+        ]
+    )
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    _seed_correction(store, df1, 1, 2, "reject")
+
+    df2 = _make_df(
+        [
+            (1, "ACME CORPORATION", "10001"),
+            (2, "Acme LLC", "10001"),
+        ]
+    )
+    scored = [(1, 2, 0.85)]
+    adjusted, stats = apply_corrections(
+        scored, store, df2, ["name", "zip"], dataset="t"
+    )
+    assert adjusted[0][2] == 0.85
+    assert stats.applied == 0
+    assert stats.stale == 1
+
+
+def test_edit_on_non_matchkey_field_still_applies(tmp_path):
+    df1 = _make_df(
+        [
+            (1, "Acme Corp", "10001"),
+            (2, "Acme LLC", "10001"),
+        ]
+    )
+    df1 = df1.with_columns(pl.lit("old_note").alias("note"))
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    _seed_correction(store, df1, 1, 2, "reject", fields=("name", "zip"))
+
+    df2 = df1.with_columns(pl.lit("new_note").alias("note"))
+    scored = [(1, 2, 0.92)]
+    adjusted, stats = apply_corrections(
+        scored, store, df2, ["name", "zip"], dataset="t"
+    )
+    assert stats.stale == 1
+
+
+def test_reanchor_disabled_falls_back_to_row_id_lookup(tmp_path):
+    df1 = _make_df(
+        [
+            (1, "Acme Corp", "10001"),
+            (2, "Acme LLC", "10001"),
+        ]
+    )
+    store = MemoryStore(backend="sqlite", path=str(tmp_path / "mem.db"))
+    _seed_correction(store, df1, 1, 2, "reject")
+
+    df2 = _make_df(
+        [
+            (10, "Acme Corp", "10001"),
+            (20, "Acme LLC", "10001"),
+        ]
+    )
+    scored = [(10, 20, 0.92)]
+    adjusted, stats = apply_corrections(
+        scored,
+        store,
+        df2,
+        ["name", "zip"],
+        dataset="t",
+        reanchor=False,
+    )
+    assert adjusted[0][2] == 0.92
+    assert stats.applied == 0

--- a/packages/python/goldenmatch/tests/test_memory_store.py
+++ b/packages/python/goldenmatch/tests/test_memory_store.py
@@ -1,7 +1,15 @@
 """Tests for MemoryStore CRUD operations."""
 import pytest
 from datetime import datetime
-from goldenmatch.core.memory.store import MemoryStore, Correction, LearnedAdjustment
+from goldenmatch.core.memory.store import (
+    CorrectionSource,
+    Decision,
+    HIGH_TRUST_SOURCES,
+    MemoryStore,
+    Correction,
+    LearnedAdjustment,
+    trust_for_source,
+)
 
 
 @pytest.fixture
@@ -179,3 +187,82 @@ class TestLastLearnTime:
         ))
         result = store.last_learn_time()
         assert result is not None
+
+
+class TestCorrectionSourceEnum:
+    """StrEnum-based source/decision constants and trust mapping."""
+
+    def test_strenum_equals_raw_string(self):
+        assert CorrectionSource.STEWARD == "steward"
+        assert CorrectionSource.BOOST == "boost"
+        assert CorrectionSource.UNMERGE == "unmerge"
+        assert CorrectionSource.AGENT == "agent"
+        assert CorrectionSource.LLM == "llm"
+        assert CorrectionSource.API == "api"
+        assert Decision.APPROVE == "approve"
+        assert Decision.REJECT == "reject"
+
+    def test_high_trust_set_membership(self):
+        assert CorrectionSource.STEWARD in HIGH_TRUST_SOURCES
+        assert CorrectionSource.BOOST in HIGH_TRUST_SOURCES
+        assert CorrectionSource.UNMERGE in HIGH_TRUST_SOURCES
+        assert CorrectionSource.AGENT not in HIGH_TRUST_SOURCES
+        assert CorrectionSource.LLM not in HIGH_TRUST_SOURCES
+        assert CorrectionSource.API not in HIGH_TRUST_SOURCES
+        # Raw-string membership also works (StrEnum is a str subclass)
+        assert "steward" in HIGH_TRUST_SOURCES
+        assert "agent" not in HIGH_TRUST_SOURCES
+
+    def test_trust_for_source_human_tier(self):
+        assert trust_for_source("steward") == 1.0
+        assert trust_for_source("boost") == 1.0
+        assert trust_for_source("unmerge") == 1.0
+        assert trust_for_source(CorrectionSource.STEWARD) == 1.0
+
+    def test_trust_for_source_agent_tier(self):
+        assert trust_for_source("api") == 0.5
+        assert trust_for_source("agent") == 0.5
+        assert trust_for_source("llm") == 0.5
+        assert trust_for_source(CorrectionSource.AGENT) == 0.5
+
+    def test_all_sources_round_trip_through_store(self, store):
+        """Every defined CorrectionSource value persists and reads back."""
+        for i, src in enumerate(CorrectionSource):
+            store.add_correction(_make_correction(
+                id=f"src-{src.value}",
+                id_a=i * 10,
+                id_b=i * 10 + 1,
+                source=src.value,
+                trust=trust_for_source(src),
+            ))
+        items = store.get_corrections(dataset="test")
+        sources_seen = {c.source for c in items}
+        assert sources_seen == {s.value for s in CorrectionSource}
+
+
+@pytest.mark.skip(
+    reason="WAL mode required for reliable concurrent writes from two "
+    "MemoryStore instances on the same SQLite file. Default journaling "
+    "intermittently raises 'database is locked'. Tracked as a follow-up; "
+    "test exists to surface the limitation rather than enforce it."
+)
+def test_concurrent_memory_store_writes_dont_lock(tmp_path):
+    """Two MemoryStore instances pointing at the same DB; each writes one
+    correction; both are visible to a third reader. Skipped by default --
+    flips green only when WAL mode is enabled (TODO)."""
+    db = str(tmp_path / "concurrent.db")
+    s1 = MemoryStore(backend="sqlite", path=db)
+    s2 = MemoryStore(backend="sqlite", path=db)
+    try:
+        s1.add_correction(_make_correction(id="c1", id_a=10, id_b=11))
+        s2.add_correction(_make_correction(id="c2", id_a=20, id_b=21))
+    finally:
+        s1.close()
+        s2.close()
+    reader = MemoryStore(backend="sqlite", path=db)
+    try:
+        items = reader.get_corrections(dataset="test")
+        ids = {c.id for c in items}
+        assert ids == {"c1", "c2"}
+    finally:
+        reader.close()

--- a/packages/python/goldenmatch/tests/test_memory_tools.py
+++ b/packages/python/goldenmatch/tests/test_memory_tools.py
@@ -1,0 +1,166 @@
+"""Phase 7: MCP memory tool surface.
+
+Five MCP tools wrap MemoryStore operations:
+  list_corrections, add_correction, learn_thresholds, memory_stats, memory_export.
+
+Each handler instantiates its own MemoryStore (matches AgentSession pattern --
+no shared global state).
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from goldenmatch.mcp.memory_tools import (
+    MEMORY_TOOLS,
+    _MEMORY_TOOL_NAMES,
+    handle_memory_tool,
+)
+
+
+EXPECTED_NAMES = {
+    "list_corrections",
+    "add_correction",
+    "learn_thresholds",
+    "memory_stats",
+    "memory_export",
+}
+
+
+def test_memory_tools_registered():
+    """MEMORY_TOOLS exposes the five tool definitions; names match frozenset."""
+    assert len(MEMORY_TOOLS) == 5
+    names = {t.name for t in MEMORY_TOOLS}
+    assert names == EXPECTED_NAMES
+    assert _MEMORY_TOOL_NAMES == frozenset(EXPECTED_NAMES)
+    # Each tool has a non-empty description and an inputSchema dict.
+    for tool in MEMORY_TOOLS:
+        assert tool.description
+        assert isinstance(tool.inputSchema, dict)
+
+
+def test_mcp_add_and_list_correction(tmp_path):
+    """add_correction round-trips to list_corrections."""
+    db = str(tmp_path / "mem.db")
+    add_result = handle_memory_tool(
+        "add_correction",
+        {
+            "id_a": 7,
+            "id_b": 3,
+            "decision": "approve",
+            "dataset": "test_ds",
+            "reason": "looks good",
+            "path": db,
+        },
+    )
+    assert len(add_result) == 1
+    add_payload = json.loads(add_result[0].text)
+    assert add_payload.get("status") == "ok"
+
+    list_result = handle_memory_tool(
+        "list_corrections",
+        {"dataset": "test_ds", "path": db},
+    )
+    list_payload = json.loads(list_result[0].text)
+    corrections = list_payload.get("corrections", [])
+    assert len(corrections) == 1
+    c = corrections[0]
+    # Pair canonicalized to (min, max).
+    assert c["id_a"] == 3
+    assert c["id_b"] == 7
+    assert c["decision"] == "approve"
+    assert c["source"] == "agent"
+    assert c["trust"] == 0.5
+    assert c["dataset"] == "test_ds"
+    assert c.get("reason") == "looks good"
+
+
+def test_mcp_memory_stats_and_export(tmp_path):
+    """memory_stats and memory_export work after a write."""
+    db = str(tmp_path / "mem.db")
+    handle_memory_tool(
+        "add_correction",
+        {
+            "id_a": 1,
+            "id_b": 2,
+            "decision": "reject",
+            "dataset": "ds1",
+            "path": db,
+        },
+    )
+
+    stats_payload = json.loads(
+        handle_memory_tool("memory_stats", {"path": db})[0].text
+    )
+    assert stats_payload.get("total_corrections") == 1
+    assert "last_learn_time" in stats_payload
+    assert "adjustments" in stats_payload
+
+    export_payload = json.loads(
+        handle_memory_tool("memory_export", {"path": db})[0].text
+    )
+    rows = export_payload.get("corrections", [])
+    assert len(rows) == 1
+    assert rows[0]["dataset"] == "ds1"
+
+
+def test_mcp_learn_thresholds_handler(tmp_path):
+    """learn_thresholds handler runs without errors on empty store."""
+    db = str(tmp_path / "mem.db")
+    payload = json.loads(
+        handle_memory_tool("learn_thresholds", {"path": db})[0].text
+    )
+    # Empty store -> no adjustments learned, but call must succeed.
+    assert "adjustments" in payload
+
+
+def test_mcp_add_correction_validates_dataset(tmp_path):
+    """add_correction with empty dataset returns a structured error."""
+    db = str(tmp_path / "mem.db")
+    result = handle_memory_tool(
+        "add_correction",
+        {
+            "id_a": 1,
+            "id_b": 2,
+            "decision": "approve",
+            "dataset": "",
+            "path": db,
+        },
+    )
+    payload = json.loads(result[0].text)
+    assert "error" in payload
+
+
+def test_memory_tools_op_error_returns_structured_error(tmp_path, monkeypatch):
+    """sqlite3.OperationalError is trapped and returned as TextContent error."""
+    import sqlite3
+
+    from goldenmatch.mcp import memory_tools as mt
+
+    class _BoomStore:
+        def __init__(self, *a, **k):
+            raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(mt, "MemoryStore", _BoomStore)
+
+    result = handle_memory_tool(
+        "memory_stats", {"path": str(tmp_path / "irrelevant.db")}
+    )
+    assert len(result) == 1
+    payload = json.loads(result[0].text)
+    assert "error" in payload
+    assert "disk I/O error" in payload["error"] or "OperationalError" in payload["error"]
+
+
+def test_server_card_description_count():
+    """server.py:1266 description string advertises 35 MCP tools."""
+    server_path = (
+        Path(__file__).resolve().parent.parent / "goldenmatch" / "mcp" / "server.py"
+    )
+    text = server_path.read_text(encoding="utf-8")
+    match = re.search(r"(\d+) MCP tools", text)
+    assert match is not None
+    assert int(match.group(1)) == 35

--- a/packages/python/goldenmatch/tests/test_review_queue.py
+++ b/packages/python/goldenmatch/tests/test_review_queue.py
@@ -37,6 +37,22 @@ class TestReviewItem:
         item.reject("bob")
         assert item.reason == ""
 
+    def test_empty_why_normalizes_to_none(self):
+        """Tier 3.3: an empty `why` string is normalized to None so callers
+        don't have to distinguish "no explainer ran" from "explainer ran and
+        produced an empty string"."""
+        item = ReviewItem(
+            job_name="j1", id_a=1, id_b=2, score=0.85, explanation="x", why="",
+        )
+        assert item.why is None
+
+    def test_nonempty_why_preserved(self):
+        item = ReviewItem(
+            job_name="j1", id_a=1, id_b=2, score=0.85, explanation="x",
+            why="name match strong",
+        )
+        assert item.why == "name match strong"
+
 
 # ── gate_pairs ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes Tasks 5–8 of the approved 2026-03-26 Learning Memory plan. Tasks 1–4 (store, corrections, learner) shipped under PR #9; this PR wires those primitives into the pipeline and surfaces, adds a row-ID-stable re-anchor via `record_hash`, and surfaces applied/stale counts in postflight.

- **Phase 1** — collision-safe vectorized re-anchor in `core/memory/corrections.py`; `MemoryConfig.reanchor` + `dataset` fields; new `stale_ambiguous` / `stale_unanchorable` counters
- **Phase 2** — pipeline hook in `_run_dedupe_pipeline` + `_run_match_pipeline`; `memory_stats: CorrectionStats | None` on `DedupeResult` + `MatchResult`; persistent SQLite stale-pair queue at `.goldenmatch/review_queue.db`
- **Phase 3** — one-line memory section in postflight, omitted when zero counts
- **Phase 4** — seven correction collection points across six files (ReviewQueue base class, `unmerge_record`, `unmerge_cluster`, `llm_score_pairs`, `agent_approve_reject`, `POST /reviews/decide`, BoostTab y/n)
- **Phase 5** — `why` field on `ReviewItem`; deterministic explainer with optional LLM upgrade via new `llm_explain_pair`
- **Phase 6** — `goldenmatch memory stats|learn|export|import|show` CLI subgroup + Python API (`get_memory`, `add_correction`, `learn`, `memory_stats`)
- **Phase 7** — five MCP tools (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`); server-card description bumped 30 → 35 tools
- **Phase 8** — eight end-to-end integration scenarios; version bump 1.5.0 → 1.6.0 + CHANGELOG

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-04-learning-memory-completion.md`
- Plan: `docs/superpowers/plans/2026-05-04-learning-memory-completion.md`

Both committed at the head of this branch.

## Diffstat

26 files changed, +3,530 / −38. ~80 net new tests across nine test files (reanchor, pipeline, postflight, collection, explainer, cli, tools, e2e).

## Zero-config posture

Memory is opt-in via `config.memory.enabled` (default `False`). When disabled, behavior is byte-identical to v1.5.0. No new required dependencies.

## Test plan

- [x] All ~115 memory tests pass
- [x] Pre-existing 1300+ goldenmatch tests pass (only pre-existing unrelated failures: 3 gitignored-dataset benchmarks + 8 `test_mcp_and_watch.py` upstream polars regression)
- [x] 8 e2e scenarios cover happy path, re-anchor on reorder, edit-on-matchkey staleness, trust conflict, threshold learning, no-API-key explainer fallback, postflight rendering, stale-ambiguous separation
- [ ] Manual smoke: `goldenmatch dedupe customers.csv` with seeded correction → applied
- [ ] Manual smoke: MCP `add_correction` from Claude Desktop → re-run → applied

## Known post-merge follow-ups (non-blocking)

1. Switch the pipeline's `memory_store` lifecycle to `with memory_store:` — the dataclass already supports `__enter__`/`__exit__`; current narrow `try/finally` leaks the SQLite handle if postflight raises (process-death cleanup recovers it, no runtime correctness impact)
2. Document `source="api"` in the trust-source enum (defaults to trust 0.5; users pass `source="steward"` for human trust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)