### PR TITLE
docs: fix mermaid node overflow (short labels + role table)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,21 +66,29 @@ Each tool stands alone, but they compose into a single pipeline:
 
 ```mermaid
 flowchart LR
-    raw["raw rows<br/><sub>(any schema)</sub>"]
-    golden["golden records"]
+    raw([raw rows])
+    golden([golden records])
 
     subgraph orchestration ["GoldenPipe orchestrates"]
         direction LR
-        infermap["InferMap<br/><sub>schema mapping</sub>"]
-        goldencheck["GoldenCheck<br/><sub>profile + validate</sub>"]
-        goldenflow["GoldenFlow<br/><sub>standardize + transform</sub>"]
-        goldenmatch["GoldenMatch<br/><sub>dedupe + cluster + survivorship</sub>"]
+        infermap[InferMap]
+        goldencheck[GoldenCheck]
+        goldenflow[GoldenFlow]
+        goldenmatch[GoldenMatch]
         infermap --> goldencheck --> goldenflow --> goldenmatch
     end
 
     raw --> infermap
     goldenmatch --> golden
 ```
+
+| Step | Role |
+|---|---|
+| **InferMap** | schema mapping — auto-aligns columns across heterogeneous sources |
+| **GoldenCheck** | profile + validate — encoding, format, anomaly detection |
+| **GoldenFlow** | standardize + transform — phone, date, address, categorical normalization |
+| **GoldenMatch** | dedupe + cluster + survivorship — fuzzy / exact / probabilistic / LLM |
+| **GoldenPipe** | orchestrator — declarative YAML pipeline wiring the four steps |
 
 - **Zero-config defaults that admit when they're unsure** — every step has a self-verifying preflight + postflight; results carry an inspectable report instead of failing silently.
 - **97.2% F1 on DBLP-ACM out of the box** for entity resolution. [DQBench ER score: 95.30](https://github.com/benzsevern/dqbench).


### PR DESCRIPTION
The mermaid diagram from #89 had its node text cropped: \"InferMap schema mapp\", \"GoldenChecl\", \"GoldenMatch dedupe + cluster + survivc\", \"golden\".

Two reasons:
- The \`<sub>\` HTML tag inside mermaid labels doesn't reliably render — some renderers show it literally, others ignore the styling but still count its bytes against width.
- Mermaid's auto-sized nodes use the longest line for width. The two-line labels ended up wider than the renderer's column allowance, especially on narrower viewports.

Fix: strip nodes to single-word labels, move per-step explanations into a Markdown table directly below the diagram. Same info, no rendering risk. Stadium shape (\`([...])\`) on the raw / golden nodes visually distinguishes I/O from the four orchestrated processing steps.

## Test plan

- [x] Mermaid renders cleanly on GitHub PR preview.
- [ ] CI: only \`changes\` job runs (this is a doc-only PR — verifies the path filter from #89 actually works).