### PR TITLE
docs(claude-md): record session learnings (post-fold workflows, memory invariants)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# Golden Suite monorepo
+
+Polyglot monorepo: `packages/{python,rust,typescript,dbt,actions}`. Per-package CLAUDE.md files own package-specific context.
+
+## TypeScript: pnpm + Turborepo (post-2026-05-02 fold)
+- `pnpm@9.15.0` pinned in root `package.json` (exact semver — Corepack rejects `9.x` ranges).
+- Windows: enable Developer Mode for pnpm symlinks. Fallback if `corepack enable` needs admin: `npm i -g pnpm@9.15.0`.
+- `.npmrc` carries two non-default settings with rationale comments — do NOT remove without reading them: `node-linker=hoisted` (turbo platform-binary conflict on Windows) and `auto-install-peers=false` (pnpm 8+ auto-installs optional peers, breaking goldenmatch fallback-path tests).
+- Local: `pnpm install` → `pnpm turbo run build test typecheck` (lint dropped from CI invocation — currently identical to typecheck via `tsc --noEmit`).
+
+## CI (.github/workflows/ci.yml)
+- Pytest step uses `--timeout=120 --timeout-method=thread`. PR #66 hit a goldencheck pytest hang on Linux that didn't reproduce locally — timeout converts hangs into actionable failures.
+- Pytest is `continue-on-error: true` per matrix package. Per-package `--ignore` lists in the case statement mirror each package's pre-fold tuning (see each `packages/python/<pkg>/CLAUDE.md` for the canonical list).
+- Single TS job (not matrix) — relies on `pnpm-lock.yaml` being committed. PPRL tests in `packages/typescript/goldenmatch/tests/unit/pprl-protocol.test.ts` need 30s/45s timeouts under the post-fold shared-runner CI (was 5s/15s on dedicated runners).
+
+## Railway: goldenmatch-mcp service
+- Project `golden-suite-mcp`, service `goldenmatch-mcp`, env `production`. IDs in `packages/python/goldenmatch/.railway/` after `railway link`.
+- Build/deploy config pinned in `packages/python/goldenmatch/railway.json`. Service `rootDirectory='packages/python/goldenmatch'` set via Railway GraphQL — DO NOT revert unless also moving `Dockerfile.mcp` back to repo root.
+- Access token: `~/.railway/config.json` → `user.accessToken`. GraphQL endpoint: `https://backboard.railway.com/graphql/v2`.
+- Status check: `cd packages/python/goldenmatch && railway deployment list | head -5`. Build logs: `railway logs --build <deployment-id>`.
+
+## ghcr.io packages
+- `publish-containers.yml` builds 7 images. 6 are new (created by this monorepo's GITHUB_TOKEN, default permissions). `goldenmatch-extensions` pre-existed from the standalone repo — its "Manage Actions access" must explicitly grant `benzsevern/goldenmatch` write role, or pushes fail with `permission_denied: write_package`.
+
+## Performance audit (docs/superpowers/specs/2026-05-02-performance-audit-checklist.md)
+- **Lesson:** the audit ranked items by static counts (boundary crossings, sequential ops). 3 of 3 measured items came in well under the framing. **Always measure wall-clock with the workload of interest before designing.** cProfile cumtime != wall (especially with threading); compare 5-run median wall on real shapes.
+
+## CI poll loop pattern
+`gh pr checks <N> | grep -qv pending` is WRONG (returns true on the first non-pending line). Use `while gh pr checks <N> | grep -qE "pending|in_progress"; do sleep 30; done`.
+
+## `gh pr merge` under GitHub 502
+First call may 502; second says "Merge already in progress" while PR state stays `OPEN`. The merge lands asynchronously seconds later. Poll with `until [ "$(gh pr view N --json state -q .state)" != "OPEN" ]; do sleep 10; gh pr merge N --squash --delete-branch 2>/dev/null || true; done` rather than treating the second error as terminal.
+
+## CI step `continue-on-error: true` and step `conclusion`
+`gh run view --json` reports `conclusion: success` for steps with `continue-on-error: true` regardless of the real exit code. Don't trust per-step JSON to gauge whether pytest is green — grep raw logs (`gh run view <id> --log | grep -E "passed|failed,"`) for the pytest summary line.
+
+## `pytest -n auto` worker isolation
+xdist runs each test in a worker process. Tests cannot share registry/global-state side effects (e.g. `register_transform` in test A is invisible to test B). Make every test self-contained — register inside the test that asserts.
+
+## Test fixture paths: CWD differs by environment
+Local CWD = package dir (e.g. `packages/python/goldencheck`); CI CWD = repo root. Bare relative paths like `Path("tests/fixtures/simple.csv")` pass locally and fail in CI. Anchor to `__file__`: `Path(__file__).parent.parent / "fixtures" / "simple.csv"`.
+
+## GitHub auth
+- `benzsevern/*` repos use personal account `benzsevern`, not work `benzsevern-mjh`. Always `gh auth switch --user benzsevern` before push, switch back after.
+
+## Post-fold GitHub Actions
+Only `.github/workflows/` at the repo root runs. Workflow files left under `packages/python/<pkg>/.github/workflows/` from pre-fold repos are orphaned (silently ignored). v1.6.0 release shipped no PyPI publish until `publish-goldenmatch.yml` was added at the root.
+- `publish-goldenmatch.yml` — fires on `release: published` for `v*` tags (skips `goldenmatch-js-v*`); `workflow_dispatch` with `ref` input for retro-publish. Uses `PYPI_TOKEN` (trusted publishing not configured).
+
+## Pre-fold archive
+`_archive/goldenmatch-pre-fold/` retains the standalone repo's git history. Old specs/plans under `_archive/goldenmatch-pre-fold/docs/superpowers/` are sometimes the foundation for current work — search there before assuming a feature is undesigned.
+
+## `gh` field-name gotchas
+- `gh repo view --json topics` errors; the field is `repositoryTopics` (object array, `.repositoryTopics | map(.name)`).
+- `gh release create --notes` body rejects em-dashes via the API (422). Keep release notes ASCII like everything else.

--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -306,7 +306,12 @@ Hosted on Railway, registered on Smithery:
 - GitHub Pages: docs workflow uses `actions/jekyll-build-pages` with source `./docs`, Just the Docs theme
 - GitHub Release triggers publish.yml workflow which auto-publishes to PyPI via trusted publishing
 - Scored pairs are canonicalized as `(min(id_a, id_b), max(id_a, id_b))` throughout cluster.py, graph.py, chunked.py, ann_blocker.py -- any new code storing/looking up pairs must canonicalize too
-- v2.0 Learning Memory: PR #9 merged. Core modules shipped (store, corrections, learner). Remaining: pipeline integration (hook after scoring), collection point wiring (review_queue, boost_tab, unmerge, llm_scorer, agent_tools, REST), CLI subcommands (memory stats/learn/export/import), MCP tools. Spec: `docs/superpowers/specs/2026-03-26-learning-memory-design.md`. Plan: `docs/superpowers/plans/2026-03-26-learning-memory-implementation.md`
+- v1.6.0 Learning Memory: end-to-end loop wired. Pipeline applies corrections + learned thresholds; 7 collection points (ReviewQueue, BoostTab, unmerge_record/cluster, LLM scorer, agent_approve_reject, REST `/reviews/decide`, Python API); 5 MCP tools (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`); CLI subgroup `goldenmatch memory ...`. Spec: `docs/superpowers/specs/2026-05-04-learning-memory-completion.md` (foundation: pre-fold 2026-03-26 spec).
+- `record_hash` excludes `__row_id__` so corrections survive row reordering across runs (the durability invariant; including it would defeat re-anchoring).
+- `Correction.source` and `Correction.decision` are `StrEnum`s in `core/memory/store.py`. Trust mapping lives in `HIGH_TRUST_SOURCES` + `trust_for_source(source)` — use these instead of inline `if source in {...}: trust = 1.0`.
+- `MemoryConfig.dataset` field validator strips whitespace and rejects empty strings; pass `None` to omit.
+- `apply_corrections` reanchor builds `record_hash → list[row_id]` via `pl.concat_str` + `map_elements` (vectorized O(N)). Ambiguous re-anchors counted as `stale_ambiguous`, never silently misapplied.
+- PyPI publish: `publish-goldenmatch.yml` lives at the **monorepo root**, not under this package. Trusted publishing NOT configured — uses `PYPI_TOKEN` secret. To enable trusted publishing later, claim PyPI publisher: owner `benzsevern`, repo `goldenmatch`, workflow `publish-goldenmatch.yml`, environment `pypi`.
 
 ## API Quick Reference
 


### PR DESCRIPTION
Captures what would have helped earlier in this session.

## Monorepo CLAUDE.md (also: now actually committed — was untracked until this PR)

- Post-fold GitHub Actions: only repo-root `.github/workflows/` runs; orphaned package-level workflows silently ignored. Cost a release cycle to find.
- `publish-goldenmatch.yml` location + PYPI_TOKEN auth path.
- `_archive/goldenmatch-pre-fold/` as a legitimate spec foundation source.
- `gh` field-name gotchas: `repositoryTopics` (not `topics`); release-notes em-dashes hit 422.

## Package CLAUDE.md

- Replace stale "v2.0 Learning Memory: Remaining: ..." line with the v1.6.0 end-to-end summary.
- Pin the load-bearing invariants: `record_hash` excludes `__row_id__`; `Correction.source`/`Decision` are `StrEnum`s with `trust_for_source` helper; `MemoryConfig.dataset` validator strips+rejects empty; reanchor algorithm shape.
- Trusted-publishing setup metadata for whoever claims it later.