### PR TITLE
release: goldenmatch (Python) 1.6.0 -> 1.7.0 (web workbench)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 
 # ── High-level API (convenience functions) ────────────────────────────────
 from goldenmatch._api import (

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.6.0"
+version = "1.7.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Ships the localhost web workbench (PRs #85, #87, #88, #89, #90, #91) to PyPI.

\`\`\`bash
pip install 'goldenmatch[web]'
goldenmatch serve-ui my-project   # opens http://localhost:5050
\`\`\`

The README banner has advertised v1.7.0 since #88 — this PR catches the published version up to it.

## Changelog

- **v1.7.0 — web workbench.** \`goldenmatch[web]\` extra ships a localhost FastAPI + React workbench. Edit matchkey / standardization / blocking rules with live Pydantic validation, run sampled previews, save back to \`goldenmatch.yml\`. Inspect saved runs with NL prose explanations. One-to-many \`match\` workflow, run-vs-run comparison (CCMS), parameter sensitivity sweeps, Learning Memory browser. See [packages/python/goldenmatch/README.md#web-ui](packages/python/goldenmatch/README.md#web-ui).

## Release plan

- [ ] Merge this PR.
- [ ] Tag \`v1.7.0\` at the merge commit (\`git tag v1.7.0 && git push origin v1.7.0\`) — or use the GitHub UI \"Draft a new release\" with tag \`v1.7.0\`.
- [ ] \`publish-goldenmatch.yml\` fires on \`release: published\` and pushes to PyPI via \`PYPI_TOKEN\`.
- [ ] PyPI JSON API takes ~20s to reflect the new version after the workflow completes.

## Test plan

- [x] Versions match in both \`pyproject.toml\` and \`goldenmatch/__init__.py\`.
- [ ] CI green (path-filter triggers \`python (goldenmatch)\` and \`web_ui_e2e\` because pyproject.toml is in the web filter).