### PR TITLE
release(infermap): 0.4.0

### DIFF
--- a/packages/python/infermap/infermap/__init__.py
+++ b/packages/python/infermap/infermap/__init__.py
@@ -1,6 +1,6 @@
 """infermap — inference-driven schema mapping engine."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 from infermap.types import FieldInfo, FieldMapping, MapResult, SchemaInfo, ScorerResult
 from infermap.errors import ApplyError, ConfigError, InferMapError

--- a/packages/python/infermap/pyproject.toml
+++ b/packages/python/infermap/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "infermap"
-version = "0.3.2"
+version = "0.4.0"
 description = "Inference-driven schema mapping engine"
 readme = "README.md"
 license = "MIT"

--- a/packages/typescript/infermap/package.json
+++ b/packages/typescript/infermap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infermap",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Schema-to-schema field mapping engine. TypeScript port of the infermap Python library.",
   "keywords": [
     "schema",


### PR DESCRIPTION
Bumps infermap (Python and JS) from 0.3.x to 0.4.0 to ship the InferMap -> GoldenCheck handoff (PR #53): `detect_domain_detailed` returning `DetectionResult`, token-boundary domain hint matching, frozen wire-format types via goldencheck-types, predicate parity, and FieldSpec.name with SCHEMA_VERSION=2.

After merge, tag `infermap-v0.4.0` -> publish-infermap.yml fires; tag `infermap-js-v0.4.0` -> publish-infermap-js.yml fires.