### PR TITLE
feat(badges): suite-wide PyPI + npm download totals

### DIFF
--- a/.github/workflows/update-download-badges.yml
+++ b/.github/workflows/update-download-badges.yml
@@ -1,0 +1,66 @@
+name: Update suite download badges
+
+on:
+  schedule:
+    # Daily at 06:17 UTC (off the top-of-hour CI rush).
+    - cron: "17 6 * * *"
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - "scripts/suite_download_badges.py"
+      - ".github/workflows/update-download-badges.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-download-badges
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compute suite-wide download totals
+        run: python scripts/suite_download_badges.py --out badges-out
+
+      - name: Publish to badges branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Fresh tree so we can replace the badges branch contents wholesale.
+          tmp=$(mktemp -d)
+          cp badges-out/*.json "$tmp/"
+
+          # Clone (or init) the orphan branch.
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads origin badges; then
+            git fetch origin badges:badges
+            git worktree add wt badges
+          else
+            git worktree add --orphan -b badges wt
+            (cd wt && git rm -rf . 2>/dev/null || true)
+          fi
+
+          cp "$tmp"/*.json wt/
+          cd wt
+
+          # Only commit if anything changed.
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No badge changes."
+            exit 0
+          fi
+
+          git add -A
+          git commit -m "chore(badges): refresh suite download totals"
+          git push origin HEAD:badges

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 [![DBLP-ACM F1](https://img.shields.io/badge/DBLP--ACM%20F1-97.2%25-d4a017)](packages/python/goldenmatch/README.md#benchmarks)
 
 <!-- Reach -->
-[![PyPI downloads](https://img.shields.io/pypi/dm/goldenmatch?color=d4a017&label=pypi%20dl%2Fmo&logo=pypi&logoColor=white)](https://pepy.tech/project/goldenmatch)
-[![npm downloads](https://img.shields.io/npm/dm/goldenmatch?color=cb3837&label=npm%20dl%2Fmo&logo=npm&logoColor=white)](https://www.npmjs.com/package/goldenmatch)
+[![PyPI downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenzsevern%2Fgoldenmatch%2Fbadges%2Fpypi-downloads.json)](https://pepy.tech/projects?q=goldenmatch+goldencheck+goldenpipe+goldenflow+infermap+goldencheck-types)
+[![npm downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenzsevern%2Fgoldenmatch%2Fbadges%2Fnpm-downloads.json)](https://www.npmjs.com/~benzsevern)
 [![GitHub stars](https://img.shields.io/github/stars/benzsevern/goldenmatch?style=flat&color=d4a017&logo=github)](https://github.com/benzsevern/goldenmatch/stargazers)
 
 <!-- Ecosystem -->

--- a/scripts/suite_download_badges.py
+++ b/scripts/suite_download_badges.py
@@ -1,0 +1,107 @@
+"""Compute suite-wide PyPI + npm download counts and emit shields.io endpoint JSON.
+
+Sums last-30-day downloads across every Golden Suite package and writes two
+JSON files in shields.io endpoint format. A GitHub Action commits these to the
+`badges` orphan branch; the README references them via
+`img.shields.io/endpoint?url=...`.
+
+Single source of truth for which packages count toward the suite totals --
+update PYPI_PACKAGES / NPM_PACKAGES when adding a new package.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+PYPI_PACKAGES = [
+    "goldenmatch",
+    "goldencheck",
+    "goldenpipe",
+    "goldenflow",
+    "infermap",
+    "goldencheck-types",
+]
+NPM_PACKAGES = [
+    "goldenmatch",
+    "goldencheck",
+    "goldenflow",
+    "infermap",
+    "goldencheck-types",
+]
+
+
+def _fetch_json(url: str) -> dict | None:
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "goldenmatch-badge-updater (+https://github.com/benzsevern/goldenmatch)"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        # 404 = package not yet indexed (e.g. just published). Treat as 0.
+        if e.code == 404:
+            return None
+        raise
+
+
+def pypi_last_month(pkg: str) -> int:
+    data = _fetch_json(f"https://pypistats.org/api/packages/{pkg}/recent")
+    if not data:
+        return 0
+    return int(data.get("data", {}).get("last_month", 0))
+
+
+def npm_last_month(pkg: str) -> int:
+    data = _fetch_json(f"https://api.npmjs.org/downloads/point/last-month/{pkg}")
+    if not data:
+        return 0
+    return int(data.get("downloads", 0))
+
+
+def humanize(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def shield(label: str, message: str, color: str, logo: str) -> dict:
+    return {
+        "schemaVersion": 1,
+        "label": label,
+        "message": f"{message}/month",
+        "color": color,
+        "namedLogo": logo,
+        "logoColor": "white",
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", type=Path, default=Path("badges"),
+                    help="Output directory for JSON files")
+    args = ap.parse_args()
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    pypi_total = sum(pypi_last_month(p) for p in PYPI_PACKAGES)
+    npm_total = sum(npm_last_month(p) for p in NPM_PACKAGES)
+
+    pypi_json = shield("pypi dl/mo", humanize(pypi_total), "d4a017", "pypi")
+    npm_json = shield("npm dl/mo", humanize(npm_total), "cb3837", "npm")
+
+    (args.out / "pypi-downloads.json").write_text(json.dumps(pypi_json, indent=2) + "\n")
+    (args.out / "npm-downloads.json").write_text(json.dumps(npm_json, indent=2) + "\n")
+
+    print(f"PyPI total (last 30d): {pypi_total} ({humanize(pypi_total)})")
+    print(f"npm  total (last 30d): {npm_total} ({humanize(npm_total)})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The previous `pypi/dm/goldenmatch` and `npm/dm/goldenmatch` badges only counted one package per ecosystem, undercounting suite-wide reach by ~3x. Today the actual suite-wide totals are ~4.7k/month PyPI and ~1.1k/month npm.

## How

- `scripts/suite_download_badges.py` — queries pypistats.org and api.npmjs.org for last-30-day downloads, sums across every package in `PYPI_PACKAGES` / `NPM_PACKAGES`, emits shields.io endpoint JSON. Pure stdlib (urllib + json), no deps.
- `.github/workflows/update-download-badges.yml` — daily cron at 06:17 UTC + manual dispatch + on-script-edit. Commits the JSON files to a `badges` orphan branch.
- README badges switched to `img.shields.io/endpoint?url=...` pointing at `raw.githubusercontent.com/benzsevern/goldenmatch/badges/...`.

## Adding a new package

Edit `PYPI_PACKAGES` / `NPM_PACKAGES` in the script. Single source of truth.

## Test plan

- [x] First workflow run after merge populates the `badges` branch with both JSON files.
- [ ] README badges render with suite-wide totals.
- [ ] Daily cron refreshes them.