### PR TITLE
ci: add PyPI publish workflow for goldenmatch (post-fold)

### DIFF
--- a/.github/workflows/publish-goldenmatch.yml
+++ b/.github/workflows/publish-goldenmatch.yml
@@ -1,0 +1,40 @@
+name: Publish goldenmatch to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    # On release events, only run for Python tags (e.g. v1.6.0). Skip TS-port tags
+    # (goldenmatch-js-v*) and other package tags so they never accidentally publish
+    # the Python package.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    environment: pypi
+    defaults:
+      run:
+        working-directory: packages/python/goldenmatch
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/python/goldenmatch/dist
+          skip-existing: true


### PR DESCRIPTION
## Summary

The pre-fold goldenmatch repo had `.github/workflows/publish.yml` triggering on `release: published`. The May 2026 monorepo fold-in left that workflow at `packages/python/goldenmatch/.github/workflows/` where GitHub Actions doesn't pick it up — only the repo-root `.github/workflows/` is honored.

Result: PR #71's v1.6.0 GitHub Release fired no PyPI publish.

This workflow restores the auto-publish behavior at the monorepo root, with two improvements:

- **Tag filter** — release-event jobs only run when `tag_name` starts with `v` (i.e. Python release tags). TS-port tags like `goldenmatch-js-v0.3.1` won't accidentally publish the Python package.
- **Manual dispatch** — `workflow_dispatch` with optional `ref` input so we can publish v1.6.0 retroactively against the existing tag.

## Test plan

- [ ] Merge to main
- [ ] Manually run `Publish goldenmatch to PyPI` workflow with `ref: v1.6.0` to publish 1.6.0 retroactively
- [ ] Verify PyPI shows goldenmatch 1.6.0 within ~25-45s
- [ ] Future Python releases (v1.6.1+) auto-publish on release creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)