### PR TITLE
docs(readme): banner reflects v0.4.0 npm + v1.6.0 cross-language parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install goldenmatch && goldenmatch dedupe customers.csv
 npm install goldenmatch
 ```
 
-> **🆕 v1.6.0 (Python)** — **Learning Memory** is now wired end-to-end in GoldenMatch. Steward decisions, unmerges, LLM votes, and agent approvals persist to a local store and apply automatically on the next run; corrections re-anchor across row reorders via record-hash. New CLI subgroup, 5 new MCP tools (35 total), and Python `add_correction()` / `learn()` / `memory_stats()`. Off by default. See [Learning Memory docs](https://benzsevern.github.io/goldenmatch/learning-memory).
+> **🆕 v1.6.0 (Python) + v0.4.0 (npm) — cross-language Learning Memory parity** — **Learning Memory** now ships in both runtimes. A correction written by Python applies identically in TypeScript and vice versa: byte-identical SHA-256 hashes, the same SQLite schema, the same collision-safe re-anchor algorithm, verified every CI run by JSON + SQLite + apply-outcome parity tests on both sides. Steward decisions, unmerges, LLM votes, and agent approvals persist to a local store, re-anchor across row reorders via record-hash, and apply automatically on the next run. Each runtime ships its own CLI subgroup (`goldenmatch memory` / `goldenmatch-js memory`), MCP tools (35 Python / 24 TS), and programmatic API (`add_correction()` / `learn()` / `memory_stats()`). Off by default. See [Learning Memory docs](https://benzsevern.github.io/goldenmatch/learning-memory).
 >
 > v1.5.0 — auto-config preflight + postflight verification layer. Built by [Ben Severn](https://bensevern.dev).
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -45,7 +45,7 @@ pip install goldenmatch && goldenmatch dedupe customers.csv
 npm install goldenmatch
 ```
 
-> **🆕 v1.6.0 (Python)** — **Learning Memory** is wired end-to-end. Steward decisions, unmerges, LLM votes, and agent approvals persist to a local SQLite (or Postgres) store, re-anchor across row reorders, and apply automatically on the next run. The pipeline reports `Memory: N applied, M stale, K stale-ambiguous, J unanchorable` in postflight. New CLI subgroup `goldenmatch memory`, five new MCP tools, and Python `goldenmatch.add_correction()` / `learn()` / `memory_stats()`. Off by default. See [Learning Memory](#learning-memory-v160).
+> **🆕 v1.6.0 (Python) + v0.4.0 (npm) — cross-language Learning Memory parity** — A correction written by Python applies identically in TypeScript and vice versa: byte-identical SHA-256 hashes, the same SQLite schema, the same collision-safe re-anchor algorithm, verified every CI run by JSON + SQLite + apply-outcome parity tests on both sides. Steward decisions, unmerges, LLM votes, and agent approvals persist to a local SQLite store, re-anchor across row reorders via record-hash, and apply automatically on the next run. The pipeline reports `Memory: N applied, M stale, K stale-ambiguous, J unanchorable` in postflight. New CLI subgroup `goldenmatch memory` (and `goldenmatch-js memory` in TS), five new MCP tools per runtime, and `goldenmatch.add_correction()` / `learn()` / `memory_stats()`. Off by default. See [Learning Memory](#learning-memory-v160).
 >
 > v1.5.0 — Auto-config preflight + postflight verification layer (still on by default). See [Auto-Config Verification](#auto-config-verification-v150). Built by [Ben Severn](https://bensevern.dev).
 


### PR DESCRIPTION
Both top-level and package READMEs now lead with the cross-language parity story now that goldenmatch-js v0.4.0 has shipped on npm.

A correction written by Python applies identically in TypeScript and vice versa, verified by JSON + SQLite + apply-outcome parity tests on every CI run.