### PR TITLE
ci: add npm publish workflow for goldenmatch-js (post-fold)

### DIFF
--- a/.github/workflows/publish-goldenmatch-js.yml
+++ b/.github/workflows/publish-goldenmatch-js.yml
@@ -1,0 +1,73 @@
+name: Publish goldenmatch-js to npm
+
+on:
+  push:
+    tags:
+      - "goldenmatch-js-v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      dry-run:
+        description: "Pack and validate without publishing"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/typescript/goldenmatch
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: pnpm
+
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit
+
+      - name: Test
+        run: pnpm exec vitest run
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Verify version matches tag
+        if: startsWith(github.ref, 'refs/tags/goldenmatch-js-v')
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/goldenmatch-js-v}"
+          PKG_VERSION=$(jq -r .version package.json)
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version OK: $PKG_VERSION"
+
+      - name: Pack (dry-run)
+        if: github.event.inputs.dry-run == 'true'
+        run: pnpm pack --dry-run
+
+      - name: Publish to npm
+        if: github.event.inputs.dry-run != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --access public --provenance --no-git-checks


### PR DESCRIPTION
Mirrors the post-fold workflow fix that landed for the Python package in PR #72 / #73. The pre-fold `publish-npm.yml` was orphaned at `packages/python/goldenmatch/.github/workflows/` (note: awkwardly under the Python package even though it publishes the TS port — a pre-fold artifact). GitHub Actions only honors the repo-root `.github/workflows/`.

## What this PR adds

`.github/workflows/publish-goldenmatch-js.yml` at the monorepo root:
- Fires on push of tags matching `goldenmatch-js-v*` (won't trigger on Python `v*` tags)
- Supports `workflow_dispatch` with optional `ref` input for retro-publish (lets us trigger on the v0.4.0 tag if needed)
- Supports `dry-run` mode to pack and validate without publishing
- Builds from `packages/typescript/goldenmatch/` via `working-directory`
- Uses pnpm with `--frozen-lockfile` (matches monorepo CI pattern)
- Verifies tag version matches package.json before publishing
- Uses existing `NPM_TOKEN` secret (npm trusted publishing not yet configured)

## Test plan

- [x] Pre-existing CI checks remain green (no source changes; workflow file only)
- [ ] After merge, push tag `goldenmatch-js-v0.4.0` to trigger publish
- [ ] If the trusted-publishing path needs configuration later, claim it at npm: package `goldenmatch`, owner `benzsevern`, workflow `publish-goldenmatch-js.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)