### PR TITLE
fix(goldenmatch): zero-config match_df / match() crashes

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -618,12 +618,21 @@ def match(
     from goldenmatch.core.pipeline import run_match
     from goldenmatch.config.schemas import GoldenMatchConfig
 
+    _auto_config = False
+
     if isinstance(config, str):
         cfg = load_config(config)
     elif config is not None:
         cfg = config
-    else:
+    elif exact or fuzzy:
         cfg = _build_config(exact, fuzzy, blocking, threshold, backend=backend)
+    else:
+        # Zero-config: defer to in-pipeline auto-config (mirrors match_df).
+        # Without this, the file API previously fell through to _build_config
+        # which emitted a stub matchkey on a non-existent ``__placeholder__``
+        # column and crashed precompute_matchkey_transforms.
+        cfg = GoldenMatchConfig()
+        _auto_config = True
 
     if backend and hasattr(cfg, "backend"):
         cfg.backend = backend
@@ -631,7 +640,7 @@ def match(
     target_spec = (str(target), Path(target).stem)
     ref_specs = [(str(reference), Path(reference).stem)]
 
-    result = run_match(target_spec, ref_specs, cfg)
+    result = run_match(target_spec, ref_specs, cfg, auto_config=_auto_config)
 
     _mem = result.get("memory_stats")
     return MatchResult(

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -78,6 +78,79 @@ def _open_memory_store(config: GoldenMatchConfig):
         return None
 
 
+def _apply_domain_extraction(
+    combined_lf: pl.LazyFrame,
+    config: GoldenMatchConfig,
+) -> pl.LazyFrame:
+    """Run domain feature extraction if configured.
+
+    Materializes derived columns (``__title_key__``, ``__brand__``,
+    ``__model__`` etc.) that auto-config may reference from matchkeys or
+    blocking keys. Shared by ``_run_dedupe_pipeline`` and
+    ``_run_match_pipeline``; without it the match pipeline crashes whenever
+    auto-config detects a domain (CRASH cause for DBLP-ACM-shaped inputs).
+    """
+    domain_cfg = config.domain
+    if not (domain_cfg and domain_cfg.enabled):
+        return combined_lf
+
+    from goldenmatch.core.domain import detect_domain, extract_features
+
+    combined_df_tmp = combined_lf.collect()
+    user_cols = [c for c in combined_df_tmp.columns if not c.startswith("__")]
+
+    if domain_cfg.mode == "auto" or domain_cfg.mode is None:
+        domain_profile = detect_domain(user_cols)
+    else:
+        from goldenmatch.core.domain import DomainProfile
+        domain_profile = DomainProfile(
+            name=domain_cfg.mode, confidence=1.0,
+            text_columns=[
+                c for c in user_cols
+                if any(p in c.lower() for p in ("name", "title", "description", "product"))
+            ],
+        )
+
+    if domain_profile.confidence <= 0.3:
+        return combined_lf
+
+    logger.info(
+        "Domain detected: %s (confidence %.2f)",
+        domain_profile.name, domain_profile.confidence,
+    )
+    combined_df_tmp, low_conf_ids = extract_features(
+        combined_df_tmp, domain_profile, domain_cfg.confidence_threshold,
+    )
+
+    if domain_cfg.llm_validation and low_conf_ids:
+        from goldenmatch.core.llm_extract import (
+            apply_llm_extractions,
+            llm_extract_features,
+        )
+        budget = None
+        if domain_cfg.budget:
+            from goldenmatch.core.llm_budget import BudgetTracker
+            budget = BudgetTracker(domain_cfg.budget)
+        text_col = (
+            domain_profile.text_columns[0]
+            if domain_profile.text_columns
+            else user_cols[0]
+        )
+        extractions = llm_extract_features(
+            combined_df_tmp, low_conf_ids, text_col,
+            domain=domain_profile.name, budget_tracker=budget,
+        )
+        combined_df_tmp = apply_llm_extractions(
+            combined_df_tmp, extractions, domain_profile.name,
+        )
+        logger.info(
+            "LLM validated %d/%d low-confidence extractions",
+            len(extractions), len(low_conf_ids),
+        )
+
+    return combined_df_tmp.lazy()
+
+
 def _apply_memory_pre(memory_store, config: GoldenMatchConfig, matchkeys: list) -> None:
     """Overlay learned threshold adjustments onto the matchkeys parameter.
 
@@ -458,43 +531,7 @@ def _run_dedupe_pipeline(
         combined_lf = apply_standardization(combined_lf, config.standardization.rules)
 
     # ── Step 1.5c: DOMAIN FEATURE EXTRACTION ──
-    domain_cfg = config.domain
-    if domain_cfg and domain_cfg.enabled:
-        from goldenmatch.core.domain import detect_domain, extract_features
-        combined_df_tmp = combined_lf.collect()
-        user_cols = [c for c in combined_df_tmp.columns if not c.startswith("__")]
-
-        if domain_cfg.mode == "auto" or domain_cfg.mode is None:
-            domain_profile = detect_domain(user_cols)
-        else:
-            from goldenmatch.core.domain import DomainProfile
-            domain_profile = DomainProfile(
-                name=domain_cfg.mode, confidence=1.0,
-                text_columns=[c for c in user_cols if any(p in c.lower() for p in ("name", "title", "description", "product"))],
-            )
-
-        if domain_profile.confidence > 0.3:
-            logger.info("Domain detected: %s (confidence %.2f)", domain_profile.name, domain_profile.confidence)
-            combined_df_tmp, low_conf_ids = extract_features(
-                combined_df_tmp, domain_profile, domain_cfg.confidence_threshold,
-            )
-
-            # LLM validation for low-confidence extractions
-            if domain_cfg.llm_validation and low_conf_ids:
-                from goldenmatch.core.llm_extract import llm_extract_features, apply_llm_extractions
-                budget = None
-                if domain_cfg.budget:
-                    from goldenmatch.core.llm_budget import BudgetTracker
-                    budget = BudgetTracker(domain_cfg.budget)
-                text_col = domain_profile.text_columns[0] if domain_profile.text_columns else user_cols[0]
-                extractions = llm_extract_features(
-                    combined_df_tmp, low_conf_ids, text_col,
-                    domain=domain_profile.name, budget_tracker=budget,
-                )
-                combined_df_tmp = apply_llm_extractions(combined_df_tmp, extractions, domain_profile.name)
-                logger.info("LLM validated %d/%d low-confidence extractions", len(extractions), len(low_conf_ids))
-
-            combined_lf = combined_df_tmp.lazy()
+    combined_lf = _apply_domain_extraction(combined_lf, config)
 
     # ── Learning Memory: pre-scoring learner overlay ──
     _apply_memory_pre(memory_store, config, matchkeys)
@@ -815,6 +852,8 @@ def run_match(
     output_scores: bool = False,
     output_report: bool = False,
     match_mode: str = "best",
+    auto_config: bool = False,
+    auto_config_llm_provider: str | None = None,
 ) -> dict:
     """Run the list-match pipeline.
 
@@ -831,7 +870,7 @@ def run_match(
     Returns:
         Dict with keys: matched, unmatched, report.
     """
-    matchkeys = config.get_matchkeys()
+    matchkeys = [] if auto_config else config.get_matchkeys()
 
     # ── Step 1: Load target ──
     if len(target_file) == 3:
@@ -870,12 +909,20 @@ def run_match(
     # Concat all
     all_frames = [target_df] + ref_frames
     combined_df = pl.concat(all_frames)
+    # Cast user columns to string for consistency with run_match_df's
+    # zero-config path: CSV inference can produce Int64 columns (e.g. year)
+    # that string transforms like lowercase/strip cannot consume.
+    combined_df = combined_df.cast(
+        {col: pl.Utf8 for col in combined_df.columns if not col.startswith("__")}
+    )
     combined_lf = combined_df.lazy()
 
     return _run_match_pipeline(
         combined_lf, config, matchkeys, target_ids,
         output_matched, output_unmatched, output_scores,
         output_report, match_mode,
+        auto_config=auto_config,
+        auto_config_llm_provider=auto_config_llm_provider,
     )
 
 
@@ -947,6 +994,13 @@ def _run_match_pipeline(
     # ── Step 2.5b: STANDARDIZE ──
     if config.standardization and config.standardization.rules:
         combined_lf = apply_standardization(combined_lf, config.standardization.rules)
+
+    # ── Step 2.5c: DOMAIN FEATURE EXTRACTION ──
+    # Mirrors the dedupe pipeline. Auto-config can emit matchkeys that
+    # reference domain-extracted columns (e.g. ``__title_key__``); without
+    # this step the precompute_matchkey_transforms call below crashes with
+    # ColumnNotFoundError.
+    combined_lf = _apply_domain_extraction(combined_lf, config)
 
     # ── Learning Memory: pre-scoring learner overlay ──
     _apply_memory_pre(memory_store, config, matchkeys)

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -78,6 +78,17 @@ def _open_memory_store(config: GoldenMatchConfig):
         return None
 
 
+def _cast_user_cols_to_str(df: pl.DataFrame) -> pl.DataFrame:
+    """Cast all non-internal columns to Utf8.
+
+    Used by both file and DataFrame match entry points so that (a) per-file
+    CSV inference cannot produce schema-incompatible columns across the
+    target/reference vstack and (b) string transforms like lowercase/strip
+    always have a string to consume in zero-config paths.
+    """
+    return df.cast({c: pl.Utf8 for c in df.columns if not c.startswith("__")})
+
+
 def _apply_domain_extraction(
     combined_lf: pl.LazyFrame,
     config: GoldenMatchConfig,
@@ -884,6 +895,11 @@ def run_match(
     target_lf = target_lf.with_columns(pl.lit(target_source).alias("__source__"))
     target_lf = _add_row_ids(target_lf, offset=0)
     target_df = target_lf.collect()
+    # Cast user columns to string before concat: target and reference files
+    # may have schema-incompatible types for the same column (e.g. DBLP
+    # ``id`` is string while ACM ``id`` is Int64), and CSV inference produces
+    # numeric columns that string transforms cannot consume downstream.
+    target_df = _cast_user_cols_to_str(target_df)
     target_ids = set(target_df["__row_id__"].to_list())
     offset = len(target_df)
 
@@ -901,20 +917,14 @@ def run_match(
             ref_lf = apply_column_map(ref_lf, ref_col_map)
         ref_lf = ref_lf.with_columns(pl.lit(ref_source).alias("__source__"))
         ref_lf = _add_row_ids(ref_lf, offset=offset)
-        ref_df = ref_lf.collect()
+        ref_df = _cast_user_cols_to_str(ref_lf.collect())
         offset += len(ref_df)
         ref_frames.append(ref_df)
         ref_sources.add(ref_source)
 
-    # Concat all
-    all_frames = [target_df] + ref_frames
-    combined_df = pl.concat(all_frames)
-    # Cast user columns to string for consistency with run_match_df's
-    # zero-config path: CSV inference can produce Int64 columns (e.g. year)
-    # that string transforms like lowercase/strip cannot consume.
-    combined_df = combined_df.cast(
-        {col: pl.Utf8 for col in combined_df.columns if not col.startswith("__")}
-    )
+    # Concat all (frames are already Utf8-cast on user columns above so the
+    # vstack can never fail on cross-file schema mismatches).
+    combined_df = pl.concat([target_df] + ref_frames)
     combined_lf = combined_df.lazy()
 
     return _run_match_pipeline(

--- a/packages/python/goldenmatch/tests/test_api.py
+++ b/packages/python/goldenmatch/tests/test_api.py
@@ -474,6 +474,75 @@ class TestMatchDfEdgeCases:
         assert isinstance(result, gm.MatchResult)
 
 
+class TestMatchZeroConfig:
+    """Zero-config (no exact / fuzzy / config) entry points must run end-to-end.
+
+    Both crashes were silent regressions: the match pipeline skipped the
+    domain-extraction step that the dedupe pipeline runs (CRASH 1), and the
+    file-based ``match()`` API never threaded auto-config into the pipeline at
+    all (CRASH 2 - emitted a placeholder matchkey using a non-existent column).
+    """
+
+    def _bibliographic_pair(self):
+        # DBLP-ACM-shaped data: title triggers domain auto-config to emit a
+        # matchkey on the derived ``__title_key__`` column.
+        target = pl.DataFrame({
+            "id": ["1", "2", "3"],
+            "title": [
+                "concurrency in the data warehouse",
+                "energy efficient indexing on air",
+                "neurorule a connectionist approach to data mining",
+            ],
+            "authors": ["richard taylor", "tomasz imielinski", "hongjun lu"],
+            "venue": ["vldb", "sigmod conference", "vldb"],
+            "year": ["2000", "1994", "1995"],
+        })
+        reference = pl.DataFrame({
+            "id": ["10", "20", "30"],
+            "title": [
+                "concurrency in the data warehouse",
+                "energy efficient indexing on air",
+                "an unrelated paper title",
+            ],
+            "authors": ["richard taylor", "tomasz imielinski", "someone else"],
+            "venue": [
+                "very large data bases",
+                "international conference on management of data",
+                "icde",
+            ],
+            "year": ["2000", "1994", "2001"],
+        })
+        return target, reference
+
+    def test_match_df_zero_config_runs(self):
+        """match_df(target, reference) with no config or kwargs must not crash.
+
+        Was: ColumnNotFoundError: __title_key__ - auto-config emitted a
+        domain-extracted matchkey but the match pipeline skipped the domain
+        extraction step that the dedupe pipeline runs.
+        """
+        import goldenmatch as gm
+        target, reference = self._bibliographic_pair()
+        result = gm.match_df(target, reference)
+        assert isinstance(result, gm.MatchResult)
+
+    def test_match_files_zero_config_runs(self, tmp_path):
+        """gm.match(file, file) with no config or kwargs must not crash.
+
+        Was: ColumnNotFoundError: __placeholder__ - the file API fell through
+        to _build_config which emitted a stub matchkey on a non-existent column
+        instead of deferring to in-pipeline auto-config like match_df does.
+        """
+        import goldenmatch as gm
+        target, reference = self._bibliographic_pair()
+        tgt_path = tmp_path / "target.csv"
+        ref_path = tmp_path / "reference.csv"
+        target.write_csv(tgt_path)
+        reference.write_csv(ref_path)
+        result = gm.match(str(tgt_path), str(ref_path))
+        assert isinstance(result, gm.MatchResult)
+
+
 class TestDedupeResultHtml:
     def test_repr_html_basic(self):
         from goldenmatch import DedupeResult


### PR DESCRIPTION
## Summary
- `gm.match_df(df, df)` with no config crashed with `ColumnNotFoundError: __title_key__` — the match pipeline skipped the Domain Feature Extraction step that the dedupe pipeline runs, so domain-aware matchkeys emitted by auto-config referenced columns that were never materialized.
- `gm.match(file, file)` with no config crashed with `ColumnNotFoundError: __placeholder__` — the file API had no zero-config branch and always fell through to `_build_config(None,None,None,None)`, which emits a stub matchkey on a non-existent column.
- `gm.match(file, file)` also crashed with `SchemaError: type Int64 is incompatible with expected type String` whenever target and reference inferred a column to different types (e.g. DBLP `id`=string, ACM `id`=Int64) — the previous Utf8 cast happened after `pl.concat` so vstack failed first.

## What changed
- Extracted the Domain Feature Extraction block into a shared `_apply_domain_extraction(combined_lf, config)` helper, called from both `_run_dedupe_pipeline` and `_run_match_pipeline`.
- Threaded `auto_config` / `auto_config_llm_provider` through `run_match` -> `_run_match_pipeline` so the file API can defer to in-pipeline auto-config (mirrors `match_df`).
- `_api.match()` now creates an empty `GoldenMatchConfig()` and sets `auto_config=True` when the caller passes no config and no exact/fuzzy kwargs.
- New `_cast_user_cols_to_str` helper runs on each frame (target + each reference) immediately after `collect()`, before `vstack`, so cross-file schema mismatches and CSV-inferred numerics never reach string transforms.

## Test plan
- [x] New `TestMatchZeroConfig` in `tests/test_api.py` — exercises both APIs on DBLP-ACM-shaped input (5 generic columns, no domain hint in field names). Both fail before this PR, pass after.
- [x] Focused suites green: `test_api`, `test_pipeline`, `test_autoconfig_verify`, `test_column_map` — 112 passed, 1 skipped.
- [x] Full goldenmatch test suite: 1572 passed, 5 skipped, 3 pre-existing failures in `test_autoconfig_benchmarks.py` (gitignored datasets missing locally — confirmed unchanged via `git stash`).
- [x] End-to-end on full Leipzig DBLP-ACM (DBLP 2616 × ACM 2294, 2224 ground-truth pairs): both `match_df` and `match` (file) complete in ~2.4s and produce identical output (P=0.4964, R=0.5247, F1=0.5102).

F1 of 0.51 is below the explicit-config baseline (~0.92 per `CLAUDE.md`); auto-config accuracy on bibliographic data is a separate concern. This PR is scoped to the crash fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)