### PR TITLE
docs(autoconfig): controller results + Febrl3 verification

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GoldenMatch are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
+## [Unreleased]
+
+### Added
+- Auto-config introspective controller (PR #103, #104). Zero-config DBLP-ACM F1 0.51→0.96. New ComplexityProfile types, RefitPolicy protocol, 7 heuristic rules, controller history surfaced via PostflightReport.
+
 ## [Unreleased] / TypeScript port
 
 ## [1.6.0] - 2026-05-04

--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -227,6 +227,9 @@ Hosted on Railway, registered on Smithery:
 - `utf8-lossy` encoding on all CSV read paths (ingest.py, agent.py, chunked.py, smart_ingest.py, skills.py)
 - `golden` records != total output. `unique + golden = total distinct people`
 - `llm_scorer` and `backend` kwargs applied uniformly after config resolution (not inside zero-config branch)
+- Controller iterates on ComplexityProfile signals (block-size dist, score histogram dip, transitivity, candidates_compared, mass_above_threshold). HeuristicRefitPolicy is the v1 policy; LearnedRefitPolicy / LLMRefitPolicy are v2 hooks.
+- Stage instrumentation in core/blocker.py, core/scorer.py, core/cluster.py, core/matchkey.py, core/autoconfig.py, core/domain.py emits sub-profiles via a thread-local ProfileEmitter stack (zero cost when no capture is active).
+- Controller history is on PostflightReport.controller_history (RunHistory with .decisions, .errors, .full_vs_sample_drift). RunHistory.decisions is the audit trail of which rules fired and why — useful for explaining auto-config output to users.
 
 ## Gotchas
 - `docs/superpowers/` is gitignored — specs and plans are local-only; do NOT `git add` them
@@ -242,7 +245,7 @@ Hosted on Railway, registered on Smithery:
 - `.profile_tmp/` is gitignored and used for local profiling artifacts (cProfile dumps, sampled parquet fixtures). `.profile_tmp/profile_ncvr.py` is the reference scorer profiling script — loads 200K NCVR voter sample and attributes scorer time across rapidfuzz vs. Python orchestration vs. Polars overhead.
 - Leipzig DBLP-ACM dataset: `DBLP2.csv` uses `latin-1` encoding (not UTF-8). `ACM.csv` also latin-1.
 - `recordlinkage.datasets.load_febrl3()` needs `return_links=True` to get ground truth pairs (default returns only DataFrame)
-- Auto-config fails on all standard benchmarks (Febrl, DBLP-ACM, NC Voter) — always use explicit config for non-trivial dedup. v1.2.7 cardinality guards improve but don't fully solve this.
+- v1.8 (2026-05-07): introspective controller (PR #103, #104) lifts zero-config to hand-tuned-or-better on DBLP-ACM (F1=0.96), holds Febrl3 (F1=0.85). The legacy "always use explicit config for non-trivial dedup" caveat no longer applies for bibliographic-shape data; explicit config still wins on Amazon-Google / Abt-Buy product matching where domain extraction + LLM scorer are required.
 - Comparison benchmark scripts in `D:\show_case\golden-showcase\comparison_bench\` — GoldenMatch, Splink, Dedupe, RecordLinkage on Febrl/DBLP-ACM/NC Voter
 - `dedupe` library class is `dedupe.Dedupe` (not `dedupe.Deduper`). Empty strings cause `ZeroDivisionError` in affinegap — use single space as placeholder. Training pairs must go through `training_file` param, not `mark_pairs` directly.
 - .docx files can't be read by Read tool — use `python-docx` or zipfile+XML

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -885,6 +885,18 @@ Head-to-head against Splink, Dedupe, and RecordLinkage on two datasets. GoldenMa
 
 **Key takeaway:** GoldenMatch is the most consistent performer — top-2 F1 on both datasets with zero training data. Splink dominates structured PII but struggles on non-PII. RecordLinkage wins DBLP-ACM but lags on PII.
 
+### Zero-Config Controller (v1.8, PR [#103](https://github.com/benzsevern/goldenmatch/pull/103) / [#104](https://github.com/benzsevern/goldenmatch/pull/104))
+
+The introspective auto-config controller iterates on ComplexityProfile signals to reach hand-tuned-or-better accuracy with no user configuration on bibliographic data.
+
+| Dataset | Mode | Precision | Recall | F1 | Notes |
+|---|---|---|---|---|---|
+| **DBLP-ACM** | zero-config (controller, v1.8) | — | — | **0.964** | Iterates 2× on a 2K-row sample; swaps blocking from `__title_key__` to `first_token(title)` + drops stale derived-column matchkey |
+| **Febrl3** | zero-config (controller, v1.8) | 1.000 | 0.743 | **0.853** | Controller commits without iteration on this dataset — clean person-matching data doesn't trigger refit rules |
+| DBLP-ACM | explicit hand-tuned config | 0.891 | 0.945 | 0.918 | (unchanged — v1.2.7 library comparison above) |
+
+**Note:** The zero-config controller achieves above-hand-tuned F1 on bibliographic-shape data (DBLP-ACM). Febrl3 held at 0.853 vs 0.971 hand-tuned — the controller's rules don't fire on clean synthetic PII. Product matching (Amazon-Google, Abt-Buy) is unverified by this work; domain extraction + LLM scorer remain the recommended path for those datasets.
+
 <details>
 <summary>Febrl explicit config example</summary>
 


### PR DESCRIPTION
## Summary

Documentation pass for the auto-config controller (PR #103, #104). Verifies Febrl3 doesn't regress with the new rules and updates CLAUDE.md / README / CHANGELOG to retire the "always use explicit config" caveat.

## Verification

Re-ran zero-config on Febrl3 with the rules from PR #104:

| Dataset | Before (legacy v1.7.1) | After (controller v1.8) | Δ |
|---|---|---|---|
| DBLP-ACM (cross-source match) | 0.5102 | **0.9641** | +0.45 |
| Febrl3 (single-source dedupe) | 0.8528 | **0.8528** | held (P=1.0, R=0.74) |
| NCVR sample | N/A — dataset not local | N/A | — |

DBLP-ACM clears the 0.918 hand-tuned ceiling per `CLAUDE.md`. Febrl3 doesn't improve (controller commits without iterating — existing v0 already produces P=1.0 output) but doesn't regress either, which is what we wanted from this verification.

## Doc changes

- **`packages/python/goldenmatch/CLAUDE.md`** — replaced the stale "Auto-config fails on all standard benchmarks" caveat with v1.8 controller results. Added entries describing ComplexityProfile signals, ProfileEmitter stage instrumentation, and `PostflightReport.controller_history` audit trail.
- **`packages/python/goldenmatch/README.md`** — new "Zero-Config Controller (v1.8)" subsection in Library Comparison with a 3-row table including the Febrl3 honest P/R breakdown. Hand-tuned DBLP-ACM (0.918) row preserved for comparison.
- **`packages/python/goldenmatch/CHANGELOG.md`** — `[Unreleased]` entry summarizing the controller feature + F1 improvement.

## What this PR explicitly does NOT claim

- **Product matching (Amazon-Google / Abt-Buy) is unverified.** Those datasets need domain extraction + LLM scorer; the controller doesn't replace that work, and the existing CLAUDE.md notes for those benchmarks are unchanged.
- **NCVR sample is missing locally** so no number for that row. Tests gated on dataset presence skip cleanly.
- **No new code** — this is a docs-only PR. The controller architecture and rule set are already in main from #103/#104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)