### PR TITLE
release(goldenpipe): 1.1.0

### DIFF
--- a/packages/python/goldenpipe/goldenpipe/__init__.py
+++ b/packages/python/goldenpipe/goldenpipe/__init__.py
@@ -1,5 +1,5 @@
 """GoldenPipe -- pluggable pipeline framework for data quality."""
-__version__ = "1.0.5"
+__version__ = "1.1.0"
 
 from goldenpipe._api import run, run_df, run_stages
 from goldenpipe.pipeline import Pipeline

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldenpipe"
-version = "1.0.6"
+version = "1.1.0"
 description = "Pluggable pipeline framework for data quality workflows"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/python/goldenpipe/tests/test_pipeline.py
+++ b/packages/python/goldenpipe/tests/test_pipeline.py
@@ -56,4 +56,4 @@ class TestImports:
         assert hasattr(gp, "PipeResult")
         assert hasattr(gp, "stage")
         assert hasattr(gp, "__version__")
-        assert gp.__version__ == "1.0.5"
+        assert gp.__version__ == "1.1.0"


### PR DESCRIPTION
Bumps goldenpipe to 1.1.0 to ship the InferMap -> GoldenCheck handoff (PR #53): `infer_schema` stage now uses `detect_domain_detailed` and surfaces confidence in InferredSchema.

After merge, tag `goldenpipe-v1.1.0` -> publish-goldenpipe.yml fires.