### PR TITLE
release(goldencheck): 1.2.0

### DIFF
--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 # Core: scanner + models
 from goldencheck.engine.scanner import scan_file, scan_file_with_llm

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "1.1.2"
+version = "1.2.0"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps goldencheck to 1.2.0 to ship the InferMap -> GoldenCheck handoff (PR #53): goldencheck-types is now an explicit dependency, FieldSpec.name end-to-end, SCHEMA_VERSION=2 wire format, lru_cache on domain pack loads, DomainPackError raised on malformed YAML.

After merge, tag `goldencheck-v1.2.0` -> publish-goldencheck.yml fires.