### PR TITLE
fix(release): goldenmatch wheel build (1.7.0 -> 1.7.1)

### DIFF
--- a/.github/workflows/publish-goldenmatch.yml
+++ b/.github/workflows/publish-goldenmatch.yml
@@ -29,9 +29,25 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      # Build the web frontend BEFORE the wheel build so the staged dist
+      # files (gitignored under goldenmatch/web/static/) are present and
+      # `packages = ["goldenmatch"]` picks them up. Without this step the
+      # wheel ships only `.gitkeep` and `goldenmatch[web]` users can't
+      # serve the UI without running build_web.py themselves.
+      - name: Install pnpm workspace deps
+        working-directory: ${{ github.workspace }}
+        run: pnpm install --frozen-lockfile
+      - name: Build + stage web frontend
+        working-directory: ${{ github.workspace }}
+        run: python packages/python/goldenmatch/scripts/build_web.py
       - run: pip install build
       - run: python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 
 # ── High-level API (convenience functions) ────────────────────────────────
 from goldenmatch._api import (

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.7.0"
+version = "1.7.1"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -109,8 +109,14 @@ all = [
 [tool.hatch.build.targets.wheel]
 packages = ["goldenmatch"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"goldenmatch/web/static" = "goldenmatch/web/static"
+# `packages = ["goldenmatch"]` already collects everything inside
+# goldenmatch/, including web/static/. A force-include here would re-add
+# the same files and PyPI rejects the wheel with "Duplicate filename in
+# local headers" (this caused the v1.7.0 publish to fail).
+#
+# The publish workflow runs scripts/build_web.py before `python -m build`
+# so the static dir contains the staged frontend at wheel-build time —
+# packages picks them up automatically.
 
 [project.scripts]
 goldenmatch = "goldenmatch.cli.main:app"


### PR DESCRIPTION
The v1.7.0 publish run failed at PyPI upload with \"400 Invalid distribution file. ZIP archive not accepted: Duplicate filename in local headers.\"

## Root causes

1. **Duplicate `goldenmatch/web/static/.gitkeep`.** \`packages = [\"goldenmatch\"]\` already collects everything under \`goldenmatch/\`, including \`web/static/\`. The \`[tool.hatch.build.targets.wheel.force-include]\` rule targeted the same path, so hatch packed \`.gitkeep\` twice. PyPI's wheel validator rejects duplicates with HTTP 400.
2. **Workflow never built the frontend.** Even if the wheel had built clean, \`publish-goldenmatch.yml\` ran \`python -m build\` directly without first calling \`scripts/build_web.py\`. The wheel would have shipped only \`.gitkeep\` under \`web/static/\` — \`goldenmatch[web]\` users would install the CLI but find no UI assets.

## Fixes

- Drop the redundant \`force-include\` from \`packages/python/goldenmatch/pyproject.toml\`.
- Add pnpm + Node setup + \`python packages/python/goldenmatch/scripts/build_web.py\` steps to \`publish-goldenmatch.yml\` before \`python -m build\`.
- Bump 1.7.0 → 1.7.1. The failed v1.7.0 release exists on GitHub but PyPI never received 1.7.0; v1.7.1 supersedes cleanly. (Tried to clean up the GitHub Release/tag but ran into auth flakiness; v1.7.1 is the lower-friction path.)

## Local verification

\`\`\`
$ python scripts/build_web.py            # stages web/frontend dist into goldenmatch/web/static/
$ python -m build                         # builds wheel + sdist
$ python -c \"import zipfile; ...\"        # 198 files, 5 under web/static/, no duplicates
\`\`\`

After merge: tag v1.7.1 + GitHub Release → publish-goldenmatch.yml fires → PyPI ships 1.7.1 with `[web]` extra functional.

## Test plan

- [x] Local wheel build clean (no duplicates, web/static/ contains staged frontend).
- [ ] CI green.
- [ ] Tag v1.7.1 + Release → PyPI 1.7.1 live.