### PR TITLE
fix(ts): point package.json repository URLs at the monorepo

### DIFF
--- a/packages/typescript/goldencheck/package.json
+++ b/packages/typescript/goldencheck/package.json
@@ -16,12 +16,12 @@
   "author": "Ben Severn (https://bensevern.dev)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/benzsevern/goldencheck.git",
-    "directory": "packages/goldencheck-js"
+    "url": "git+https://github.com/benzsevern/goldenmatch.git",
+    "directory": "packages/typescript/goldencheck"
   },
-  "homepage": "https://benzsevern.github.io/goldencheck/",
+  "homepage": "https://github.com/benzsevern/goldenmatch/tree/main/packages/typescript/goldencheck",
   "bugs": {
-    "url": "https://github.com/benzsevern/goldencheck/issues"
+    "url": "https://github.com/benzsevern/goldenmatch/issues"
   },
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -16,12 +16,12 @@
   "author": "Ben Severn (https://bensevern.dev)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/benzsevern/goldenflow.git",
-    "directory": "packages/goldenflow-js"
+    "url": "git+https://github.com/benzsevern/goldenmatch.git",
+    "directory": "packages/typescript/goldenflow"
   },
-  "homepage": "https://benzsevern.github.io/goldenflow/",
+  "homepage": "https://github.com/benzsevern/goldenmatch/tree/main/packages/typescript/goldenflow",
   "bugs": {
-    "url": "https://github.com/benzsevern/goldenflow/issues"
+    "url": "https://github.com/benzsevern/goldenmatch/issues"
   },
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/typescript/infermap/package.json
+++ b/packages/typescript/infermap/package.json
@@ -16,12 +16,12 @@
   "author": "Ben Severn (https://bensevern.dev)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/benzsevern/infermap.git",
-    "directory": "packages/infermap-js"
+    "url": "git+https://github.com/benzsevern/goldenmatch.git",
+    "directory": "packages/typescript/infermap"
   },
-  "homepage": "https://benzsevern.github.io/infermap/",
+  "homepage": "https://github.com/benzsevern/goldenmatch/tree/main/packages/typescript/infermap",
   "bugs": {
-    "url": "https://github.com/benzsevern/infermap/issues"
+    "url": "https://github.com/benzsevern/goldenmatch/issues"
   },
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
infermap-js v0.4.0 publish failed sigstore provenance check because TS packages still pointed at pre-fold standalone repo URLs (benzsevern/infermap, /goldencheck, /goldenflow). With npm provenance, the build context must match repository.url.

Updates infermap, goldencheck, goldenflow TS package.json files to point at benzsevern/goldenmatch (the monorepo home since 2026-05-02). goldenmatch and goldencheck-types already correct.

After merge, delete + recreate the infermap-js-v0.4.0 release tag against HEAD-of-main so publish-infermap-js.yml fires against the fixed commit.