### PR TITLE
ci: publish workflows for goldencheck, goldenpipe, infermap, goldencheck-types

### DIFF
--- a/.github/workflows/publish-goldencheck-types-js.yml
+++ b/.github/workflows/publish-goldencheck-types-js.yml
@@ -1,0 +1,73 @@
+name: Publish goldencheck-types to npm
+
+on:
+  push:
+    tags:
+      - "goldencheck-types-js-v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      dry-run:
+        description: "Pack and validate without publishing"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/typescript/goldencheck-types
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: pnpm
+
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit
+
+      - name: Test
+        run: pnpm exec vitest run
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Verify version matches tag
+        if: startsWith(github.ref, 'refs/tags/goldencheck-types-js-v')
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/goldencheck-types-js-v}"
+          PKG_VERSION=$(jq -r .version package.json)
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version OK: $PKG_VERSION"
+
+      - name: Pack (dry-run validation)
+        if: github.event.inputs.dry-run == 'true'
+        run: pnpm pack
+
+      - name: Publish to npm
+        if: github.event.inputs.dry-run != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --access public --provenance --no-git-checks

--- a/.github/workflows/publish-goldencheck-types.yml
+++ b/.github/workflows/publish-goldencheck-types.yml
@@ -1,0 +1,40 @@
+name: Publish goldencheck-types to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    # Only run for goldencheck-types-v* tags. Skip goldencheck-v* (handled
+    # by publish-goldencheck.yml) and goldencheck-types-js-v* (npm).
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.release.tag_name, 'goldencheck-types-v') && !startsWith(github.event.release.tag_name, 'goldencheck-types-js-v'))
+    runs-on: ubuntu-latest
+    environment: pypi
+    defaults:
+      run:
+        working-directory: packages/python/goldencheck-types
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/python/goldencheck-types/dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true

--- a/.github/workflows/publish-goldencheck.yml
+++ b/.github/workflows/publish-goldencheck.yml
@@ -1,0 +1,40 @@
+name: Publish goldencheck to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    # Only run for goldencheck-v* tags. Skip goldencheck-types-v*
+    # (handled by publish-goldencheck-types.yml) and other package tags.
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.release.tag_name, 'goldencheck-v') && !startsWith(github.event.release.tag_name, 'goldencheck-types-v'))
+    runs-on: ubuntu-latest
+    environment: pypi
+    defaults:
+      run:
+        working-directory: packages/python/goldencheck
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/python/goldencheck/dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true

--- a/.github/workflows/publish-goldenpipe.yml
+++ b/.github/workflows/publish-goldenpipe.yml
@@ -1,0 +1,39 @@
+name: Publish goldenpipe to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    # Only run for goldenpipe-v* tags.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenpipe-v')
+    runs-on: ubuntu-latest
+    environment: pypi
+    defaults:
+      run:
+        working-directory: packages/python/goldenpipe
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/python/goldenpipe/dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true

--- a/.github/workflows/publish-infermap-js.yml
+++ b/.github/workflows/publish-infermap-js.yml
@@ -1,0 +1,76 @@
+name: Publish infermap to npm
+
+on:
+  push:
+    tags:
+      - "infermap-js-v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      dry-run:
+        description: "Pack and validate without publishing"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/typescript/infermap
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: pnpm
+
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit
+
+      - name: Test
+        run: pnpm exec vitest run
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Verify version matches tag
+        if: startsWith(github.ref, 'refs/tags/infermap-js-v')
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/infermap-js-v}"
+          PKG_VERSION=$(jq -r .version package.json)
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version OK: $PKG_VERSION"
+
+      - name: Pack (dry-run validation)
+        if: github.event.inputs.dry-run == 'true'
+        # pnpm pack always writes a .tgz; running it in dry-run validates the
+        # package can be packed cleanly (file list, entry points, version)
+        # without publishing. The artifact is discarded on job teardown.
+        run: pnpm pack
+
+      - name: Publish to npm
+        if: github.event.inputs.dry-run != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --access public --provenance --no-git-checks

--- a/.github/workflows/publish-infermap.yml
+++ b/.github/workflows/publish-infermap.yml
@@ -1,0 +1,40 @@
+name: Publish infermap to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    # Only run for infermap-v* tags. Skip infermap-js-v* (handled by
+    # publish-infermap-js.yml) and other package tags.
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.release.tag_name, 'infermap-v') && !startsWith(github.event.release.tag_name, 'infermap-js-v'))
+    runs-on: ubuntu-latest
+    environment: pypi
+    defaults:
+      run:
+        working-directory: packages/python/infermap
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/python/infermap/dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
Closes the publish-workflow gap flagged in CLAUDE.md ("Post-fold GitHub Actions"). Today only \`publish-goldenmatch.yml\` exists; tagging \`goldencheck-v1.2.0\` would do nothing.

## What's added

| Workflow | Trigger | Target |
|---|---|---|
| \`publish-goldencheck.yml\` | \`goldencheck-v*\` release | PyPI |
| \`publish-goldenpipe.yml\` | \`goldenpipe-v*\` release | PyPI |
| \`publish-infermap.yml\` | \`infermap-v*\` release | PyPI |
| \`publish-goldencheck-types.yml\` | \`goldencheck-types-v*\` release | PyPI |
| \`publish-infermap-js.yml\` | \`infermap-js-v*\` tag push | npm |
| \`publish-goldencheck-types-js.yml\` | \`goldencheck-types-js-v*\` tag push | npm |

Modeled on existing \`publish-goldenmatch.yml\` (Python) and \`publish-goldenmatch-js.yml\` (npm). Same secrets (\`PYPI_TOKEN\`, \`NPM_TOKEN\`).

## Tag-prefix collision guards

The release-trigger pattern is checked with \`startsWith\` and an explicit \`!startsWith\` for sibling prefixes:
- \`publish-goldencheck.yml\` skips \`goldencheck-types-v*\`.
- \`publish-infermap.yml\` skips \`infermap-js-v*\`.
- \`publish-goldencheck-types.yml\` skips \`goldencheck-types-js-v*\`.

So \`goldencheck-v1.2.0\` and \`goldencheck-types-v0.1.0\` can never accidentally cross-publish.

## Why land before #53?

The \`goldencheck-types\` workflow references \`packages/python/goldencheck-types/\` — a directory that only exists on the \`feat/infermap-handoff\` branch. That's fine: the workflow file is dormant until a \`goldencheck-types-v*\` tag is pushed (which only makes sense post-#53-merge). Landing the workflow on main now means the release SOP is unblocked the moment #53 lands.

## Pre-flight before first releases

Each Python package needs PyPI Trusted Publisher claim (or the \`PYPI_TOKEN\` secret to cover them). Today only \`goldenmatch\` is configured; the new packages will need the same setup before \`goldencheck-v1.2.0\` etc. fires successfully. The workflow uses \`skip-existing: true\` so a duplicate tag won't fail.

## Test plan

- [x] All 9 publish workflows parse cleanly (\`yaml.safe_load\` on each).
- [ ] CI green (workflow-only PR; \`changes\` job + \`action\` will run, no other jobs).
- [ ] After #53 merges and \`goldencheck-types-v0.1.0\` is tagged, the PyPI publish fires (separate PR / verification).