### PR TITLE
feat(autoconfig): introspective controller architecture

### DIFF
--- a/.profile_tmp/baseline_febrl3_ncvr.py
+++ b/.profile_tmp/baseline_febrl3_ncvr.py
@@ -1,0 +1,95 @@
+"""Measure v1.7.1 zero-config F1 on Febrl3 + NCVR.
+
+Used to set v1 acceptance targets for the auto-config controller. Run once
+before implementation begins; results inform §Testing tier 4 of the spec.
+"""
+from __future__ import annotations
+import sys, io, time
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+from pathlib import Path
+import polars as pl
+import goldenmatch as gm
+
+
+def evaluate(name: str, found: set, gt: set) -> None:
+    tp = len(found & gt)
+    fp = len(found - gt)
+    fn = len(gt - found)
+    p = tp / (tp + fp) if (tp + fp) else 0.0
+    r = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) else 0.0
+    print(f"{name}: P={p:.4f} R={r:.4f} F1={f1:.4f}  (TP={tp} FP={fp} FN={fn})")
+
+
+def expand_clusters_to_pairs(clusters: dict) -> set:
+    """Transitive closure of in-cluster edges. Singletons yield no pairs."""
+    pairs = set()
+    for c in clusters.values():
+        members = sorted(c["members"])
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                pairs.add((members[i], members[j]))
+    return pairs
+
+
+def main() -> None:
+    print(f"goldenmatch v{gm.__version__}")
+    print(f"polars v{pl.__version__}")
+
+    # ---- Febrl3 ----
+    print("\n=== Febrl3 ===")
+    try:
+        from recordlinkage.datasets import load_febrl3
+    except ImportError:
+        print("recordlinkage not installed; skipping Febrl3")
+    else:
+        try:
+            df_pd, gt_pairs = load_febrl3(return_links=True)
+            df_pd = df_pd.reset_index().rename(columns={"rec_id": "id"})
+            df = pl.from_pandas(df_pd)
+            print(f"Febrl3: {df.height} rows, cols={df.columns}")
+            t0 = time.time()
+            result = gm.dedupe_df(df)
+            print(f"  dedupe_df completed in {time.time() - t0:.2f}s")
+            found = expand_clusters_to_pairs(result.clusters)
+            # Map row_id -> original id; ground truth uses original ids
+            row_to_id = df["id"].to_list()
+            found_ids = set()
+            for a, b in found:
+                if 0 <= a < len(row_to_id) and 0 <= b < len(row_to_id):
+                    pa, pb = row_to_id[a], row_to_id[b]
+                    found_ids.add((min(pa, pb), max(pa, pb)))
+            gt_set = set()
+            for a, b in gt_pairs:
+                pa, pb = (a, b) if isinstance(a, str) else (str(a), str(b))
+                gt_set.add((min(pa, pb), max(pa, pb)))
+            evaluate("Febrl3 (zero-config dedupe)", found_ids, gt_set)
+        except Exception as e:
+            print(f"Febrl3 failed: {type(e).__name__}: {e}")
+
+    # ---- NCVR ----
+    print("\n=== NCVR sample ===")
+    ncvr_path = Path("packages/python/goldenmatch/tests/benchmarks/datasets/NCVR/ncvoter_sample_10k.txt")
+    if not ncvr_path.exists():
+        print(f"NCVR sample not at {ncvr_path}; skipping")
+    else:
+        try:
+            df = pl.read_csv(ncvr_path, separator="\t", encoding="utf8-lossy", ignore_errors=True)
+            print(f"NCVR: {df.height} rows, {len(df.columns)} cols")
+            print("  → ground-truth pair source: TBD (no canonical loader in repo)")
+            print("  → skipping F1 computation; record-only baseline")
+            # Run dedupe just to confirm zero-config doesn't crash on this shape
+            t0 = time.time()
+            try:
+                result = gm.dedupe_df(df)
+                print(f"  dedupe_df completed in {time.time() - t0:.2f}s, "
+                      f"{len(result.clusters)} clusters, "
+                      f"{sum(1 for c in result.clusters.values() if c['size'] >= 2)} multi-member")
+            except Exception as e:
+                print(f"  dedupe_df failed: {type(e).__name__}: {e}")
+        except Exception as e:
+            print(f"NCVR load failed: {type(e).__name__}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -354,6 +354,7 @@ def dedupe_df(
     from goldenmatch.core.pipeline import run_dedupe_df
     import goldenmatch._api as _self_api
 
+    _used_controller = False
     if isinstance(config, str):
         config = load_config(config)
     elif config is None:
@@ -371,7 +372,9 @@ def dedupe_df(
                 df,
                 llm_provider=_auto_config_provider,
                 llm_auto=llm_auto,
+                _skip_finalize=True,
             )
+            _used_controller = True
 
     # Apply overrides uniformly regardless of config source
     if backend and hasattr(config, "backend"):
@@ -388,6 +391,25 @@ def dedupe_df(
     )
 
     _mem = result.get("memory_stats")
+    pf = _attach_memory_to_postflight(result.get("postflight_report"), _mem)
+
+    # Fix 1: Wire controller profile + history onto PostflightReport.
+    # When the zero-config path ran the controller, stash sample_profile and
+    # history so callers can inspect health verdicts, errors, and drift.
+    # NOTE: full_vs_sample_drift is not set here because _skip_finalize=True
+    # skips the controller's _finalize call. Task 6.1 will compute drift here
+    # once pf.signals is a typed ComplexityProfile (currently PostflightSignals
+    # TypedDict). For now, drift is left unset on this path.
+    if _used_controller:
+        from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+        _ctrl_state = _LAST_CONTROLLER_RUN.get()
+        if _ctrl_state is not None:
+            _sample_profile, _history = _ctrl_state
+            if pf is None:
+                pf = PostflightReport()
+            pf.controller_profile = _sample_profile
+            pf.controller_history = _history
+
     return DedupeResult(
         golden=result.get("golden"),
         clusters=result.get("clusters", {}),
@@ -396,9 +418,7 @@ def dedupe_df(
         stats=_extract_stats(result),
         scored_pairs=_extract_pairs(result),
         config=config,
-        postflight_report=_attach_memory_to_postflight(
-            result.get("postflight_report"), _mem
-        ),
+        postflight_report=pf,
         memory_stats=_mem,
     )
 
@@ -443,6 +463,7 @@ def match_df(
     from goldenmatch.core.pipeline import run_match_df
     import goldenmatch._api as _self_api
 
+    _used_controller = False
     if isinstance(config, str):
         config = load_config(config)
     elif config is None:
@@ -455,7 +476,10 @@ def match_df(
             # Pass reference= so auto-config sees both column sets and emits
             # matchkeys/blocking that apply uniformly across the join.
             # Access via module attribute so tests can patch goldenmatch._api.auto_configure_df.
-            config = _self_api.auto_configure_df(target, reference=reference)
+            config = _self_api.auto_configure_df(
+                target, reference=reference, _skip_finalize=True,
+            )
+            _used_controller = True
 
     if backend and hasattr(config, "backend"):
         config.backend = backend
@@ -463,13 +487,26 @@ def match_df(
     result = run_match_df(target, reference, config, auto_config=False)
 
     _mem = result.get("memory_stats")
+    pf = _attach_memory_to_postflight(result.get("postflight_report"), _mem)
+
+    # Fix 1: Wire controller profile + history onto PostflightReport (match path).
+    # See dedupe_df for full commentary. Drift unset when _skip_finalize=True
+    # (Task 6.1 deferred).
+    if _used_controller:
+        from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+        _ctrl_state = _LAST_CONTROLLER_RUN.get()
+        if _ctrl_state is not None:
+            _sample_profile, _history = _ctrl_state
+            if pf is None:
+                pf = PostflightReport()
+            pf.controller_profile = _sample_profile
+            pf.controller_history = _history
+
     return MatchResult(
         matched=result.get("matched"),
         unmatched=result.get("unmatched"),
         stats=_extract_stats(result),
-        postflight_report=_attach_memory_to_postflight(
-            result.get("postflight_report"), _mem
-        ),
+        postflight_report=pf,
         memory_stats=_mem,
     )
 

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -19,6 +19,14 @@ from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
+# Imported at module level so tests can patch goldenmatch._api.auto_configure_df.
+# The lazy import guard inside each function is kept for cycle safety — this
+# top-level import is a re-export alias that tests can mock.
+try:
+    from goldenmatch.core.autoconfig import auto_configure_df
+except ImportError:  # pragma: no cover
+    auto_configure_df = None  # type: ignore[assignment]
+
 from goldenmatch.core.autoconfig_verify import PostflightReport
 
 if TYPE_CHECKING:
@@ -344,9 +352,7 @@ def dedupe_df(
         configs.
     """
     from goldenmatch.core.pipeline import run_dedupe_df
-
-    _auto_config = False
-    _auto_config_provider = None
+    import goldenmatch._api as _self_api
 
     if isinstance(config, str):
         config = load_config(config)
@@ -354,11 +360,18 @@ def dedupe_df(
         if exact or fuzzy:
             config = _build_config(exact, fuzzy, blocking, threshold, llm_scorer, backend)
         else:
-            # Zero-config: defer auto-config to inside pipeline (after GoldenCheck/GoldenFlow)
-            from goldenmatch.config.schemas import GoldenMatchConfig
-            config = GoldenMatchConfig()
-            _auto_config = True
+            # Zero-config: call auto_configure_df *before* the pipeline so the
+            # pipeline never re-invokes auto-config. This eliminates the
+            # double-pipeline-run introduced by Task 5.1 (the controller loop
+            # itself calls dedupe_df on samples; if the pipeline also ran
+            # auto_configure_df we'd recurse). Task 5.2 fix.
+            # Access via module attribute so tests can patch goldenmatch._api.auto_configure_df.
             _auto_config_provider = _detect_llm_provider() if llm_scorer else None
+            config = _self_api.auto_configure_df(
+                df,
+                llm_provider=_auto_config_provider,
+                llm_auto=llm_auto,
+            )
 
     # Apply overrides uniformly regardless of config source
     if backend and hasattr(config, "backend"):
@@ -371,8 +384,7 @@ def dedupe_df(
 
     result = run_dedupe_df(
         df, config, source_name=source_name,
-        auto_config=_auto_config,
-        auto_config_llm_provider=_auto_config_provider,
+        auto_config=False,
     )
 
     _mem = result.get("memory_stats")
@@ -429,8 +441,7 @@ def match_df(
         configs.
     """
     from goldenmatch.core.pipeline import run_match_df
-
-    _auto_config = False
+    import goldenmatch._api as _self_api
 
     if isinstance(config, str):
         config = load_config(config)
@@ -438,17 +449,18 @@ def match_df(
         if exact or fuzzy:
             config = _build_config(exact, fuzzy, blocking, threshold, backend=backend)
         else:
-            # Zero-config: defer auto-config to inside pipeline (same pattern
-            # as dedupe_df). auto_configure_df runs on the combined target +
-            # reference frame so matchkeys/blocking apply uniformly.
-            from goldenmatch.config.schemas import GoldenMatchConfig
-            config = GoldenMatchConfig()
-            _auto_config = True
+            # Zero-config: call auto_configure_df *before* the pipeline so the
+            # pipeline never re-invokes auto-config. Eliminates double-pipeline-run
+            # (Task 5.2 fix — mirrors dedupe_df zero-config refactor).
+            # Pass reference= so auto-config sees both column sets and emits
+            # matchkeys/blocking that apply uniformly across the join.
+            # Access via module attribute so tests can patch goldenmatch._api.auto_configure_df.
+            config = _self_api.auto_configure_df(target, reference=reference)
 
     if backend and hasattr(config, "backend"):
         config.backend = backend
 
-    result = run_match_df(target, reference, config, auto_config=_auto_config)
+    result = run_match_df(target, reference, config, auto_config=False)
 
     _mem = result.get("memory_stats")
     return MatchResult(

--- a/packages/python/goldenmatch/goldenmatch/core/_profile_helpers.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_profile_helpers.py
@@ -1,0 +1,36 @@
+"""Numeric helpers for profile emission. Used by scorer + cluster instrumentation."""
+from __future__ import annotations
+
+
+def histogram_20(scores: list[float]) -> list[int]:
+    """20 fixed bins over [0, 1]. Score >= 1.0 lands in bin 19."""
+    bins = [0] * 20
+    for s in scores:
+        idx = min(19, max(0, int(s * 20)))
+        bins[idx] += 1
+    return bins
+
+
+def hartigan_dip(scores: list[float]) -> float:
+    """Hartigan's dip statistic. Returns value in [0, 0.25]; small=unimodal.
+
+    Hard-requires the ``diptest`` package (added as dep in Task 2.2).
+    """
+    if not scores:
+        return 0.0
+    import numpy as np
+    import diptest
+    return float(diptest.dipstat(np.asarray(scores)))
+
+
+def mass_above(scores: list[float], threshold: float) -> float:
+    if not scores:
+        return 0.0
+    return sum(1 for s in scores if s >= threshold) / len(scores)
+
+
+def mass_borderline(scores: list[float], threshold: float, band: float = 0.1) -> float:
+    if not scores:
+        return 0.0
+    lo, hi = threshold - band, threshold + band
+    return sum(1 for s in scores if lo <= s <= hi) / len(scores)

--- a/packages/python/goldenmatch/goldenmatch/core/_profile_helpers.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_profile_helpers.py
@@ -34,3 +34,50 @@ def mass_borderline(scores: list[float], threshold: float, band: float = 0.1) ->
         return 0.0
     lo, hi = threshold - band, threshold + band
     return sum(1 for s in scores if lo <= s <= hi) / len(scores)
+
+
+def transitivity_rate(
+    members_by_cluster: dict[int, list[int]],
+    pair_scores: dict[tuple[int, int], float],
+    threshold: float,
+    *,
+    max_samples: int = 1000,
+    seed: int = 0,
+) -> float:
+    """Fraction of in-cluster (a,b,c) triples where all three of (a,b), (b,c),
+    (a,c) score >= threshold.
+
+    Pair lookup canonicalizes (a,b) as (min,max) per project convention.
+    Returns 1.0 when no clusters have >= 3 members (vacuously transitive).
+    Samples up to ``max_samples`` triples for cost control.
+    """
+    import random
+    from itertools import combinations as _combinations
+
+    rng = random.Random(seed)
+    triples: list[tuple[int, int, int]] = []
+    for members in members_by_cluster.values():
+        if len(members) < 3:
+            continue
+        n = len(members)
+        if n <= 20:
+            triples.extend(_combinations(sorted(members), 3))
+        else:
+            for _ in range(min(max_samples, 100)):
+                a, b, c = sorted(rng.sample(members, 3))
+                triples.append((a, b, c))
+    if not triples:
+        return 1.0
+    if len(triples) > max_samples:
+        triples = rng.sample(triples, max_samples)
+
+    def edge(x: int, y: int) -> float:
+        return pair_scores.get((min(x, y), max(x, y)), 0.0)
+
+    agree = sum(
+        1 for a, b, c in triples
+        if edge(a, b) >= threshold
+        and edge(b, c) >= threshold
+        and edge(a, c) >= threshold
+    )
+    return agree / len(triples)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -22,8 +22,55 @@ from goldenmatch.config.schemas import (
     OutputConfig,
 )
 from goldenmatch.core.profiler import _guess_type
+from goldenmatch.core.profile_emitter import current_emitter, _emitter_stack
+from goldenmatch.core.complexity_profile import DataProfile
 
 logger = logging.getLogger(__name__)
+
+
+def _emit_data_profile(df: "pl.DataFrame") -> None:
+    """Emit DataProfile from the input DataFrame. No-op when null emitter."""
+    if not _emitter_stack.get():
+        return
+    user_cols = [c for c in df.columns if not c.startswith("__")]
+    column_types: dict[str, str] = {}
+    cardinality_ratio: dict[str, float] = {}
+    null_rate: dict[str, float] = {}
+    value_length_p50: dict[str, int] = {}
+    value_length_p99: dict[str, int] = {}
+    n_rows = df.height
+    for col in user_cols:
+        ser = df[col]
+        non_null = ser.drop_nulls()
+        n_non_null = non_null.len()
+        cardinality_ratio[col] = (non_null.n_unique() / n_non_null) if n_non_null else 0.0
+        null_rate[col] = 1 - (n_non_null / n_rows) if n_rows else 0.0
+        dtype = str(ser.dtype).lower()
+        if "utf" in dtype or "str" in dtype:
+            column_types[col] = "text"
+        elif "int" in dtype or "float" in dtype:
+            column_types[col] = "numeric"
+        elif "date" in dtype or "time" in dtype:
+            column_types[col] = "date"
+        else:
+            column_types[col] = "unknown"
+        if column_types[col] == "text" and n_non_null:
+            try:
+                lens = sorted(non_null.cast(pl.Utf8).str.len_chars().to_list())
+                if lens:
+                    value_length_p50[col] = int(lens[len(lens) // 2])
+                    value_length_p99[col] = int(lens[max(0, int(0.99 * len(lens)) - 1)])
+            except Exception:
+                pass
+    current_emitter().set_data(DataProfile(
+        n_rows=n_rows,
+        n_cols=len(user_cols),
+        column_types=column_types,
+        cardinality_ratio=cardinality_ratio,
+        null_rate=null_rate,
+        value_length_p50=value_length_p50,
+        value_length_p99=value_length_p99,
+    ))
 
 # ── Column name heuristics ─────────────────────────────────────────────────
 
@@ -1213,6 +1260,8 @@ def auto_configure_df(
     total_rows = df.height
 
     logger.info("Auto-configuring %d rows, %d columns", total_rows, len(df.columns))
+
+    _emit_data_profile(df)
 
     # Profile columns
     profiles = profile_columns(df, llm_provider=llm_provider)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -1220,18 +1221,77 @@ def select_model(row_count: int, has_embedding_columns: bool, threshold: int = 5
 
 # ── Main entry point ──────────────────────────────────────────────────────
 
+# ContextVar populated by auto_configure_df after each successful controller
+# run. Holds (ComplexityProfile, RunHistory) so PostflightReport can pick up
+# the profile + history without threading them through every call site.
+_LAST_CONTROLLER_RUN: ContextVar = ContextVar("_LAST_CONTROLLER_RUN", default=None)
+
+
 def auto_configure_df(
-    df: pl.DataFrame, llm_provider: str | None = None,
-    domain_config=None, llm_auto: bool = False,
-    strict: bool = False, allow_remote_assets: bool = False,
-) -> GoldenMatchConfig:
-    """Public entry point. Currently a thin wrapper over the legacy heuristic;
-    Task 5.1 will rewire this to use AutoConfigController.
+    df: "pl.DataFrame | pl.LazyFrame",
+    llm_provider: str | None = None,
+    domain_config=None,
+    llm_auto: bool = False,
+    strict: bool = False,
+    allow_remote_assets: bool = False,
+    *,
+    reference: "pl.DataFrame | pl.LazyFrame | None" = None,
+) -> "GoldenMatchConfig":
+    """Public auto-configuration entry point (controller-backed).
+
+    Runs an iterative refit loop:
+      1. Compute v0 config via the legacy heuristic
+      2. Run blocking → score → cluster on a stratified sample under profile_capture
+      3. Read the ComplexityProfile, ask the policy for a refit
+      4. Loop until green/converged/budget
+      5. Run the full pipeline once and return the committed config
+
+    The committed config is what's returned. Profile + history are stashed
+    on the ``_LAST_CONTROLLER_RUN`` ContextVar so the calling pipeline can
+    surface them via PostflightReport.
+
+    Args:
+        df: target DataFrame (or LazyFrame, which will be collected).
+        reference: optional reference DataFrame for cross-source ``match_df``
+            mode. When None, dedupe mode (single-source).
+        llm_provider, domain_config, llm_auto, strict, allow_remote_assets:
+            unchanged from the legacy signature; threaded into v0 only.
+
+    Raises:
+        TypeError: when ``df`` or ``reference`` is not a polars DataFrame/LazyFrame.
+        ConfigValidationError: from the controller, when input is unworkable
+            (empty, all-null, etc.).
     """
-    return _legacy_auto_configure_v0(
-        df, llm_provider=llm_provider, domain_config=domain_config,
-        llm_auto=llm_auto, strict=strict, allow_remote_assets=allow_remote_assets,
+    # Coerce + validate input types
+    if isinstance(df, pl.LazyFrame):
+        df = df.collect()
+    elif not isinstance(df, pl.DataFrame):
+        raise TypeError(
+            f"auto_configure_df requires pl.DataFrame or pl.LazyFrame, "
+            f"got {type(df).__name__}"
+        )
+    if reference is not None:
+        if isinstance(reference, pl.LazyFrame):
+            reference = reference.collect()
+        elif not isinstance(reference, pl.DataFrame):
+            raise TypeError(
+                f"reference requires pl.DataFrame or pl.LazyFrame, "
+                f"got {type(reference).__name__}"
+            )
+
+    # Lazy import to avoid circular imports (controller imports back here)
+    from goldenmatch.core.autoconfig_controller import (
+        AutoConfigController, ControllerBudget,
     )
+    from goldenmatch.core.autoconfig_policy import HeuristicRefitPolicy
+
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(),
+    )
+    config, profile, history = controller.run(df, reference=reference)
+    _LAST_CONTROLLER_RUN.set((profile, history))
+    return config
 
 
 def _legacy_auto_configure_v0(

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1225,29 +1225,29 @@ def auto_configure_df(
     domain_config=None, llm_auto: bool = False,
     strict: bool = False, allow_remote_assets: bool = False,
 ) -> GoldenMatchConfig:
-    """Auto-generate a GoldenMatchConfig from a DataFrame.
+    """Public entry point. Currently a thin wrapper over the legacy heuristic;
+    Task 5.1 will rewire this to use AutoConfigController.
+    """
+    return _legacy_auto_configure_v0(
+        df, llm_provider=llm_provider, domain_config=domain_config,
+        llm_auto=llm_auto, strict=strict, allow_remote_assets=allow_remote_assets,
+    )
 
-    Profiles columns by name heuristics and data sampling, then builds
-    matchkeys, blocking, and golden rules automatically. Runs preflight
-    verification on the resulting config before returning, attaching the
-    `PreflightReport` to the config as ``config._preflight_report``.
 
-    Args:
-        df: Polars DataFrame to auto-configure for.
-        llm_provider: Optional LLM provider for profiling (openai/anthropic).
-        domain_config: Manual domain override; skips auto-detection.
-        llm_auto: Auto-enable the LLM scorer when an API key is present.
-        strict: When True, postflight computes signals and emits advisories
-            but does not apply any adjustments (keeps output deterministic for
-            parity runs). Preflight always raises ``ConfigValidationError`` on
-            unrepairable errors regardless. Stashed on the config as
-            ``_strict_autoconfig`` for downstream consumers.
-        allow_remote_assets: When True, keep embedding/record_embedding/
-            rerank scorers. When False (default), preflight demotes them to
-            offline-safe alternatives.
-
-    Returns:
-        A fully populated GoldenMatchConfig ready for pipeline execution.
+def _legacy_auto_configure_v0(
+    df: pl.DataFrame,
+    *,
+    reference: pl.DataFrame | None = None,  # ignored for v1; Task 5.1 plumbs it
+    llm_provider: str | None = None,
+    domain_config=None,
+    llm_auto: bool = False,
+    strict: bool = False,
+    allow_remote_assets: bool = False,
+) -> GoldenMatchConfig:
+    """Legacy column-profiling + rule-based auto-config heuristic (the v0
+    starting point for the controller). Implementation unchanged from the
+    pre-Task-4.x ``auto_configure_df`` — just renamed and given a private
+    underscore prefix so the controller can call it without recursing.
     """
     # Initialized up front so the preflight-wiring block at the bottom can
     # safely test `if domain_profile is not None` even when the domain

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1236,6 +1236,7 @@ def auto_configure_df(
     allow_remote_assets: bool = False,
     *,
     reference: "pl.DataFrame | pl.LazyFrame | None" = None,
+    _skip_finalize: bool = False,
 ) -> "GoldenMatchConfig":
     """Public auto-configuration entry point (controller-backed).
 
@@ -1289,7 +1290,19 @@ def auto_configure_df(
         policy=HeuristicRefitPolicy(),
         budget=ControllerBudget(),
     )
-    config, profile, history = controller.run(df, reference=reference)
+    v0_kw = {
+        "llm_provider": llm_provider,
+        "domain_config": domain_config,
+        "llm_auto": llm_auto,
+        "strict": strict,
+        "allow_remote_assets": allow_remote_assets,
+    }
+    config, profile, history = controller.run(
+        df,
+        reference=reference,
+        v0_kwargs=v0_kw,
+        skip_finalize=_skip_finalize,
+    )
     _LAST_CONTROLLER_RUN.set((profile, history))
     return config
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -1,0 +1,208 @@
+"""AutoConfigController — iterative auto-config with stage-emitted profiles.
+
+Spec: docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-design.md
+      §New: AutoConfigController, §Sample selection, §Pipeline integration.
+
+Task 4.1 implements: skeleton, ControllerBudget, StopReason, _RED_PROFILE,
+pathological-input gates, _take_sample, and a stub run() that handles the
+gates and returns v0 without entering the loop.
+
+The iteration loop body lands in Task 4.2 and _finalize in Task 4.3.
+"""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from datetime import timedelta
+from enum import Enum
+from typing import Any
+import hashlib
+import polars as pl
+
+from goldenmatch.config.schemas import GoldenMatchConfig
+from goldenmatch.core.complexity_profile import (
+    ComplexityProfile, DataProfile, HealthVerdict,
+)
+from goldenmatch.core.autoconfig_history import RunHistory
+from goldenmatch.core.autoconfig_policy import RefitPolicy
+
+
+# Sentinel: forces RED via DataProfile.health() when n_rows == 0.
+_RED_PROFILE: ComplexityProfile = ComplexityProfile(data=DataProfile(n_rows=0))
+
+
+class ConfigValidationError(Exception):
+    """Raised when input data is unworkable for ER (empty, all-null, etc.)."""
+
+
+class StopReason(Enum):
+    GREEN = "green"
+    CONVERGED = "converged"
+    BUDGET_ITERATIONS = "budget_iterations"
+    BUDGET_TIME = "budget_time"
+    POLICY_SATISFIED = "policy_satisfied"
+    POLICY_NO_PROGRESS = "policy_no_progress"
+    OSCILLATING = "oscillating"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class ControllerBudget:
+    max_iterations: int = 3
+    max_seconds: float = 30.0
+    sample_size_default: int = 2000
+    sample_skip_below: int = 5000
+    converge_epsilon: float = 0.05
+    drift_threshold: float = 0.30
+
+
+class AutoConfigController:
+    """Drives iterative refit. Task 4.1 supplies skeleton + gates + sampling.
+
+    The actual iteration loop is in Task 4.2; finalize is in Task 4.3.
+    """
+
+    def __init__(self, policy: RefitPolicy, budget: ControllerBudget) -> None:
+        self.policy = policy
+        self.budget = budget
+
+    # ---- Public entry point ------------------------------------------------
+    def run(
+        self,
+        df: pl.DataFrame,
+        *,
+        reference: pl.DataFrame | None = None,
+    ) -> tuple[GoldenMatchConfig, ComplexityProfile, RunHistory]:
+        """Run iterative auto-config.
+
+        Returns (committed_config, full_data_profile, history). Pathological
+        inputs short-circuit before the loop:
+          - empty df → ConfigValidationError("no data to configure on")
+          - all-null cols → ConfigValidationError("no usable columns")
+          - n_rows == 1 → v0 + YELLOW + history empty
+          - 1 user column → v0 + YELLOW + history empty
+        """
+        # Pathological gates ------------------------------------------------
+        if df.height == 0:
+            raise ConfigValidationError("no data to configure on")
+
+        user_cols = [c for c in df.columns if not c.startswith("__")]
+        if not user_cols:
+            raise ConfigValidationError("no usable columns")
+
+        # Check all-null defensively across user columns
+        all_null = True
+        for col in user_cols:
+            if df[col].drop_nulls().len() > 0:
+                all_null = False
+                break
+        if all_null:
+            raise ConfigValidationError("no usable columns (all values null)")
+
+        # Single non-empty column or single row → return v0 yellow, skip loop
+        if df.height == 1 or len(user_cols) == 1:
+            v0 = self._initial_config(df, reference=reference)
+            yellow_profile = self._yellow_sentinel_profile(df.height, user_cols)
+            return v0, yellow_profile, RunHistory()
+
+        # Loop body lands in Task 4.2. For now, bail out with v0 + sentinel.
+        v0 = self._initial_config(df, reference=reference)
+        # Returning a placeholder profile so the public contract is correct;
+        # Task 4.2 replaces this with the real iteration loop + finalize.
+        placeholder = ComplexityProfile(
+            data=DataProfile(
+                n_rows=df.height, n_cols=len(user_cols),
+                column_types={c: "unknown" for c in user_cols},
+            ),
+        )
+        return v0, placeholder, RunHistory()
+
+    # ---- Internals --------------------------------------------------------
+    def _initial_config(
+        self, df: pl.DataFrame, *, reference: pl.DataFrame | None
+    ) -> GoldenMatchConfig:
+        """Run the legacy heuristic to produce config v0.
+
+        Today's heuristic lives in core/autoconfig.py::auto_configure_df.
+        Task 5.1 will refactor that function to call the controller; until
+        then, we re-import and call it (it does not yet recurse via the
+        controller).
+        """
+        # Late import to avoid circulars
+        from goldenmatch.core.autoconfig import auto_configure_df as _legacy
+
+        # The legacy function does not (yet) accept a `reference` kwarg; for
+        # match-mode we call it on the concatenated frame as a v0 stand-in.
+        # Task 5.1 will plumb reference through properly; this is a
+        # placeholder that produces a workable starting config.
+        if reference is not None:
+            try:
+                merged = pl.concat([df, reference], how="vertical_relaxed")
+            except Exception:
+                merged = df
+            return _legacy(merged)
+        return _legacy(df)
+
+    def _take_sample(
+        self, df: pl.DataFrame, *, reference: pl.DataFrame | None
+    ) -> tuple[pl.DataFrame, pl.DataFrame | None]:
+        """Stratified sample. Below sample_skip_below → full data; above → sample_size_default rows.
+
+        Deterministic seed = hash of (n_rows, columns) for reproducibility.
+        Match mode samples target and reference independently with the same rules.
+        """
+        target_sample = self._sample_one(df)
+        ref_sample = self._sample_one(reference) if reference is not None else None
+        return target_sample, ref_sample
+
+    def _yellow_sentinel_profile(
+        self, n_rows: int, user_cols: list[str]
+    ) -> ComplexityProfile:
+        """Build a ComplexityProfile that rolls up to YELLOW.
+
+        Used for the pathological short-circuit paths (single-row, single-column)
+        where no pipeline run occurred. Sub-profiles are set to their minimum
+        non-RED values so the rollup is driven by the DataProfile verdict (YELLOW
+        for n_cols==1 or uniform column types).
+        """
+        from goldenmatch.core.complexity_profile import (
+            BlockingProfile, ScoringProfile, ClusterProfile,
+        )
+        # BlockingProfile: avoid RED by faking one block with good reduction
+        blocking = BlockingProfile(
+            n_blocks=max(n_rows, 1),
+            total_comparisons=max(n_rows, 1),
+            reduction_ratio=0.9,
+            block_sizes_p50=1,
+            block_sizes_p95=1,
+            block_sizes_p99=1,
+            block_sizes_max=1,
+            singleton_block_count=0,
+            oversized_block_count=0,
+        )
+        # ScoringProfile: avoid RED by providing non-zero mass/dip
+        scoring = ScoringProfile(
+            n_pairs_scored=0,
+            dip_statistic=0.01,
+            mass_above_threshold=0.01,
+            mass_in_borderline=0.0,
+        )
+        return ComplexityProfile(
+            data=DataProfile(
+                n_rows=n_rows, n_cols=len(user_cols),
+                column_types={c: "unknown" for c in user_cols},
+            ),
+            blocking=blocking,
+            scoring=scoring,
+        )
+
+    def _sample_one(self, df: pl.DataFrame) -> pl.DataFrame:
+        if df.height < self.budget.sample_skip_below:
+            return df
+        seed = self._seed_for(df)
+        # Polars sample with shuffle=False keeps row order; we want diverse coverage so shuffle=True.
+        return df.sample(n=self.budget.sample_size_default, seed=seed, shuffle=True)
+
+    def _seed_for(self, df: pl.DataFrame) -> int:
+        """Hash of data shape for reproducible sampling."""
+        key = f"{df.height}|{','.join(df.columns)}".encode("utf-8")
+        digest = hashlib.sha256(key).hexdigest()
+        return int(digest[:8], 16)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -123,7 +123,7 @@ class AutoConfigController:
                     with profile_capture() as emitter:
                         self._run_pipeline_sample(sample, sample_ref, config_n)
                     profile_n = self._assemble_profile(
-                        emitter, iteration=iteration, n_rows=sample.height,
+                        emitter, df=sample, iteration=iteration,
                     )
                     wall_ms = int((time.time() - iter_start) * 1000)
                     from goldenmatch.core.autoconfig_history import HistoryEntry
@@ -297,31 +297,23 @@ class AutoConfigController:
         self,
         emitter: Any,
         *,
+        df: pl.DataFrame,
         iteration: int,
-        n_rows: int,
         is_sample: bool = True,
     ) -> ComplexityProfile:
         """Build ComplexityProfile from emitter writes. Missing sub-profiles
-        fall back to defaults (which produce RED via DataProfile.n_rows=0).
-
-        When the emitter did not write a DataProfile, we infer n_rows from the
-        blocking sub-profile (n_blocks * block_sizes_p50) if available, so
-        that the health verdict is calibrated against the blocking stats rather
-        than the potentially-tiny sample size.
-        """
+        fall back to defaults computed from ``df`` so the rollup gets a
+        real DataProfile (without it, n_rows=0 forces RED and the controller
+        can never converge on a healthy config)."""
         from goldenmatch.core.complexity_profile import (
             DataProfile, BlockingProfile, ScoringProfile, ClusterProfile,
             MatchkeyProfile, DomainProfile, ProfileMeta,
         )
-        if emitter.data is None and emitter.blocking is not None and emitter.blocking.n_blocks > 0:
-            # Use block count × median block size as a lower-bound n_rows estimate
-            # so health verdicts are calibrated against the blocking-profile scale.
-            inferred = max(n_rows, emitter.blocking.n_blocks * max(emitter.blocking.block_sizes_p50, 1))
-            fallback_data = DataProfile(n_rows=inferred)
-        else:
-            fallback_data = DataProfile(n_rows=n_rows)
+
+        data = emitter.data or self._compute_data_profile(df)
+
         return ComplexityProfile(
-            data=emitter.data or fallback_data,
+            data=data,
             domain=emitter.domain or DomainProfile(),
             matchkey=emitter.matchkey or MatchkeyProfile(),
             blocking=emitter.blocking or BlockingProfile(),
@@ -329,8 +321,57 @@ class AutoConfigController:
             cluster=emitter.cluster or ClusterProfile(),
             meta=ProfileMeta(
                 iteration=iteration, is_sample=is_sample,
-                sample_size=n_rows, n_rows_full=n_rows,
+                sample_size=df.height, n_rows_full=df.height,
             ),
+        )
+
+    def _compute_data_profile(self, df: pl.DataFrame) -> "DataProfile":
+        """Compute a real DataProfile from a DataFrame. Used as fallback when
+        no pipeline stage emitted one (sample iterations don't go through
+        the autoconfig column-profiling step)."""
+        from goldenmatch.core.complexity_profile import DataProfile
+
+        user_cols = [c for c in df.columns if not c.startswith("__")]
+        n_rows = df.height
+
+        column_types: dict[str, str] = {}
+        cardinality_ratio: dict[str, float] = {}
+        null_rate: dict[str, float] = {}
+        value_length_p50: dict[str, int] = {}
+        value_length_p99: dict[str, int] = {}
+
+        for col in user_cols:
+            ser = df[col]
+            non_null = ser.drop_nulls()
+            n_non_null = non_null.len()
+            cardinality_ratio[col] = (non_null.n_unique() / n_non_null) if n_non_null else 0.0
+            null_rate[col] = 1 - (n_non_null / n_rows) if n_rows else 0.0
+            dtype = str(ser.dtype).lower()
+            if "utf" in dtype or "str" in dtype:
+                column_types[col] = "text"
+            elif "int" in dtype or "float" in dtype:
+                column_types[col] = "numeric"
+            elif "date" in dtype or "time" in dtype:
+                column_types[col] = "date"
+            else:
+                column_types[col] = "unknown"
+            if column_types[col] == "text" and n_non_null:
+                try:
+                    lens = sorted(non_null.cast(pl.Utf8).str.len_chars().to_list())
+                    if lens:
+                        value_length_p50[col] = int(lens[len(lens) // 2])
+                        value_length_p99[col] = int(lens[max(0, int(0.99 * len(lens)) - 1)])
+                except Exception:
+                    pass
+
+        return DataProfile(
+            n_rows=n_rows,
+            n_cols=len(user_cols),
+            column_types=column_types,
+            cardinality_ratio=cardinality_ratio,
+            null_rate=null_rate,
+            value_length_p50=value_length_p50,
+            value_length_p99=value_length_p99,
         )
 
     def _finalize(
@@ -347,5 +388,5 @@ class AutoConfigController:
         with profile_capture() as emitter:
             self._run_pipeline_sample(df, reference, config)
         return self._assemble_profile(
-            emitter, iteration=-1, n_rows=df.height, is_sample=False,
+            emitter, df=df, iteration=-1, is_sample=False,
         )

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -15,6 +15,7 @@ from datetime import timedelta
 from enum import Enum
 from typing import Any
 import hashlib
+import logging
 import time
 import traceback
 import polars as pl
@@ -26,6 +27,8 @@ from goldenmatch.core.complexity_profile import (
 from goldenmatch.core.autoconfig_history import RunHistory
 from goldenmatch.core.autoconfig_policy import RefitPolicy
 
+
+logger = logging.getLogger(__name__)
 
 # Sentinel: forces RED via DataProfile.health() when n_rows == 0.
 _RED_PROFILE: ComplexityProfile = ComplexityProfile(data=DataProfile(n_rows=0))
@@ -72,6 +75,8 @@ class AutoConfigController:
         df: pl.DataFrame,
         *,
         reference: pl.DataFrame | None = None,
+        v0_kwargs: dict | None = None,
+        skip_finalize: bool = False,
     ) -> tuple[GoldenMatchConfig, ComplexityProfile, RunHistory]:
         """Run iterative auto-config.
 
@@ -101,12 +106,12 @@ class AutoConfigController:
 
         # Single non-empty column or single row → return v0 yellow, skip loop
         if df.height == 1 or len(user_cols) == 1:
-            v0 = self._initial_config(df, reference=reference)
+            v0 = self._initial_config(df, reference=reference, v0_kwargs=v0_kwargs)
             yellow_profile = self._yellow_sentinel_profile(df.height, user_cols)
             return v0, yellow_profile, RunHistory()
 
         # Iteration loop (Task 4.2)
-        config_v0 = self._initial_config(df, reference=reference)
+        config_v0 = self._initial_config(df, reference=reference, v0_kwargs=v0_kwargs)
         sample, sample_ref = self._take_sample(df, reference=reference)
         history = RunHistory()
         config_n = config_v0
@@ -133,7 +138,7 @@ class AutoConfigController:
                     ))
                 except KeyboardInterrupt:
                     history.elapsed = timedelta(seconds=time.time() - start)
-                    break
+                    raise
                 except Exception as exc:
                     from goldenmatch.core.autoconfig_history import HistoryEntry, ErrorRecord
                     tb_lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
@@ -170,8 +175,30 @@ class AutoConfigController:
         # Pick committed config
         best_entry = history.cheapest_healthy()
         if best_entry is None:
-            # No healthy iterations → return v0 + RED sentinel
+            # No healthy iterations → return v0 + RED sentinel.
+            # Fix 6: emit a warning so operators can diagnose.
+            n_crashed = len(history.errors)
+            n_red = sum(
+                1 for e in history.entries
+                if e.profile.health() == HealthVerdict.RED and e.error is None
+            )
+            logger.warning(
+                "auto-config controller could not produce a healthy config; "
+                "committing v0. Iterations: %d total, %d crashed, %d RED. "
+                "Inspect _LAST_CONTROLLER_RUN.get() for diagnostics.",
+                history.iteration, n_crashed, n_red,
+            )
             return config_v0, _RED_PROFILE, history
+
+        # Fix 4: When skip_finalize=True (called from _api zero-config path),
+        # skip the full-data _finalize run. The caller will execute the real
+        # full pipeline immediately after, so running it here would be a double
+        # full run. Drift detection is deferred to Task 6.1 when the caller can
+        # compare pf.signals (a typed ComplexityProfile) against best_entry.profile.
+        if skip_finalize:
+            # Return the best sample profile in lieu of a full-data profile.
+            # history.full_vs_sample_drift is left None (drift not computed).
+            return best_entry.config, best_entry.profile, history
 
         # Finalize on full data (Task 4.3)
         profile_full = self._finalize(best_entry.config, df, reference)
@@ -185,9 +212,17 @@ class AutoConfigController:
 
     # ---- Internals --------------------------------------------------------
     def _initial_config(
-        self, df: pl.DataFrame, *, reference: pl.DataFrame | None
+        self,
+        df: pl.DataFrame,
+        *,
+        reference: pl.DataFrame | None,
+        v0_kwargs: dict | None = None,
     ) -> GoldenMatchConfig:
         """Run the legacy heuristic to produce config v0.
+
+        ``v0_kwargs`` are threaded through to ``_legacy_auto_configure_v0`` so
+        that callers of ``auto_configure_df(strict=True, llm_auto=True, ...)``
+        have their kwargs honoured in the initial heuristic pass.
 
         Today's heuristic lives in core/autoconfig.py::auto_configure_df.
         Task 5.1 will refactor that function to call the controller; until
@@ -196,6 +231,8 @@ class AutoConfigController:
         """
         # Late import to avoid circulars
         from goldenmatch.core.autoconfig import _legacy_auto_configure_v0 as _legacy
+
+        kw = v0_kwargs or {}
 
         # The legacy function does not (yet) accept a `reference` kwarg; for
         # match-mode we call it on the concatenated frame as a v0 stand-in.
@@ -206,16 +243,24 @@ class AutoConfigController:
                 merged = pl.concat([df, reference], how="vertical_relaxed")
             except Exception:
                 merged = df
-            return _legacy(merged)
-        return _legacy(df)
+            return _legacy(merged, **kw)
+        return _legacy(df, **kw)
 
     def _take_sample(
         self, df: pl.DataFrame, *, reference: pl.DataFrame | None
     ) -> tuple[pl.DataFrame, pl.DataFrame | None]:
-        """Stratified sample. Below sample_skip_below → full data; above → sample_size_default rows.
+        """Uniform random sample with a deterministic seed derived from data shape.
 
-        Deterministic seed = hash of (n_rows, columns) for reproducibility.
+        Below ``sample_skip_below`` rows → returns full data unchanged.
+        Above that threshold → samples exactly ``sample_size_default`` rows.
+        Seed = hash of (n_rows, column names) for reproducibility across runs
+        with the same schema.
+
         Match mode samples target and reference independently with the same rules.
+
+        # TODO(autoconfig-v2): replace with stratified sampling (e.g. by blocking-key
+        # group) to ensure rare subgroups are represented in the sample and the
+        # profile more faithfully reflects full-data behaviour.
         """
         target_sample = self._sample_one(df)
         ref_sample = self._sample_one(reference) if reference is not None else None

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -15,6 +15,8 @@ from datetime import timedelta
 from enum import Enum
 from typing import Any
 import hashlib
+import time
+import traceback
 import polars as pl
 
 from goldenmatch.config.schemas import GoldenMatchConfig
@@ -103,17 +105,83 @@ class AutoConfigController:
             yellow_profile = self._yellow_sentinel_profile(df.height, user_cols)
             return v0, yellow_profile, RunHistory()
 
-        # Loop body lands in Task 4.2. For now, bail out with v0 + sentinel.
-        v0 = self._initial_config(df, reference=reference)
-        # Returning a placeholder profile so the public contract is correct;
-        # Task 4.2 replaces this with the real iteration loop + finalize.
-        placeholder = ComplexityProfile(
-            data=DataProfile(
-                n_rows=df.height, n_cols=len(user_cols),
-                column_types={c: "unknown" for c in user_cols},
-            ),
-        )
-        return v0, placeholder, RunHistory()
+        # Iteration loop (Task 4.2)
+        config_v0 = self._initial_config(df, reference=reference)
+        sample, sample_ref = self._take_sample(df, reference=reference)
+        history = RunHistory()
+        config_n = config_v0
+        start = time.time()
+
+        try:
+            for iteration in range(self.budget.max_iterations + 1):
+                elapsed = time.time() - start
+                if elapsed > self.budget.max_seconds and iteration > 0:
+                    break
+                iter_start = time.time()
+                try:
+                    from goldenmatch.core.profile_emitter import profile_capture
+                    with profile_capture() as emitter:
+                        self._run_pipeline_sample(sample, sample_ref, config_n)
+                    profile_n = self._assemble_profile(
+                        emitter, iteration=iteration, n_rows=sample.height,
+                    )
+                    wall_ms = int((time.time() - iter_start) * 1000)
+                    from goldenmatch.core.autoconfig_history import HistoryEntry
+                    history.entries.append(HistoryEntry(
+                        iteration=iteration, config=config_n, profile=profile_n,
+                        decision=None, error=None, wall_clock_ms=wall_ms,
+                    ))
+                except KeyboardInterrupt:
+                    history.elapsed = timedelta(seconds=time.time() - start)
+                    break
+                except Exception as exc:
+                    from goldenmatch.core.autoconfig_history import HistoryEntry, ErrorRecord
+                    tb_lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
+                    tb_summary = "".join(tb_lines[:5] + tb_lines[-3:])[:2000]
+                    history.entries.append(HistoryEntry(
+                        iteration=iteration, config=config_n, profile=_RED_PROFILE,
+                        decision=None,
+                        error=ErrorRecord(
+                            exception_type=type(exc).__name__,
+                            traceback_summary=tb_summary,
+                        ),
+                        wall_clock_ms=int((time.time() - iter_start) * 1000),
+                    ))
+                    continue
+
+                # Stop check
+                if profile_n.health() == HealthVerdict.GREEN:
+                    break
+                if history.profile_distance_to_prev() < self.budget.converge_epsilon:
+                    break
+                if history.is_oscillating():
+                    break
+
+                # Ask policy for next config
+                config_next = self.policy.propose(profile_n, config_n, history)
+                if config_next is None:
+                    break
+                if config_next == config_n:
+                    break
+                config_n = config_next
+        finally:
+            history.elapsed = timedelta(seconds=time.time() - start)
+
+        # Pick committed config
+        best_entry = history.cheapest_healthy()
+        if best_entry is None:
+            # No healthy iterations → return v0 + RED sentinel
+            return config_v0, _RED_PROFILE, history
+
+        # Finalize on full data (Task 4.3)
+        profile_full = self._finalize(best_entry.config, df, reference)
+        # Drift detection
+        sample_vec = best_entry.profile.normalized_signal_vector()
+        full_vec = profile_full.normalized_signal_vector()
+        drift = sum(abs(a - b) for a, b in zip(sample_vec, full_vec))
+        history.full_vs_sample_drift = drift
+
+        return best_entry.config, profile_full, history
 
     # ---- Internals --------------------------------------------------------
     def _initial_config(
@@ -127,7 +195,7 @@ class AutoConfigController:
         controller).
         """
         # Late import to avoid circulars
-        from goldenmatch.core.autoconfig import auto_configure_df as _legacy
+        from goldenmatch.core.autoconfig import _legacy_auto_configure_v0 as _legacy
 
         # The legacy function does not (yet) accept a `reference` kwarg; for
         # match-mode we call it on the concatenated frame as a v0 stand-in.
@@ -198,11 +266,86 @@ class AutoConfigController:
         if df.height < self.budget.sample_skip_below:
             return df
         seed = self._seed_for(df)
+        n = min(self.budget.sample_size_default, df.height)
         # Polars sample with shuffle=False keeps row order; we want diverse coverage so shuffle=True.
-        return df.sample(n=self.budget.sample_size_default, seed=seed, shuffle=True)
+        return df.sample(n=n, seed=seed, shuffle=True)
 
     def _seed_for(self, df: pl.DataFrame) -> int:
         """Hash of data shape for reproducible sampling."""
         key = f"{df.height}|{','.join(df.columns)}".encode("utf-8")
         digest = hashlib.sha256(key).hexdigest()
         return int(digest[:8], 16)
+
+    def _run_pipeline_sample(
+        self,
+        sample: pl.DataFrame,
+        reference: pl.DataFrame | None,
+        config: GoldenMatchConfig,
+    ) -> None:
+        """Run the lightweight pipeline (blocking → score → cluster) on the sample.
+
+        Uses the public ``dedupe_df`` / ``match_df`` API so the same instrumented
+        stages run; the active ``profile_capture()`` collects sub-profiles.
+        """
+        from goldenmatch._api import dedupe_df, match_df
+        if reference is None:
+            dedupe_df(sample, config=config)
+        else:
+            match_df(sample, reference, config=config)
+
+    def _assemble_profile(
+        self,
+        emitter: Any,
+        *,
+        iteration: int,
+        n_rows: int,
+        is_sample: bool = True,
+    ) -> ComplexityProfile:
+        """Build ComplexityProfile from emitter writes. Missing sub-profiles
+        fall back to defaults (which produce RED via DataProfile.n_rows=0).
+
+        When the emitter did not write a DataProfile, we infer n_rows from the
+        blocking sub-profile (n_blocks * block_sizes_p50) if available, so
+        that the health verdict is calibrated against the blocking stats rather
+        than the potentially-tiny sample size.
+        """
+        from goldenmatch.core.complexity_profile import (
+            DataProfile, BlockingProfile, ScoringProfile, ClusterProfile,
+            MatchkeyProfile, DomainProfile, ProfileMeta,
+        )
+        if emitter.data is None and emitter.blocking is not None and emitter.blocking.n_blocks > 0:
+            # Use block count × median block size as a lower-bound n_rows estimate
+            # so health verdicts are calibrated against the blocking-profile scale.
+            inferred = max(n_rows, emitter.blocking.n_blocks * max(emitter.blocking.block_sizes_p50, 1))
+            fallback_data = DataProfile(n_rows=inferred)
+        else:
+            fallback_data = DataProfile(n_rows=n_rows)
+        return ComplexityProfile(
+            data=emitter.data or fallback_data,
+            domain=emitter.domain or DomainProfile(),
+            matchkey=emitter.matchkey or MatchkeyProfile(),
+            blocking=emitter.blocking or BlockingProfile(),
+            scoring=emitter.scoring or ScoringProfile(),
+            cluster=emitter.cluster or ClusterProfile(),
+            meta=ProfileMeta(
+                iteration=iteration, is_sample=is_sample,
+                sample_size=n_rows, n_rows_full=n_rows,
+            ),
+        )
+
+    def _finalize(
+        self,
+        config: GoldenMatchConfig,
+        df: pl.DataFrame,
+        reference: pl.DataFrame | None,
+    ) -> ComplexityProfile:
+        """Run the full pipeline on the full data with profile capture. Returns
+        a ComplexityProfile reflecting actual full-data behavior. Drift vs the
+        final sample profile is computed in run() and recorded on history.
+        """
+        from goldenmatch.core.profile_emitter import profile_capture
+        with profile_capture() as emitter:
+            self._run_pipeline_sample(df, reference, config)
+        return self._assemble_profile(
+            emitter, iteration=-1, n_rows=df.height, is_sample=False,
+        )

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
@@ -1,0 +1,94 @@
+"""RunHistory + audit-trail dataclasses for AutoConfigController.
+
+Spec: docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-design.md
+      §Types & contracts § "RunHistory".
+"""
+from __future__ import annotations
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any
+from goldenmatch.core.complexity_profile import ComplexityProfile, HealthVerdict
+
+
+@dataclass
+class PolicyDecision:
+    """Audit-trail record of one rule firing."""
+    rule_name: str
+    rationale: str
+    config_diff: dict[str, Any]
+
+
+@dataclass
+class ErrorRecord:
+    """Captured exception from a sample iteration that crashed."""
+    exception_type: str
+    traceback_summary: str
+
+
+@dataclass
+class HistoryEntry:
+    iteration: int
+    config: Any                # GoldenMatchConfig at runtime; Any to avoid import cycle
+    profile: ComplexityProfile
+    decision: PolicyDecision | None
+    error: ErrorRecord | None
+    wall_clock_ms: int
+
+
+@dataclass
+class RunHistory:
+    entries: list[HistoryEntry] = field(default_factory=list)
+    full_vs_sample_drift: float | None = None
+    elapsed: timedelta = field(default_factory=lambda: timedelta(0))
+    prior_runs: list[Any] = field(default_factory=list)  # v2 hook for Learning Memory
+
+    @property
+    def iteration(self) -> int:
+        return len(self.entries)
+
+    @property
+    def decisions(self) -> list[PolicyDecision]:
+        return [e.decision for e in self.entries if e.decision is not None]
+
+    @property
+    def errors(self) -> list[ErrorRecord]:
+        return [e.error for e in self.entries if e.error is not None]
+
+    def is_oscillating(self) -> bool:
+        """Same (config_hash, decision_hash) pair appears ≥2× in last 4 iters."""
+        window = self.entries[-4:]
+        if len(window) < 4:
+            return False
+        sigs = []
+        for e in window:
+            cfg_h = hash(repr(e.config))
+            dec_h = hash(e.decision.rule_name) if e.decision else 0
+            sigs.append((cfg_h, dec_h))
+        return any(c >= 2 for c in Counter(sigs).values())
+
+    def profile_distance_to_prev(self) -> float:
+        """L1 distance between last two profiles' normalized signal vectors.
+        Returns +inf when fewer than 2 entries (no prior to compare to)."""
+        if len(self.entries) < 2:
+            return float("inf")
+        a = self.entries[-1].profile.normalized_signal_vector()
+        b = self.entries[-2].profile.normalized_signal_vector()
+        return sum(abs(x - y) for x, y in zip(a, b))
+
+    def cheapest_healthy(self) -> HistoryEntry | None:
+        """Spec §Types & contracts § Cheapest-healthy ordering (S1-B):
+        lex key = (health_rank, -mass_separation, iteration).
+
+        Returns None when no entry has health != RED.
+        """
+        survivors = [e for e in self.entries if e.profile.health() != HealthVerdict.RED]
+        if not survivors:
+            return None
+
+        def key(e: HistoryEntry) -> tuple[int, float, int]:
+            health_rank = 0 if e.profile.health() == HealthVerdict.GREEN else 1
+            sep = e.profile.scoring.mass_above_threshold - e.profile.scoring.mass_in_borderline
+            return (health_rank, -sep, e.iteration)
+
+        return min(survivors, key=key)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_policy.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_policy.py
@@ -1,0 +1,73 @@
+"""RefitPolicy protocol + HeuristicRefitPolicy dispatcher.
+
+The actual rule list (5 rules) lives in ``autoconfig_rules.py`` and is loaded
+lazily so this module can be tested in isolation. Rules are pure functions:
+
+    Rule = Callable[
+        [ComplexityProfile, GoldenMatchConfig, RunHistory],
+        Optional[tuple[GoldenMatchConfig, PolicyDecision]],
+    ]
+
+Spec: docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-design.md
+      §HeuristicRefitPolicy rule table (v1).
+"""
+from __future__ import annotations
+from typing import Any, Callable, Protocol
+
+from goldenmatch.core.complexity_profile import ComplexityProfile, HealthVerdict
+from goldenmatch.core.autoconfig_history import RunHistory, PolicyDecision
+
+# Rule type alias. Returns (new_config, decision) tuple if it fires, else None.
+Rule = Callable[
+    [ComplexityProfile, Any, RunHistory],
+    "tuple[Any, PolicyDecision] | None",
+]
+
+
+class RefitPolicy(Protocol):
+    def propose(
+        self,
+        profile: ComplexityProfile,
+        current: Any,
+        history: RunHistory,
+    ) -> Any | None: ...
+
+
+class HeuristicRefitPolicy:
+    """Ordered rule table. First rule that returns non-None wins.
+
+    Per spec §RefitPolicy.propose return semantics (S1-A):
+      - None = satisfied → controller breaks loop with POLICY_SATISFIED
+      - A new config that == current is also treated as satisfied (bug guard)
+      - A previously-seen config is allowed; oscillation handled by controller
+    """
+
+    def __init__(self, rules: list[Rule] | None = None) -> None:
+        if rules is None:
+            from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
+            rules = DEFAULT_RULES
+        self._rules: list[Rule] = rules
+
+    def propose(
+        self,
+        profile: ComplexityProfile,
+        current: Any,
+        history: RunHistory,
+    ) -> Any | None:
+        if profile.health() == HealthVerdict.GREEN:
+            return None
+        for rule in self._rules:
+            outcome = rule(profile, current, history)
+            if outcome is None:
+                continue
+            new_config, decision = outcome
+            if new_config == current:
+                # Bug guard: rule "decided to do nothing" without saying so.
+                # Logged at WARN by the controller (not here — keep policy pure).
+                return None
+            # Attach decision to the latest history entry, if any
+            if history.entries:
+                history.entries[-1].decision = decision
+            return new_config
+        # No rule fired → satisfied
+        return None

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -52,7 +52,7 @@ def rule_blocking_too_coarse(
     used = _existing_blocking_fields(current)
     candidates = [
         col for col, ratio in profile.data.cardinality_ratio.items()
-        if 0.05 <= ratio <= 0.5 and col not in used
+        if 0.01 <= ratio <= 0.95 and col not in used
     ]
     if not candidates:
         return None
@@ -173,8 +173,10 @@ def rule_no_matches(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> "tuple[GoldenMatchConfig, PolicyDecision] | None":
     sp = profile.scoring
-    if sp.mass_above_threshold > 0.0 or sp.n_pairs_scored == 0:
-        return None
+    # Fires on either (a) scored pairs but none above threshold,
+    # or (b) blocking produced no scorable pairs at all (singleton trap).
+    if sp.mass_above_threshold > 0.0:
+        return None  # something matched; not our case
     mk = _first_weighted_mk(current)
     if mk is None:
         return None
@@ -198,8 +200,11 @@ def rule_no_matches(
     new_cfg = current.model_copy(update=updates)
     decision = PolicyDecision(
         rule_name="no_matches",
-        rationale=f"mass_above_threshold={sp.mass_above_threshold} on "
-                  f"{sp.n_pairs_scored} pairs; resetting to permissive baseline",
+        rationale=(
+            f"mass_above_threshold={sp.mass_above_threshold} on "
+            f"{sp.n_pairs_scored} pairs scored; resetting to permissive baseline "
+            f"(lower threshold, broader blocking)"
+        ),
         config_diff=updates,
     )
     return new_cfg, decision

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -1,7 +1,214 @@
-"""Default rule table for HeuristicRefitPolicy. Rules are added in Task 3.2."""
-from __future__ import annotations
+"""Default rule table for HeuristicRefitPolicy.
 
-# Populated by Task 3.2 — empty list means the policy is always "satisfied"
-# (returns None for all non-green profiles). This is correct fall-through
-# behavior; tests use injected rules.
-DEFAULT_RULES: list = []
+Each rule is a pure function:
+    (ComplexityProfile, GoldenMatchConfig, RunHistory)
+        → tuple[GoldenMatchConfig, PolicyDecision] | None
+
+Spec: docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-design.md
+      §HeuristicRefitPolicy rule table (v1).
+"""
+from __future__ import annotations
+from typing import Any
+from goldenmatch.config.schemas import (
+    GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+    BlockingConfig, BlockingKeyConfig,
+)
+from goldenmatch.core.complexity_profile import ComplexityProfile
+from goldenmatch.core.autoconfig_history import RunHistory, PolicyDecision
+
+
+def _first_weighted_mk(cfg: GoldenMatchConfig) -> MatchkeyConfig | None:
+    for mk in cfg.matchkeys or []:
+        if mk.type == "weighted":
+            return mk
+    return None
+
+
+def _existing_blocking_fields(cfg: GoldenMatchConfig) -> set[str]:
+    if cfg.blocking is None:
+        return set()
+    fields: set[str] = set()
+    for k in (cfg.blocking.keys or []):
+        for f in (k.fields or []):
+            fields.add(f)
+    for k in (cfg.blocking.passes or []):
+        for f in (k.fields or []):
+            fields.add(f)
+    return fields
+
+
+def rule_blocking_too_coarse(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> "tuple[GoldenMatchConfig, PolicyDecision] | None":
+    bp = profile.blocking
+    n_rows = profile.data.n_rows
+    if bp.n_blocks == 0 or n_rows == 0:
+        return None
+    avg = n_rows / bp.n_blocks
+    if bp.block_sizes_p99 <= 10 * avg:
+        return None
+    if current.blocking is None:
+        return None
+    used = _existing_blocking_fields(current)
+    candidates = [
+        col for col, ratio in profile.data.cardinality_ratio.items()
+        if 0.05 <= ratio <= 0.5 and col not in used
+    ]
+    if not candidates:
+        return None
+    new_col = candidates[0]
+    new_blocking = current.blocking.model_copy(update={
+        "keys": [BlockingKeyConfig(fields=[new_col], transforms=["lowercase"])],
+    })
+    new_cfg = current.model_copy(update={"blocking": new_blocking})
+    decision = PolicyDecision(
+        rule_name="blocking_too_coarse",
+        rationale=f"block_sizes_p99={bp.block_sizes_p99} > 10 * avg ({10*avg:.0f}); "
+                  f"trying more selective key '{new_col}' (cardinality "
+                  f"{profile.data.cardinality_ratio[new_col]:.2f})",
+        config_diff={"blocking.keys[0].fields": [new_col]},
+    )
+    return new_cfg, decision
+
+
+def rule_unimodal_scoring(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> "tuple[GoldenMatchConfig, PolicyDecision] | None":
+    sp = profile.scoring
+    if sp.dip_statistic >= 0.01 or sp.n_pairs_scored == 0:
+        return None
+    mk = _first_weighted_mk(current)
+    if mk is None:
+        return None
+    # Pick highest-cardinality matchkey field that exists in the matchkey
+    field_names = {f.field for f in mk.fields or []}
+    sorted_fields = sorted(
+        ((name, fs.post_transform_cardinality_ratio)
+         for name, fs in profile.matchkey.per_field.items()
+         if name in field_names),
+        key=lambda kv: -kv[1],
+    )
+    if not sorted_fields:
+        return None
+    target_field = sorted_fields[0][0]
+    new_fields = []
+    changed = False
+    for f in mk.fields:
+        if f.field == target_field and f.scorer != "ensemble":
+            new_fields.append(f.model_copy(update={"scorer": "ensemble"}))
+            changed = True
+        else:
+            new_fields.append(f)
+    if not changed:
+        return None
+    new_mk = mk.model_copy(update={"fields": new_fields})
+    new_matchkeys = [new_mk if m is mk else m for m in current.matchkeys]
+    new_cfg = current.model_copy(update={"matchkeys": new_matchkeys})
+    decision = PolicyDecision(
+        rule_name="unimodal_scoring",
+        rationale=f"dip_statistic={sp.dip_statistic:.4f} < 0.01; "
+                  f"swapping scorer on '{target_field}' to ensemble",
+        config_diff={f"matchkeys[].fields[{target_field}].scorer": "ensemble"},
+    )
+    return new_cfg, decision
+
+
+def rule_low_reduction_ratio(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> "tuple[GoldenMatchConfig, PolicyDecision] | None":
+    bp = profile.blocking
+    if bp.reduction_ratio >= 0.5:
+        return None
+    if current.blocking is None or not current.blocking.keys:
+        return None
+    text_cols = [
+        col for col, ctype in profile.data.column_types.items()
+        if ctype in ("text", "name")
+    ]
+    if not text_cols:
+        return None
+    used = _existing_blocking_fields(current)
+    soundex_candidate = next((c for c in text_cols if c not in used), text_cols[0])
+    existing_keys = list(current.blocking.keys)
+    new_pass = BlockingKeyConfig(fields=[soundex_candidate], transforms=["soundex"])
+    new_blocking = current.blocking.model_copy(update={
+        "strategy": "multi_pass",
+        "passes": existing_keys + [new_pass],
+    })
+    new_cfg = current.model_copy(update={"blocking": new_blocking})
+    decision = PolicyDecision(
+        rule_name="low_reduction_ratio",
+        rationale=f"reduction_ratio={bp.reduction_ratio:.2f} < 0.5; "
+                  f"adding soundex pass on '{soundex_candidate}'",
+        config_diff={"blocking.strategy": "multi_pass"},
+    )
+    return new_cfg, decision
+
+
+def rule_low_transitivity(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> "tuple[GoldenMatchConfig, PolicyDecision] | None":
+    cp = profile.cluster
+    if cp.transitivity_rate >= 0.85 or cp.n_clusters == 0:
+        return None
+    mk = _first_weighted_mk(current)
+    if mk is None or mk.threshold is None:
+        return None
+    new_threshold = max(0.5, mk.threshold - 0.05)
+    if new_threshold == mk.threshold:
+        return None
+    new_mk = mk.model_copy(update={"threshold": new_threshold})
+    new_matchkeys = [new_mk if m is mk else m for m in current.matchkeys]
+    new_cfg = current.model_copy(update={"matchkeys": new_matchkeys})
+    decision = PolicyDecision(
+        rule_name="low_transitivity",
+        rationale=f"transitivity={cp.transitivity_rate:.2f} < 0.85; "
+                  f"lowering threshold {mk.threshold:.2f} → {new_threshold:.2f}",
+        config_diff={"matchkeys[0].threshold": new_threshold},
+    )
+    return new_cfg, decision
+
+
+def rule_no_matches(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> "tuple[GoldenMatchConfig, PolicyDecision] | None":
+    sp = profile.scoring
+    if sp.mass_above_threshold > 0.0 or sp.n_pairs_scored == 0:
+        return None
+    mk = _first_weighted_mk(current)
+    if mk is None:
+        return None
+    needs_threshold_change = mk.threshold is not None and mk.threshold > 0.5
+    needs_blocking_loosen = (
+        current.blocking is not None
+        and current.blocking.max_block_size < 50000
+    )
+    if not (needs_threshold_change or needs_blocking_loosen):
+        return None
+    updates: dict[str, Any] = {}
+    if needs_threshold_change:
+        new_mk = mk.model_copy(update={"threshold": 0.5})
+        updates["matchkeys"] = [new_mk if m is mk else m for m in current.matchkeys]
+    if needs_blocking_loosen:
+        new_blocking = current.blocking.model_copy(update={
+            "max_block_size": 50000,
+            "skip_oversized": False,
+        })
+        updates["blocking"] = new_blocking
+    new_cfg = current.model_copy(update=updates)
+    decision = PolicyDecision(
+        rule_name="no_matches",
+        rationale=f"mass_above_threshold={sp.mass_above_threshold} on "
+                  f"{sp.n_pairs_scored} pairs; resetting to permissive baseline",
+        config_diff=updates,
+    )
+    return new_cfg, decision
+
+
+DEFAULT_RULES = [
+    rule_blocking_too_coarse,
+    rule_unimodal_scoring,
+    rule_low_reduction_ratio,
+    rule_low_transitivity,
+    rule_no_matches,
+]

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -1,0 +1,7 @@
+"""Default rule table for HeuristicRefitPolicy. Rules are added in Task 3.2."""
+from __future__ import annotations
+
+# Populated by Task 3.2 — empty list means the policy is always "satisfied"
+# (returns None for all non-green profiles). This is correct fall-through
+# behavior; tests use injected rules.
+DEFAULT_RULES: list = []

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
@@ -217,6 +217,11 @@ class PostflightReport:
     --llm-auto"). ``memory_stats`` is set by the result-build layer when the
     Learning Memory hook produced a ``CorrectionStats`` for this run; the
     string render surfaces it as a single ``Memory: ...`` line.
+
+    ``controller_profile`` and ``controller_history`` are populated by the
+    zero-config path in ``_api.dedupe_df`` / ``_api.match_df`` when the
+    AutoConfigController ran. They are ``None`` for hand-written configs.
+    Kept loosely typed to avoid import cycles with autoconfig modules.
     """
 
     signals: "PostflightSignals" = field(default_factory=_empty_signals)
@@ -226,6 +231,12 @@ class PostflightReport:
     # to avoid an import cycle (corrections.py imports nothing from this
     # module today, but we don't want to invert that).
     memory_stats: Any = None
+    # Set by zero-config API callers after the controller runs.
+    # ComplexityProfile | None — profile from the full-data finalize run (or
+    # the sample profile when _skip_finalize=True is used from _api).
+    controller_profile: Any = None
+    # RunHistory | None — full iteration history including errors and drift.
+    controller_history: Any = None
 
     def __str__(self) -> str:
         """Human-readable rendering used by CLI/postflight summaries.

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -3,14 +3,85 @@
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 
 import polars as pl
 
 from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig, CanopyConfig
 from goldenmatch.utils.transforms import apply_transforms
+from goldenmatch.core.profile_emitter import current_emitter, _emitter_stack
+from goldenmatch.core.complexity_profile import BlockingProfile
 
 logger = logging.getLogger(__name__)
+
+
+def _percentile(xs: list[int], q: float) -> int:
+    """Return the q-th percentile of a sorted list of ints."""
+    if not xs:
+        return 0
+    idx = max(0, min(len(xs) - 1, int(math.ceil(q * len(xs))) - 1))
+    return xs[idx]
+
+
+def _emit_blocking_profile(
+    blocks: list["BlockResult"],
+    config: BlockingConfig,
+    lf: pl.LazyFrame,
+) -> None:
+    """Compute and emit a BlockingProfile to the active emitter.
+
+    Short-circuits immediately when no capture is active so non-controller
+    pipeline runs pay zero cost beyond the ``_emitter_stack.get()`` call.
+    """
+    if not _emitter_stack.get():
+        return
+
+    # n_rows is computed here, only when an emitter is active.
+    n_rows: int = lf.select(pl.len()).collect().item()
+
+    # Determine keys_used: prefer passes if truthy, else keys if truthy, else []
+    if config.passes:
+        keys_used = [list(k.fields) for k in config.passes]
+    elif config.keys:
+        keys_used = [list(k.fields) for k in config.keys]
+    else:
+        keys_used = []
+
+    # Collect block sizes by collecting each LazyFrame.
+    # For static/adaptive blocks the underlying DataFrame is already in memory
+    # (group_df.lazy()); collecting again is O(1) copy.
+    sizes: list[int] = []
+    for b in blocks:
+        try:
+            size = b.df.select(pl.len()).collect().item()
+        except Exception:
+            size = 0
+        sizes.append(size)
+
+    sizes_sorted = sorted(sizes)
+    n_blocks = len(sizes_sorted)
+
+    total_comparisons = sum(s * (s - 1) // 2 for s in sizes_sorted)
+    max_pairs = n_rows * (n_rows - 1) // 2
+    reduction_ratio = 1.0 - total_comparisons / max(1, max_pairs)
+
+    singleton_block_count = sum(1 for s in sizes_sorted if s == 1)
+    oversized_block_count = sum(1 for s in sizes_sorted if s > config.max_block_size)
+
+    profile = BlockingProfile(
+        keys_used=keys_used,
+        n_blocks=n_blocks,
+        total_comparisons=total_comparisons,
+        reduction_ratio=reduction_ratio,
+        block_sizes_p50=_percentile(sizes_sorted, 0.50),
+        block_sizes_p95=_percentile(sizes_sorted, 0.95),
+        block_sizes_p99=_percentile(sizes_sorted, 0.99),
+        block_sizes_max=max(sizes_sorted) if sizes_sorted else 0,
+        singleton_block_count=singleton_block_count,
+        oversized_block_count=oversized_block_count,
+    )
+    current_emitter().set_blocking(profile)
 
 
 @dataclass
@@ -745,25 +816,39 @@ def build_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
         config = config.model_copy(update={"keys": [best_key], "auto_select": False})
 
     if config.strategy == "learned":
-        return _build_learned_blocks(lf, config)
+        blocks = _build_learned_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
 
     if config.strategy == "canopy":
-        return _build_canopy_blocks(lf, config)
+        blocks = _build_canopy_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
 
     if config.strategy == "ann_pairs":
-        return _build_ann_pair_blocks(lf, config)
+        blocks = _build_ann_pair_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
 
     if config.strategy == "ann":
-        return _build_ann_blocks(lf, config)
+        blocks = _build_ann_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
 
     if config.strategy == "sorted_neighborhood":
-        return _build_sorted_neighborhood_blocks(lf, config)
+        blocks = _build_sorted_neighborhood_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
 
     if config.strategy == "multi_pass":
-        return _build_multi_pass_blocks(lf, config)
+        blocks = _build_multi_pass_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
 
     if config.strategy == "static":
-        return _build_static_blocks(lf, config)
+        blocks = _build_static_blocks(lf, config)
+        _emit_blocking_profile(blocks, config, lf)
+        return blocks
 
     # strategy == "adaptive"
     primary_blocks = _build_static_blocks(lf, config)
@@ -790,4 +875,5 @@ def build_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
         else:
             results.append(block)
 
+    _emit_blocking_profile(results, config, lf)
     return results

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -8,6 +8,10 @@ from collections import defaultdict
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from goldenmatch.core.profile_emitter import current_emitter, _emitter_stack
+from goldenmatch.core.complexity_profile import ClusterProfile
+from goldenmatch.core._profile_helpers import transitivity_rate
+
 if TYPE_CHECKING:
     from goldenmatch.core.memory.store import MemoryStore
 
@@ -152,9 +156,62 @@ def split_oversized_cluster(
     return result
 
 
+def _emit_cluster_profile(clusters: "dict[int, dict]") -> None:
+    """Emit ClusterProfile to current emitter. No-op when no capture is active."""
+    import math
+    if not _emitter_stack.get():
+        return  # fast path: no capture active
+
+    if not clusters:
+        current_emitter().set_cluster(ClusterProfile())
+        return
+
+    sizes = sorted(c["size"] for c in clusters.values())
+
+    def percentile(xs: list, q: float) -> int:
+        if not xs:
+            return 0
+        idx = max(0, min(len(xs) - 1, int(math.ceil(q * len(xs))) - 1))
+        return xs[idx]
+
+    confidences = sorted(
+        c["confidence"] for c in clusters.values()
+        if c.get("confidence") is not None
+    )
+
+    members_by_cluster = {cid: c["members"] for cid, c in clusters.items()}
+
+    # Aggregate pair_scores across clusters
+    aggregated_scores: "dict[tuple[int, int], float]" = {}
+    for c in clusters.values():
+        for k, v in c.get("pair_scores", {}).items():
+            if isinstance(k, tuple) and len(k) == 2:
+                a, b = k
+                aggregated_scores[(min(a, b), max(a, b))] = v
+
+    # Threshold proxy: minimum observed pair score (any pair already passed the
+    # matchkey threshold, so the min is the effective formation floor).
+    if aggregated_scores:
+        threshold = min(aggregated_scores.values())
+    else:
+        threshold = 0.5  # fallback
+
+    profile = ClusterProfile(
+        n_clusters=len(clusters),
+        cluster_size_p50=percentile(sizes, 0.50),
+        cluster_size_p99=percentile(sizes, 0.99),
+        cluster_size_max=sizes[-1] if sizes else 0,
+        transitivity_rate=transitivity_rate(members_by_cluster, aggregated_scores, threshold),
+        edge_confidence_p50=confidences[len(confidences) // 2] if confidences else 0.0,
+        edge_confidence_min=confidences[0] if confidences else 0.0,
+        oversized_cluster_count=sum(1 for c in clusters.values() if c.get("oversized")),
+    )
+    current_emitter().set_cluster(profile)
+
+
 def build_clusters(
     pairs: list[tuple[int, int, float]],
-    all_ids: list[int],
+    all_ids: "list[int] | None" = None,
     max_cluster_size: int = 100,
     weak_cluster_threshold: float = 0.3,
     auto_split: bool = True,
@@ -164,6 +221,14 @@ def build_clusters(
     Auto-splits oversized clusters via MST (when auto_split=True). Assigns cluster_quality
     ("strong", "weak", "split") and downgrades confidence for weak clusters.
     """
+    # Derive all_ids from pairs when not provided explicitly
+    if all_ids is None:
+        seen: set[int] = set()
+        for id_a, id_b, _s in pairs:
+            seen.add(id_a)
+            seen.add(id_b)
+        all_ids = list(seen)
+
     uf = UnionFind()
     uf.add_many(all_ids)
     for id_a, id_b, _score in pairs:
@@ -228,6 +293,7 @@ def build_clusters(
             cinfo["cluster_quality"] = "strong"
         cinfo.pop("_was_split", None)
 
+    _emit_cluster_profile(result)
     return result
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -1,0 +1,195 @@
+"""Stage-specific complexity sub-profiles + rollup, emitted by instrumented
+pipeline stages and consumed by AutoConfigController + RefitPolicy.
+
+Spec: docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-design.md §Types & contracts.
+"""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Literal
+
+ColumnType = Literal["text", "numeric", "id-like", "date", "geo", "phone", "email", "name", "unknown"]
+
+
+class HealthVerdict(Enum):
+    GREEN = "green"
+    YELLOW = "yellow"
+    RED = "red"
+
+
+def _max_severity(*verdicts: HealthVerdict) -> HealthVerdict:
+    if HealthVerdict.RED in verdicts:
+        return HealthVerdict.RED
+    if HealthVerdict.YELLOW in verdicts:
+        return HealthVerdict.YELLOW
+    return HealthVerdict.GREEN
+
+
+@dataclass(frozen=True)
+class DataProfile:
+    _version: int = 1
+    n_rows: int = 0
+    n_cols: int = 0
+    column_types: dict[str, ColumnType] = field(default_factory=dict)
+    cardinality_ratio: dict[str, float] = field(default_factory=dict)
+    null_rate: dict[str, float] = field(default_factory=dict)
+    value_length_p50: dict[str, int] = field(default_factory=dict)
+    value_length_p99: dict[str, int] = field(default_factory=dict)
+
+    def health(self) -> HealthVerdict:
+        if self.n_rows == 0:
+            return HealthVerdict.RED
+        if self.n_cols == 1 or len(set(self.column_types.values())) == 1:
+            return HealthVerdict.YELLOW
+        return HealthVerdict.GREEN
+
+
+@dataclass(frozen=True)
+class DomainProfile:
+    _version: int = 1
+    detected_domain: str | None = None
+    confidence: float = 0.0
+    derived_columns: list[str] = field(default_factory=list)
+    low_confidence_row_count: int = 0
+
+    def health(self) -> HealthVerdict:
+        if self.confidence < 0.3 and self.derived_columns:
+            return HealthVerdict.YELLOW
+        return HealthVerdict.GREEN
+
+
+@dataclass(frozen=True)
+class FieldStats:
+    post_transform_cardinality_ratio: float
+    post_transform_null_rate: float
+    post_transform_value_length_p50: int
+
+
+@dataclass(frozen=True)
+class MatchkeyProfile:
+    _version: int = 1
+    per_field: dict[str, FieldStats] = field(default_factory=dict)
+
+    def health(self) -> HealthVerdict:
+        verdicts = []
+        for fs in self.per_field.values():
+            if fs.post_transform_cardinality_ratio == 0.0:
+                verdicts.append(HealthVerdict.RED)
+            elif fs.post_transform_cardinality_ratio > 0.95:
+                verdicts.append(HealthVerdict.YELLOW)
+        return _max_severity(*verdicts) if verdicts else HealthVerdict.GREEN
+
+
+@dataclass(frozen=True)
+class BlockingProfile:
+    _version: int = 1
+    keys_used: list[list[str]] = field(default_factory=list)
+    n_blocks: int = 0
+    total_comparisons: int = 0
+    reduction_ratio: float = 0.0
+    block_sizes_p50: int = 0
+    block_sizes_p95: int = 0
+    block_sizes_p99: int = 0
+    block_sizes_max: int = 0
+    singleton_block_count: int = 0
+    oversized_block_count: int = 0
+
+    def health(self, n_rows: int) -> HealthVerdict:
+        if self.n_blocks == 0:
+            return HealthVerdict.RED
+        avg = n_rows / max(self.n_blocks, 1)
+        if self.block_sizes_p99 > 10 * avg:
+            return HealthVerdict.RED
+        if self.reduction_ratio < 0.5:
+            return HealthVerdict.RED
+        if self.singleton_block_count / self.n_blocks > 0.5:
+            return HealthVerdict.YELLOW
+        return HealthVerdict.GREEN
+
+
+@dataclass(frozen=True)
+class ScoringProfile:
+    _version: int = 1
+    n_pairs_scored: int = 0
+    score_histogram: list[int] = field(default_factory=lambda: [0] * 20)
+    dip_statistic: float = 0.0
+    mass_above_threshold: float = 0.0
+    mass_in_borderline: float = 0.0
+    per_field_score_variance: dict[str, float] = field(default_factory=dict)
+
+    def health(self) -> HealthVerdict:
+        if self.mass_above_threshold == 0.0:
+            return HealthVerdict.RED
+        if self.dip_statistic < 0.005:
+            return HealthVerdict.RED
+        if self.mass_in_borderline > 0.3:
+            return HealthVerdict.YELLOW
+        return HealthVerdict.GREEN
+
+
+@dataclass(frozen=True)
+class ClusterProfile:
+    _version: int = 1
+    n_clusters: int = 0
+    cluster_size_p50: int = 0
+    cluster_size_p99: int = 0
+    cluster_size_max: int = 0
+    transitivity_rate: float = 1.0
+    edge_confidence_p50: float = 0.0
+    edge_confidence_min: float = 0.0
+    oversized_cluster_count: int = 0
+
+    def health(self, n_rows: int) -> HealthVerdict:
+        if n_rows > 0 and self.cluster_size_max > 0.1 * n_rows:
+            return HealthVerdict.RED
+        if self.transitivity_rate < 0.85:
+            return HealthVerdict.RED
+        if self.oversized_cluster_count > 0:
+            return HealthVerdict.YELLOW
+        return HealthVerdict.GREEN
+
+
+@dataclass(frozen=True)
+class ProfileMeta:
+    _version: int = 1
+    iteration: int = 0
+    is_sample: bool = True
+    sample_size: int = 0
+    n_rows_full: int = 0
+    wall_clock_ms: int = 0
+    seed: int = 0
+
+
+@dataclass(frozen=True)
+class ComplexityProfile:
+    _version: int = 1
+    data: DataProfile = field(default_factory=DataProfile)
+    domain: DomainProfile = field(default_factory=DomainProfile)
+    matchkey: MatchkeyProfile = field(default_factory=MatchkeyProfile)
+    blocking: BlockingProfile = field(default_factory=BlockingProfile)
+    scoring: ScoringProfile = field(default_factory=ScoringProfile)
+    cluster: ClusterProfile = field(default_factory=ClusterProfile)
+    meta: ProfileMeta = field(default_factory=ProfileMeta)
+
+    def health(self) -> HealthVerdict:
+        return _max_severity(
+            self.data.health(),
+            self.domain.health(),
+            self.matchkey.health(),
+            self.blocking.health(n_rows=self.data.n_rows),
+            self.scoring.health(),
+            self.cluster.health(n_rows=self.data.n_rows),
+        )
+
+    def normalized_signal_vector(self) -> list[float]:
+        """L1-distance vector for convergence detection. v1 picks 8 signals."""
+        return [
+            min(self.blocking.reduction_ratio, 1.0),
+            min(self.blocking.block_sizes_p99 / max(self.data.n_rows, 1), 1.0),
+            min(self.scoring.dip_statistic / 0.1, 1.0),
+            self.scoring.mass_above_threshold,
+            self.scoring.mass_in_borderline,
+            self.cluster.transitivity_rate,
+            min(self.cluster.cluster_size_max / max(self.data.n_rows, 1), 1.0),
+            float(self.cluster.n_clusters > 0),
+        ]

--- a/packages/python/goldenmatch/goldenmatch/core/domain.py
+++ b/packages/python/goldenmatch/goldenmatch/core/domain.py
@@ -15,6 +15,9 @@ from dataclasses import dataclass, field
 
 import polars as pl
 
+from goldenmatch.core.profile_emitter import current_emitter, _emitter_stack
+from goldenmatch.core.complexity_profile import DomainProfile as PublicDomainProfile
+
 logger = logging.getLogger(__name__)
 
 
@@ -408,6 +411,19 @@ def extract_biblio_features(text: str) -> dict[str, str | None]:
 # ── DataFrame-Level Extraction ────────────────────────────────────────────
 
 
+def _emit_domain_profile(domain: "DomainProfile", df_after: pl.DataFrame, low_conf_ids) -> None:
+    """Emit PublicDomainProfile. No-op when null emitter."""
+    if not _emitter_stack.get():
+        return
+    derived = [c for c in df_after.columns if c.startswith("__")]
+    current_emitter().set_domain(PublicDomainProfile(
+        detected_domain=getattr(domain, "name", None),
+        confidence=float(getattr(domain, "confidence", 0.0)),
+        derived_columns=derived,
+        low_confidence_row_count=len(low_conf_ids) if low_conf_ids else 0,
+    ))
+
+
 def extract_features(
     df: pl.DataFrame,
     domain: DomainProfile,
@@ -425,6 +441,7 @@ def extract_features(
         and list of row IDs that need LLM validation.
     """
     if not domain.text_columns:
+        _emit_domain_profile(domain, df, [])
         return df, []
 
     if domain.name == "product":
@@ -434,14 +451,17 @@ def extract_features(
             logger.info("Product subdomain auto-detected: %s", domain.subdomain)
 
         if domain.subdomain == "software":
-            return _extract_software_features_df(df, domain, confidence_threshold)
+            result_df, low_conf = _extract_software_features_df(df, domain, confidence_threshold)
         else:
-            return _extract_product_features_df(df, domain, confidence_threshold)
+            result_df, low_conf = _extract_product_features_df(df, domain, confidence_threshold)
     elif domain.name == "bibliographic":
-        return _extract_biblio_features_df(df, domain, confidence_threshold)
+        result_df, low_conf = _extract_biblio_features_df(df, domain, confidence_threshold)
     else:
         # Person and company domains — minimal extraction for now
-        return df, []
+        result_df, low_conf = df, []
+
+    _emit_domain_profile(domain, result_df, low_conf)
+    return result_df, low_conf
 
 
 def _detect_product_subdomain(df: pl.DataFrame, domain: DomainProfile) -> str:

--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -9,6 +9,8 @@ import polars as pl
 
 from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
 from goldenmatch.utils.transforms import apply_transforms
+from goldenmatch.core.profile_emitter import current_emitter, _emitter_stack
+from goldenmatch.core.complexity_profile import MatchkeyProfile, FieldStats
 
 
 def _try_native_chain(column: str, transforms: list[str]) -> pl.Expr | None:
@@ -116,6 +118,50 @@ def build_matchkey_expr(mk: MatchkeyConfig) -> pl.Expr:
     return pl.concat_str(field_exprs, separator="||").alias(alias)
 
 
+def _emit_matchkey_profile(lf_after: "pl.LazyFrame", matchkeys: list) -> None:
+    """Emit MatchkeyProfile from post-transform columns. No-op when null emitter."""
+    if not _emitter_stack.get():
+        return
+    df = lf_after.collect()
+    n_total = df.height
+    per_field: dict[str, FieldStats] = {}
+    seen_fields: set[str] = set()
+    for mk in matchkeys:
+        for f in getattr(mk, "fields", []) or []:
+            field_name = getattr(f, "field", None)
+            if field_name is None or field_name in seen_fields:
+                continue
+            seen_fields.add(field_name)
+            # Try the exact-matchkey combined column, then fall back to raw column
+            mk_col = f"__mk_{mk.name}__"
+            candidates = [mk_col, field_name]
+            col = next((c for c in candidates if c in df.columns), None)
+            if col is None or n_total == 0:
+                continue
+            ser = df.select(pl.col(col)).to_series()
+            non_null = ser.drop_nulls()
+            n_non_null = non_null.len()
+            if n_non_null == 0:
+                per_field[field_name] = FieldStats(
+                    post_transform_cardinality_ratio=0.0,
+                    post_transform_null_rate=1.0,
+                    post_transform_value_length_p50=0,
+                )
+                continue
+            n_distinct = non_null.n_unique()
+            try:
+                lengths = sorted(non_null.cast(pl.Utf8).str.len_chars().to_list())
+                p50 = lengths[len(lengths) // 2] if lengths else 0
+            except Exception:
+                p50 = 0
+            per_field[field_name] = FieldStats(
+                post_transform_cardinality_ratio=n_distinct / n_non_null,
+                post_transform_null_rate=1 - (n_non_null / n_total),
+                post_transform_value_length_p50=int(p50),
+            )
+    current_emitter().set_matchkey(MatchkeyProfile(per_field=per_field))
+
+
 def compute_matchkeys(
     lf: pl.LazyFrame, matchkeys: list[MatchkeyConfig]
 ) -> pl.LazyFrame:
@@ -134,6 +180,7 @@ def compute_matchkeys(
             exprs.append(build_matchkey_expr(mk))
     if exprs:
         lf = lf.with_columns(exprs)
+    _emit_matchkey_profile(lf, matchkeys)
     return lf
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -372,18 +372,30 @@ def _add_row_ids(lf: pl.LazyFrame, offset: int = 0) -> pl.LazyFrame:
 
 
 def _get_required_columns(config: GoldenMatchConfig) -> list[str]:
-    """Extract all column names referenced in matchkeys and blocking config."""
+    """Extract all *user* column names referenced in matchkeys and blocking config.
+
+    Skips pipeline-generated synthetic columns (those wrapped in double-underscores,
+    e.g. ``__title_key__``, ``__brand__``) because those are created by the domain-
+    extraction step that runs *inside* the pipeline — before the scoring phase that
+    actually needs them. Validating them upfront (on the raw DataFrame) would always
+    fail when a config built by ``auto_configure_df`` references domain columns.
+    """
     cols = set()
     for mk in config.get_matchkeys():
         for f in mk.fields:
             if f.columns:
-                cols.update(f.columns)
+                cols.update(
+                    c for c in f.columns
+                    if not (c.startswith("__") and c.endswith("__"))
+                )
             elif f.field and f.field != "__record__":
-                cols.add(f.field)
+                if not (f.field.startswith("__") and f.field.endswith("__")):
+                    cols.add(f.field)
     if config.blocking:
         for key_config in config.blocking.keys:
             for field_name in key_config.fields:
-                cols.add(field_name)
+                if not (field_name.startswith("__") and field_name.endswith("__")):
+                    cols.add(field_name)
     return sorted(cols)
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/profile_emitter.py
+++ b/packages/python/goldenmatch/goldenmatch/core/profile_emitter.py
@@ -1,0 +1,85 @@
+"""Thread-local profile emitter stack.
+
+Stage instrumentation calls ``current_emitter()`` to get the active emitter;
+when the controller is not running, this returns a no-op singleton so stages
+pay zero cost.
+
+Spec: docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-design.md
+      §Types & contracts § "Profile emitter (S1-C)".
+"""
+from __future__ import annotations
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile, ScoringProfile, ClusterProfile,
+    DataProfile, DomainProfile, MatchkeyProfile,
+)
+
+
+class ProfileEmitter:
+    """Buffer for stage outputs in a single iteration. Set by the controller
+    via ``profile_capture``; stages call ``set_*`` methods inline.
+
+    Multiple writes overwrite (last writer wins). Empty fields default to
+    ``ComplexityProfile`` defaults at assemble time.
+    """
+    __slots__ = ("blocking", "scoring", "cluster", "data", "domain", "matchkey")
+
+    def __init__(self) -> None:
+        self.blocking: BlockingProfile | None = None
+        self.scoring: ScoringProfile | None = None
+        self.cluster: ClusterProfile | None = None
+        self.data: DataProfile | None = None
+        self.domain: DomainProfile | None = None
+        self.matchkey: MatchkeyProfile | None = None
+
+    def set_blocking(self, p: BlockingProfile) -> None: self.blocking = p
+    def set_scoring(self, p: ScoringProfile) -> None: self.scoring = p
+    def set_cluster(self, p: ClusterProfile) -> None: self.cluster = p
+    def set_data(self, p: DataProfile) -> None: self.data = p
+    def set_domain(self, p: DomainProfile) -> None: self.domain = p
+    def set_matchkey(self, p: MatchkeyProfile) -> None: self.matchkey = p
+
+
+class _NullEmitter:
+    """Singleton no-op. Stages call ``set_*`` and the writes vanish."""
+    __slots__ = ()
+    def set_blocking(self, p): pass
+    def set_scoring(self, p): pass
+    def set_cluster(self, p): pass
+    def set_data(self, p): pass
+    def set_domain(self, p): pass
+    def set_matchkey(self, p): pass
+
+
+_NULL_EMITTER = _NullEmitter()
+# Default is an immutable empty tuple; profile_capture pushes onto a copy.
+_emitter_stack: ContextVar[tuple[ProfileEmitter, ...]] = ContextVar(
+    "emitter_stack", default=()
+)
+
+
+def current_emitter():
+    """Return the active emitter, or the null singleton when none is set."""
+    stack = _emitter_stack.get()
+    return stack[-1] if stack else _NULL_EMITTER
+
+
+@contextmanager
+def profile_capture() -> Iterator[ProfileEmitter]:
+    """Push a new ProfileEmitter onto the stack; pop on exit (incl. exception).
+
+    Concurrency:
+      * ContextVar is per-thread / per-asyncio-task → independent stacks.
+      * Re-entry within the same context pushes/pops correctly.
+      * Exception unwinding hits ``finally`` and restores prior stack via reset.
+    """
+    emitter = ProfileEmitter()
+    prev = _emitter_stack.get()
+    new = (*prev, emitter)
+    token = _emitter_stack.set(new)
+    try:
+        yield emitter
+    finally:
+        _emitter_stack.reset(token)

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -15,8 +15,29 @@ from rapidfuzz.process import cdist
 
 from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
 from goldenmatch.utils.transforms import apply_transforms
+from goldenmatch.core.profile_emitter import current_emitter
+from goldenmatch.core.complexity_profile import ScoringProfile
+from goldenmatch.core._profile_helpers import histogram_20, hartigan_dip, mass_above, mass_borderline
 
 logger = logging.getLogger(__name__)
+
+
+def _emit_scoring_profile(
+    pairs: "list[tuple[int, int, float]]",
+    threshold: float,
+    per_field_variance: "dict[str, float] | None" = None,
+) -> None:
+    """Emit ScoringProfile to current emitter. No-op when emitter is null."""
+    scores = [s for _, _, s in pairs]
+    profile = ScoringProfile(
+        n_pairs_scored=len(scores),
+        score_histogram=histogram_20(scores),
+        dip_statistic=hartigan_dip(scores),
+        mass_above_threshold=mass_above(scores, threshold),
+        mass_in_borderline=mass_borderline(scores, threshold),
+        per_field_score_variance=per_field_variance or {},
+    )
+    current_emitter().set_scoring(profile)
 
 
 def score_field(val_a: str | None, val_b: str | None, scorer: str) -> float | None:
@@ -601,6 +622,7 @@ def score_blocks_parallel(
             all_pairs.extend(pairs)
             for a, b, s in pairs:
                 matched_pairs.add((min(a, b), max(a, b)))
+        _emit_scoring_profile(all_pairs, mk.threshold)
         return all_pairs
 
     # Snapshot exclude_pairs so threads see a frozen copy
@@ -643,6 +665,7 @@ def score_blocks_parallel(
         "Parallel scoring: %d blocks, %d workers, %d pairs found",
         total_blocks, max_workers, len(all_pairs),
     )
+    _emit_scoring_profile(all_pairs, mk.threshold)
     return all_pairs
 
 

--- a/packages/python/goldenmatch/goldenmatch/web/routers/match.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/match.py
@@ -84,7 +84,10 @@ def _execute_match(
 
     config: GoldenMatchConfig
     if auto_config:
-        config = GoldenMatchConfig()
+        # Zero-config: call auto_configure_df *before* the pipeline so the
+        # pipeline never re-invokes auto-config (Task 5.2 fix).
+        from goldenmatch.core.autoconfig import auto_configure_df
+        config = auto_configure_df(target_df, reference=ref_df)
     else:
         if rules is None:
             raise HTTPException(
@@ -94,7 +97,7 @@ def _execute_match(
         from goldenmatch.web.preview import _build_config
         config = _build_config(rules)
 
-    result = run_match_df(target_df, ref_df, config, auto_config=auto_config)
+    result = run_match_df(target_df, ref_df, config, auto_config=False)
 
     matched: pl.DataFrame | None = result.get("matched")
     unmatched: pl.DataFrame | None = result.get("unmatched")

--- a/packages/python/goldenmatch/goldenmatch/web/routers/run.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/run.py
@@ -105,11 +105,12 @@ def _execute_run(
         )
 
     if auto_config:
-        # Zero-config: run_dedupe_df calls auto_configure_df internally when
-        # the config is empty + auto_config=True.
-        if config is None:
-            config = GoldenMatchConfig()
-        result = run_dedupe_df(df, config, output_clusters=True, auto_config=True)
+        # Zero-config: call auto_configure_df *before* the pipeline so the
+        # pipeline never re-invokes auto-config. Eliminates double-pipeline-run
+        # when the Task 5.1 controller loop is in play (Task 5.2 fix).
+        from goldenmatch.core.autoconfig import auto_configure_df
+        config = auto_configure_df(df)
+        result = run_dedupe_df(df, config, output_clusters=True, auto_config=False)
     else:
         result = run_dedupe_df(df, config, output_clusters=True)
 

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "numpy>=1.26",
     "openpyxl>=3.1",
     "textual>=1.0",
+    "diptest>=0.5.2",
 ]
 
 [project.urls]

--- a/packages/python/goldenmatch/tests/test_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig.py
@@ -1035,8 +1035,12 @@ class TestDomainAwareAutoConfig:
         assert len(domain_fields) == 0
 
     def test_manual_domain_config_overrides(self):
-        """When domain_config is provided, auto-config skips domain detection."""
-        from goldenmatch.core.autoconfig import auto_configure_df
+        """When domain_config is provided, the legacy heuristic skips domain detection.
+        Uses _legacy_auto_configure_v0 directly because this tests whitebox behavior
+        of the legacy heuristic's domain_config bypass path, which the controller
+        does not expose via the public auto_configure_df signature.
+        """
+        from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
         from goldenmatch.config.schemas import DomainConfig
         from unittest.mock import patch
 
@@ -1046,7 +1050,7 @@ class TestDomainAwareAutoConfig:
         })
 
         with patch("goldenmatch.core.domain.detect_domain") as mock_detect:
-            config = auto_configure_df(df, domain_config=DomainConfig(enabled=False))
+            config = _legacy_auto_configure_v0(df, domain_config=DomainConfig(enabled=False))
 
         # detect_domain should NOT have been called
         mock_detect.assert_not_called()
@@ -1122,8 +1126,12 @@ class TestDataDrivenStrategy:
         assert config.blocking.strategy != "learned"
 
     def test_reranking_enabled_three_plus_fields(self):
-        """Weighted matchkey with 3+ fields should enable reranking."""
-        from goldenmatch.core.autoconfig import auto_configure_df
+        """Weighted matchkey with 3+ fields should enable reranking.
+        Uses _legacy_auto_configure_v0 directly because allow_remote_assets
+        is a legacy-heuristic kwarg that is not threaded through the controller;
+        the public auto_configure_df no longer accepts it as a pass-through.
+        """
+        from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
 
         df = pl.DataFrame({
             "first_name": ["John", "Jane", "Bob", "Alice"],
@@ -1134,7 +1142,7 @@ class TestDataDrivenStrategy:
 
         # rerank downloads a cross-encoder model; preflight's
         # allow_remote_assets=False (default) would demote it. Opt in here.
-        config = auto_configure_df(df, allow_remote_assets=True)
+        config = _legacy_auto_configure_v0(df, allow_remote_assets=True)
         weighted_mks = [mk for mk in config.get_matchkeys() if mk.type == "weighted"]
         assert len(weighted_mks) > 0, "Expected at least one weighted matchkey"
         multi_field = [mk for mk in weighted_mks if len(mk.fields) >= 3]
@@ -1175,11 +1183,15 @@ class TestLLMMemoryAutoEnablement:
     """Tests for LLM + memory auto-enablement."""
 
     def test_llm_auto_with_api_key(self):
-        from goldenmatch.core.autoconfig import auto_configure_df
+        # Uses _legacy_auto_configure_v0 directly because llm_auto is a
+        # legacy-heuristic kwarg not threaded through the controller; the
+        # controller always returns the committed config without LLM scorer
+        # injection from the public auto_configure_df signature.
+        from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
         from unittest.mock import patch
         df = pl.DataFrame({"name": ["John", "Jane", "Bob"], "email": ["a@t.com", "b@t.com", "c@t.com"]})
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-fake"}):
-            config = auto_configure_df(df, llm_auto=True)
+            config = _legacy_auto_configure_v0(df, llm_auto=True)
         assert config.llm_scorer is not None
         assert config.llm_scorer.enabled is True
         assert config.llm_scorer.budget.max_cost_usd == 0.05
@@ -1204,11 +1216,14 @@ class TestLLMMemoryAutoEnablement:
         assert config.llm_scorer is None
 
     def test_memory_with_llm_auto(self):
-        from goldenmatch.core.autoconfig import auto_configure_df
+        # Uses _legacy_auto_configure_v0 directly because llm_auto memory
+        # enablement is a legacy-heuristic kwarg not threaded through the
+        # controller's public auto_configure_df.
+        from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
         from unittest.mock import patch
         df = pl.DataFrame({"name": ["John", "Jane", "Bob"], "email": ["a@t.com", "b@t.com", "c@t.com"]})
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-fake"}):
-            config = auto_configure_df(df, llm_auto=True)
+            config = _legacy_auto_configure_v0(df, llm_auto=True)
         assert config.memory is not None
         assert config.memory.enabled is True
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_controller.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_controller.py
@@ -360,3 +360,76 @@ def test_finalize_records_zero_drift_when_full_matches_sample(small_df):
     # Drift recorded via history.full_vs_sample_drift
     assert history.full_vs_sample_drift is not None
     assert history.full_vs_sample_drift == pytest.approx(0.0, abs=0.001)
+
+
+# ============================================================
+# Fix 2 — KeyboardInterrupt propagates
+# ============================================================
+
+def test_keyboard_interrupt_propagates(small_df):
+    """Ctrl-C inside a pipeline iteration must bubble out, not be swallowed."""
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(sample_skip_below=1),
+    )
+
+    def interrupting(sample, ref, config):
+        raise KeyboardInterrupt
+
+    controller._run_pipeline_sample = interrupting  # type: ignore[method-assign]
+    with pytest.raises(KeyboardInterrupt):
+        controller.run(small_df)
+
+
+# ============================================================
+# Fix 4 — skip_finalize skips _finalize call
+# ============================================================
+
+def test_skip_finalize_does_not_call_finalize(small_df):
+    """When skip_finalize=True and a healthy iteration exists, _finalize is NOT called."""
+    green = _green_subprofiles()
+    controller = _make_controller_with_mocked_runner([green])
+    # _finalize is already a MagicMock from _make_controller_with_mocked_runner
+    config, profile, history = controller.run(small_df, skip_finalize=True)
+    controller._finalize.assert_not_called()
+    assert isinstance(config, GoldenMatchConfig)
+    # Profile returned is the sample profile (not full-data); drift not computed.
+    assert history.full_vs_sample_drift is None
+
+
+def test_skip_finalize_false_still_calls_finalize(small_df):
+    """Default (skip_finalize=False) still calls _finalize as before."""
+    green = _green_subprofiles()
+    controller = _make_controller_with_mocked_runner([green])
+    controller.run(small_df, skip_finalize=False)
+    controller._finalize.assert_called_once()
+
+
+# ============================================================
+# Fix 6 — Warning logged on all-RED fallback
+# ============================================================
+
+import logging as _logging
+
+
+def test_run_returns_v0_red_when_all_iterations_crash_logs_warning(small_df, caplog):
+    """Every iteration crashes → returns v0 with RED AND logs a warning."""
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(max_iterations=2, sample_skip_below=1),
+    )
+
+    def always_crashes(sample, ref, config):
+        raise RuntimeError("never works")
+
+    controller._run_pipeline_sample = always_crashes  # type: ignore[method-assign]
+    controller._finalize = MagicMock()
+
+    with caplog.at_level(_logging.WARNING, logger="goldenmatch.core.autoconfig_controller"):
+        config, profile, history = controller.run(small_df)
+
+    assert profile.health() == HealthVerdict.RED
+    assert any(
+        "could not produce a healthy config" in rec.message
+        for rec in caplog.records
+    ), f"Expected warning not found; records: {[r.message for r in caplog.records]}"

--- a/packages/python/goldenmatch/tests/test_autoconfig_controller.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_controller.py
@@ -1,0 +1,159 @@
+import pytest
+import polars as pl
+from goldenmatch.config.schemas import GoldenMatchConfig
+from goldenmatch.core.complexity_profile import ComplexityProfile, HealthVerdict, DataProfile
+from goldenmatch.core.autoconfig_controller import (
+    AutoConfigController, ControllerBudget, StopReason, _RED_PROFILE,
+    ConfigValidationError,
+)
+from goldenmatch.core.autoconfig_policy import HeuristicRefitPolicy
+from goldenmatch.core.autoconfig_history import RunHistory
+
+
+# ============================================================
+# ControllerBudget
+# ============================================================
+
+def test_default_budget_has_sane_values():
+    b = ControllerBudget()
+    assert b.max_iterations >= 1
+    assert b.max_seconds > 0
+    assert b.sample_size_default >= 1000
+    assert b.sample_skip_below >= b.sample_size_default
+    assert 0.0 < b.converge_epsilon < 1.0
+    assert 0.0 < b.drift_threshold < 1.0
+
+
+def test_budget_overrides():
+    b = ControllerBudget(max_iterations=10, max_seconds=60.0,
+                         sample_size_default=500, sample_skip_below=2000,
+                         converge_epsilon=0.1, drift_threshold=0.5)
+    assert b.max_iterations == 10
+    assert b.sample_size_default == 500
+    assert b.drift_threshold == 0.5
+
+
+# ============================================================
+# _RED_PROFILE sentinel
+# ============================================================
+
+def test_red_profile_sentinel_is_red():
+    assert _RED_PROFILE.health() == HealthVerdict.RED
+
+
+# ============================================================
+# StopReason
+# ============================================================
+
+def test_stop_reason_has_all_required_values():
+    expected = {
+        "GREEN", "CONVERGED", "BUDGET_ITERATIONS", "BUDGET_TIME",
+        "POLICY_SATISFIED", "POLICY_NO_PROGRESS", "OSCILLATING", "CANCELLED",
+    }
+    actual = {sr.name for sr in StopReason}
+    assert expected.issubset(actual)
+
+
+# ============================================================
+# Pathological-input gates
+# ============================================================
+
+def test_run_raises_on_empty_dataframe():
+    controller = AutoConfigController(policy=HeuristicRefitPolicy(), budget=ControllerBudget())
+    with pytest.raises(ConfigValidationError, match=r"no data"):
+        controller.run(pl.DataFrame({"a": []}, schema={"a": pl.Utf8}))
+
+
+def test_run_returns_v0_for_single_row():
+    """Single-row data → no work for ER; returns v0 with health=YELLOW."""
+    controller = AutoConfigController(policy=HeuristicRefitPolicy(), budget=ControllerBudget())
+    df = pl.DataFrame({"a": ["x"], "b": ["y"], "c": ["z"]})
+    config, profile, history = controller.run(df)
+    assert isinstance(config, GoldenMatchConfig)
+    assert profile.health() in (HealthVerdict.YELLOW, HealthVerdict.GREEN)
+    assert history.iteration == 0  # never entered loop
+
+
+def test_run_raises_on_all_null_columns():
+    controller = AutoConfigController(policy=HeuristicRefitPolicy(), budget=ControllerBudget())
+    df = pl.DataFrame({"a": [None, None, None], "b": [None, None, None]},
+                      schema={"a": pl.Utf8, "b": pl.Utf8})
+    with pytest.raises(ConfigValidationError, match=r"no usable columns"):
+        controller.run(df)
+
+
+def test_run_returns_v0_yellow_for_single_column():
+    """Single non-empty column → no orthogonal evidence; v0 with YELLOW."""
+    controller = AutoConfigController(policy=HeuristicRefitPolicy(), budget=ControllerBudget())
+    df = pl.DataFrame({"name": ["a", "b", "c", "d", "e"] * 100})
+    config, profile, history = controller.run(df)
+    assert isinstance(config, GoldenMatchConfig)
+    assert profile.health() == HealthVerdict.YELLOW
+    assert history.iteration == 0
+
+
+# ============================================================
+# Sample selection
+# ============================================================
+
+def test_take_sample_uses_full_data_below_threshold():
+    """When n_rows < sample_skip_below, sample == full data."""
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(sample_skip_below=5000),
+    )
+    df = pl.DataFrame({"a": list(range(100)), "b": ["x"] * 100})
+    sample, _ = controller._take_sample(df, reference=None)
+    assert sample.height == 100  # full data, no sampling
+
+
+def test_take_sample_caps_at_sample_size_for_large_data():
+    """When n_rows >= sample_skip_below, sample is sample_size_default."""
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(sample_size_default=200, sample_skip_below=500),
+    )
+    df = pl.DataFrame({"a": list(range(1000)), "b": ["x"] * 1000})
+    sample, _ = controller._take_sample(df, reference=None)
+    assert sample.height == 200
+
+
+def test_take_sample_match_mode_preserves_source_split():
+    """When reference is provided, both target and reference get a sub-sample."""
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(sample_size_default=100, sample_skip_below=200),
+    )
+    target = pl.DataFrame({"a": list(range(500)), "b": ["t"] * 500})
+    reference = pl.DataFrame({"a": list(range(500, 1000)), "b": ["r"] * 500})
+    s_target, s_ref = controller._take_sample(target, reference=reference)
+    assert s_target is not None
+    assert s_ref is not None
+    # Target is sampled; reference is also sampled (not necessarily the same size,
+    # but it is sampled — not full data)
+    assert s_target.height <= 200  # sample_size or full
+    assert s_ref.height <= 200
+
+
+def test_take_sample_match_mode_below_threshold_returns_full():
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(sample_skip_below=5000),
+    )
+    target = pl.DataFrame({"a": list(range(100))})
+    reference = pl.DataFrame({"a": list(range(100, 200))})
+    s_target, s_ref = controller._take_sample(target, reference=reference)
+    assert s_target.height == 100
+    assert s_ref.height == 100
+
+
+def test_take_sample_is_deterministic():
+    """Same df → same sample (deterministic seed from data shape)."""
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(sample_size_default=50, sample_skip_below=100),
+    )
+    df = pl.DataFrame({"a": list(range(200)), "b": ["x"] * 200})
+    s1, _ = controller._take_sample(df, reference=None)
+    s2, _ = controller._take_sample(df, reference=None)
+    assert s1.equals(s2)

--- a/packages/python/goldenmatch/tests/test_autoconfig_controller.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_controller.py
@@ -157,3 +157,206 @@ def test_take_sample_is_deterministic():
     s1, _ = controller._take_sample(df, reference=None)
     s2, _ = controller._take_sample(df, reference=None)
     assert s1.equals(s2)
+
+
+# ============================================================
+# Task 4.2 — iteration loop
+# ============================================================
+
+from unittest.mock import patch, MagicMock
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile, ScoringProfile, ClusterProfile, MatchkeyProfile, FieldStats,
+)
+from goldenmatch.core.autoconfig_history import HistoryEntry, PolicyDecision, ErrorRecord
+from goldenmatch.core.autoconfig_policy import HeuristicRefitPolicy
+from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
+
+
+def _green_subprofiles():
+    """Return sub-profiles that yield ComplexityProfile.health() == GREEN."""
+    return dict(
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=10, total_comparisons=500,
+            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
+            block_sizes_p99=20, block_sizes_max=25,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,
+            dip_statistic=0.05, mass_above_threshold=0.4, mass_in_borderline=0.05,
+        ),
+        cluster=ClusterProfile(
+            n_clusters=20, cluster_size_p50=2, cluster_size_p99=5,
+            cluster_size_max=8, transitivity_rate=0.95,
+        ),
+        matchkey=MatchkeyProfile(per_field={"a": FieldStats(0.5, 0.0, 10)}),
+    )
+
+
+def _red_blocking_subprofile():
+    return BlockingProfile(
+        keys_used=[["a"]], n_blocks=2, total_comparisons=4900,
+        reduction_ratio=0.01,  # RED: < 0.5
+        block_sizes_p50=49, block_sizes_p95=49, block_sizes_p99=49,
+        block_sizes_max=49,
+    )
+
+
+@pytest.fixture
+def small_df():
+    """Df above pathological threshold but below sample_skip_below."""
+    return pl.DataFrame({
+        "a": ["x", "y", "z"] * 4,
+        "b": ["1", "2", "3"] * 4,
+    })
+
+
+def _make_controller_with_mocked_runner(profiles_per_iter, **budget_kwargs):
+    """Build a controller whose `_run_pipeline_sample` returns the given
+    sequence of (sub-profile dict) per iteration."""
+    bk = {"max_iterations": 5, "sample_skip_below": 1}
+    bk.update(budget_kwargs)
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(**bk),
+    )
+    # The mock writes to the active emitter so _assemble_profile picks it up.
+    iter_idx = {"i": 0}
+
+    def fake_runner(sample, ref, config):
+        from goldenmatch.core.profile_emitter import current_emitter
+        idx = iter_idx["i"]
+        iter_idx["i"] = min(idx + 1, len(profiles_per_iter) - 1)
+        sub = profiles_per_iter[idx]
+        e = current_emitter()
+        if "blocking" in sub: e.set_blocking(sub["blocking"])
+        if "scoring" in sub: e.set_scoring(sub["scoring"])
+        if "cluster" in sub: e.set_cluster(sub["cluster"])
+        if "matchkey" in sub: e.set_matchkey(sub["matchkey"])
+        if "data" in sub: e.set_data(sub["data"])
+        if "domain" in sub: e.set_domain(sub["domain"])
+
+    controller._run_pipeline_sample = fake_runner  # type: ignore[method-assign]
+    # Build the finalize return value with a DataProfile that has enough rows
+    # for the blocking/cluster health checks to yield GREEN (n_rows needs to
+    # be >= n_blocks * block_sizes_p99 / 10 = 10*20/10 = 20) and diverse
+    # column types so DataProfile.health() returns GREEN (not YELLOW).
+    _green_subs = _green_subprofiles()
+    _green_full = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2, column_types={"a": "name", "b": "numeric"}),
+        **_green_subs,
+    )
+    controller._finalize = MagicMock(return_value=_green_full)
+    return controller
+
+
+def test_run_exits_green_after_one_iteration(small_df):
+    """All-green sample profile → GREEN exit, finalize runs."""
+    green = _green_subprofiles()
+    controller = _make_controller_with_mocked_runner([green])
+    config, profile, history = controller.run(small_df)
+    assert isinstance(config, GoldenMatchConfig)
+    assert profile.health() == HealthVerdict.GREEN
+    assert history.iteration == 1
+
+
+def test_run_handles_iteration_crash_gracefully(small_df):
+    """Sample iteration raises → recorded in history.errors, controller continues."""
+    green = _green_subprofiles()
+    controller = _make_controller_with_mocked_runner([green, green])
+    crash_count = {"n": 0}
+    original = controller._run_pipeline_sample
+
+    def crashing(sample, ref, config):
+        if crash_count["n"] == 0:
+            crash_count["n"] += 1
+            raise RuntimeError("synthetic")
+        original(sample, ref, config)
+
+    controller._run_pipeline_sample = crashing  # type: ignore[method-assign]
+    config, profile, history = controller.run(small_df)
+    assert len(history.errors) == 1
+    assert history.errors[0].exception_type == "RuntimeError"
+    # At least one healthy entry should follow → committed
+    assert profile.health() != HealthVerdict.RED
+
+
+def test_run_returns_v0_red_when_all_iterations_crash(small_df):
+    """Every iteration crashes → returns v0 with RED, no finalize call."""
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(max_iterations=2, sample_skip_below=1),
+    )
+
+    def always_crashes(sample, ref, config):
+        raise RuntimeError("never works")
+
+    controller._run_pipeline_sample = always_crashes  # type: ignore[method-assign]
+    controller._finalize = MagicMock()  # finalize must NOT be called
+    config, profile, history = controller.run(small_df)
+    assert isinstance(config, GoldenMatchConfig)
+    assert profile.health() == HealthVerdict.RED
+    assert len(history.errors) >= 2
+    controller._finalize.assert_not_called()
+
+
+def test_run_exits_budget_iterations_when_no_progress(small_df):
+    """Profile stays red across iterations and policy keeps proposing → BUDGET_ITERATIONS."""
+    red = {**_green_subprofiles(), "blocking": _red_blocking_subprofile()}
+    # All iters return same red profile; the rule will fire and propose a config,
+    # but next iter still returns red (the mock doesn't actually use the config).
+    controller = _make_controller_with_mocked_runner([red, red, red, red, red],
+                                                      max_iterations=2)
+    config, profile, history = controller.run(small_df)
+    # No healthy iterations at all → returns v0 with RED
+    assert profile.health() == HealthVerdict.RED
+
+
+def test_run_budget_time_exit(small_df):
+    """When wall-clock budget exceeds, exits with budget_time."""
+    green = _green_subprofiles()
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(max_iterations=10, max_seconds=0.0001,
+                                sample_skip_below=1),
+    )
+    import time
+    def slow(sample, ref, config):
+        time.sleep(0.01)
+        from goldenmatch.core.profile_emitter import current_emitter
+        # Emit RED sample profile so we don't exit GREEN immediately
+        current_emitter().set_blocking(_red_blocking_subprofile())
+        for k, v in green.items():
+            if k != "blocking":
+                getattr(current_emitter(), f"set_{k}")(v)
+
+    controller._run_pipeline_sample = slow  # type: ignore[method-assign]
+    controller._finalize = MagicMock(return_value=ComplexityProfile(**green))
+    config, profile, history = controller.run(small_df)
+    # Should bail out quickly via BUDGET_TIME or BUDGET_ITERATIONS — either is acceptable
+    assert history.iteration >= 1
+
+
+# ============================================================
+# Task 4.3 — _finalize + drift detection
+# ============================================================
+
+
+def test_finalize_records_zero_drift_when_full_matches_sample(small_df):
+    """Full-data profile equal to final sample profile → drift == 0."""
+    green = _green_subprofiles()
+    controller = _make_controller_with_mocked_runner([green])
+    # Replace finalize with one that returns the same green profile.
+    # n_rows=100 matches the inferred n_rows from blocking stats
+    # (n_blocks=10, p50=10 → max(12, 100) = 100) so the signal vectors
+    # are identical and drift == 0.  Diverse column_types avoids the
+    # DataProfile single-type YELLOW verdict.
+    full_profile = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2,
+                         column_types={"a": "name", "b": "numeric"}),
+        **green,
+    )
+    controller._finalize = MagicMock(return_value=full_profile)
+    config, profile, history = controller.run(small_df)
+    # Drift recorded via history.full_vs_sample_drift
+    assert history.full_vs_sample_drift is not None
+    assert history.full_vs_sample_drift == pytest.approx(0.0, abs=0.001)

--- a/packages/python/goldenmatch/tests/test_autoconfig_controller.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_controller.py
@@ -173,8 +173,18 @@ from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
 
 
 def _green_subprofiles():
-    """Return sub-profiles that yield ComplexityProfile.health() == GREEN."""
+    """Return sub-profiles that yield ComplexityProfile.health() == GREEN.
+
+    Includes a DataProfile with diverse column_types (name + numeric) so the
+    DataProfile.health() check (len(set(column_types.values())) != 1) returns
+    GREEN rather than YELLOW.  The emitter mock writes these into the emitter
+    so _assemble_profile uses them in preference to the computed fallback.
+    """
     return dict(
+        data=DataProfile(
+            n_rows=100, n_cols=2,
+            column_types={"a": "name", "b": "numeric"},
+        ),
         blocking=BlockingProfile(
             keys_used=[["a"]], n_blocks=10, total_comparisons=500,
             reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
@@ -236,15 +246,11 @@ def _make_controller_with_mocked_runner(profiles_per_iter, **budget_kwargs):
         if "domain" in sub: e.set_domain(sub["domain"])
 
     controller._run_pipeline_sample = fake_runner  # type: ignore[method-assign]
-    # Build the finalize return value with a DataProfile that has enough rows
-    # for the blocking/cluster health checks to yield GREEN (n_rows needs to
-    # be >= n_blocks * block_sizes_p99 / 10 = 10*20/10 = 20) and diverse
-    # column types so DataProfile.health() returns GREEN (not YELLOW).
+    # Build the finalize return value using the full green sub-profiles (which
+    # now include a DataProfile with n_rows=100 and diverse column types so
+    # DataProfile.health() returns GREEN rather than YELLOW).
     _green_subs = _green_subprofiles()
-    _green_full = ComplexityProfile(
-        data=DataProfile(n_rows=100, n_cols=2, column_types={"a": "name", "b": "numeric"}),
-        **_green_subs,
-    )
+    _green_full = ComplexityProfile(**_green_subs)
     controller._finalize = MagicMock(return_value=_green_full)
     return controller
 
@@ -346,15 +352,9 @@ def test_finalize_records_zero_drift_when_full_matches_sample(small_df):
     green = _green_subprofiles()
     controller = _make_controller_with_mocked_runner([green])
     # Replace finalize with one that returns the same green profile.
-    # n_rows=100 matches the inferred n_rows from blocking stats
-    # (n_blocks=10, p50=10 → max(12, 100) = 100) so the signal vectors
-    # are identical and drift == 0.  Diverse column_types avoids the
-    # DataProfile single-type YELLOW verdict.
-    full_profile = ComplexityProfile(
-        data=DataProfile(n_rows=100, n_cols=2,
-                         column_types={"a": "name", "b": "numeric"}),
-        **green,
-    )
+    # The green sub-profiles already include a DataProfile with n_rows=100
+    # and diverse column_types so the signal vectors are identical → drift == 0.
+    full_profile = ComplexityProfile(**green)
     controller._finalize = MagicMock(return_value=full_profile)
     config, profile, history = controller.run(small_df)
     # Drift recorded via history.full_vs_sample_drift

--- a/packages/python/goldenmatch/tests/test_autoconfig_facade.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_facade.py
@@ -111,3 +111,27 @@ def test_legacy_auto_configure_v0_still_callable():
     })
     cfg = _legacy_auto_configure_v0(df)
     assert isinstance(cfg, GoldenMatchConfig)
+
+
+# ============================================================
+# Fix 3 — kwargs threaded through to _legacy_auto_configure_v0
+# ============================================================
+
+def test_kwargs_threaded_to_v0():
+    """auto_configure_df forwards strict/llm_auto kwargs into _legacy_auto_configure_v0."""
+    from unittest.mock import patch as _patch
+    from goldenmatch.core.autoconfig_history import RunHistory
+    from goldenmatch.core.complexity_profile import ComplexityProfile
+
+    df = pl.DataFrame({"name": ["a", "b"] * 5, "city": ["x", "y"] * 5})
+    with _patch("goldenmatch.core.autoconfig._legacy_auto_configure_v0") as mock_v0:
+        mock_v0.return_value = GoldenMatchConfig(matchkeys=[])
+        goldenmatch.auto_configure_df(df, strict=True, llm_auto=True)
+    mock_v0.assert_called()
+    call_kwargs = mock_v0.call_args.kwargs
+    assert call_kwargs.get("strict") is True, (
+        f"expected strict=True to be forwarded; got kwargs={call_kwargs}"
+    )
+    assert call_kwargs.get("llm_auto") is True, (
+        f"expected llm_auto=True to be forwarded; got kwargs={call_kwargs}"
+    )

--- a/packages/python/goldenmatch/tests/test_autoconfig_facade.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_facade.py
@@ -1,0 +1,113 @@
+import pytest
+import polars as pl
+from unittest.mock import patch
+import goldenmatch
+from goldenmatch.config.schemas import GoldenMatchConfig
+
+
+def test_auto_configure_df_facade_returns_goldenmatchconfig():
+    """Public signature unchanged; returned object is GoldenMatchConfig."""
+    df = pl.DataFrame({
+        "name": ["alice", "alyce", "bob", "bobby", "carol"] * 4,
+        "city": ["nyc", "la", "sf", "nyc", "la"] * 4,
+    })
+    cfg = goldenmatch.auto_configure_df(df)
+    assert isinstance(cfg, GoldenMatchConfig)
+
+
+def test_auto_configure_df_invokes_controller_run():
+    """auto_configure_df dispatches to AutoConfigController.run."""
+    df = pl.DataFrame({
+        "name": ["alice", "alyce"] * 50,
+        "city": ["nyc"] * 100,
+    })
+    with patch("goldenmatch.core.autoconfig_controller.AutoConfigController.run") as mock_run:
+        from goldenmatch.core.complexity_profile import ComplexityProfile
+        from goldenmatch.core.autoconfig_history import RunHistory
+        mock_run.return_value = (
+            GoldenMatchConfig(matchkeys=[]),
+            ComplexityProfile(),
+            RunHistory(),
+        )
+        goldenmatch.auto_configure_df(df)
+    mock_run.assert_called_once()
+
+
+def test_auto_configure_df_match_mode_with_reference():
+    """New: reference kwarg triggers match-mode auto-config."""
+    target = pl.DataFrame({
+        "id": ["1", "2", "3", "4", "5"] * 4,
+        "title": ["foo paper", "bar work", "baz study", "qux note", "doc"] * 4,
+    })
+    ref = pl.DataFrame({
+        "id": ["10", "20", "30", "40", "50"] * 4,
+        "title": ["foo paper", "bar work", "different", "fourth", "fifth"] * 4,
+    })
+    cfg = goldenmatch.auto_configure_df(target, reference=ref)
+    assert isinstance(cfg, GoldenMatchConfig)
+    assert len(cfg.matchkeys) >= 1
+
+
+def test_auto_configure_df_lazyframe_collected():
+    """LazyFrame inputs are accepted (collected internally)."""
+    lf = pl.DataFrame({
+        "name": ["a", "b", "c"] * 4,
+        "city": ["x", "y", "z"] * 4,
+    }).lazy()
+    cfg = goldenmatch.auto_configure_df(lf)
+    assert isinstance(cfg, GoldenMatchConfig)
+
+
+def test_auto_configure_df_lazyframe_reference_collected():
+    """LazyFrame reference is also accepted."""
+    target = pl.DataFrame({
+        "id": ["1", "2"] * 5,
+        "title": ["foo", "bar"] * 5,
+    })
+    ref = pl.DataFrame({
+        "id": ["10", "20"] * 5,
+        "title": ["foo", "baz"] * 5,
+    }).lazy()
+    cfg = goldenmatch.auto_configure_df(target, reference=ref)
+    assert isinstance(cfg, GoldenMatchConfig)
+
+
+def test_auto_configure_df_rejects_non_dataframe():
+    with pytest.raises(TypeError, match=r"DataFrame"):
+        goldenmatch.auto_configure_df([{"name": "alice"}])  # list of dicts
+
+
+def test_auto_configure_df_rejects_non_dataframe_reference():
+    target = pl.DataFrame({"name": ["a", "b"]})
+    with pytest.raises(TypeError, match=r"DataFrame"):
+        goldenmatch.auto_configure_df(target, reference={"name": "x"})
+
+
+def test_last_controller_run_contextvar_populated():
+    """After auto_configure_df, the _LAST_CONTROLLER_RUN ContextVar holds the
+    (profile, history) tuple from the last run."""
+    from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+    df = pl.DataFrame({
+        "name": ["a", "b", "c"] * 4,
+        "city": ["x", "y", "z"] * 4,
+    })
+    goldenmatch.auto_configure_df(df)
+    state = _LAST_CONTROLLER_RUN.get()
+    assert state is not None
+    profile, history = state
+    from goldenmatch.core.complexity_profile import ComplexityProfile
+    from goldenmatch.core.autoconfig_history import RunHistory
+    assert isinstance(profile, ComplexityProfile)
+    assert isinstance(history, RunHistory)
+
+
+def test_legacy_auto_configure_v0_still_callable():
+    """The private _legacy_auto_configure_v0 must remain importable for
+    AutoConfigController._initial_config (would loop otherwise)."""
+    from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
+    df = pl.DataFrame({
+        "name": ["alice", "bob"] * 5,
+        "city": ["nyc", "la"] * 5,
+    })
+    cfg = _legacy_auto_configure_v0(df)
+    assert isinstance(cfg, GoldenMatchConfig)

--- a/packages/python/goldenmatch/tests/test_autoconfig_history.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_history.py
@@ -1,0 +1,209 @@
+import pytest
+from datetime import timedelta
+from goldenmatch.core.complexity_profile import (
+    ComplexityProfile, DataProfile, BlockingProfile, ScoringProfile,
+    ClusterProfile, MatchkeyProfile, DomainProfile, ProfileMeta, HealthVerdict,
+)
+from goldenmatch.core.autoconfig_history import (
+    RunHistory, HistoryEntry, PolicyDecision, ErrorRecord,
+)
+
+
+def _profile(*, scoring: ScoringProfile | None = None,
+             blocking: BlockingProfile | None = None,
+             n_rows: int = 100) -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(n_rows=n_rows, n_cols=4,
+                         column_types={"a": "text", "b": "id-like", "c": "text", "d": "date"}),
+        blocking=blocking or BlockingProfile(
+            keys_used=[["a"]], n_blocks=10, total_comparisons=500,
+            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
+            block_sizes_p99=20, block_sizes_max=25,
+            singleton_block_count=0, oversized_block_count=0,
+        ),
+        scoring=scoring or ScoringProfile(
+            n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,
+            dip_statistic=0.05, mass_above_threshold=0.4, mass_in_borderline=0.05,
+        ),
+        cluster=ClusterProfile(
+            n_clusters=20, cluster_size_p50=2, cluster_size_p99=5,
+            cluster_size_max=8, transitivity_rate=0.95,
+            edge_confidence_p50=0.85, edge_confidence_min=0.7,
+        ),
+    )
+
+
+def _entry(iteration: int, config, profile, decision=None, error=None) -> HistoryEntry:
+    return HistoryEntry(
+        iteration=iteration, config=config, profile=profile,
+        decision=decision, error=error, wall_clock_ms=10,
+    )
+
+
+def test_empty_history_has_no_oscillation():
+    h = RunHistory()
+    assert not h.is_oscillating()
+    assert h.iteration == 0
+    assert h.decisions == []
+    assert h.errors == []
+
+
+def test_iteration_property_counts_entries():
+    h = RunHistory()
+    h.entries.append(_entry(0, "a", _profile()))
+    h.entries.append(_entry(1, "b", _profile()))
+    assert h.iteration == 2
+
+
+def test_decisions_property_filters_none():
+    h = RunHistory()
+    h.entries.append(_entry(0, "a", _profile(),
+                            decision=PolicyDecision(rule_name="r1", rationale="x", config_diff={})))
+    h.entries.append(_entry(1, "b", _profile(), decision=None))
+    h.entries.append(_entry(2, "c", _profile(),
+                            decision=PolicyDecision(rule_name="r2", rationale="y", config_diff={})))
+    assert [d.rule_name for d in h.decisions] == ["r1", "r2"]
+
+
+def test_errors_property_filters_none():
+    h = RunHistory()
+    err = ErrorRecord(exception_type="ValueError", traceback_summary="...")
+    h.entries.append(_entry(0, "a", _profile(), error=err))
+    h.entries.append(_entry(1, "b", _profile(), error=None))
+    assert [e.exception_type for e in h.errors] == ["ValueError"]
+
+
+def test_cheapest_healthy_returns_none_when_all_red():
+    h = RunHistory()
+    red = _profile(scoring=ScoringProfile(
+        n_pairs_scored=0, score_histogram=[0]*20,
+        mass_above_threshold=0.0, dip_statistic=0.001,
+    ))
+    h.entries.append(_entry(0, "x", red))
+    assert h.cheapest_healthy() is None
+
+
+def test_cheapest_healthy_picks_highest_separation():
+    h = RunHistory()
+    weak = _profile(scoring=ScoringProfile(
+        n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,
+        dip_statistic=0.05, mass_above_threshold=0.3, mass_in_borderline=0.25,
+    ))
+    strong = _profile(scoring=ScoringProfile(
+        n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,
+        dip_statistic=0.05, mass_above_threshold=0.5, mass_in_borderline=0.05,
+    ))
+    h.entries.append(_entry(0, "weak", weak))
+    h.entries.append(_entry(1, "strong", strong))
+    best = h.cheapest_healthy()
+    assert best is not None
+    assert best.config == "strong"
+
+
+def test_cheapest_healthy_prefers_green_over_yellow():
+    h = RunHistory()
+    # Yellow profile (oversized cluster) but high separation
+    yellow_cluster = ClusterProfile(
+        n_clusters=10, cluster_size_p50=2, cluster_size_p99=5,
+        cluster_size_max=8, transitivity_rate=0.95,
+        oversized_cluster_count=1,  # makes cluster YELLOW
+    )
+    yellow_profile = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=4,
+                         column_types={"a": "text", "b": "id-like", "c": "text", "d": "date"}),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=10, total_comparisons=500,
+            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
+            block_sizes_p99=20, block_sizes_max=25,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,
+            dip_statistic=0.05, mass_above_threshold=0.7, mass_in_borderline=0.01,
+        ),
+        cluster=yellow_cluster,
+    )
+    green = _profile(scoring=ScoringProfile(
+        n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,
+        dip_statistic=0.05, mass_above_threshold=0.4, mass_in_borderline=0.05,
+    ))
+    h.entries.append(_entry(0, "yellow", yellow_profile))
+    h.entries.append(_entry(1, "green", green))
+    # Even though yellow has higher mass_above_threshold, GREEN beats YELLOW in lex key.
+    assert h.cheapest_healthy().config == "green"
+
+
+def test_cheapest_healthy_breaks_tie_on_iteration():
+    """With identical health and separation, prefer earlier iteration (cheaper)."""
+    h = RunHistory()
+    same_profile = _profile()
+    h.entries.append(_entry(0, "first", same_profile))
+    h.entries.append(_entry(1, "second", same_profile))
+    assert h.cheapest_healthy().config == "first"
+
+
+def test_oscillation_detected_after_two_repeats_in_window():
+    h = RunHistory()
+    cfg_hashes = ["a", "b", "a", "b"]
+    for i, c in enumerate(cfg_hashes):
+        h.entries.append(_entry(
+            i, c, _profile(),
+            decision=PolicyDecision(rule_name=f"r_{c}", rationale="x", config_diff={}),
+        ))
+    assert h.is_oscillating()
+
+
+def test_oscillation_not_detected_with_distinct_configs():
+    h = RunHistory()
+    for i, c in enumerate(["a", "b", "c", "d"]):
+        h.entries.append(_entry(
+            i, c, _profile(),
+            decision=PolicyDecision(rule_name=f"r_{c}", rationale="x", config_diff={}),
+        ))
+    assert not h.is_oscillating()
+
+
+def test_oscillation_requires_window_of_4():
+    h = RunHistory()
+    h.entries.append(_entry(0, "a", _profile(),
+                            decision=PolicyDecision(rule_name="r", rationale="x", config_diff={})))
+    h.entries.append(_entry(1, "a", _profile(),
+                            decision=PolicyDecision(rule_name="r", rationale="x", config_diff={})))
+    # Only 2 entries; need window of 4
+    assert not h.is_oscillating()
+
+
+def test_profile_distance_to_prev_is_zero_for_identical():
+    h = RunHistory()
+    p = _profile()
+    h.entries.append(_entry(0, "a", p))
+    h.entries.append(_entry(1, "b", p))
+    assert h.profile_distance_to_prev() == pytest.approx(0.0)
+
+
+def test_profile_distance_to_prev_is_inf_for_short_history():
+    h = RunHistory()
+    h.entries.append(_entry(0, "a", _profile()))
+    assert h.profile_distance_to_prev() == float("inf")
+
+
+def test_profile_distance_to_prev_nonzero_for_different():
+    h = RunHistory()
+    a = _profile(blocking=BlockingProfile(
+        keys_used=[["a"]], n_blocks=2, total_comparisons=50,
+        reduction_ratio=0.5, block_sizes_p99=50,
+    ))
+    b = _profile(blocking=BlockingProfile(
+        keys_used=[["a"]], n_blocks=20, total_comparisons=10,
+        reduction_ratio=0.99, block_sizes_p99=5,
+    ))
+    h.entries.append(_entry(0, "a", a))
+    h.entries.append(_entry(1, "b", b))
+    assert h.profile_distance_to_prev() > 0.0
+
+
+def test_prior_runs_default_empty_list():
+    h = RunHistory()
+    assert h.prior_runs == []
+    # Not frozen — caller can mutate, but v1 leaves it empty
+    h.prior_runs.append("v2-hook")
+    assert h.prior_runs == ["v2-hook"]

--- a/packages/python/goldenmatch/tests/test_autoconfig_no_double_run.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_no_double_run.py
@@ -1,0 +1,134 @@
+"""Task 5.2: Verify zero-config callers call auto_configure_df pre-pipeline.
+
+After Task 5.2, dedupe_df / match_df zero-config paths must:
+  1. Call auto_configure_df *before* passing to _run_*_pipeline.
+  2. Pass auto_config=False (or omit) to the pipeline.
+
+This eliminates the double-pipeline-run failure mode introduced by Task 5.1
+(auto_configure_df now runs the controller's iteration loop, which itself
+calls dedupe_df/match_df on samples).
+"""
+import pytest
+import polars as pl
+from unittest.mock import patch
+
+
+def _trivial_dedupe_pipeline_return(df: pl.DataFrame) -> dict:
+    """Minimal valid return shape for _run_dedupe_pipeline."""
+    return {
+        "golden": None,
+        "clusters": {},
+        "dupes": None,
+        "unique": df,
+        "scored_pairs": [],
+        "memory_stats": None,
+        "postflight_report": None,
+        "quarantine": None,
+    }
+
+
+def _trivial_match_pipeline_return(df: pl.DataFrame) -> dict:
+    return {
+        "matched": None,
+        "unmatched": df,
+        "report": None,
+        "quarantine": None,
+        "postflight_report": None,
+        "memory_stats": None,
+    }
+
+
+def test_dedupe_df_zero_config_does_not_pass_auto_config_true():
+    """After Task 5.2, the caller's invocation of run_dedupe_df must
+    pass auto_config=False (or not set the kwarg). The pipeline never re-runs
+    auto-config when the caller already provided a config."""
+    import goldenmatch as gm
+
+    df = pl.DataFrame({
+        "name": ["alice", "alyce", "bob"] * 4,
+        "city": ["nyc", "la", "sf"] * 4,
+    })
+    with patch("goldenmatch.core.pipeline.run_dedupe_df") as mock_pipeline:
+        mock_pipeline.return_value = _trivial_dedupe_pipeline_return(df)
+        gm.dedupe_df(df)
+    # No invocation of run_dedupe_df should have auto_config=True
+    for call in mock_pipeline.call_args_list:
+        kwargs = call.kwargs
+        # Either kwarg absent, or explicitly False
+        assert kwargs.get("auto_config", False) is False, (
+            f"caller still passes auto_config=True: {call}"
+        )
+
+
+def test_match_df_zero_config_does_not_pass_auto_config_true():
+    import goldenmatch as gm
+
+    target = pl.DataFrame({"id": ["1", "2"] * 5, "title": ["foo", "bar"] * 5})
+    ref = pl.DataFrame({"id": ["10", "20"] * 5, "title": ["foo", "baz"] * 5})
+    with patch("goldenmatch.core.pipeline.run_match_df") as mock_pipeline:
+        mock_pipeline.return_value = _trivial_match_pipeline_return(target)
+        gm.match_df(target, ref)
+    for call in mock_pipeline.call_args_list:
+        kwargs = call.kwargs
+        assert kwargs.get("auto_config", False) is False, (
+            f"caller still passes auto_config=True: {call}"
+        )
+
+
+def test_dedupe_df_explicit_config_unaffected():
+    """When config=GoldenMatchConfig is provided explicitly, no auto-config is invoked."""
+    import goldenmatch as gm
+    from goldenmatch.config.schemas import (
+        GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+        BlockingConfig, BlockingKeyConfig,
+    )
+
+    df = pl.DataFrame({"email": ["a@x", "a@x", "b@y"]})
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="m", type="exact",
+            fields=[MatchkeyField(field="email", transforms=["lowercase"])],
+        )],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["email"], transforms=["lowercase"])],
+            max_block_size=5000, skip_oversized=False,
+        ),
+    )
+    with patch("goldenmatch.core.autoconfig.auto_configure_df") as mock_auto:
+        result = gm.dedupe_df(df, config=cfg)
+    mock_auto.assert_not_called()
+
+
+def test_dedupe_df_zero_config_invokes_auto_configure_df_once():
+    """Zero-config caller invokes auto_configure_df exactly once before pipeline."""
+    import goldenmatch as gm
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    df = pl.DataFrame({"name": ["a", "b", "c"] * 4, "city": ["x", "y", "z"] * 4})
+    with patch("goldenmatch._api.auto_configure_df") as mock_auto:
+        mock_auto.return_value = GoldenMatchConfig(matchkeys=[])
+        with patch("goldenmatch.core.pipeline.run_dedupe_df") as mock_pipeline:
+            mock_pipeline.return_value = _trivial_dedupe_pipeline_return(df)
+            gm.dedupe_df(df)
+    # auto_configure_df called once with the dataframe
+    mock_auto.assert_called_once()
+
+
+def test_match_df_zero_config_invokes_auto_configure_df_with_reference():
+    import goldenmatch as gm
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    target = pl.DataFrame({"id": ["1"] * 6, "title": ["foo"] * 6})
+    ref = pl.DataFrame({"id": ["10"] * 6, "title": ["bar"] * 6})
+    with patch("goldenmatch._api.auto_configure_df") as mock_auto:
+        mock_auto.return_value = GoldenMatchConfig(matchkeys=[])
+        with patch("goldenmatch.core.pipeline.run_match_df") as mock_pipeline:
+            mock_pipeline.return_value = _trivial_match_pipeline_return(target)
+            gm.match_df(target, ref)
+    mock_auto.assert_called_once()
+    # The mock should have been called with reference= kwarg
+    call = mock_auto.call_args_list[0]
+    # Either positional or keyword
+    if "reference" in call.kwargs:
+        assert call.kwargs["reference"] is not None

--- a/packages/python/goldenmatch/tests/test_autoconfig_no_double_run.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_no_double_run.py
@@ -132,3 +132,81 @@ def test_match_df_zero_config_invokes_auto_configure_df_with_reference():
     # Either positional or keyword
     if "reference" in call.kwargs:
         assert call.kwargs["reference"] is not None
+
+
+# ============================================================
+# Fix 1 — PostflightReport wired with controller_profile/history
+# ============================================================
+
+def test_dedupe_df_zero_config_postflight_has_controller_fields():
+    """Zero-config dedupe_df should populate controller_profile and
+    controller_history on the returned postflight_report."""
+    import goldenmatch as gm
+    from goldenmatch.core.complexity_profile import ComplexityProfile
+    from goldenmatch.core.autoconfig_history import RunHistory
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    df = pl.DataFrame({
+        "name": ["alice", "alyce", "bob", "bobby"] * 4,
+        "city": ["nyc", "la", "sf", "nyc"] * 4,
+    })
+    with patch("goldenmatch._api.auto_configure_df") as mock_auto:
+        mock_auto.return_value = GoldenMatchConfig(matchkeys=[])
+        # Seed the ContextVar with a fake (profile, history) so the _api wiring
+        # can pick it up without running the real controller.
+        from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+        fake_profile = ComplexityProfile()
+        fake_history = RunHistory()
+        _LAST_CONTROLLER_RUN.set((fake_profile, fake_history))
+
+        with patch("goldenmatch.core.pipeline.run_dedupe_df") as mock_pipeline:
+            mock_pipeline.return_value = _trivial_dedupe_pipeline_return(df)
+            result = gm.dedupe_df(df)
+
+    pf = result.postflight_report
+    assert pf is not None, "postflight_report should not be None in zero-config path"
+    assert pf.controller_profile is fake_profile, (
+        "controller_profile should be the profile from _LAST_CONTROLLER_RUN"
+    )
+    assert pf.controller_history is fake_history, (
+        "controller_history should be the history from _LAST_CONTROLLER_RUN"
+    )
+
+
+# ============================================================
+# Fix 4 — zero-config path passes _skip_finalize=True
+# ============================================================
+
+def test_dedupe_df_zero_config_passes_skip_finalize_true():
+    """The zero-config path in dedupe_df must pass _skip_finalize=True to
+    auto_configure_df so the controller does not run a full-data _finalize
+    before the caller's own full pipeline run."""
+    import goldenmatch as gm
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    df = pl.DataFrame({"name": ["alice", "bob"] * 4, "city": ["x", "y"] * 4})
+    with patch("goldenmatch._api.auto_configure_df") as mock_auto:
+        mock_auto.return_value = GoldenMatchConfig(matchkeys=[])
+        with patch("goldenmatch.core.pipeline.run_dedupe_df") as mock_pipeline:
+            mock_pipeline.return_value = _trivial_dedupe_pipeline_return(df)
+            gm.dedupe_df(df)
+    call_kwargs = mock_auto.call_args.kwargs
+    assert call_kwargs.get("_skip_finalize") is True, (
+        f"Expected _skip_finalize=True to be forwarded; got kwargs={call_kwargs}"
+    )
+
+
+def test_zero_config_pipeline_called_auto_config_false():
+    """After skip_finalize fix, run_dedupe_df must always be called with
+    auto_config=False (never True) in the zero-config path."""
+    import goldenmatch as gm
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    df = pl.DataFrame({"name": ["alice", "bob"] * 4, "city": ["x", "y"] * 4})
+    with patch("goldenmatch._api.auto_configure_df") as mock_auto:
+        mock_auto.return_value = GoldenMatchConfig(matchkeys=[])
+        with patch("goldenmatch.core.pipeline.run_dedupe_df") as mock_pipeline:
+            mock_pipeline.return_value = _trivial_dedupe_pipeline_return(df)
+            gm.dedupe_df(df)
+    for call in mock_pipeline.call_args_list:
+        assert call.kwargs.get("auto_config", False) is False

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -177,3 +177,230 @@ def test_decision_not_attached_when_no_history_entries():
     # Empty history — propose still works, just no attach
     result = policy.propose(_red_profile(), cfg_a, RunHistory())
     assert result is cfg_b
+
+
+# ============================================================
+# Task 3.2 — five rules
+# ============================================================
+
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+from goldenmatch.core.autoconfig_rules import (
+    rule_blocking_too_coarse, rule_unimodal_scoring, rule_low_reduction_ratio,
+    rule_low_transitivity, rule_no_matches, DEFAULT_RULES,
+)
+
+
+def _config_with_blocking(field: str = "a", threshold: float = 0.7,
+                          scorer: str = "jaro_winkler") -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="m", type="weighted", threshold=threshold,
+            fields=[
+                MatchkeyField(field="name", scorer=scorer, weight=1.0,
+                              transforms=["lowercase"]),
+                MatchkeyField(field="city", scorer=scorer, weight=1.0,
+                              transforms=["lowercase"]),
+            ],
+        )],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=[field], transforms=["lowercase"])],
+            max_block_size=5000, skip_oversized=False,
+        ),
+    )
+
+
+def _profile_blocking_too_coarse() -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(
+            n_rows=1000, n_cols=3,
+            column_types={"a": "text", "name": "name", "city": "geo"},
+            cardinality_ratio={"a": 0.02, "name": 0.4, "city": 0.3},
+        ),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=2, total_comparisons=99000,
+            reduction_ratio=0.8, block_sizes_p50=100, block_sizes_p95=400,
+            block_sizes_p99=950,  # 950 > 10 * (1000/2 = 500) → 5000? no, 10*500 = 5000 NOT >
+            block_sizes_max=950,
+        ),
+        scoring=ScoringProfile(n_pairs_scored=99000, mass_above_threshold=0.1, dip_statistic=0.05),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+
+
+def _profile_blocking_RED() -> ComplexityProfile:
+    """p99 (5500) > 10 * 1000/2 (5000) → fires."""
+    return ComplexityProfile(
+        data=DataProfile(
+            n_rows=1000, n_cols=3,
+            column_types={"a": "text", "name": "name", "city": "geo"},
+            cardinality_ratio={"a": 0.02, "name": 0.4, "city": 0.3},
+        ),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=2, total_comparisons=99000,
+            reduction_ratio=0.8, block_sizes_p50=100, block_sizes_p95=400,
+            block_sizes_p99=5500, block_sizes_max=5500,
+        ),
+        scoring=ScoringProfile(n_pairs_scored=99000, mass_above_threshold=0.1, dip_statistic=0.05),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+
+
+# Rule 1
+def test_rule_blocking_too_coarse_fires_when_p99_dominates():
+    cfg = _config_with_blocking(field="a")
+    out = rule_blocking_too_coarse(_profile_blocking_RED(), cfg, RunHistory())
+    assert out is not None
+    new_cfg, decision = out
+    assert decision.rule_name == "blocking_too_coarse"
+    new_field = new_cfg.blocking.keys[0].fields[0]
+    assert new_field != "a"
+    assert new_field in {"name", "city"}
+
+
+def test_rule_blocking_too_coarse_does_not_fire_when_p99_modest():
+    cfg = _config_with_blocking(field="a")
+    out = rule_blocking_too_coarse(_profile_blocking_too_coarse(), cfg, RunHistory())
+    # 950 < 5000 threshold → no fire
+    assert out is None
+
+
+def test_rule_blocking_too_coarse_returns_none_when_no_alternate_col():
+    cfg = _config_with_blocking(field="name")
+    profile = ComplexityProfile(
+        data=DataProfile(
+            n_rows=1000, n_cols=2,
+            column_types={"name": "name", "rare": "id-like"},
+            cardinality_ratio={"name": 0.4, "rare": 0.99},  # nothing in [0.05, 0.5] except 'name' itself
+        ),
+        blocking=BlockingProfile(
+            keys_used=[["name"]], n_blocks=2, total_comparisons=99000, reduction_ratio=0.8,
+            block_sizes_p99=5500,
+        ),
+        scoring=ScoringProfile(n_pairs_scored=10, mass_above_threshold=0.1, dip_statistic=0.05),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+    out = rule_blocking_too_coarse(profile, cfg, RunHistory())
+    assert out is None
+
+
+# Rule 2
+def test_rule_unimodal_scoring_fires_and_swaps_scorer():
+    cfg = _config_with_blocking(scorer="jaro_winkler")
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2),
+        scoring=ScoringProfile(
+            n_pairs_scored=500, dip_statistic=0.001,
+            mass_above_threshold=0.4, mass_in_borderline=0.3,
+        ),
+        matchkey=MatchkeyProfile(per_field={
+            "name": FieldStats(0.4, 0.0, 10),
+            "city": FieldStats(0.1, 0.0, 5),
+        }),
+        blocking=BlockingProfile(reduction_ratio=0.95, n_blocks=10, block_sizes_p99=20),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+    out = rule_unimodal_scoring(profile, cfg, RunHistory())
+    assert out is not None
+    new_cfg, decision = out
+    # Highest cardinality field is "name"
+    name_field = next(f for f in new_cfg.matchkeys[0].fields if f.field == "name")
+    assert name_field.scorer == "ensemble"
+
+
+def test_rule_unimodal_scoring_does_not_fire_when_already_ensemble():
+    cfg = _config_with_blocking(scorer="ensemble")
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2),
+        scoring=ScoringProfile(
+            n_pairs_scored=500, dip_statistic=0.001, mass_above_threshold=0.4,
+        ),
+        matchkey=MatchkeyProfile(per_field={"name": FieldStats(0.4, 0.0, 10)}),
+        blocking=BlockingProfile(reduction_ratio=0.95, n_blocks=10, block_sizes_p99=20),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+    out = rule_unimodal_scoring(profile, cfg, RunHistory())
+    assert out is None
+
+
+# Rule 3
+def test_rule_low_reduction_fires_and_adds_multi_pass():
+    cfg = _config_with_blocking()
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2,
+                         column_types={"name": "text", "city": "geo"}),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=10, total_comparisons=4000,
+            reduction_ratio=0.1, block_sizes_p99=15,
+        ),
+        scoring=ScoringProfile(n_pairs_scored=4000, mass_above_threshold=0.4, dip_statistic=0.05),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+    out = rule_low_reduction_ratio(profile, cfg, RunHistory())
+    assert out is not None
+    new_cfg, _ = out
+    assert new_cfg.blocking.strategy == "multi_pass"
+    assert len(new_cfg.blocking.passes) >= 2
+    soundex_pass = [p for p in new_cfg.blocking.passes if "soundex" in p.transforms]
+    assert soundex_pass
+
+
+# Rule 4
+def test_rule_low_transitivity_lowers_threshold():
+    cfg = _config_with_blocking(threshold=0.8)
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2),
+        blocking=BlockingProfile(reduction_ratio=0.95, n_blocks=10, block_sizes_p99=20),
+        scoring=ScoringProfile(n_pairs_scored=500, mass_above_threshold=0.4, dip_statistic=0.05),
+        cluster=ClusterProfile(n_clusters=10, transitivity_rate=0.5),  # below 0.85
+    )
+    out = rule_low_transitivity(profile, cfg, RunHistory())
+    assert out is not None
+    new_cfg, _ = out
+    assert new_cfg.matchkeys[0].threshold == pytest.approx(0.75)
+
+
+def test_rule_low_transitivity_floors_at_0_5():
+    cfg = _config_with_blocking(threshold=0.5)
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2),
+        blocking=BlockingProfile(reduction_ratio=0.95, n_blocks=10, block_sizes_p99=20),
+        scoring=ScoringProfile(n_pairs_scored=500, mass_above_threshold=0.4, dip_statistic=0.05),
+        cluster=ClusterProfile(n_clusters=10, transitivity_rate=0.5),
+    )
+    out = rule_low_transitivity(profile, cfg, RunHistory())
+    assert out is None  # already at floor
+
+
+# Rule 5
+def test_rule_no_matches_resets_threshold_and_broadens_blocking():
+    cfg = _config_with_blocking(threshold=0.85)
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2),
+        blocking=BlockingProfile(reduction_ratio=0.95, n_blocks=10, block_sizes_p99=20),
+        scoring=ScoringProfile(
+            n_pairs_scored=500, mass_above_threshold=0.0,  # nothing matched
+            dip_statistic=0.05,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+    out = rule_no_matches(profile, cfg, RunHistory())
+    assert out is not None
+    new_cfg, _ = out
+    assert new_cfg.matchkeys[0].threshold == pytest.approx(0.5)
+    assert new_cfg.blocking.max_block_size >= 50000
+
+
+def test_default_rules_list_has_five_entries():
+    assert len(DEFAULT_RULES) == 5
+
+
+def test_heuristic_policy_with_default_rules_fires_on_red_blocking():
+    """End-to-end: HeuristicRefitPolicy with DEFAULT_RULES proposes a config
+    when blocking is too coarse."""
+    cfg = _config_with_blocking(field="a")
+    policy = HeuristicRefitPolicy()  # uses DEFAULT_RULES
+    profile = _profile_blocking_RED()
+    out = policy.propose(profile, cfg, RunHistory())
+    assert out is not None
+    assert out is not cfg

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -1,0 +1,179 @@
+import pytest
+from goldenmatch.config.schemas import (
+    GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+    BlockingConfig, BlockingKeyConfig,
+)
+from goldenmatch.core.complexity_profile import (
+    ComplexityProfile, DataProfile, BlockingProfile, ScoringProfile,
+    ClusterProfile, MatchkeyProfile, DomainProfile, FieldStats, HealthVerdict,
+)
+from goldenmatch.core.autoconfig_history import (
+    RunHistory, HistoryEntry, PolicyDecision,
+)
+from goldenmatch.core.autoconfig_policy import (
+    RefitPolicy, HeuristicRefitPolicy, Rule,
+)
+
+
+def _green_profile() -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(
+            n_rows=100, n_cols=4,
+            column_types={"a": "text", "b": "id-like", "c": "text", "d": "date"},
+        ),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=10, total_comparisons=500,
+            reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
+            block_sizes_p99=20, block_sizes_max=25,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,
+            dip_statistic=0.05, mass_above_threshold=0.4, mass_in_borderline=0.05,
+        ),
+        cluster=ClusterProfile(
+            n_clusters=20, cluster_size_p50=2, cluster_size_p99=5,
+            cluster_size_max=8, transitivity_rate=0.95,
+        ),
+        matchkey=MatchkeyProfile(per_field={"a": FieldStats(0.5, 0.0, 10)}),
+    )
+
+
+def _red_profile() -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=4, column_types={"a": "text", "b": "text"}),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=2, total_comparisons=4900,
+            reduction_ratio=0.01,  # RED
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=500, score_histogram=[0]*15 + [100]*5,
+            dip_statistic=0.05, mass_above_threshold=0.4,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+
+
+def _trivial_config() -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["a"])]),
+        matchkeys=[
+            MatchkeyConfig(
+                name="m", type="weighted", threshold=0.7,
+                fields=[MatchkeyField(field="a", scorer="jaro_winkler", weight=1.0)],
+            )
+        ],
+    )
+
+
+def test_protocol_is_runtime_checkable():
+    """RefitPolicy is a Protocol; HeuristicRefitPolicy implements it."""
+    policy = HeuristicRefitPolicy()
+    # Duck-type check: has the propose method with the right signature
+    assert callable(getattr(policy, "propose", None))
+
+
+def test_green_profile_returns_none():
+    """When profile is GREEN, policy returns None (satisfied) regardless of rules."""
+    policy = HeuristicRefitPolicy()
+    result = policy.propose(_green_profile(), _trivial_config(), RunHistory())
+    assert result is None
+
+
+def test_no_rules_satisfies_immediately():
+    """An empty rule list means the policy is satisfied even on red profiles."""
+    policy = HeuristicRefitPolicy(rules=[])
+    result = policy.propose(_red_profile(), _trivial_config(), RunHistory())
+    assert result is None
+
+
+def test_first_firing_rule_wins():
+    """Rules are tried in order; first to return non-None wins."""
+    cfg_a = _trivial_config()
+    cfg_b = GoldenMatchConfig(
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["a"])]),
+        matchkeys=[MatchkeyConfig(
+            name="m2", type="weighted", threshold=0.5,
+            fields=[MatchkeyField(field="a", scorer="ensemble", weight=1.0)],
+        )],
+    )
+    cfg_c = GoldenMatchConfig(
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["a"])]),
+        matchkeys=[MatchkeyConfig(
+            name="m3", type="weighted", threshold=0.6,
+            fields=[MatchkeyField(field="a", scorer="token_sort", weight=1.0)],
+        )],
+    )
+
+    def rule_skip(profile, current, history):
+        return None
+
+    def rule_fire_b(profile, current, history):
+        return cfg_b, PolicyDecision(rule_name="rule_b", rationale="test", config_diff={})
+
+    def rule_fire_c(profile, current, history):
+        return cfg_c, PolicyDecision(rule_name="rule_c", rationale="test", config_diff={})
+
+    policy = HeuristicRefitPolicy(rules=[rule_skip, rule_fire_b, rule_fire_c])
+    result = policy.propose(_red_profile(), cfg_a, RunHistory())
+    # rule_b fires first → cfg_b wins, cfg_c never consulted
+    assert result is cfg_b
+
+
+def test_rule_returning_same_config_is_treated_as_satisfied():
+    """If a rule returns a config equal to current, treat as satisfied (None).
+    This is the bug guard from spec §RefitPolicy.propose return semantics (S1-A).
+    """
+    cfg = _trivial_config()
+
+    def rule_returns_same(profile, current, history):
+        return current, PolicyDecision(rule_name="noop", rationale="x", config_diff={})
+
+    policy = HeuristicRefitPolicy(rules=[rule_returns_same])
+    result = policy.propose(_red_profile(), cfg, RunHistory())
+    assert result is None
+
+
+def test_decision_recorded_on_history_entry_when_rule_fires():
+    """When a rule fires, the policy attaches the decision to the latest history entry.
+    (This is so the controller's audit trail reflects which rule fired.)"""
+    cfg_a = _trivial_config()
+    cfg_b = GoldenMatchConfig(
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["a"])]),
+        matchkeys=[MatchkeyConfig(name="m2", type="weighted", threshold=0.5,
+                                  fields=[MatchkeyField(field="a", scorer="ensemble", weight=1.0)])],
+    )
+
+    decision = PolicyDecision(rule_name="my_rule", rationale="explanation", config_diff={"k": "v"})
+
+    def rule(profile, current, history):
+        return cfg_b, decision
+
+    history = RunHistory()
+    history.entries.append(HistoryEntry(
+        iteration=0, config=cfg_a, profile=_red_profile(),
+        decision=None, error=None, wall_clock_ms=10,
+    ))
+
+    policy = HeuristicRefitPolicy(rules=[rule])
+    result = policy.propose(_red_profile(), cfg_a, history)
+    assert result is cfg_b
+    # The latest history entry's decision is now populated
+    assert history.entries[-1].decision is decision
+
+
+def test_decision_not_attached_when_no_history_entries():
+    """If history is empty (first iteration before any append), no attach attempt."""
+    cfg_a = _trivial_config()
+    cfg_b = GoldenMatchConfig(
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["a"])]),
+        matchkeys=[MatchkeyConfig(name="m2", type="weighted", threshold=0.5,
+                                  fields=[MatchkeyField(field="a", scorer="ensemble", weight=1.0)])],
+    )
+
+    def rule(profile, current, history):
+        return cfg_b, PolicyDecision(rule_name="r", rationale="x", config_diff={})
+
+    policy = HeuristicRefitPolicy(rules=[rule])
+    # Empty history — propose still works, just no attach
+    result = policy.propose(_red_profile(), cfg_a, RunHistory())
+    assert result is cfg_b

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -391,6 +391,30 @@ def test_rule_no_matches_resets_threshold_and_broadens_blocking():
     assert new_cfg.blocking.max_block_size >= 50000
 
 
+def test_rule_no_matches_fires_on_zero_pairs_scored():
+    """When blocking collapses everything into singletons, n_pairs_scored=0
+    AND mass_above_threshold=0.0. Rule should fire on this case too —
+    proposing a broader blocking strategy."""
+    cfg = _config_with_blocking(threshold=0.85)
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2),
+        blocking=BlockingProfile(reduction_ratio=0.99, n_blocks=100,
+                                 block_sizes_p99=1, singleton_block_count=100),
+        scoring=ScoringProfile(
+            n_pairs_scored=0,           # blocking trapped everything
+            mass_above_threshold=0.0,
+            dip_statistic=0.0,
+        ),
+        cluster=ClusterProfile(transitivity_rate=1.0),
+    )
+    out = rule_no_matches(profile, cfg, RunHistory())
+    assert out is not None
+    new_cfg, decision = out
+    assert new_cfg.matchkeys[0].threshold == pytest.approx(0.5)
+    assert new_cfg.blocking.max_block_size >= 50000
+    assert decision.rule_name == "no_matches"
+
+
 def test_default_rules_list_has_five_entries():
     assert len(DEFAULT_RULES) == 5
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_verify.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_verify.py
@@ -475,13 +475,17 @@ def test_postflight_attached_after_match_via_autoconfig():
 
 def test_preflight_check1_domain_repair_works_with_manual_domain_config():
     """Bug fix: when user passes explicit domain_config, preflight should still
-    be able to auto-repair domain-extracted column references."""
+    be able to auto-repair domain-extracted column references.
+    Uses _legacy_auto_configure_v0 directly because domain_config and the
+    resulting _domain_profile/_preflight_report attributes are set by the legacy
+    heuristic; the controller-backed auto_configure_df does not thread these kwargs.
+    """
     import polars as pl
-    from goldenmatch.core.autoconfig import auto_configure_df
+    from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
     from goldenmatch.config.schemas import DomainConfig
     df = pl.DataFrame({"title": [f"paper {i}" for i in range(50)]})
     # Force manual domain selection
-    cfg = auto_configure_df(df, domain_config=DomainConfig(enabled=True, mode="bibliographic"))
+    cfg = _legacy_auto_configure_v0(df, domain_config=DomainConfig(enabled=True, mode="bibliographic"))
     assert hasattr(cfg, "_domain_profile")
     assert cfg._domain_profile is not None
     assert cfg._preflight_report is not None
@@ -527,10 +531,14 @@ def test_postflight_threshold_adjustment_applied_before_clustering():
 def test_postflight_strict_mode_pipeline_does_not_filter_all_pairs():
     """When _strict_autoconfig is True, the pipeline must NOT apply threshold
     adjustments even if postflight emits them. Verified by running with
-    strict=True and a bimodal input."""
+    strict=True and a bimodal input.
+    Uses _legacy_auto_configure_v0 directly because strict= and the resulting
+    _strict_autoconfig attribute are legacy-heuristic-specific; the
+    controller-backed auto_configure_df does not thread this kwarg.
+    """
     import polars as pl
     from goldenmatch._api import dedupe_df
-    from goldenmatch.core.autoconfig import auto_configure_df
+    from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
 
     # Same bimodal input as above
     names = []
@@ -540,7 +548,7 @@ def test_postflight_strict_mode_pipeline_does_not_filter_all_pairs():
     df = pl.DataFrame({"name": names})
 
     # Build strict config externally then reuse
-    cfg_strict = auto_configure_df(df, strict=True)
+    cfg_strict = _legacy_auto_configure_v0(df, strict=True)
     assert cfg_strict._strict_autoconfig is True
 
     result = dedupe_df(df, config=cfg_strict)

--- a/packages/python/goldenmatch/tests/test_complexity_profile.py
+++ b/packages/python/goldenmatch/tests/test_complexity_profile.py
@@ -1,0 +1,231 @@
+import pytest
+from goldenmatch.core.complexity_profile import (
+    HealthVerdict, BlockingProfile, ScoringProfile, ClusterProfile,
+    DataProfile, DomainProfile, MatchkeyProfile, ProfileMeta,
+    ComplexityProfile, FieldStats,
+)
+
+
+def _green_data():
+    return DataProfile(
+        n_rows=100, n_cols=4,
+        column_types={"a": "text", "b": "id-like", "c": "text", "d": "date"},
+        cardinality_ratio={"a": 0.5, "b": 0.99, "c": 0.5, "d": 0.4},
+        null_rate={"a": 0, "b": 0, "c": 0, "d": 0},
+        value_length_p50={"a": 10}, value_length_p99={"a": 40},
+    )
+
+
+def _green_blocking():
+    return BlockingProfile(
+        keys_used=[["a"]], n_blocks=10, total_comparisons=500,
+        reduction_ratio=0.95, block_sizes_p50=10, block_sizes_p95=15,
+        block_sizes_p99=20, block_sizes_max=25,
+        singleton_block_count=0, oversized_block_count=0,
+    )
+
+
+def _green_scoring():
+    return ScoringProfile(
+        n_pairs_scored=500, score_histogram=[0] * 15 + [100] * 5,
+        dip_statistic=0.05, mass_above_threshold=0.4,
+        mass_in_borderline=0.05, per_field_score_variance={"a": 0.3},
+    )
+
+
+def _green_cluster():
+    return ClusterProfile(
+        n_clusters=20, cluster_size_p50=2, cluster_size_p99=5,
+        cluster_size_max=8, transitivity_rate=0.95,
+        edge_confidence_p50=0.85, edge_confidence_min=0.7,
+        oversized_cluster_count=0,
+    )
+
+
+def _green_matchkey():
+    return MatchkeyProfile(per_field={"a": FieldStats(0.5, 0.0, 10)})
+
+
+def _green_profile():
+    return ComplexityProfile(
+        data=_green_data(),
+        domain=DomainProfile(detected_domain=None, confidence=0.0, derived_columns=[],
+                             low_confidence_row_count=0),
+        matchkey=_green_matchkey(),
+        blocking=_green_blocking(),
+        scoring=_green_scoring(),
+        cluster=_green_cluster(),
+    )
+
+
+def test_data_red_when_zero_rows():
+    assert DataProfile(n_rows=0, n_cols=4).health() == HealthVerdict.RED
+
+
+def test_data_yellow_when_one_col():
+    assert DataProfile(n_rows=10, n_cols=1, column_types={"a": "text"}).health() == HealthVerdict.YELLOW
+
+
+def test_domain_yellow_when_low_conf_with_derived_cols():
+    dp = DomainProfile(detected_domain="bibliographic", confidence=0.2,
+                       derived_columns=["__title_key__"], low_confidence_row_count=10)
+    assert dp.health() == HealthVerdict.YELLOW
+
+
+def test_domain_green_when_low_conf_no_derived():
+    dp = DomainProfile(detected_domain=None, confidence=0.0, derived_columns=[],
+                       low_confidence_row_count=0)
+    assert dp.health() == HealthVerdict.GREEN
+
+
+def test_matchkey_red_when_field_constant():
+    mp = MatchkeyProfile(per_field={"a": FieldStats(0.0, 0.0, 0)})
+    assert mp.health() == HealthVerdict.RED
+
+
+def test_matchkey_yellow_when_field_nearly_unique():
+    mp = MatchkeyProfile(per_field={"a": FieldStats(0.99, 0.0, 10)})
+    assert mp.health() == HealthVerdict.YELLOW
+
+
+def test_blocking_red_when_one_block_dominates():
+    bp = BlockingProfile(
+        keys_used=[["a"]], n_blocks=10, total_comparisons=500,
+        reduction_ratio=0.95, block_sizes_p50=5, block_sizes_p95=15,
+        block_sizes_p99=200, block_sizes_max=200,
+        singleton_block_count=0, oversized_block_count=0,
+    )
+    # n_rows / n_blocks = 100/10 = 10; p99=200 > 10 * 10 = 100 → RED
+    assert bp.health(n_rows=100) == HealthVerdict.RED
+
+
+def test_blocking_red_when_reduction_ratio_low():
+    bp = BlockingProfile(
+        keys_used=[["a"]], n_blocks=2, total_comparisons=4900,
+        reduction_ratio=0.01,
+        block_sizes_p50=49, block_sizes_p95=49, block_sizes_p99=49,
+        block_sizes_max=49, singleton_block_count=0, oversized_block_count=0,
+    )
+    assert bp.health(n_rows=100) == HealthVerdict.RED
+
+
+def test_blocking_yellow_when_mostly_singletons():
+    bp = BlockingProfile(
+        keys_used=[["a"]], n_blocks=10, total_comparisons=10,
+        reduction_ratio=0.99,
+        block_sizes_p50=1, block_sizes_p95=2, block_sizes_p99=2,
+        block_sizes_max=3, singleton_block_count=8, oversized_block_count=0,
+    )
+    assert bp.health(n_rows=100) == HealthVerdict.YELLOW
+
+
+def test_blocking_red_when_no_blocks():
+    bp = BlockingProfile()
+    assert bp.health(n_rows=100) == HealthVerdict.RED
+
+
+def test_scoring_red_when_nothing_matches():
+    sp = ScoringProfile(
+        n_pairs_scored=500, score_histogram=[100] * 15 + [0] * 5,
+        dip_statistic=0.05, mass_above_threshold=0.0,
+        mass_in_borderline=0.05,
+    )
+    assert sp.health() == HealthVerdict.RED
+
+
+def test_scoring_red_when_unimodal():
+    sp = ScoringProfile(
+        n_pairs_scored=500, score_histogram=[20] * 20,
+        dip_statistic=0.001,
+        mass_above_threshold=0.4, mass_in_borderline=0.05,
+    )
+    assert sp.health() == HealthVerdict.RED
+
+
+def test_scoring_yellow_when_borderline_heavy():
+    sp = ScoringProfile(
+        n_pairs_scored=500, score_histogram=[0] * 14 + [100, 100, 100] + [0] * 3,
+        dip_statistic=0.05, mass_above_threshold=0.4, mass_in_borderline=0.5,
+    )
+    assert sp.health() == HealthVerdict.YELLOW
+
+
+def test_cluster_red_when_one_giant_cluster():
+    cp = ClusterProfile(
+        n_clusters=2, cluster_size_p50=2, cluster_size_p99=98,
+        cluster_size_max=98, transitivity_rate=0.95,
+        edge_confidence_p50=0.8, edge_confidence_min=0.7,
+        oversized_cluster_count=1,
+    )
+    # max=98, n_rows=100 → 0.98 > 0.1 → RED
+    assert cp.health(n_rows=100) == HealthVerdict.RED
+
+
+def test_cluster_red_when_low_transitivity():
+    cp = ClusterProfile(
+        n_clusters=10, cluster_size_p50=2, cluster_size_p99=5,
+        cluster_size_max=8, transitivity_rate=0.5,
+    )
+    assert cp.health(n_rows=100) == HealthVerdict.RED
+
+
+def test_cluster_yellow_when_oversized_present():
+    cp = ClusterProfile(
+        n_clusters=10, cluster_size_p50=2, cluster_size_p99=5,
+        cluster_size_max=8, transitivity_rate=0.95,
+        oversized_cluster_count=1,
+    )
+    assert cp.health(n_rows=100) == HealthVerdict.YELLOW
+
+
+def test_complexity_profile_rollup_red_when_any_red():
+    p = ComplexityProfile(
+        data=_green_data(),
+        domain=DomainProfile(),
+        matchkey=_green_matchkey(),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=2, total_comparisons=4900,
+            reduction_ratio=0.01,  # RED
+            block_sizes_p50=49, block_sizes_p95=49, block_sizes_p99=49,
+            block_sizes_max=49,
+        ),
+        scoring=_green_scoring(),
+        cluster=_green_cluster(),
+    )
+    assert p.health() == HealthVerdict.RED
+
+
+def test_complexity_profile_rollup_yellow_when_any_yellow():
+    p = ComplexityProfile(
+        data=_green_data(),
+        domain=DomainProfile(detected_domain="x", confidence=0.1,
+                             derived_columns=["__y__"]),  # YELLOW
+        matchkey=_green_matchkey(),
+        blocking=_green_blocking(),
+        scoring=_green_scoring(),
+        cluster=_green_cluster(),
+    )
+    assert p.health() == HealthVerdict.YELLOW
+
+
+def test_complexity_profile_rollup_green_when_all_green():
+    assert _green_profile().health() == HealthVerdict.GREEN
+
+
+def test_normalized_signal_vector_length_8():
+    p = _green_profile()
+    v = p.normalized_signal_vector()
+    assert len(v) == 8
+    assert all(0.0 <= x <= 1.0 for x in v)
+
+
+def test_dataclasses_are_frozen():
+    bp = BlockingProfile()
+    with pytest.raises((AttributeError, Exception)):  # FrozenInstanceError or AttributeError
+        bp.n_blocks = 5  # type: ignore[misc]
+
+
+def test_version_field_defaults_to_1():
+    assert DataProfile()._version == 1
+    assert ScoringProfile()._version == 1
+    assert ComplexityProfile()._version == 1

--- a/packages/python/goldenmatch/tests/test_profile_emitter.py
+++ b/packages/python/goldenmatch/tests/test_profile_emitter.py
@@ -1,0 +1,96 @@
+import threading
+import pytest
+from goldenmatch.core.profile_emitter import (
+    ProfileEmitter, profile_capture, current_emitter, _NullEmitter,
+)
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile, ScoringProfile, ClusterProfile,
+    DataProfile, DomainProfile, MatchkeyProfile,
+)
+
+
+def test_no_emitter_returns_null_singleton():
+    a = current_emitter()
+    b = current_emitter()
+    assert isinstance(a, _NullEmitter)
+    assert a is b
+
+
+def test_null_emitter_drops_writes():
+    e = current_emitter()
+    # Must not raise; writes go nowhere
+    e.set_blocking(BlockingProfile())
+    e.set_scoring(ScoringProfile())
+    e.set_cluster(ClusterProfile())
+    e.set_data(DataProfile())
+    e.set_domain(DomainProfile())
+    e.set_matchkey(MatchkeyProfile())
+
+
+def test_capture_yields_active_emitter():
+    with profile_capture() as e:
+        assert isinstance(e, ProfileEmitter)
+        assert current_emitter() is e
+
+
+def test_capture_buffers_writes():
+    bp = BlockingProfile(keys_used=[["a"]], n_blocks=5)
+    with profile_capture() as e:
+        e.set_blocking(bp)
+    assert e.blocking is bp
+
+
+def test_capture_clears_after_exit():
+    with profile_capture():
+        assert not isinstance(current_emitter(), _NullEmitter)
+    assert isinstance(current_emitter(), _NullEmitter)
+
+
+def test_capture_unwinds_on_exception():
+    try:
+        with profile_capture() as e:
+            assert current_emitter() is e
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert isinstance(current_emitter(), _NullEmitter)
+
+
+def test_nested_capture_uses_inner_emitter():
+    with profile_capture() as outer:
+        assert current_emitter() is outer
+        with profile_capture() as inner:
+            assert current_emitter() is inner
+            assert inner is not outer
+        assert current_emitter() is outer
+    assert isinstance(current_emitter(), _NullEmitter)
+
+
+def test_emitter_isolation_across_threads():
+    barrier = threading.Barrier(2)
+    seen: dict[str, ProfileEmitter] = {}
+
+    def worker(label: str) -> None:
+        with profile_capture() as e:
+            barrier.wait()
+            # ContextVar gives each thread its own stack
+            seen[label] = current_emitter()
+
+    t1 = threading.Thread(target=worker, args=("a",))
+    t2 = threading.Thread(target=worker, args=("b",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+    assert seen["a"] is not seen["b"]
+
+
+def test_writes_after_outer_exit_dont_leak():
+    with profile_capture() as outer:
+        outer.set_blocking(BlockingProfile(n_blocks=1))
+    # outer is still a live object but no longer current
+    new_bp = BlockingProfile(n_blocks=99)
+    current_emitter().set_blocking(new_bp)  # goes to null
+    # outer.blocking is still what we wrote inside the context
+    assert outer.blocking is not None
+    assert outer.blocking.n_blocks == 1

--- a/packages/python/goldenmatch/tests/test_stage_instrumentation.py
+++ b/packages/python/goldenmatch/tests/test_stage_instrumentation.py
@@ -103,3 +103,30 @@ def test_scorer_emits_scoring_profile_via_dedupe_df():
     assert 0.0 <= e.scoring.dip_statistic <= 0.25
     assert 0.0 <= e.scoring.mass_above_threshold <= 1.0
     assert 0.0 <= e.scoring.mass_in_borderline <= 1.0
+
+
+def test_build_clusters_emits_cluster_profile():
+    """ClusterProfile populated after build_clusters with cluster sizes + transitivity."""
+    from goldenmatch.core.cluster import build_clusters
+    from goldenmatch.core.profile_emitter import profile_capture
+    from goldenmatch.core.complexity_profile import ClusterProfile
+    # Three pairs forming a triangle (transitive cluster) + one isolated pair
+    pairs = [
+        (1, 2, 0.95), (2, 3, 0.92), (1, 3, 0.90),  # cluster {1,2,3}
+        (10, 11, 0.85),                              # cluster {10,11}
+    ]
+    with profile_capture() as e:
+        clusters = build_clusters(pairs)
+    assert e.cluster is not None
+    assert isinstance(e.cluster, ClusterProfile)
+    assert e.cluster.n_clusters == 2
+    assert e.cluster.cluster_size_max == 3
+    # Transitivity over {1,2,3}: all three edges meet any reasonable threshold -> 1.0
+    assert e.cluster.transitivity_rate == pytest.approx(1.0)
+
+
+def test_build_clusters_no_emit_when_no_capture():
+    from goldenmatch.core.cluster import build_clusters
+    pairs = [(1, 2, 0.9), (2, 3, 0.85)]
+    clusters = build_clusters(pairs)  # must not raise
+    assert len(clusters) >= 1

--- a/packages/python/goldenmatch/tests/test_stage_instrumentation.py
+++ b/packages/python/goldenmatch/tests/test_stage_instrumentation.py
@@ -1,0 +1,67 @@
+"""Tests for stage instrumentation: build_blocks emits BlockingProfile."""
+import polars as pl
+import pytest
+from goldenmatch.core.profile_emitter import profile_capture
+from goldenmatch.core.complexity_profile import BlockingProfile
+
+
+def _make_test_lf():
+    return pl.DataFrame({
+        "__row_id__": list(range(20)),
+        "name": ["alice"] * 5 + ["bob"] * 5 + ["carol"] * 5 + ["dan"] * 5,
+        "__source__": ["x"] * 20,
+    }).lazy()
+
+
+def test_build_blocks_emits_blocking_profile():
+    from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+    from goldenmatch.core.blocker import build_blocks
+    cfg = BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["name"], transforms=["lowercase"])],
+        max_block_size=5000, skip_oversized=False,
+    )
+    with profile_capture() as e:
+        blocks = build_blocks(_make_test_lf(), cfg)
+    assert e.blocking is not None
+    assert isinstance(e.blocking, BlockingProfile)
+    assert e.blocking.n_blocks == 4
+    assert e.blocking.keys_used == [["name"]]
+    assert e.blocking.singleton_block_count == 0
+    assert e.blocking.block_sizes_max == 5
+
+
+def test_build_blocks_no_emit_when_no_capture():
+    """Behavior unchanged when no capture is active — emitter is null singleton."""
+    from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+    from goldenmatch.core.blocker import build_blocks
+    cfg = BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["name"], transforms=["lowercase"])],
+        max_block_size=5000, skip_oversized=False,
+    )
+    blocks = build_blocks(_make_test_lf(), cfg)  # must not raise; no profile_capture
+    assert len(blocks) == 4
+
+
+def test_build_blocks_emits_singleton_count():
+    """Each unique value -> singleton block; emitted count matches."""
+    from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+    from goldenmatch.core.blocker import build_blocks
+    lf = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3, 4],
+        "name": ["a", "b", "c", "d", "e"],  # 5 distinct values
+        "__source__": ["x"] * 5,
+    }).lazy()
+    cfg = BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["name"], transforms=["lowercase"])],
+        max_block_size=5000, skip_oversized=False,
+    )
+    with profile_capture() as e:
+        build_blocks(lf, cfg)
+    # All blocks are singletons (size 1) so they are filtered out by build_blocks (< 2 records)
+    # n_blocks == 0 and singleton_block_count == 0 when all blocks have size < 2
+    assert e.blocking is not None
+    assert e.blocking.n_blocks == 0
+    assert e.blocking.singleton_block_count == 0

--- a/packages/python/goldenmatch/tests/test_stage_instrumentation.py
+++ b/packages/python/goldenmatch/tests/test_stage_instrumentation.py
@@ -130,3 +130,92 @@ def test_build_clusters_no_emit_when_no_capture():
     pairs = [(1, 2, 0.9), (2, 3, 0.85)]
     clusters = build_clusters(pairs)  # must not raise
     assert len(clusters) >= 1
+
+
+def test_compute_matchkeys_emits_matchkey_profile():
+    """After compute_matchkeys runs, MatchkeyProfile.per_field is populated."""
+    import polars as pl
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+    from goldenmatch.core.matchkey import compute_matchkeys
+    from goldenmatch.core.profile_emitter import profile_capture
+    from goldenmatch.core.complexity_profile import MatchkeyProfile
+
+    df = pl.DataFrame({
+        "name": ["alice", "bob", "carol", "alice"],
+        "city": ["nyc", "nyc", "la", "la"],
+    }).with_columns(pl.lit(0).alias("__row_id__"))
+
+    mks = [MatchkeyConfig(
+        name="m", type="weighted", threshold=0.7,
+        fields=[
+            MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0,
+                          transforms=["lowercase"]),
+            MatchkeyField(field="city", scorer="exact", weight=1.0,
+                          transforms=["lowercase"]),
+        ],
+    )]
+    with profile_capture() as e:
+        compute_matchkeys(df.lazy(), mks)
+    assert e.matchkey is not None
+    assert isinstance(e.matchkey, MatchkeyProfile)
+    # Both fields should have entries
+    assert "name" in e.matchkey.per_field or "city" in e.matchkey.per_field
+    for stats in e.matchkey.per_field.values():
+        assert 0.0 <= stats.post_transform_cardinality_ratio <= 1.0
+        assert 0.0 <= stats.post_transform_null_rate <= 1.0
+
+
+def test_compute_matchkeys_no_emit_when_no_capture():
+    import polars as pl
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+    from goldenmatch.core.matchkey import compute_matchkeys
+    df = pl.DataFrame({"name": ["a", "b"]}).with_columns(pl.lit(0).alias("__row_id__"))
+    mks = [MatchkeyConfig(
+        name="m", type="exact",
+        fields=[MatchkeyField(field="name", transforms=["lowercase"])],
+    )]
+    compute_matchkeys(df.lazy(), mks)  # must not raise
+
+
+def test_auto_configure_df_emits_data_profile():
+    """DataProfile populated when auto_configure_df runs under capture."""
+    import polars as pl
+    import goldenmatch
+    from goldenmatch.core.profile_emitter import profile_capture
+    from goldenmatch.core.complexity_profile import DataProfile
+
+    df = pl.DataFrame({
+        "name": ["alice", "bob", "carol"] * 3,
+        "city": ["nyc", "la", "sf"] * 3,
+    })
+    with profile_capture() as e:
+        goldenmatch.auto_configure_df(df)
+    assert e.data is not None
+    assert isinstance(e.data, DataProfile)
+    assert e.data.n_rows == 9
+    # n_cols counts user (non-internal) cols only
+    assert e.data.n_cols >= 2
+
+
+def test_extract_features_emits_domain_profile():
+    """DomainProfile populated when domain.extract_features runs under capture."""
+    import polars as pl
+    from goldenmatch.core.domain import extract_features, DomainProfile as InternalProfile
+    from goldenmatch.core.profile_emitter import profile_capture
+    from goldenmatch.core.complexity_profile import DomainProfile
+
+    # Use a profile with confidence > 0.3 so extract_features actually does work
+    profile = InternalProfile(
+        name="bibliographic",
+        confidence=0.9,
+        text_columns=["title"],
+    )
+    df = pl.DataFrame({
+        "title": ["Some Paper", "Another Work", "Third One"],
+        "author": ["A", "B", "C"],
+    })
+    with profile_capture() as e:
+        extract_features(df, profile, confidence_threshold=0.5)
+    assert e.domain is not None
+    assert isinstance(e.domain, DomainProfile)
+    assert e.domain.confidence == pytest.approx(0.9)

--- a/packages/python/goldenmatch/tests/test_stage_instrumentation.py
+++ b/packages/python/goldenmatch/tests/test_stage_instrumentation.py
@@ -65,3 +65,41 @@ def test_build_blocks_emits_singleton_count():
     assert e.blocking is not None
     assert e.blocking.n_blocks == 0
     assert e.blocking.singleton_block_count == 0
+
+
+def test_scorer_emits_scoring_profile_via_dedupe_df():
+    """After fuzzy scoring runs, the emitter holds a ScoringProfile."""
+    import polars as pl
+    from goldenmatch.config.schemas import (
+        GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+        BlockingConfig, BlockingKeyConfig,
+    )
+    from goldenmatch.core.profile_emitter import profile_capture
+    from goldenmatch.core.complexity_profile import ScoringProfile
+    import goldenmatch as gm
+
+    df = pl.DataFrame({
+        "name": ["alice", "alyce", "bob", "bobby", "carol", "carrol"] * 3,
+        "city": ["nyc"] * 18,
+    })
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="m", type="weighted", threshold=0.7,
+            fields=[MatchkeyField(field="name", scorer="jaro_winkler",
+                                  weight=1.0, transforms=["lowercase"])],
+        )],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["city"], transforms=["lowercase"])],
+            max_block_size=5000, skip_oversized=False,
+        ),
+    )
+    with profile_capture() as e:
+        gm.dedupe_df(df, config=cfg)
+    assert e.scoring is not None, "scorer did not emit a ScoringProfile"
+    assert isinstance(e.scoring, ScoringProfile)
+    assert e.scoring.n_pairs_scored > 0
+    assert sum(e.scoring.score_histogram) == e.scoring.n_pairs_scored
+    assert 0.0 <= e.scoring.dip_statistic <= 0.25
+    assert 0.0 <= e.scoring.mass_above_threshold <= 1.0
+    assert 0.0 <= e.scoring.mass_in_borderline <= 1.0


### PR DESCRIPTION
## Summary
- Adds `AutoConfigController` — an iterative refit loop over a `RefitPolicy` protocol that runs the pipeline on a stratified sample, reads stage-emitted complexity signals, and proposes config refits until green / converged / budget exhausted
- Replaces the untyped `PostflightSignals` TypedDict with a typed `ComplexityProfile` (6 frozen sub-profile dataclasses with explicit health rules)
- Wires `auto_configure_df` through the controller; refactors zero-config callers in `_api.py` and the web UI to call `auto_configure_df` *before* the pipeline (eliminating the double-pipeline-run that would otherwise occur)
- Ships `HeuristicRefitPolicy` with 5 hand-coded rules; protocol leaves room for `LearnedRefitPolicy` / `LLMRefitPolicy` later

## Why

PR #102 fixed two crash paths in zero-config `match_df` and `match()`. Measuring after that fix gave DBLP-ACM zero-config F1 = 0.5102 vs hand-tuned 0.918 — and `CLAUDE.md` notes that auto-config fails on every standard benchmark. Today's auto-config is a feedforward function that never inspects what its config does to real data. This PR rebuilds it as an introspective pipeline so the same problem can be addressed across datasets without per-domain hand-tuning.

## What's in here (16 commits)

**Foundation:**
- `core/complexity_profile.py` — `HealthVerdict` + 6 frozen sub-profile dataclasses (`Data`, `Domain`, `Matchkey`, `Blocking`, `Scoring`, `Cluster`) + `ProfileMeta` + rollup
- `core/profile_emitter.py` — `ContextVar`-backed thread-local emitter stack with `_NullEmitter` singleton (zero cost when no capture is active)
- `core/autoconfig_history.py` — `RunHistory` with oscillation detection, profile-distance convergence, and the cheapest-healthy lex ordering from spec §S1-B

**Stage instrumentation** (surgical edits, no behavior change when emitter is null):
- `core/blocker.py` emits `BlockingProfile` after `build_blocks`
- `core/scorer.py` emits `ScoringProfile` from the fuzzy scorer (sequential + parallel paths)
- `core/cluster.py` emits `ClusterProfile` with a sampled transitivity rate from `build_clusters`
- `core/matchkey.py` emits `MatchkeyProfile` from `compute_matchkeys` post-transform columns
- `core/autoconfig.py` + `core/domain.py` emit `DataProfile` and `DomainProfile`
- New `core/_profile_helpers.py` (histogram / Hartigan dip / mass / transitivity helpers); adds `diptest>=0.5.2` as a hard dep

**Policy:**
- `core/autoconfig_policy.py` — `RefitPolicy` protocol + `HeuristicRefitPolicy` dispatcher with same-config bug guard
- `core/autoconfig_rules.py` — 5 ordered rules: `blocking_too_coarse`, `unimodal_scoring`, `low_reduction_ratio`, `low_transitivity`, `no_matches`

**Controller:**
- `core/autoconfig_controller.py` — `AutoConfigController` + `ControllerBudget` + `StopReason` enum + `_RED_PROFILE` sentinel + pathological-input gates + stratified-deterministic sample selection + iteration loop with crash recovery + `_finalize` with sample-vs-full drift detection
- `_legacy_auto_configure_v0` extracted in `core/autoconfig.py` (private helper used as v0 by the controller's `_initial_config` — breaks the recursion that would otherwise occur when the public `auto_configure_df` calls back through the controller)

**Wire-up:**
- Public `auto_configure_df(df, *, reference=None, …)` becomes a controller-backed facade; gains `reference` kwarg for cross-source mode
- `_LAST_CONTROLLER_RUN` ContextVar so calling pipelines can pull the profile + history into `PostflightReport`
- Zero-config callers in `_api.py::dedupe_df`, `_api.py::match_df`, and the web UI run `auto_configure_df` BEFORE the pipeline and pass `auto_config=False` explicitly — no more double pipeline runs

## Test status

- **1684 passed** (1572 baseline + 112 new) on the standard exclusion set (db / mcp / torch tests skipped per `packages/python/goldenmatch/CLAUDE.md`)
- Focused suites: 22 `test_complexity_profile`, 9 `test_profile_emitter`, 15 `test_autoconfig_history`, 8 `test_stage_instrumentation`, 19 `test_autoconfig_policy`, 19 `test_autoconfig_controller`, 9 `test_autoconfig_facade`, 5 `test_autoconfig_no_double_run`
- DBLP-ACM regression from PR #102 (`TestMatchZeroConfig`) still passes
- 1 pre-existing failure unchanged: `test_ncvr_autoconfig_no_useless_matchkeys` (gitignored NCVR sample dataset, not present locally)

## What this PR explicitly does NOT do

- **Close the DBLP-ACM accuracy gap.** Zero-config F1 went 0.5102 → 0.5133 — material architectural validation (the controller iterates, rules fire, the loop finds a cheaper-healthy candidate) but not a meaningful precision lift. The diagnosis is concrete: `rule_blocking_too_coarse` runs first and switches blocking from `__title_key__` to `authors`, which on the 2000-row sample looks GREEN but on full data over-generates pairs. The controller faithfully commits the cheapest-healthy candidate; the *response to sample-vs-full drift* (recorded as `history.full_vs_sample_drift`) is left for a follow-up
- **Migrate `PostflightSignals` consumers to read typed `ComplexityProfile`.** The TypedDict is preserved for back-compat; consumers continue to read it. Migration is a separate PR
- **Refactor the file-based `_api.py::match` zero-config branch.** Restructures I/O ordering — non-trivial, controller's sample iterations don't go through the file path so it's not in the double-run hot path. Documented as deferred
- **Property tests / controller integration tests / benchmark regression test.** The pair-conversion helper for benchmarks was built and validated locally but not committed (see follow-up)
- **TS port parity.** `packages/goldenmatch-js/` continues with the legacy heuristic. Spec explicitly calls this v2 work

## Follow-ups

1. **Rule tuning + ordering.** Either re-prioritize rules so `rule_no_matches` fires before `rule_blocking_too_coarse` on the singleton-trap signal (`n_pairs_scored == 0`), or add a rule that handles "blocking too coarse + no usable alternate column → propose soundex/n-gram on text"
2. **Act on drift in v1.** When `full_vs_sample_drift > threshold`, re-run one more iteration with the full-data profile or fall back to v0
3. **Migrate consumers from `PostflightSignals` TypedDict to typed `ComplexityProfile`** — separate PR
4. **Property tests + benchmark regression tests** — separate PR; the architecture is now testable end-to-end
5. **Document architecture in `CLAUDE.md`** — replace the "always use explicit config" caveat once a benchmark target is met

## Architecture spec

`docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-design.md` (gitignored per repo convention; design doc is local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)