### PR TITLE
docs(readme): web inspector hero + Discussions / Last commit / Web UI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,19 @@
 <!-- Ecosystem -->
 [![Docs](https://img.shields.io/badge/docs-bensevern.dev-d4a017)](https://bensevern.dev/)
 [![Wiki](https://img.shields.io/badge/wiki-github-d4a017)](https://github.com/benzsevern/goldenmatch/wiki)
+[![Web UI](https://img.shields.io/badge/web%20ui-FastAPI%20%2B%20React-d4a017?logo=react&logoColor=white)](https://github.com/benzsevern/goldenmatch/wiki/Web-UI)
 [![Smithery MCP](https://img.shields.io/badge/MCP-smithery-6e40c9)](https://smithery.ai/servers/benzsevern/goldenmatch)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/benzsevern/goldenmatch/blob/main/packages/python/goldenmatch/scripts/gpu_colab_notebook.ipynb)
 
+<!-- Activity -->
+[![GitHub Discussions](https://img.shields.io/github/discussions/benzsevern/goldenmatch?color=d4a017&logo=github&label=discussions)](https://github.com/benzsevern/goldenmatch/discussions)
+[![Last commit](https://img.shields.io/github/last-commit/benzsevern/goldenmatch?color=d4a017&label=last%20commit)](https://github.com/benzsevern/goldenmatch/commits/main)
+
 </div>
 
-![GoldenMatch Demo](packages/python/goldenmatch/docs/screenshots/demo.svg)
+[![GoldenMatch web workbench — pair drilldown with NL prose](packages/python/goldenmatch/docs/screenshots/web/web-inspector.png)](https://github.com/benzsevern/goldenmatch/wiki/Web-UI)
+
+<p align="center"><sub><em>Pair drilldown in the web workbench: cluster members, field-level diff, and a one-line NL explanation per pair. <code>pip install goldenmatch[web]</code> then <code>goldenmatch serve-ui &lt;project&gt;</code>. <a href="https://github.com/benzsevern/goldenmatch/wiki/Web-UI">More screenshots →</a></em></sub></p>
 
 ```bash
 # Headline package: dedupe a CSV in 30 seconds

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -35,7 +35,9 @@
 
 </div>
 
-![GoldenMatch Demo](docs/screenshots/demo.svg)
+[![GoldenMatch web workbench — pair drilldown with NL prose](docs/screenshots/web/web-inspector.png)](#web-ui)
+
+<p align="center"><sub><em>Pair drilldown in the web workbench: cluster members, field-level diff, and a one-line NL explanation per pair. <code>pip install goldenmatch[web]</code> then <code>goldenmatch serve-ui &lt;project&gt;</code>. <a href="#web-ui">More screenshots →</a></em></sub></p>
 
 ```bash
 # Python


### PR DESCRIPTION
## Hero swap

The old \`packages/python/goldenmatch/docs/screenshots/demo.svg\` was a hand-drawn terminal mockup with fake names. The new hero is the real Inspector screenshot — actual entity resolution happening in the web workbench, with a one-line NL prose explanation above the field-level diff (\"Match (identical, score 0.98): name are identical...\").

Stronger first impression. Click-through to the [Web UI wiki page](https://github.com/benzsevern/goldenmatch/wiki/Web-UI).

Same swap on the package README.

| Before | After |
|---|---|
| Hand-drawn terminal mockup with fake names | Real screenshot: cluster + field diff + NL prose explanation |

## New badges

Added three to a new \"Activity\" row:

| Badge | Why |
|---|---|
| \`GitHub Discussions\` | Community signal; auto-updates as new threads land. |
| \`Last commit\` | Signals active development at a glance. |
| \`Web UI\` (custom) | Highlights the new \`pip install goldenmatch[web]\` capability with a link to the wiki page. |

The existing 16 badges (packages, quality, downloads, ecosystem) are unchanged.

## Test plan

- [x] Markdown renders correctly locally
- [ ] Image loads in GitHub README on PR preview
- [ ] All three new badges resolve (shields.io endpoints)

## What didn't change

- The old \`demo.svg\` file stays on disk. Nothing else references it but removing would break any external deep-links from old blog posts / tweets / wiki entries that pointed at it directly.