### PR TITLE
fix(ci): use PYPI_TOKEN secret for goldenmatch publish

### DIFF
--- a/.github/workflows/publish-goldenmatch.yml
+++ b/.github/workflows/publish-goldenmatch.yml
@@ -37,4 +37,5 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/python/goldenmatch/dist
+          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true


### PR DESCRIPTION
Trusted publishing was not configured on PyPI side; the publish workflow added in #72 fell back to OIDC and got 'invalid-publisher' from PyPI. Switching to the PYPI_TOKEN repo secret (already exists, 2026-03-21) per the fallback path documented in packages/python/goldenmatch/CLAUDE.md.

Once merged, will manually re-trigger the workflow on v1.6.0.