### PR TITLE
fix(ts-ci): hoist vite to root so per-package vitest can resolve it

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "turbo run clean"
   },
   "devDependencies": {
-    "turbo": "^2.0.0"
+    "turbo": "^2.0.0",
+    "vite": "^8.0.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       turbo:
         specifier: ^2.0.0
         version: 2.9.7
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(yaml@2.8.4)
 
   packages/python/goldenmatch/web/frontend:
     dependencies:


### PR DESCRIPTION
## Why

After #85 (web UI) merged, the \`typescript\` CI job started failing on every push:

\`\`\`
ERR_MODULE_NOT_FOUND: Cannot find package 'vite' imported from
node_modules/vitest/dist/chunks/cli-api.Cjt90eJu.js
\`\`\`

Reproduces locally: \`cd packages/typescript/goldencheck-types && pnpm test\`.

## Cause

The TS packages each declare \`vitest ^4.1.0\` but no \`vite\`. With \`node-linker=hoisted\` + \`auto-install-peers=false\` (both deliberate, see \`.npmrc\`), pnpm doesn't promote vite to root on behalf of vitest's peer requirement. Before #85 something else was probably providing vite at root incidentally. Now that the new \`web/frontend\` workspace pins \`vite ^8\` for its own use, vite lands inside that workspace's resolution tree but doesn't reach root, so the per-package vitest invocations all fail at startup.

## Fix

Declare \`vite ^8.0.10\` at the root \`package.json\` devDeps. Pinned to the same major as \`web/frontend\` so the lockfile stays single-versioned.

## Test plan

- [x] Local repro: \`pnpm turbo run build test typecheck\` -> 17/17 tasks pass.
- [ ] CI \`typescript\` job goes green.
- [ ] No knock-on effects on the \`web_ui_e2e\` job.