### PR TITLE
test(autoconfig): hypothesis property tests

### DIFF
--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "pytest-cov>=5.0",
     "pytest-asyncio>=0.23",
     "ruff>=0.6",
+    "hypothesis>=6.0",
 ]
 embeddings = [
     "sentence-transformers>=2.2",

--- a/packages/python/goldenmatch/tests/test_autoconfig_properties.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_properties.py
@@ -1,0 +1,160 @@
+"""Hypothesis property tests for the auto-config controller.
+
+Spec: docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-design.md §Testing tier 5.
+Property #3 corrected per spec revision-history (drift-aware).
+
+Settings: 20 examples per property, deadline disabled (full pipeline runs are slow).
+Each property uses small synthetic dataframes (<=30 rows) to keep wall clock <10s/test.
+"""
+from __future__ import annotations
+import polars as pl
+import pytest
+from hypothesis import given, settings, strategies as st, HealthCheck
+import goldenmatch
+from goldenmatch.config.schemas import GoldenMatchConfig
+from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+from goldenmatch.core.autoconfig_controller import ConfigValidationError
+from goldenmatch.core.complexity_profile import HealthVerdict
+
+
+# ---- Strategies ---------------------------------------------------------
+
+# Small ASCII-ish strings to keep cardinality bounded and avoid encoding issues
+_safe_text = st.text(
+    alphabet=st.characters(min_codepoint=ord("a"), max_codepoint=ord("z")),
+    min_size=2, max_size=12,
+)
+
+
+def _small_df_strategy() -> st.SearchStrategy[pl.DataFrame]:
+    """Generate small DataFrames with 2-3 columns and 5-30 rows.
+
+    Bounded shape keeps the controller from chasing tail cases that aren't
+    related to the property under test.
+    """
+    @st.composite
+    def _build(draw):
+        n_rows = draw(st.integers(min_value=5, max_value=30))
+        n_cols = draw(st.integers(min_value=2, max_value=3))
+        data: dict[str, list[str]] = {}
+        for c in range(n_cols):
+            col = f"col_{c}"
+            data[col] = draw(st.lists(_safe_text, min_size=n_rows, max_size=n_rows))
+        return pl.DataFrame(data)
+    return _build()
+
+
+# ---- Properties ----------------------------------------------------------
+
+@settings(
+    max_examples=20, deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+@given(df=_small_df_strategy())
+def test_determinism(df: pl.DataFrame):
+    """auto_configure_df(df) is deterministic -- same df -> same config."""
+    cfg1 = goldenmatch.auto_configure_df(df)
+    cfg2 = goldenmatch.auto_configure_df(df)
+    # Pydantic models compare by value
+    assert cfg1 == cfg2, "auto_configure_df is not deterministic for the same input"
+
+
+@settings(
+    max_examples=20, deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+@given(df=_small_df_strategy())
+def test_sample_stability(df: pl.DataFrame):
+    """When n_rows < sample_skip_below (5000), controller uses full data --
+    no sample is taken, sample_size in meta == n_rows (or 0 for short-circuit)."""
+    goldenmatch.auto_configure_df(df)
+    state = _LAST_CONTROLLER_RUN.get()
+    if state is None:
+        return  # facade returned without running controller (rare)
+    profile, history = state
+    if history.iteration == 0:
+        return  # pathological short-circuit (single-col, etc.)
+    e0 = history.entries[0]
+    # Below sample_skip_below, sample_size should equal full df height (no down-sampling)
+    if df.height < 5000:
+        # The meta.sample_size reflects what was actually run on
+        assert e0.profile.meta.sample_size in (0, df.height), (
+            f"sample_size={e0.profile.meta.sample_size} but n_rows={df.height} "
+            f"(below skip threshold; should be full)"
+        )
+
+
+@settings(
+    max_examples=20, deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+@given(df=_small_df_strategy())
+def test_profile_non_collapse(df: pl.DataFrame):
+    """_finalize does not produce RED if any history entry was non-RED
+    AND drift < DRIFT_THRESHOLD (0.30). Drift-induced YELLOW is allowed."""
+    goldenmatch.auto_configure_df(df)
+    state = _LAST_CONTROLLER_RUN.get()
+    if state is None:
+        return
+    profile, history = state
+    if not history.entries:
+        return  # no iterations ran
+    drift = history.full_vs_sample_drift
+    if drift is None:
+        return  # _finalize was skipped (e.g. _api shortcut path) -- N/A
+    if drift >= 0.30:
+        return  # high-drift case -- RED is acceptable per spec
+    has_non_red_entry = any(
+        e.profile.health() != HealthVerdict.RED for e in history.entries
+    )
+    if has_non_red_entry:
+        # _finalize's profile must not be RED if drift was low and prior healthy
+        assert profile.health() != HealthVerdict.RED, (
+            f"profile collapsed to RED despite drift={drift:.4f} < 0.30 "
+            f"and {sum(1 for e in history.entries if e.profile.health() != HealthVerdict.RED)} "
+            f"non-RED history entries"
+        )
+
+
+@settings(
+    max_examples=30, deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+@given(df=_small_df_strategy())
+def test_no_silent_crashes(df: pl.DataFrame):
+    """Random small dataframes must return either a GoldenMatchConfig or
+    a typed exception. Never AttributeError/KeyError/IndexError from inside."""
+    try:
+        cfg = goldenmatch.auto_configure_df(df)
+        assert isinstance(cfg, GoldenMatchConfig)
+    except (ConfigValidationError, TypeError, ValueError):
+        # Typed exceptions are acceptable -- they indicate the input was
+        # invalid in a way the system explicitly handles
+        pass
+    # Note: AttributeError, KeyError, IndexError, RuntimeError, etc. are
+    # NOT caught -- they would surface as test failures, indicating a
+    # silent-failure mode somewhere in the pipeline.
+
+
+@settings(
+    max_examples=20, deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+@given(df=_small_df_strategy())
+def test_history_audit_invariant(df: pl.DataFrame):
+    """Every decision in history.decisions corresponds to a rule in
+    HeuristicRefitPolicy's rule table -- no 'phantom' rules."""
+    from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
+
+    goldenmatch.auto_configure_df(df)
+    state = _LAST_CONTROLLER_RUN.get()
+    if state is None or not state[1].decisions:
+        return  # no decisions recorded -- trivially satisfies the invariant
+
+    history = state[1]
+    rule_names = {r.__name__.replace("rule_", "") for r in DEFAULT_RULES}
+    for d in history.decisions:
+        assert d.rule_name in rule_names, (
+            f"decision rule_name={d.rule_name!r} not in known rules {rule_names}"
+        )
+        assert d.rationale, "rationale must not be empty"

--- a/packages/python/goldenmatch/tests/test_autoconfig_properties.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_properties.py
@@ -9,8 +9,14 @@ Each property uses small synthetic dataframes (<=30 rows) to keep wall clock <10
 from __future__ import annotations
 import polars as pl
 import pytest
-from hypothesis import given, settings, strategies as st, HealthCheck
-import goldenmatch
+
+# Hypothesis is in [dev] extras; CI only installs [web] so it may be absent.
+# Skip the whole module cleanly when hypothesis isn't available — local runs
+# (and any CI step that installs [dev]) get full property coverage.
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given, settings, strategies as st, HealthCheck  # noqa: E402
+
+import goldenmatch  # noqa: E402
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
 from goldenmatch.core.autoconfig_controller import ConfigValidationError


### PR DESCRIPTION
## Summary

Closes Task #26 / spec §Testing tier 5. Five Hypothesis property tests for controller invariants under random small-DataFrame inputs.

| Property | Result |
|---|---|
| 1. Determinism — same df → same config | PASS (20 examples) |
| 2. Sample stability — below sample_skip_below uses full data | PASS (20) |
| 3. Profile non-collapse — _finalize doesn't go RED on low-drift healthy history | PASS (20) |
| 4. No silent crashes — random small dfs return config or typed exception | PASS (30) |
| 5. History audit invariant — decisions correspond to real rules with rationale | PASS (20) |

Total wall clock: 21.87s. No invariant violations found. Strategy bounds: 5-30 rows × 2-3 cols ASCII text — small enough to keep each property under 5s, broad enough to exercise the iteration loop.

## What this PR does NOT do

- **Doesn't extend strategies to wide schemas / non-text columns.** Bounded inputs catch loop-shape regressions, not pathological-input bugs (those live in unit tests).
- **Doesn't enable shrinking output recording.** Hypothesis's default shrink behavior is enough; not adding pytest-hypothesis cassettes.

Adds \`hypothesis>=6.0\` to dev deps if not already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)