### PR TITLE
docs: surface Learning Memory across docs/README/wiki (v1.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ pip install goldenmatch && goldenmatch dedupe customers.csv
 npm install goldenmatch
 ```
 
-> **🆕 v1.5.0 (Python) · v0.3.1 (npm)** — Auto-config now runs a **preflight + postflight verification layer**. Biblio / domain-extracted schemas no longer crash under zero-config, remote-asset scorers are demoted by default (offline-safe CI), strict mode for deterministic parity runs, and every `DedupeResult` carries an inspectable `postflight_report`. Built by [Ben Severn](https://bensevern.dev).
+> **🆕 v1.6.0 (Python)** — **Learning Memory** is now wired end-to-end in GoldenMatch. Steward decisions, unmerges, LLM votes, and agent approvals persist to a local store and apply automatically on the next run; corrections re-anchor across row reorders via record-hash. New CLI subgroup, 5 new MCP tools (35 total), and Python `add_correction()` / `learn()` / `memory_stats()`. Off by default. See [Learning Memory docs](https://benzsevern.github.io/goldenmatch/learning-memory).
+>
+> v1.5.0 — auto-config preflight + postflight verification layer. Built by [Ben Severn](https://bensevern.dev).
 
 ---
 
@@ -63,8 +65,9 @@ Each tool stands alone, but they compose into a single pipeline:
 
 - **Zero-config defaults that admit when they're unsure** — every step has a self-verifying preflight + postflight; results carry an inspectable report instead of failing silently.
 - **97.2% F1 on DBLP-ACM out of the box** for entity resolution. [DQBench ER score: 95.30](https://github.com/benzsevern/dqbench).
+- **Learning Memory** — corrections persist across runs and re-anchor across row reorders, so the system stops needing the same correction twice (GoldenMatch v1.6.0; off by default).
 - **Privacy-preserving record linkage** — match across organizations without sharing raw data (PPRL, 92.4% F1 on FEBRL4).
-- **AI-native by design** — every package ships an MCP server, a REST API, and an A2A agent surface. 30+ MCP tools across the suite.
+- **AI-native by design** — every package ships an MCP server, a REST API, and an A2A agent surface. 35+ MCP tools across the suite.
 - **Polyglot parity** — Python and TypeScript implementations track the same scorer outputs to 4-decimal precision via a parity harness.
 - **Production paths** — Postgres sync, daemon mode, lineage tracking, review queues, dbt integration, GitHub Actions, and a Rust extension layer for Postgres / DuckDB.
 
@@ -201,7 +204,7 @@ GoldenMatch is hosted as an MCP server on [Smithery](https://smithery.ai/servers
 }
 ```
 
-30+ MCP tools across the suite: deduplicate, match, explain, review, link privately, configure, scan quality, transform, synthesize golden records.
+35+ MCP tools across the suite: deduplicate, match, explain, review, link privately, configure, scan quality, transform, synthesize golden records, and manage Learning Memory corrections.
 
 ---
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -45,7 +45,9 @@ pip install goldenmatch && goldenmatch dedupe customers.csv
 npm install goldenmatch
 ```
 
-> **🆕 v1.5.0 (Python) · v0.3.1 (npm)** — Auto-config now runs a **preflight + postflight verification layer**. Biblio / domain-extracted schemas no longer crash under zero-config, remote-asset scorers are demoted by default (offline-safe CI), strict mode for deterministic parity runs, and every `DedupeResult` carries an inspectable `postflight_report`. See [Auto-Config Verification](#auto-config-verification-v150). Built by [Ben Severn](https://bensevern.dev).
+> **🆕 v1.6.0 (Python)** — **Learning Memory** is wired end-to-end. Steward decisions, unmerges, LLM votes, and agent approvals persist to a local SQLite (or Postgres) store, re-anchor across row reorders, and apply automatically on the next run. The pipeline reports `Memory: N applied, M stale, K stale-ambiguous, J unanchorable` in postflight. New CLI subgroup `goldenmatch memory`, five new MCP tools, and Python `goldenmatch.add_correction()` / `learn()` / `memory_stats()`. Off by default. See [Learning Memory](#learning-memory-v160).
+>
+> v1.5.0 — Auto-config preflight + postflight verification layer (still on by default). See [Auto-Config Verification](#auto-config-verification-v150). Built by [Ben Severn](https://bensevern.dev).
 
 ---
 
@@ -53,8 +55,9 @@ npm install goldenmatch
 
 - **Zero-config** — auto-detects columns, picks scorers, and runs. No training data needed
 - **97.2% F1** on DBLP-ACM out of the box. [DQBench ER score: 95.30](https://github.com/benzsevern/dqbench)
+- **Learning Memory** — corrections from stewards, unmerges, and LLM votes persist to disk and apply automatically on the next run; survives row reorders via record-hash re-anchoring (v1.6.0)
 - **Privacy-preserving** — match across organizations without sharing raw data (PPRL, 92.4% F1)
-- **30 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
+- **35 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
 - **Production-ready** — Postgres sync, daemon mode, lineage tracking, review queues
 
 ### Choose your path
@@ -68,6 +71,7 @@ npm install goldenmatch
 | Write TypeScript / Node.js | [TypeScript API](https://benzsevern.github.io/goldenmatch/typescript) |
 | Deploy to Vercel Edge / Cloudflare Workers | [TypeScript API](https://benzsevern.github.io/goldenmatch/typescript) |
 | Use the interactive TUI | [TUI Guide](https://benzsevern.github.io/goldenmatch/tui) |
+| Train the system on my corrections | [Learning Memory](https://benzsevern.github.io/goldenmatch/learning-memory) |
 
 ---
 
@@ -105,6 +109,14 @@ npm install goldenmatch
 - **DuckDB backend** — out-of-core processing for 10M+ records without Spark
 - **Ray distributed backend** — scale to 50M+ records with `pip install goldenmatch[ray]`
 - **dbt integration** — `dbt-goldenmatch` package for DuckDB-based ER in dbt pipelines
+
+### Learning Memory (v1.6.0)
+- **Persistent corrections** — every steward decision, unmerge, boost-tab y/n, LLM vote, and agent approve/reject writes to a local SQLite (or Postgres) store
+- **Re-anchor via record_hash** — corrections survive row reordering and refresh; ambiguous re-anchors report as `stale_ambiguous` rather than misapplying
+- **Automatic application** — `dedupe_df` and `match_df` overlay learned thresholds before scoring and apply hard 1.0/0.0 overrides after; postflight reports impact
+- **Threshold learner** — trust-weighted grid search auto-tunes matchkey thresholds once 10+ corrections accumulate
+- **CLI / Python / MCP triad** — `goldenmatch memory stats|learn|export|import|show`, `goldenmatch.add_correction()` / `learn()` / `memory_stats()`, and 5 new MCP tools (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`)
+- **Off by default** — zero-config posture preserved; opt in via `config.memory.enabled = True`
 
 ### Developer Experience
 - **Gold-themed TUI** — interactive interface with keyboard shortcuts, live threshold tuning
@@ -208,6 +220,82 @@ result = gm.dedupe("products.csv", fuzzy={"title": 0.80}, llm_scorer=True)
 # With Ray backend for large datasets
 result = gm.dedupe("huge.parquet", exact=["email"], backend="ray")
 ```
+
+### Learning Memory (v1.6.0)
+
+GoldenMatch can remember past steward decisions and apply them automatically on every subsequent run. Reject a pair once -- it stays rejected. Approve a borderline pair once -- it stays approved. After 10+ corrections accumulate against a matchkey, the learner adjusts its threshold so the system stops needing the same correction twice. Off by default; enable via `config.memory.enabled = True` or a `memory:` block in YAML. Full guide: [Learning Memory docs](https://benzsevern.github.io/goldenmatch/learning-memory).
+
+**`goldenmatch.yml`:**
+
+```yaml
+matchkeys:
+  - name: identity
+    type: weighted
+    threshold: 0.85
+    fields:
+      - field: name
+        scorer: jaro_winkler
+        transforms: [lowercase, strip]
+        weight: 1.0
+      - field: email
+        scorer: exact
+        weight: 1.0
+
+blocking:
+  strategy: static
+  keys:
+    - fields: [zip]
+      transforms: [lowercase]
+
+memory:
+  enabled: true
+  backend: sqlite
+  path: .goldenmatch/memory.db
+  reanchor: true
+  dataset: customers
+  learning:
+    threshold_min_corrections: 10
+    weights_min_corrections: 50
+```
+
+**Three commands users actually run:**
+
+```bash
+# 1. First run -- produces the review queue
+goldenmatch dedupe customers.csv --config goldenmatch.yml
+
+# 2. Steward decides borderline pairs (writes to .goldenmatch/memory.db)
+goldenmatch review --config goldenmatch.yml      # interactive TUI
+
+# 3. Re-run -- corrections apply automatically; postflight reports impact
+goldenmatch dedupe customers.csv --config goldenmatch.yml
+# > Memory: 12 corrections applied, 0 stale, 0 stale-ambiguous, 0 unanchorable
+```
+
+**Python API equivalent:**
+
+```python
+import goldenmatch
+
+# Programmatically register a correction
+goldenmatch.add_correction(
+    id_a=42, id_b=87, decision="reject", source="steward",
+    reason="Different EIN despite name match", dataset="customers",
+)
+
+# Force a learning pass (otherwise auto-runs at next pipeline call)
+adjustments = goldenmatch.learn()
+print(f"Adjusted {len(adjustments)} matchkey thresholds")
+
+# Inspect what's stored
+print(goldenmatch.memory_stats())
+```
+
+**MCP equivalent (from Claude Desktop / Code):**
+
+> "Show me uncertain pairs from the last goldenmatch run on customers.csv, then mark rows 17 and 23 as not-a-match because they have different EINs."
+
+The host LLM calls `list_corrections` -> `add_correction` -> `learn_thresholds`.
 
 ### Auto-Config Verification (v1.5.0)
 
@@ -392,7 +480,7 @@ Guides you through GPU mode selection, Vertex AI / Colab / local GPU configurati
 | Privacy-preserving (PPRL) | Built-in (92.4% F1) | No | No | No | No |
 | Interactive TUI | Yes | No | No | No | No |
 | Golden record synthesis | 5 strategies | No | No | No | No |
-| MCP server (AI integration) | Yes (30 tools) | No | No | No | No |
+| MCP server (AI integration) | Yes (35 tools) | No | No | No | No |
 | Database sync | Postgres + DuckDB | No | No | No | Spark/DuckDB |
 | Single `pip install` | Yes | Yes | Yes | No (Java/Spark) | Yes |
 | Polars-native | Yes | No (pandas) | No (pandas) | No (Spark) | Yes (DuckDB) |
@@ -800,6 +888,7 @@ Settings tuned in the TUI can be saved to the project file. Next run picks them 
 | `goldenmatch analyze-blocking FILE` | Analyze data and suggest blocking strategies |
 | `goldenmatch label FILE --config --gt` | Interactively label pairs to build ground truth CSV |
 | `goldenmatch config save/load/list/show` | Manage config presets |
+| `goldenmatch memory stats/learn/export/import/show` | Manage Learning Memory store (v1.6.0) |
 
 **Key dedupe flags:**
 
@@ -836,7 +925,7 @@ pip install goldenmatch[mcp]
 goldenmatch mcp-serve data.csv
 ```
 
-30 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, and synthesize golden records.
+35 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
 
 ## Architecture
 

--- a/packages/python/goldenmatch/docs/cli.md
+++ b/packages/python/goldenmatch/docs/cli.md
@@ -282,6 +282,35 @@ goldenmatch watch --table customers --connection-string "$DATABASE_URL" --daemon
 
 ---
 
+## memory (v1.6.0)
+
+Inspect, train, and move the Learning Memory store. Requires `memory.enabled = true` in your config (see [Configuration]({% link configuration.md %})).
+
+```bash
+# Inspect what's stored
+goldenmatch memory stats --config goldenmatch.yml
+goldenmatch memory show  --config goldenmatch.yml --limit 50
+
+# Force a learning pass (otherwise auto-runs at next pipeline call)
+goldenmatch memory learn --config goldenmatch.yml
+
+# Move memory between environments
+goldenmatch memory export --config goldenmatch.yml --output corrections.jsonl
+goldenmatch memory import --config goldenmatch.yml --input  corrections.jsonl
+```
+
+| Subcommand | Purpose |
+|---|---|
+| `memory stats` | Counts by source / decision, learned threshold deltas, last-learned timestamp. |
+| `memory show` | List recent corrections with reason and trust. |
+| `memory learn` | Run the threshold learner over the current store. |
+| `memory export` | JSONL dump of all corrections (one record per line). |
+| `memory import` | Bulk-load corrections from JSONL with trust-based upsert. |
+
+Full guide: [Learning Memory]({% link learning-memory.md %}).
+
+---
+
 ## Other commands
 
 | Command | Description |

--- a/packages/python/goldenmatch/docs/configuration.md
+++ b/packages/python/goldenmatch/docs/configuration.md
@@ -159,6 +159,16 @@ llm_scorer:
     max_calls: 100
     warn_at_pct: 80
 
+memory:
+  enabled: true                 # default: false. Off => no memory work, zero overhead.
+  backend: sqlite               # sqlite | postgres
+  path: .goldenmatch/memory.db  # sqlite path or postgres DSN
+  reanchor: true                # default: true. Look up corrections by record_hash when row IDs miss.
+  dataset: customers            # tag corrections so one DB can hold memory for many tables
+  learning:
+    threshold_min_corrections: 10   # learner runs once per matchkey at this floor
+    weights_min_corrections: 50     # field-weight learner floor (stub in v1.6, returns null)
+
 output:
   directory: ./output
   format: csv
@@ -397,3 +407,21 @@ for finding in cfg._preflight_report.findings:
 ```
 
 See the [Verification section in the Python API docs](python-api.html#verification-v150) for the full `preflight` / `postflight` signatures and the `PostflightSignals` schema.
+
+---
+
+## Learning Memory (v1.6.0)
+
+The optional `memory:` section enables persistent corrections. Once a steward, agent, or LLM decides a pair, that decision is stored, re-anchored across row reorders by `record_hash`, and applied automatically on every subsequent `dedupe_df` / `match_df` call. After 10+ corrections accumulate against a matchkey, the learner adjusts that matchkey's threshold for the next run. Off by default; enable via the YAML block above or `config.memory.enabled = True`.
+
+| Field | Default | Notes |
+|---|---|---|
+| `enabled` | `false` | Zero-config preserved. Enabling does not change pipeline output until corrections exist. |
+| `backend` | `"sqlite"` | `"postgres"` requires `pip install goldenmatch[postgres]`. |
+| `path` | `".goldenmatch/memory.db"` | SQLite file or full DSN for postgres. |
+| `reanchor` | `true` | Re-anchor by `record_hash` when row IDs miss; ambiguous re-anchors report `stale_ambiguous`. |
+| `dataset` | `null` | Tag corrections; isolates per-table memory in shared DBs. |
+| `learning.threshold_min_corrections` | `10` | Trust-weighted grid search runs once a matchkey crosses this floor. |
+| `learning.weights_min_corrections` | `50` | Field-weight learning is stubbed in v1.6.0 and returns `null`. |
+
+Full guide: [Learning Memory]({% link learning-memory.md %}).

--- a/packages/python/goldenmatch/docs/index.md
+++ b/packages/python/goldenmatch/docs/index.md
@@ -100,6 +100,7 @@ Scale: 7,823 records/sec on a laptop (fuzzy + exact + golden).
 | [Domain Packs](domain-packs) | 7 built-in YAML rulebooks |
 | [PPRL](pprl) | Privacy-preserving record linkage |
 | [LLM Integration](llm) | LLM scorer, LLM clustering, budget tracking |
+| [Learning Memory](learning-memory) | Persistent corrections + threshold learning (v1.6.0) |
 | [Streaming & Incremental](streaming) | Real-time matching, append-only mode |
 | [PostgreSQL Extension](sql-postgres) | 18 SQL functions, pipeline schema |
 | [DuckDB Extension](sql-duckdb) | 12 Python UDFs |

--- a/packages/python/goldenmatch/docs/learning-memory.md
+++ b/packages/python/goldenmatch/docs/learning-memory.md
@@ -1,0 +1,265 @@
+---
+layout: default
+title: Learning Memory
+nav_order: 19
+---
+
+# Learning Memory
+
+GoldenMatch can remember past steward decisions and apply them automatically on every subsequent run. Reject a pair once -- it stays rejected. Approve a borderline pair once -- it stays approved. After enough corrections accumulate, the learner adjusts matchkey thresholds so the system stops needing the same correction twice.
+
+This is the third layer that sits beside zero-config and explicit YAML: a feedback loop that survives input refresh and re-orders, with no rules to write and no models to train.
+
+> **Status.** Shipped in v1.6.0. Off by default -- the zero-config posture is preserved. Enable via `config.memory.enabled = True` or a `memory:` block in YAML.
+
+---
+
+## What it does
+
+Learning Memory is a persistent store of `(id_a, id_b, decision)` corrections plus a learner that turns enough corrections into threshold adjustments.
+
+- **Pipeline applies corrections automatically.** `dedupe_df` and `match_df` apply stored corrections after scoring (hard `1.0` for approve, hard `0.0` for reject) and overlay learned threshold deltas before scoring.
+- **Re-anchors via `record_hash`.** Corrections survive row reordering and refresh. If a correction's row IDs are no longer present, the system looks the entity up by content hash. Ambiguous rehydrations (duplicate rows) report as `stale_ambiguous` rather than silently misapplying.
+- **Seven collection points.** Every place a steward, an LLM, or an agent makes a decision writes a correction: review queue, boost tab, `unmerge_record` / `unmerge_cluster`, LLM scorer, MCP `agent_approve_reject`, REST `POST /reviews/decide`, Python `add_correction()`.
+- **Threshold learning.** Once a matchkey accumulates `threshold_min_corrections` (default 10) corrections, the learner runs a trust-weighted grid search and stores per-matchkey threshold deltas. The pipeline overlays them on the next run.
+- **Postflight reports impact.** Every run with memory active emits `Memory: N applied, M stale, K stale-ambiguous, J unanchorable`.
+
+---
+
+## Quick walkthrough
+
+Three commands. The data and the config don't change between runs -- the system improves because it remembers.
+
+**`goldenmatch.yml`:**
+
+```yaml
+matchkeys:
+  - name: identity
+    type: weighted
+    threshold: 0.85
+    fields:
+      - field: name
+        scorer: jaro_winkler
+        transforms: [lowercase, strip]
+        weight: 1.0
+      - field: email
+        scorer: exact
+        weight: 1.0
+
+blocking:
+  strategy: static
+  keys:
+    - fields: [zip]
+      transforms: [lowercase]
+
+memory:
+  enabled: true
+  backend: sqlite
+  path: .goldenmatch/memory.db
+  reanchor: true
+  dataset: customers
+  learning:
+    threshold_min_corrections: 10
+    weights_min_corrections: 50
+```
+
+**Run 1 -- produce the review queue.** Memory is empty, no corrections apply.
+
+```bash
+goldenmatch dedupe customers.csv --config goldenmatch.yml
+```
+
+**Run 2 -- the steward decides.** The interactive review TUI writes approve / reject decisions to `.goldenmatch/memory.db` with `source=steward, trust=1.0`.
+
+```bash
+goldenmatch review --config goldenmatch.yml
+```
+
+**Run 3 -- corrections apply automatically.** Same data, same config; the pipeline reads memory, hard-overrides scored pairs, and reports impact in postflight.
+
+```bash
+goldenmatch dedupe customers.csv --config goldenmatch.yml
+# > Memory: 12 corrections applied, 0 stale, 0 stale-ambiguous, 0 unanchorable
+```
+
+After 10+ corrections accumulate against a matchkey, `goldenmatch memory learn` (or the auto-learn pass on the next pipeline call) tunes that matchkey's threshold so future runs need fewer corrections.
+
+---
+
+## Configuration
+
+`MemoryConfig` lives at `config.memory`. Top-level YAML:
+
+```yaml
+memory:
+  enabled: true                 # default: false. Off => no memory work, zero overhead.
+  backend: sqlite               # sqlite | postgres
+  path: .goldenmatch/memory.db  # sqlite path or postgres DSN
+  reanchor: true                # default: true. Set false to require exact (id_a, id_b) match.
+  dataset: customers            # tag corrections; isolates per-table memory in shared DBs
+  learning:
+    threshold_min_corrections: 10   # learner runs once per matchkey at this floor
+    weights_min_corrections: 50     # field-weight learning floor (stub in v1.6, returns None)
+```
+
+| Field | Default | Notes |
+|---|---|---|
+| `enabled` | `false` | Zero-config preserved. Enabling does not change pipeline output until corrections exist. |
+| `backend` | `"sqlite"` | `"postgres"` requires `pip install goldenmatch[postgres]`. |
+| `path` | `".goldenmatch/memory.db"` | SQLite file or full DSN for postgres. |
+| `reanchor` | `true` | Re-anchor by `record_hash` when row IDs miss. Disable for strictly positional behavior. |
+| `dataset` | `None` | Use one DB across multiple tables; the pipeline filters corrections by dataset tag. |
+| `learning.threshold_min_corrections` | `10` | Trust-weighted grid search runs once a matchkey crosses this floor. |
+| `learning.weights_min_corrections` | `50` | Field-weight learning is stubbed in v1.6.0 and returns `None`. |
+
+Postgres backend:
+
+```yaml
+memory:
+  enabled: true
+  backend: postgres
+  path: postgresql://user:pass@host:5432/db
+  dataset: customers_prod
+```
+
+---
+
+## CLI
+
+The `goldenmatch memory` subgroup exposes the store directly.
+
+```bash
+# Inspect
+goldenmatch memory stats --config goldenmatch.yml
+goldenmatch memory show --config goldenmatch.yml --limit 50
+
+# Train (run the learner over the current store)
+goldenmatch memory learn --config goldenmatch.yml
+
+# Move memory between environments
+goldenmatch memory export --config goldenmatch.yml --output corrections.jsonl
+goldenmatch memory import --config goldenmatch.yml --input corrections.jsonl
+```
+
+| Command | Purpose |
+|---|---|
+| `memory stats` | Counts by source / decision, learned threshold deltas, last-learned timestamp. |
+| `memory show` | List recent corrections with reason and trust. |
+| `memory learn` | Force a learning pass; otherwise auto-runs at next pipeline call. |
+| `memory export` | JSONL dump of all corrections (one record per line). |
+| `memory import` | Bulk-load corrections from JSONL. Trust-based upsert (higher trust wins). |
+
+---
+
+## Python API
+
+```python
+import goldenmatch
+
+# Programmatically register a correction (same effect as the review TUI)
+goldenmatch.add_correction(
+    id_a=42,
+    id_b=87,
+    decision="reject",
+    source="steward",
+    reason="Different EIN despite name match",
+    dataset="customers",
+)
+
+# Force a learning pass (otherwise auto-runs at next pipeline call)
+adjustments = goldenmatch.learn()
+print(f"Adjusted {len(adjustments)} matchkey thresholds")
+
+# Inspect what's stored
+print(goldenmatch.memory_stats())
+
+# Direct store access
+store = goldenmatch.get_memory()
+for c in store.get_corrections(dataset="customers"):
+    print(c.id_a, c.id_b, c.decision, c.trust, c.reason)
+```
+
+| Function | Returns |
+|---|---|
+| `goldenmatch.get_memory()` | The active `MemoryStore` (constructed from `config.memory`). |
+| `goldenmatch.add_correction(id_a, id_b, decision, ...)` | Upserts a correction, trust-weighted. |
+| `goldenmatch.learn()` | Runs `MemoryLearner`, returns the dict of threshold adjustments. |
+| `goldenmatch.memory_stats()` | Same dict the CLI prints. |
+
+After a pipeline run, every result also carries a `memory_stats` field:
+
+```python
+result = goldenmatch.dedupe_df(df, config=config)
+print(result.memory_stats)
+# {'applied': 12, 'stale': 0, 'stale_ambiguous': 0, 'unanchorable': 0}
+```
+
+---
+
+## MCP
+
+Five new MCP tools (`memory_*`) bring Learning Memory into Claude Desktop / Code. Total tool count is now 35.
+
+| Tool | Behavior |
+|---|---|
+| `list_corrections` | Page through stored corrections, optionally filtered by dataset and source. |
+| `add_correction` | Same arguments as the Python API; writes a correction with caller-supplied trust. |
+| `learn_thresholds` | Runs `MemoryLearner.learn()`; returns the adjustment dict. |
+| `memory_stats` | Counts and last-learned timestamps. |
+| `memory_export` | Returns all corrections as a JSON array (use server-side for review portability). |
+
+A natural-language workflow against an MCP-connected goldenmatch run:
+
+> "Show me uncertain pairs from the last goldenmatch run on customers.csv, then mark rows 17 and 23 as not-a-match because they have different EINs."
+
+The host LLM calls `list_corrections` -> `add_correction` -> `learn_thresholds`.
+
+---
+
+## How it works
+
+```
+            scored_pairs                          stored corrections
+                |                                          |
+                v                                          v
+           apply_corrections() -- match by (id_a,id_b) ----+
+                |                                          |
+                | row IDs missing?                         |
+                v                                          |
+            re-anchor via record_hash  <-------------------+
+                |
+                v
+           overridden pairs ---> cluster ---> golden ---> postflight
+                                                              |
+                                                              v
+                                              Memory: N applied, M stale, ...
+```
+
+- **Trust-weighted upsert.** Every correction has a `trust` score (`steward`/`unmerge` 1.0, `agent`/`llm` 0.5). New corrections only override existing ones when their trust is at least as high.
+- **Dual-hash staleness.** Each correction stores both a `field_hash` (only the matchkey fields) and a `record_hash` (all columns). On apply, if either hash diverges from the live data, the correction is reported `stale` rather than applied -- it would no longer be safe.
+- **Re-anchoring.** When a correction's stored `(id_a, id_b)` are not present in the current frame, the system looks both rows up by `record_hash`. Single hits re-anchor cleanly; multiple hits report `stale_ambiguous`; no hits report `unanchorable`. Ambiguous and unanchorable corrections are not applied.
+- **Stale persistence.** Stale corrections are enqueued to a sibling SQLite review queue (`.goldenmatch/review_queue.db`) so the next `goldenmatch review` invocation surfaces them for human re-decision.
+- **Threshold learner.** A trust-weighted grid search picks the threshold that maximizes agreement with the stored decisions for that matchkey. Learned deltas overlay before the next scoring pass.
+
+The full design lives in `docs/superpowers/specs/2026-05-04-learning-memory-completion.md` for readers who want algorithm-level detail.
+
+---
+
+## When to enable
+
+- **Always**, if you have stewards reviewing borderline pairs. Their decisions otherwise evaporate.
+- **Always**, if you re-run the same dataset on a schedule. The same false positives shouldn't keep coming back.
+- **Probably not**, for one-shot dedupes on data you'll never see again.
+- **Probably not**, if you need byte-for-byte reproducible output (e.g. DQBench parity runs). Use `auto_configure_df(df, strict=True)` and leave memory off.
+
+---
+
+## See also
+
+| Topic | Link |
+|---|---|
+| YAML reference | [Configuration](configuration) |
+| `goldenmatch memory ...` | [CLI Reference](cli) |
+| `goldenmatch.add_correction` etc. | [Python API](python-api) |
+| MCP `list_corrections` etc. | [MCP Server](mcp) |
+| Review queue (the steward UI) | [REST API](rest-api) |

--- a/packages/python/goldenmatch/docs/llms-full.txt
+++ b/packages/python/goldenmatch/docs/llms-full.txt
@@ -256,18 +256,41 @@ from goldenmatch import (
 )
 ```
 
-## Learning Memory
+## Learning Memory (v1.6.0 — wired end-to-end)
+
+Persistent corrections + threshold learning. Off by default; enable via `config.memory.enabled = True` or YAML `memory:` block.
 
 ```python
+import goldenmatch
+
+# High-level API (the way most users interact with it)
+goldenmatch.add_correction(
+    id_a=42, id_b=87, decision="reject", source="steward",
+    reason="Different EIN despite name match", dataset="customers",
+)
+adjustments = goldenmatch.learn()         # trust-weighted threshold learner
+print(goldenmatch.memory_stats())         # counts, last-learned timestamps
+store = goldenmatch.get_memory()          # underlying MemoryStore
+
+# Low-level building blocks (for custom integrations)
 from goldenmatch import (
     MemoryStore,         # MemoryStore(backend="sqlite", path="memory.db")
-    Correction,          # Correction(pair, decision, reason)
+    Correction,          # Correction(id_a, id_b, decision, source, trust, ...)
     LearnedAdjustment,   # Learned threshold/weight adjustment
-    CorrectionStats,     # Stats on stored corrections
-    MemoryLearner,       # MemoryLearner(store) -- .learn() -> list[LearnedAdjustment]
-    apply_corrections,   # apply_corrections(pairs, store) -> pairs
+    CorrectionStats,     # {applied, stale, stale_ambiguous, unanchorable}
+    MemoryLearner,       # MemoryLearner(store).learn() -> list[LearnedAdjustment]
+    apply_corrections,   # apply_corrections(pairs, store, df, fields, dataset)
 )
+
+# Pipeline integration: result objects carry memory impact
+result = goldenmatch.dedupe_df(df, config=config)
+print(result.memory_stats)
+# {'applied': 12, 'stale': 0, 'stale_ambiguous': 0, 'unanchorable': 0}
 ```
+
+Seven collection points write to the store: review queue (`steward`/1.0), boost tab (`boost`/1.0), `unmerge_record` and `unmerge_cluster` (`unmerge`/1.0), LLM scorer decisions (`llm`/0.5), MCP `agent_approve_reject` (`agent`/0.5), REST `POST /reviews/decide` (`steward`/1.0), and the Python `add_correction()` API.
+
+Five MCP tools: `list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`. CLI subgroup: `goldenmatch memory stats|learn|export|import|show`.
 
 ## Common Usage Patterns
 
@@ -355,6 +378,16 @@ llm_scorer:
     max_cost_usd: 0.05
     max_calls: 100
 
+memory:
+  enabled: true
+  backend: sqlite
+  path: .goldenmatch/memory.db
+  reanchor: true
+  dataset: customers
+  learning:
+    threshold_min_corrections: 10
+    weights_min_corrections: 50
+
 output:
   format: csv
   path: output/
@@ -374,12 +407,16 @@ goldenmatch incremental new.csv --base existing.csv  # Incremental matching
 goldenmatch explain cluster-42                       # Explain a cluster
 goldenmatch unmerge record-123                       # Unmerge a record
 goldenmatch label pairs.csv                          # Label training pairs
+goldenmatch memory stats   --config config.yaml      # Inspect Learning Memory
+goldenmatch memory learn   --config config.yaml      # Force a learner pass
+goldenmatch memory export  --config config.yaml --output corrections.jsonl
+goldenmatch memory import  --config config.yaml --input  corrections.jsonl
 ```
 
 ## Interfaces
 
-- **MCP Server**: `goldenmatch mcp-serve` — 13 tools for Claude Desktop integration
-- **Remote MCP**: https://goldenmatch-mcp-production.up.railway.app/mcp/ (30 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- **MCP Server**: `goldenmatch mcp-serve` — 35 tools (13 agent + 17 data + 5 memory) for Claude Desktop integration
+- **Remote MCP**: https://goldenmatch-mcp-production.up.railway.app/mcp/ (35 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
 - **A2A Server**: `goldenmatch agent-serve --port 8200` — 10 skills via Agent-to-Agent protocol
 - **REST API**: `goldenmatch serve` on port 8000 — match, clusters, explain, reviews endpoints
 - **CLI**: 20+ Typer commands

--- a/packages/python/goldenmatch/docs/llms.txt
+++ b/packages/python/goldenmatch/docs/llms.txt
@@ -3,11 +3,11 @@
 > Entity resolution toolkit — deduplicate records and match across datasets using fuzzy, probabilistic, and LLM-powered scoring.
 
 ## Interfaces
-- MCP Server: `goldenmatch mcp-serve` (13 agent tools + 17 data tools = 30 total)
-- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (30 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- MCP Server: `goldenmatch mcp-serve` (13 agent tools + 17 data tools + 5 memory tools = 35 total)
+- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (35 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
 - A2A Server: `goldenmatch agent-serve --port 8200` (10 skills)
-- CLI: `goldenmatch dedupe`, `goldenmatch match`, + 18 more commands
-- Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~101 exports
+- CLI: `goldenmatch dedupe`, `goldenmatch match`, `goldenmatch memory ...`, + more
+- Python API: `import goldenmatch` -- `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, `add_correction()`, `learn()`, `memory_stats()`, `get_memory()`, ~106 exports
 - REST API: `goldenmatch serve` on port 8000
 
 ## Install
@@ -104,8 +104,19 @@ exact, jaro_winkler, levenshtein, token_sort, ensemble, dice, jaccard, soundex_m
 ## Transforms
 lowercase, uppercase, strip, soundex, metaphone, digits_only, alpha_only, normalize_whitespace, token_sort, first_token, last_token, substring:start:end
 
+## Learning Memory (v1.6.0)
+Persistent corrections + threshold learning. Off by default; enable with `memory.enabled = true`.
+- Store: SQLite (default) or Postgres. Path: `.goldenmatch/memory.db`.
+- Collection points: review queue, boost tab, unmerge_record/cluster, LLM scorer, MCP `agent_approve_reject`, REST `/reviews/decide`, Python `add_correction()`.
+- Re-anchors via `record_hash`; ambiguous rehydrations report `stale_ambiguous`. Postflight reports `Memory: N applied, M stale, K stale-ambiguous, J unanchorable`.
+- CLI: `goldenmatch memory stats|learn|export|import|show`.
+- Python: `goldenmatch.add_correction(...)`, `learn()`, `memory_stats()`, `get_memory()`. Result objects expose `result.memory_stats`.
+- MCP tools: `list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`.
+- Learner runs at `learning.threshold_min_corrections` (default 10) per matchkey via trust-weighted grid search.
+
 ## Docs
-- [Full docs](https://benzsevern.github.io/goldenmatch/): 22 guides
+- [Learning Memory](https://benzsevern.github.io/goldenmatch/learning-memory)
+- [Full docs](https://benzsevern.github.io/goldenmatch/): 23 guides
 - [Full API reference](https://benzsevern.github.io/goldenmatch/python-api): 101 exports
 - [PyPI](https://pypi.org/project/goldenmatch/)
 - [GitHub](https://github.com/benzsevern/goldenmatch)

--- a/packages/python/goldenmatch/docs/mcp.md
+++ b/packages/python/goldenmatch/docs/mcp.md
@@ -6,7 +6,7 @@ nav_order: 18
 
 # MCP Server
 
-GoldenMatch provides an MCP (Model Context Protocol) server for integration with Claude Desktop, Claude Code, and other MCP-compatible AI assistants. 30 tools total: 13 agent-level tools for autonomous ER + 17 data tools for inspection and management.
+GoldenMatch provides an MCP (Model Context Protocol) server for integration with Claude Desktop, Claude Code, and other MCP-compatible AI assistants. 35 tools total: 13 agent-level tools for autonomous ER, 17 data tools for inspection and management, and 5 Learning Memory tools (v1.6.0) for persisting steward decisions.
 
 > **Looking for AI-to-AI autonomy?** See the [ER Agent (A2A)](agent) page for agent framework integration (LangChain, CrewAI, AutoGen).
 
@@ -207,6 +207,24 @@ Normalize phone numbers (E.164), dates (ISO), categorical spelling, and Unicode.
 ```
 
 In addition, 13 **agent-level tools** are available for autonomous operation (analyze_data, auto_configure, agent_deduplicate, agent_match_sources, agent_explain_pair, agent_explain_cluster, agent_review_queue, agent_approve_reject, agent_compare_strategies, suggest_pprl, scan_quality, fix_quality, run_transforms). See [ER Agent](agent) for details.
+
+### Learning Memory tools (v1.6.0)
+
+Five tools surface the persistent corrections store. See [Learning Memory]({% link learning-memory.md %}) for the full feature.
+
+| Tool | Behavior |
+|---|---|
+| `list_corrections` | Page through stored corrections, optionally filtered by dataset and source. |
+| `add_correction` | Writes a correction with caller-supplied trust (`steward`/`unmerge` 1.0, `agent`/`llm` 0.5). |
+| `learn_thresholds` | Runs `MemoryLearner.learn()`; returns the adjustment dict per matchkey. |
+| `memory_stats` | Counts plus last-learned timestamps. |
+| `memory_export` | Returns all corrections as a JSON array (use server-side for review portability). |
+
+Natural-language workflow:
+
+> "Show me uncertain pairs from the last goldenmatch run on customers.csv, then mark rows 17 and 23 as not-a-match because they have different EINs."
+
+The host LLM calls `list_corrections` -> `add_correction` -> `learn_thresholds`.
 
 ---
 

--- a/packages/python/goldenmatch/docs/python-api.md
+++ b/packages/python/goldenmatch/docs/python-api.md
@@ -864,6 +864,49 @@ gm.generate_dedupe_report(result) -> str  # HTML report
 
 ---
 
+## Learning Memory (v1.6.0)
+
+```python
+import goldenmatch
+
+# Programmatically register a correction (same effect as the review TUI)
+goldenmatch.add_correction(
+    id_a=42, id_b=87, decision="reject", source="steward",
+    reason="Different EIN despite name match", dataset="customers",
+)
+
+# Force a learning pass (otherwise auto-runs at next pipeline call)
+adjustments = goldenmatch.learn()
+print(f"Adjusted {len(adjustments)} matchkey thresholds")
+
+# Inspect what's stored
+print(goldenmatch.memory_stats())
+
+# Direct store access (for custom queries / migrations)
+store = goldenmatch.get_memory()
+for c in store.get_corrections(dataset="customers"):
+    print(c.id_a, c.id_b, c.decision, c.trust, c.reason)
+```
+
+| Function | Returns |
+|---|---|
+| `goldenmatch.get_memory()` | The active `MemoryStore` (constructed from `config.memory`). |
+| `goldenmatch.add_correction(id_a, id_b, decision, ...)` | Upserts a correction, trust-weighted. Higher trust wins on conflict. |
+| `goldenmatch.learn()` | Runs `MemoryLearner`, returns the dict of threshold adjustments. |
+| `goldenmatch.memory_stats()` | Counts and last-learned timestamps. |
+
+After a pipeline run, every `DedupeResult` / `MatchResult` carries a `memory_stats` field:
+
+```python
+result = goldenmatch.dedupe_df(df, config=config)
+print(result.memory_stats)
+# {'applied': 12, 'stale': 0, 'stale_ambiguous': 0, 'unanchorable': 0}
+```
+
+Full guide: [Learning Memory]({% link learning-memory.md %}).
+
+---
+
 ## REST API client
 
 ```python

--- a/packages/python/goldenmatch/docs/wiki/Home.md
+++ b/packages/python/goldenmatch/docs/wiki/Home.md
@@ -31,6 +31,7 @@ goldenmatch setup
 | [GPU Routing & Vertex AI](GPU-Routing.md) | Managed embeddings via Google Cloud |
 | [Database Integration](Database-Integration.md) | Incremental Postgres sync with golden record versioning |
 | [LLM Boost](LLM-Boost.md) | Claude/GPT-4 labeling + fine-tuning |
+| [Learning Memory](Learning-Memory) | Persistent corrections + threshold learning (v1.6.0) |
 | [dbt Integration](dbt-Integration.md) | Post-hooks, Postgres sync, Snowflake/BigQuery recipes |
 
 ## Reference
@@ -65,6 +66,7 @@ goldenmatch setup
 | `goldenmatch analyze-blocking FILE` | Analyze and suggest blocking strategies |
 | `goldenmatch label FILE --config --gt` | Interactively label pairs to build ground truth CSV |
 | `goldenmatch config save/load/list/show` | Manage config presets |
+| `goldenmatch memory stats/learn/export/import/show` | Manage Learning Memory store (v1.6.0) |
 | `goldenmatch compare-clusters A.json B.json` | Compare two clustering outcomes (CCMS) |
 | `goldenmatch sensitivity FILE --sweep ...` | Parameter sensitivity analysis |
 

--- a/packages/python/goldenmatch/docs/wiki/Learning-Memory.md
+++ b/packages/python/goldenmatch/docs/wiki/Learning-Memory.md
@@ -1,0 +1,133 @@
+# Learning Memory
+
+GoldenMatch can remember past steward decisions and apply them automatically on every subsequent run. Reject a pair once -- it stays rejected. Approve a borderline pair once -- it stays approved. After enough corrections accumulate, the learner adjusts matchkey thresholds so the system stops needing the same correction twice.
+
+Off by default. Enable via `config.memory.enabled = True` or a `memory:` section in YAML. Shipped in v1.6.0.
+
+## What it does
+
+- **Pipeline applies corrections automatically** -- `dedupe_df` and `match_df` apply stored corrections after scoring (hard 1.0 for approve, hard 0.0 for reject) and overlay learned threshold deltas before scoring.
+- **Re-anchors via `record_hash`** -- corrections survive row reordering and refresh; ambiguous re-anchors report as `stale_ambiguous` rather than silently misapplying.
+- **Seven collection points** -- review queue, boost tab, `unmerge_record` / `unmerge_cluster`, LLM scorer, MCP `agent_approve_reject`, REST `POST /reviews/decide`, Python `add_correction()`.
+- **Threshold learning** -- once a matchkey accumulates 10+ corrections, a trust-weighted grid search adjusts that matchkey's threshold for the next run.
+- **Postflight reports impact** -- every run with memory active emits `Memory: N applied, M stale, K stale-ambiguous, J unanchorable`.
+
+## Walkthrough
+
+`goldenmatch.yml`:
+
+```yaml
+matchkeys:
+  - name: identity
+    type: weighted
+    threshold: 0.85
+    fields:
+      - field: name
+        scorer: jaro_winkler
+        transforms: [lowercase, strip]
+        weight: 1.0
+      - field: email
+        scorer: exact
+        weight: 1.0
+
+blocking:
+  strategy: static
+  keys:
+    - fields: [zip]
+      transforms: [lowercase]
+
+memory:
+  enabled: true
+  backend: sqlite
+  path: .goldenmatch/memory.db
+  reanchor: true
+  dataset: customers
+  learning:
+    threshold_min_corrections: 10
+    weights_min_corrections: 50
+```
+
+```bash
+# 1. First run -- produces the review queue
+goldenmatch dedupe customers.csv --config goldenmatch.yml
+
+# 2. Steward decides borderline pairs (writes to .goldenmatch/memory.db)
+goldenmatch review --config goldenmatch.yml
+
+# 3. Re-run -- corrections apply automatically; postflight reports impact
+goldenmatch dedupe customers.csv --config goldenmatch.yml
+# > Memory: 12 corrections applied, 0 stale, 0 stale-ambiguous, 0 unanchorable
+```
+
+## Configuration
+
+| Field | Default | Notes |
+|---|---|---|
+| `enabled` | `false` | Zero-config preserved. |
+| `backend` | `sqlite` | `postgres` requires `pip install goldenmatch[postgres]`. |
+| `path` | `.goldenmatch/memory.db` | SQLite path or full DSN for postgres. |
+| `reanchor` | `true` | Re-anchor by `record_hash` when row IDs miss. |
+| `dataset` | `null` | Tag corrections; isolates per-table memory in shared DBs. |
+| `learning.threshold_min_corrections` | `10` | Floor for the threshold learner. |
+| `learning.weights_min_corrections` | `50` | Field-weight learning floor (stub in v1.6, returns `null`). |
+
+## CLI
+
+```bash
+goldenmatch memory stats   --config goldenmatch.yml
+goldenmatch memory show    --config goldenmatch.yml --limit 50
+goldenmatch memory learn   --config goldenmatch.yml
+goldenmatch memory export  --config goldenmatch.yml --output corrections.jsonl
+goldenmatch memory import  --config goldenmatch.yml --input  corrections.jsonl
+```
+
+## Python API
+
+```python
+import goldenmatch
+
+goldenmatch.add_correction(
+    id_a=42, id_b=87, decision="reject", source="steward",
+    reason="Different EIN despite name match", dataset="customers",
+)
+
+adjustments = goldenmatch.learn()
+print(f"Adjusted {len(adjustments)} matchkey thresholds")
+
+print(goldenmatch.memory_stats())
+
+result = goldenmatch.dedupe_df(df, config=config)
+print(result.memory_stats)
+# {'applied': 12, 'stale': 0, 'stale_ambiguous': 0, 'unanchorable': 0}
+```
+
+## MCP
+
+Five new MCP tools (total now 35):
+
+| Tool | Behavior |
+|---|---|
+| `list_corrections` | Page through stored corrections (optionally filtered by dataset/source). |
+| `add_correction` | Writes a correction with caller-supplied trust. |
+| `learn_thresholds` | Runs the learner and returns the adjustment dict. |
+| `memory_stats` | Counts plus last-learned timestamps. |
+| `memory_export` | Returns all corrections as a JSON array. |
+
+Natural-language workflow:
+
+> "Show me uncertain pairs from the last goldenmatch run on customers.csv, then mark rows 17 and 23 as not-a-match because they have different EINs."
+
+The host LLM calls `list_corrections` -> `add_correction` -> `learn_thresholds`.
+
+## How it works
+
+- **Trust-weighted upsert.** `steward`/`unmerge` write trust 1.0; `agent`/`llm` write trust 0.5. New corrections only override existing ones at equal-or-higher trust.
+- **Dual-hash staleness.** Each correction stores `field_hash` (matchkey fields only) and `record_hash` (all columns). If either diverges, the correction reports `stale` instead of applying.
+- **Re-anchoring.** When stored row IDs are missing, the system looks rows up by `record_hash`. Single hits re-anchor; multiple hits report `stale_ambiguous`; no hits report `unanchorable`. Stale corrections enqueue to a sibling review queue for human re-decision.
+- **Threshold learner.** A trust-weighted grid search picks the threshold that maximizes agreement with stored decisions for that matchkey.
+
+## See also
+
+- [[Quick-Start]]
+- [[Python-API]]
+- [[Pipeline-Overview]]

--- a/packages/python/goldenmatch/docs/wiki/Quick-Start.md
+++ b/packages/python/goldenmatch/docs/wiki/Quick-Start.md
@@ -93,6 +93,29 @@ goldenmatch dedupe products.csv --llm-boost
 goldenmatch dedupe products.csv --llm-boost
 ```
 
+## 6. Remember Steward Decisions (Learning Memory, v1.6.0)
+
+If you have humans reviewing borderline pairs, persist their decisions so the same correction never has to be made twice.
+
+```yaml
+# add to your config
+memory:
+  enabled: true
+  backend: sqlite
+  path: .goldenmatch/memory.db
+  reanchor: true
+  dataset: customers
+```
+
+```bash
+goldenmatch dedupe customers.csv --config goldenmatch.yml   # 1. produce review queue
+goldenmatch review              --config goldenmatch.yml   # 2. steward decides
+goldenmatch dedupe customers.csv --config goldenmatch.yml   # 3. corrections apply
+# > Memory: 12 corrections applied, 0 stale, 0 stale-ambiguous, 0 unanchorable
+```
+
+Corrections re-anchor across row reorders via `record_hash`. After 10+ corrections accumulate against a matchkey, `goldenmatch memory learn` adjusts that matchkey's threshold automatically. See [[Learning-Memory]] for the full feature.
+
 ## Output Files
 
 With `--output-all`, GoldenMatch produces:


### PR DESCRIPTION
## Summary

Wires the v1.6.0 Learning Memory feature (PR #71) into evergreen documentation across the monorepo. The off-by-default posture is preserved throughout -- nothing in these docs implies users have to opt in.

## What changed by surface

**Monorepo `README.md`**
- Updated version banner to v1.6.0 (Learning Memory headline) and demoted v1.5.0 to one-liner
- New \"Why a suite?\" bullet for Learning Memory
- Bumped \"30+ MCP tools\" -> \"35+ MCP tools\"

**Package `packages/python/goldenmatch/README.md`**
- New v1.6.0 banner (v1.5.0 demoted)
- New \"Why GoldenMatch?\" bullet
- New \"Learning Memory (v1.6.0)\" subsection inside the \"All features\" expandable
- New top-level \"Learning Memory (v1.6.0)\" walkthrough section with YAML config + CLI/Python/MCP triad (placed before Auto-Config Verification)
- New row in \"Choose your path\" routing to the new docs page
- New row in CLI Reference table (\`memory stats/learn/export/import/show\`)
- Bumped MCP tool counts (30 -> 35) in two places

**Jekyll docs (`packages/python/goldenmatch/docs/`)**
- **NEW** \`learning-memory.md\` (~280 lines, nav_order 19) -- full feature documentation: walkthrough, config table, CLI/Python/MCP API, internals diagram, when-to-enable
- \`configuration.md\` -- added \`memory:\` YAML block in the full reference and a new \"Learning Memory (v1.6.0)\" section with the field table
- \`cli.md\` -- new \`memory\` subgroup section above Other commands
- \`python-api.md\` -- new \"Learning Memory (v1.6.0)\" section with \`add_correction\` / \`learn\` / \`memory_stats\` / \`get_memory\` and \`result.memory_stats\`
- \`mcp.md\` -- updated tool count to 35; new \"Learning Memory tools (v1.6.0)\" subsection listing the 5 new tools
- \`index.md\` -- new docs-table row linking to \`learning-memory\`
- \`llms.txt\` and \`llms-full.txt\` -- updated tool counts, added Learning Memory section, added \`memory:\` YAML block to the example, added \`goldenmatch memory ...\` CLI lines

**Wiki (`packages/python/goldenmatch/docs/wiki/`)**
- **NEW** \`Learning-Memory.md\` -- wiki-flavored version of the feature page (uses \`[[Page]]\` link convention)
- \`Home.md\` -- TOC link under Advanced Features and CLI command row
- \`Quick-Start.md\` -- new \"6. Remember Steward Decisions\" step

**CHANGELOG**
- Verified existing \`[1.6.0]\` entry from PR #71 already covers the shipped surfaces; no edits needed.

## Wiki sync needed

The wiki files in \`packages/python/goldenmatch/docs/wiki/\` need to be cp'd into the local wiki clone and pushed to the wiki repo (separate operation, not done by this PR). Files awaiting sync:

- \`packages/python/goldenmatch/docs/wiki/Learning-Memory.md\` (new page)
- \`packages/python/goldenmatch/docs/wiki/Home.md\` (modified)
- \`packages/python/goldenmatch/docs/wiki/Quick-Start.md\` (modified)

## Judgment calls

- Did not invent a sidebar in \`_includes/\` -- no sidebar exists today; the theme reads nav from index.md and frontmatter \`nav_order\`. Set \`nav_order: 19\` for the new page (slots between MCP Server at 18 and the rest).
- Kept the v1.5.0 banner content in the package README (demoted to one line) rather than deleting it; the docs are evergreen and the verification layer is still on by default.
- Did not touch \`docs/superpowers/\`, \`packages/python/goldencheck/\`, or anything outside the listed surfaces.

## Test plan

- [ ] Visual review of the Jekyll diff at https://benzsevern.github.io/goldenmatch/learning-memory once Pages rebuilds
- [ ] Confirm internal links resolve (\`{% link learning-memory.md %}\` in configuration.md, cli.md, python-api.md, mcp.md)
- [ ] Wiki sync (cp + push) tracked separately

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>