### PR TITLE
feat(autoconfig): post-iteration LLM scorer decoration with dynamic bounds

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -225,6 +225,13 @@ class AutoConfigController:
             )
             return config_v0, _RED_PROFILE, history
 
+        # Post-iteration: decorate committed config with LLM scorer if appropriate.
+        # This runs ONCE, outside the iteration loop, so it never competes with
+        # structural rules for the iteration budget.
+        committed_config = self._maybe_decorate_with_llm_scorer(
+            best_entry.config, best_entry.profile,
+        )
+
         # Fix 4: When skip_finalize=True (called from _api zero-config path),
         # skip the full-data _finalize run. The caller will execute the real
         # full pipeline immediately after, so running it here would be a double
@@ -234,10 +241,10 @@ class AutoConfigController:
             # Return the best sample profile in lieu of a full-data profile.
             # history.full_vs_sample_drift is left None (drift not computed).
             self._record_run(df, reference, best_entry, history)
-            return best_entry.config, best_entry.profile, history
+            return committed_config, best_entry.profile, history
 
         # Finalize on full data (Task 4.3)
-        profile_full = self._finalize(best_entry.config, df, reference)
+        profile_full = self._finalize(committed_config, df, reference)
         # Drift detection
         sample_vec = best_entry.profile.normalized_signal_vector()
         full_vec = profile_full.normalized_signal_vector()
@@ -245,7 +252,7 @@ class AutoConfigController:
         history.full_vs_sample_drift = drift
 
         self._record_run(df, reference, best_entry, history)
-        return best_entry.config, profile_full, history
+        return committed_config, profile_full, history
 
     # ---- Internals --------------------------------------------------------
     def _initial_config(
@@ -603,6 +610,70 @@ class AutoConfigController:
             emitter, df=df, iteration=-1, is_sample=False,
             reference=reference, config=None,
         )
+
+    def _maybe_decorate_with_llm_scorer(
+        self,
+        config: GoldenMatchConfig,
+        profile: ComplexityProfile,
+    ) -> GoldenMatchConfig:
+        """If the committed profile is borderline-heavy AND an LLM API key is
+        available, enable LLMScorerConfig on the committed config so the
+        user-facing pipeline run uses per-pair LLM scoring on borderline pairs.
+
+        This runs ONCE after the controller iteration loop commits, not inside
+        the loop — so LLM decoration never competes with structural rules for
+        the iteration budget. On DQbench, structural rules dominate every
+        iteration; the old rule_enable_llm_scorer (position 10 in DEFAULT_RULES)
+        never got a turn.
+
+        Bounds (candidate_lo / candidate_hi / auto_threshold) track the weighted
+        matchkey's threshold dynamically (Change B): with controller-lowered
+        thresholds (~0.5 typical), the hardcoded 0.60–0.90 band was entirely
+        above the score distribution and no LLM calls fired.
+        """
+        from goldenmatch.core.autoconfig_rules import _llm_api_key_available
+        sp = profile.scoring
+        if sp.candidates_compared == 0:
+            return config
+        if sp.mass_in_borderline < 0.10:
+            return config
+        if not _llm_api_key_available():
+            return config
+        if config.llm_scorer is not None and config.llm_scorer.enabled:
+            return config
+
+        # Find the weighted matchkey threshold
+        weighted_mk = next(
+            (mk for mk in (config.matchkeys or []) if mk.type == "weighted"),
+            None,
+        )
+        if weighted_mk is None or weighted_mk.threshold is None:
+            return config
+        threshold = float(weighted_mk.threshold)
+
+        # Dynamic bounds: straddle the threshold with more headroom above
+        # (where pairs are more likely to be true matches worth verifying).
+        candidate_lo = max(0.0, threshold - 0.10)
+        candidate_hi = min(1.0, threshold + 0.20)
+        auto_threshold = candidate_hi
+
+        from goldenmatch.config.schemas import LLMScorerConfig, BudgetConfig
+        new_cfg = config.model_copy(update={
+            "llm_scorer": LLMScorerConfig(
+                enabled=True,
+                candidate_lo=candidate_lo,
+                candidate_hi=candidate_hi,
+                auto_threshold=auto_threshold,
+                budget=BudgetConfig(max_calls=500, max_cost_usd=1.0),
+            ),
+        })
+        logger.info(
+            "auto-config: enabling LLMScorerConfig on committed config "
+            "(mass_in_borderline=%.3f, threshold=%.2f, "
+            "candidate_lo=%.2f, candidate_hi=%.2f)",
+            sp.mass_in_borderline, threshold, candidate_lo, candidate_hi,
+        )
+        return new_cfg
 
     def _record_run(
         self,

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -629,7 +629,7 @@ def rule_enable_llm_scorer(
 
 
 DEFAULT_RULES = [
-    rule_blocking_field_null_heavy,   # NEW: structural null-rate guard (runs first)
+    rule_blocking_field_null_heavy,   # structural null-rate guard (runs first)
     rule_blocking_singleton_trap,     # catches __title_key__-style traps before blocking_too_coarse
     rule_blocking_too_coarse,
     rule_unimodal_scoring,
@@ -638,5 +638,9 @@ DEFAULT_RULES = [
     rule_no_matches,
     rule_blocking_key_swap,           # iter-1+ fallback when threshold/block loosening didn't help
     rule_recall_gap_suspected,        # probe-based recall signal
-    rule_enable_llm_scorer,           # NEW: last — enables LLM scorer when borderline-heavy + key available
+    # NOTE: rule_enable_llm_scorer is intentionally NOT in DEFAULT_RULES.
+    # LLM scorer decoration happens post-iteration via
+    # AutoConfigController._maybe_decorate_with_llm_scorer(), which runs once
+    # after the controller commits a config so it never competes with structural
+    # rules for the iteration budget.
 ]

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -563,6 +563,71 @@ def rule_recall_gap_suspected(
     return new_cfg, decision
 
 
+def _llm_api_key_available() -> bool:
+    """True when at least one supported LLM provider key is set in env."""
+    import os
+    return bool(
+        os.environ.get("OPENAI_API_KEY")
+        or os.environ.get("ANTHROPIC_API_KEY")
+    )
+
+
+def rule_enable_llm_scorer(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> "tuple[GoldenMatchConfig, PolicyDecision] | None":
+    """Enable per-pair LLM scoring (LLMScorerConfig) when there's a meaningful
+    borderline mass and an API key is available.
+
+    The hand-tuned DQbench adapter explicitly enables LLMScorerConfig with
+    candidate_lo=0.60 / candidate_hi=0.90 / auto_threshold=0.90 — this rule
+    auto-applies the same settings whenever the controller observes that
+    a non-trivial fraction of scored pairs land in the borderline band.
+
+    Silent no-op when no API key is set (key check via env). Bounded cost:
+    BudgetConfig(max_calls=500, max_cost_usd=1.0).
+    """
+    sp = profile.scoring
+    # Need real signal: scoring profile must have run at least once
+    if sp.candidates_compared == 0:
+        return None
+    # Borderline-heavy threshold: 10% of scored pairs in [threshold-0.1, threshold+0.1]
+    if sp.mass_in_borderline < 0.10:
+        return None
+    if not _llm_api_key_available():
+        return None
+    # Already enabled? Don't re-fire.
+    if current.llm_scorer is not None and current.llm_scorer.enabled:
+        return None
+
+    from goldenmatch.config.schemas import LLMScorerConfig, BudgetConfig
+
+    new_cfg = current.model_copy(update={
+        "llm_scorer": LLMScorerConfig(
+            enabled=True,
+            candidate_lo=0.60,
+            candidate_hi=0.90,
+            auto_threshold=0.90,
+            budget=BudgetConfig(max_calls=500, max_cost_usd=1.0),
+        ),
+    })
+    decision = PolicyDecision(
+        rule_name="enable_llm_scorer",
+        rationale=(
+            f"mass_in_borderline={sp.mass_in_borderline:.3f} > 0.10 with "
+            f"LLM API key available; enabling per-pair LLM scoring on "
+            f"pairs scoring 0.60-0.90 (auto-accept above 0.90, "
+            f"budget=$1.00 / 500 calls)"
+        ),
+        config_diff={
+            "llm_scorer.enabled": True,
+            "llm_scorer.candidate_lo": 0.60,
+            "llm_scorer.candidate_hi": 0.90,
+            "llm_scorer.auto_threshold": 0.90,
+        },
+    )
+    return new_cfg, decision
+
+
 DEFAULT_RULES = [
     rule_blocking_field_null_heavy,   # NEW: structural null-rate guard (runs first)
     rule_blocking_singleton_trap,     # catches __title_key__-style traps before blocking_too_coarse
@@ -572,5 +637,6 @@ DEFAULT_RULES = [
     rule_low_transitivity,
     rule_no_matches,
     rule_blocking_key_swap,           # iter-1+ fallback when threshold/block loosening didn't help
-    rule_recall_gap_suspected,        # NEW: probe-based recall signal (runs last)
+    rule_recall_gap_suspected,        # probe-based recall signal
+    rule_enable_llm_scorer,           # NEW: last — enables LLM scorer when borderline-heavy + key available
 ]

--- a/packages/python/goldenmatch/tests/test_autoconfig_controller.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_controller.py
@@ -620,3 +620,95 @@ def test_env_var_disables_default_memory(monkeypatch):
     df = pl.DataFrame({"name": ["a", "b", "c"] * 4, "city": ["x", "y", "z"] * 4})
     cfg = goldenmatch.auto_configure_df(df)
     assert isinstance(cfg, _GoldenMatchConfig)
+
+
+# ============================================================
+# _maybe_decorate_with_llm_scorer (Change A + B: post-iteration LLM decoration)
+# ============================================================
+
+def _borderline_profile_for_llm():
+    """A ComplexityProfile with meaningful borderline mass (triggers LLM decoration)."""
+    from goldenmatch.core.complexity_profile import (
+        BlockingProfile, ScoringProfile, ClusterProfile,
+    )
+    return ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2),
+        blocking=BlockingProfile(reduction_ratio=0.95, n_blocks=10,
+                                  block_sizes_p99=20),
+        scoring=ScoringProfile(
+            n_pairs_scored=100, candidates_compared=300,
+            mass_above_threshold=0.4, mass_in_borderline=0.25,
+            dip_statistic=0.05,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+
+
+def _cfg_with_threshold(threshold: float) -> _GoldenMatchConfig:
+    from goldenmatch.config.schemas import (
+        MatchkeyConfig, MatchkeyField, BlockingConfig, BlockingKeyConfig,
+    )
+    return _GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="m", type="weighted", threshold=threshold,
+            fields=[MatchkeyField(field="name", scorer="jaro_winkler",
+                                   weight=1.0, transforms=["lowercase"])],
+        )],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["city"], transforms=["lowercase"])],
+            max_block_size=5000, skip_oversized=False,
+        ),
+    )
+
+
+def test_decorate_with_llm_scorer_fires_with_borderline_and_key(monkeypatch):
+    """When the committed profile is borderline-heavy and an API key is
+    available, _maybe_decorate_with_llm_scorer enables LLMScorerConfig on
+    the returned config."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg = _cfg_with_threshold(0.7)
+    profile = _borderline_profile_for_llm()
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(),
+    )
+    out = controller._maybe_decorate_with_llm_scorer(cfg, profile)
+    assert out.llm_scorer is not None
+    assert out.llm_scorer.enabled is True
+    # Dynamic bounds: threshold 0.7 → lo=0.6, hi=0.9
+    assert out.llm_scorer.candidate_lo == pytest.approx(0.60)
+    assert out.llm_scorer.candidate_hi == pytest.approx(0.90)
+    assert out.llm_scorer.auto_threshold == pytest.approx(0.90)
+
+
+def test_decorate_with_llm_scorer_uses_lowered_threshold(monkeypatch):
+    """With threshold=0.5 (controller-lowered), bounds should track:
+    lo=0.4, hi=0.7, auto=0.7."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg = _cfg_with_threshold(0.5)
+    profile = _borderline_profile_for_llm()
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(),
+        budget=ControllerBudget(),
+    )
+    out = controller._maybe_decorate_with_llm_scorer(cfg, profile)
+    assert out.llm_scorer is not None
+    assert out.llm_scorer.candidate_lo == pytest.approx(0.40)
+    assert out.llm_scorer.candidate_hi == pytest.approx(0.70)
+
+
+def test_decorate_with_llm_scorer_silent_no_key(monkeypatch):
+    """Without an API key, _maybe_decorate_with_llm_scorer returns config unchanged."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    cfg = _cfg_with_threshold(0.7)
+    from goldenmatch.core.complexity_profile import ScoringProfile
+    profile = ComplexityProfile(
+        scoring=ScoringProfile(candidates_compared=100, mass_in_borderline=0.25),
+    )
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(), budget=ControllerBudget(),
+    )
+    out = controller._maybe_decorate_with_llm_scorer(cfg, profile)
+    assert out is cfg or out.llm_scorer is None

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -415,7 +415,8 @@ def test_rule_no_matches_does_not_fire_on_zero_candidates_compared():
 def test_default_rules_list_has_five_entries():
     # Updated to 6 after rule_blocking_singleton_trap was added (2026-05-07)
     # Updated to 7 after rule_blocking_key_swap was added (2026-05-07)
-    assert len(DEFAULT_RULES) == 9
+    # Updated to 10 after rule_enable_llm_scorer was added (2026-05-07)
+    assert len(DEFAULT_RULES) == 10
 
 
 def test_heuristic_policy_with_default_rules_fires_on_red_blocking():
@@ -592,9 +593,10 @@ def test_rule_singleton_trap_returns_none_when_no_text_field_in_matchkey():
 
 def test_default_rules_now_has_six_entries():
     """Singleton-trap rule is added to DEFAULT_RULES.
-    Updated to 7 after rule_blocking_key_swap was added (2026-05-07)."""
+    Updated to 7 after rule_blocking_key_swap was added (2026-05-07).
+    Updated to 10 after rule_enable_llm_scorer was added (2026-05-07)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 9
+    assert len(DEFAULT_RULES) == 10
 
 
 def test_singleton_trap_runs_before_blocking_too_coarse():
@@ -802,9 +804,10 @@ def test_rule_key_swap_returns_none_when_no_text_field_in_matchkey():
 
 
 def test_default_rules_now_has_seven_entries():
-    """Adding rule_blocking_key_swap brings the count to 7."""
+    """Adding rule_blocking_key_swap brings the count to 7.
+    Updated to 10 after rule_enable_llm_scorer was added (2026-05-07)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 9
+    assert len(DEFAULT_RULES) == 10
 
 
 def test_rule_key_swap_is_after_rule_no_matches():
@@ -1116,14 +1119,15 @@ def test_rule_null_heavy_does_not_fire_on_low_null_field():
 
 
 def test_default_rules_now_has_nine_entries():
-    """Adding rule_blocking_field_null_heavy and rule_recall_gap_suspected brings the count to 9."""
+    """Adding rule_blocking_field_null_heavy and rule_recall_gap_suspected brings the count to 9.
+    Updated to 10 after rule_enable_llm_scorer was added (2026-05-07)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 9
+    assert len(DEFAULT_RULES) == 10
 
 
-def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_last():
+def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_before_llm_scorer():
     """Order: rule_blocking_field_null_heavy first (structural check),
-    rule_recall_gap_suspected last (probe signal)."""
+    rule_recall_gap_suspected before rule_enable_llm_scorer (probe signal before LLM)."""
     from goldenmatch.core.autoconfig_rules import (
         DEFAULT_RULES, rule_blocking_field_null_heavy,
         rule_recall_gap_suspected, rule_no_matches,
@@ -1133,4 +1137,142 @@ def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_last():
     idx_recall_gap = DEFAULT_RULES.index(rule_recall_gap_suspected)
     assert idx_null_heavy < idx_no_matches, "null_heavy must run before no_matches"
     assert idx_recall_gap > idx_no_matches, "recall_gap must run after no_matches"
-    assert idx_recall_gap == len(DEFAULT_RULES) - 1, "recall_gap must be the last rule"
+    # recall_gap is second-to-last (rule_enable_llm_scorer is last)
+    assert idx_recall_gap == len(DEFAULT_RULES) - 2, "recall_gap must be second-to-last"
+
+
+# ============================================================
+# rule_enable_llm_scorer (added 2026-05-07)
+# ============================================================
+
+from goldenmatch.core.autoconfig_rules import (
+    rule_enable_llm_scorer, _llm_api_key_available,
+)
+
+
+def _config_no_llm_scorer():
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="m", type="weighted", threshold=0.7,
+            fields=[MatchkeyField(field="name", scorer="jaro_winkler",
+                                   weight=1.0, transforms=["lowercase"])],
+        )],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["city"], transforms=["lowercase"])],
+            max_block_size=5000, skip_oversized=False,
+        ),
+        # llm_scorer left as default None
+    )
+
+
+def _profile_borderline_heavy():
+    return ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2),
+        blocking=BlockingProfile(reduction_ratio=0.95, n_blocks=10,
+                                  block_sizes_p99=20),
+        scoring=ScoringProfile(
+            n_pairs_scored=100, candidates_compared=300,
+            mass_above_threshold=0.4,
+            mass_in_borderline=0.25,    # > 0.10
+            dip_statistic=0.05,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+
+
+def test_rule_enable_llm_scorer_fires_with_borderline_and_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg = _config_no_llm_scorer()
+    out = rule_enable_llm_scorer(_profile_borderline_heavy(), cfg, RunHistory())
+    assert out is not None
+    new_cfg, decision = out
+    assert decision.rule_name == "enable_llm_scorer"
+    assert new_cfg.llm_scorer is not None
+    assert new_cfg.llm_scorer.enabled is True
+    assert new_cfg.llm_scorer.candidate_lo == 0.60
+    assert new_cfg.llm_scorer.candidate_hi == 0.90
+
+
+def test_rule_enable_llm_scorer_silent_when_no_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    cfg = _config_no_llm_scorer()
+    out = rule_enable_llm_scorer(_profile_borderline_heavy(), cfg, RunHistory())
+    assert out is None
+
+
+def test_rule_enable_llm_scorer_does_not_fire_with_low_borderline(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg = _config_no_llm_scorer()
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2),
+        blocking=BlockingProfile(reduction_ratio=0.95, n_blocks=10,
+                                  block_sizes_p99=20),
+        scoring=ScoringProfile(
+            n_pairs_scored=100, candidates_compared=300,
+            mass_above_threshold=0.4,
+            mass_in_borderline=0.05,    # < 0.10
+            dip_statistic=0.05,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+    out = rule_enable_llm_scorer(profile, cfg, RunHistory())
+    assert out is None
+
+
+def test_rule_enable_llm_scorer_does_not_fire_when_no_candidates(monkeypatch):
+    """No scoring data yet → don't speculatively enable LLM."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg = _config_no_llm_scorer()
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=100, n_cols=2),
+        blocking=BlockingProfile(reduction_ratio=0.95, n_blocks=10,
+                                  block_sizes_p99=20),
+        scoring=ScoringProfile(
+            n_pairs_scored=0, candidates_compared=0,
+            mass_above_threshold=0.0,
+            mass_in_borderline=0.0,
+            dip_statistic=0.0,
+        ),
+        cluster=ClusterProfile(transitivity_rate=1.0),
+    )
+    out = rule_enable_llm_scorer(profile, cfg, RunHistory())
+    assert out is None
+
+
+def test_rule_enable_llm_scorer_does_not_fire_when_already_enabled(monkeypatch):
+    from goldenmatch.config.schemas import LLMScorerConfig
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg = _config_no_llm_scorer().model_copy(update={
+        "llm_scorer": LLMScorerConfig(enabled=True, candidate_lo=0.7, candidate_hi=0.95),
+    })
+    out = rule_enable_llm_scorer(_profile_borderline_heavy(), cfg, RunHistory())
+    assert out is None
+
+
+def test_default_rules_now_has_ten_entries():
+    """Adding rule_enable_llm_scorer brings count to 10."""
+    from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
+    assert len(DEFAULT_RULES) == 10
+
+
+def test_rule_enable_llm_scorer_runs_last(monkeypatch):
+    """It's the LAST rule — runs only after structural fixes attempt to fix
+    blocking/scoring issues. Adding LLM scoring to a fundamentally broken
+    config is wasted spend."""
+    from goldenmatch.core.autoconfig_rules import (
+        DEFAULT_RULES, rule_enable_llm_scorer,
+    )
+    assert DEFAULT_RULES[-1] is rule_enable_llm_scorer
+
+
+def test_llm_api_key_helper_reads_openai_or_anthropic(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert not _llm_api_key_available()
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert _llm_api_key_available()
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-test")
+    assert _llm_api_key_available()

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -416,7 +416,9 @@ def test_default_rules_list_has_five_entries():
     # Updated to 6 after rule_blocking_singleton_trap was added (2026-05-07)
     # Updated to 7 after rule_blocking_key_swap was added (2026-05-07)
     # Updated to 10 after rule_enable_llm_scorer was added (2026-05-07)
-    assert len(DEFAULT_RULES) == 10
+    # Reverted to 9: rule_enable_llm_scorer moved out of DEFAULT_RULES into
+    # AutoConfigController._maybe_decorate_with_llm_scorer (post-iteration decoration)
+    assert len(DEFAULT_RULES) == 9
 
 
 def test_heuristic_policy_with_default_rules_fires_on_red_blocking():
@@ -594,9 +596,10 @@ def test_rule_singleton_trap_returns_none_when_no_text_field_in_matchkey():
 def test_default_rules_now_has_six_entries():
     """Singleton-trap rule is added to DEFAULT_RULES.
     Updated to 7 after rule_blocking_key_swap was added (2026-05-07).
-    Updated to 10 after rule_enable_llm_scorer was added (2026-05-07)."""
+    Updated to 10 after rule_enable_llm_scorer was added (2026-05-07).
+    Reverted to 9: rule_enable_llm_scorer moved to post-iteration decoration."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 10
+    assert len(DEFAULT_RULES) == 9
 
 
 def test_singleton_trap_runs_before_blocking_too_coarse():
@@ -805,9 +808,10 @@ def test_rule_key_swap_returns_none_when_no_text_field_in_matchkey():
 
 def test_default_rules_now_has_seven_entries():
     """Adding rule_blocking_key_swap brings the count to 7.
-    Updated to 10 after rule_enable_llm_scorer was added (2026-05-07)."""
+    Updated to 10 after rule_enable_llm_scorer was added (2026-05-07).
+    Reverted to 9: rule_enable_llm_scorer moved to post-iteration decoration."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 10
+    assert len(DEFAULT_RULES) == 9
 
 
 def test_rule_key_swap_is_after_rule_no_matches():
@@ -1120,14 +1124,15 @@ def test_rule_null_heavy_does_not_fire_on_low_null_field():
 
 def test_default_rules_now_has_nine_entries():
     """Adding rule_blocking_field_null_heavy and rule_recall_gap_suspected brings the count to 9.
-    Updated to 10 after rule_enable_llm_scorer was added (2026-05-07)."""
+    (rule_enable_llm_scorer was moved out of DEFAULT_RULES into
+    AutoConfigController._maybe_decorate_with_llm_scorer post-iteration decoration.)"""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 10
+    assert len(DEFAULT_RULES) == 9
 
 
-def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_before_llm_scorer():
+def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_last():
     """Order: rule_blocking_field_null_heavy first (structural check),
-    rule_recall_gap_suspected before rule_enable_llm_scorer (probe signal before LLM)."""
+    rule_recall_gap_suspected last (probe signal, no LLM rule in the table)."""
     from goldenmatch.core.autoconfig_rules import (
         DEFAULT_RULES, rule_blocking_field_null_heavy,
         rule_recall_gap_suspected, rule_no_matches,
@@ -1137,8 +1142,8 @@ def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_before_llm_scorer
     idx_recall_gap = DEFAULT_RULES.index(rule_recall_gap_suspected)
     assert idx_null_heavy < idx_no_matches, "null_heavy must run before no_matches"
     assert idx_recall_gap > idx_no_matches, "recall_gap must run after no_matches"
-    # recall_gap is second-to-last (rule_enable_llm_scorer is last)
-    assert idx_recall_gap == len(DEFAULT_RULES) - 2, "recall_gap must be second-to-last"
+    # recall_gap is now LAST (rule_enable_llm_scorer removed from DEFAULT_RULES)
+    assert idx_recall_gap == len(DEFAULT_RULES) - 1, "recall_gap must be last"
 
 
 # ============================================================
@@ -1251,20 +1256,23 @@ def test_rule_enable_llm_scorer_does_not_fire_when_already_enabled(monkeypatch):
     assert out is None
 
 
-def test_default_rules_now_has_ten_entries():
-    """Adding rule_enable_llm_scorer brings count to 10."""
+def test_default_rules_now_has_nine_entries():
+    """rule_enable_llm_scorer was moved out of DEFAULT_RULES into
+    AutoConfigController._maybe_decorate_with_llm_scorer (post-iteration
+    decoration), bringing count back to 9."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 10
+    assert len(DEFAULT_RULES) == 9
 
 
-def test_rule_enable_llm_scorer_runs_last(monkeypatch):
-    """It's the LAST rule — runs only after structural fixes attempt to fix
-    blocking/scoring issues. Adding LLM scoring to a fundamentally broken
-    config is wasted spend."""
+def test_rule_enable_llm_scorer_not_in_default_rules():
+    """rule_enable_llm_scorer must NOT be in DEFAULT_RULES — it runs as a
+    post-iteration decoration via _maybe_decorate_with_llm_scorer, not inside
+    the iteration loop. On DQbench, structural rules dominate the budget and
+    the rule would never get a turn."""
     from goldenmatch.core.autoconfig_rules import (
         DEFAULT_RULES, rule_enable_llm_scorer,
     )
-    assert DEFAULT_RULES[-1] is rule_enable_llm_scorer
+    assert rule_enable_llm_scorer not in DEFAULT_RULES
 
 
 def test_llm_api_key_helper_reads_openai_or_anthropic(monkeypatch):


### PR DESCRIPTION
## Summary

Two related changes to the LLM-scorer auto-enable logic:

**A.** Move the LLM-enable decision out of the iteration rule loop. Was: \`rule_enable_llm_scorer\` at position 10 in DEFAULT_RULES, competing with structural rules for iteration budget. Now: \`AutoConfigController._maybe_decorate_with_llm_scorer\` runs once after \`cheapest_healthy()\` selects the committed config, before \`_finalize\`. Doesn't compete with structural rules for budget. The decorated config is what gets returned (and stored in memory).

**B.** Dynamic bounds. Was: hardcoded \`candidate_lo=0.60, candidate_hi=0.90\` (assumed default threshold ~0.7-0.8). Now: \`candidate_lo = threshold - 0.10\`, \`candidate_hi = threshold + 0.20\`, \`auto_threshold = candidate_hi\` — tracks whatever threshold the controller landed on (e.g. 0.5 after \`rule_no_matches\` fires).

## Measured impact

| Dataset | Before | After | Δ |
|---|---|---|---|
| DBLP-ACM | 0.9641 | 0.9544 | -0.010 |
| Febrl3 | 0.9443 | 0.9443 | held |
| NCVR | 0.9719 | 0.9719 | held |
| DQbench | 62.07 | 62.07 | unchanged |

DBLP-ACM regresses 0.010 because the controller-lowered threshold (0.5) creates a 47.5% borderline mass; with dynamic bounds the LLM inspects nearly half of all pairs, and at that volume LLM judgment noise produces a small net negative. Still well above the 0.918 hand-tuned ceiling.

DQbench unchanged for a separate reason: every controller iteration on T1/T2/T3 returns RED (uniform-heavy blocks fail BlockingProfile.health), so \`cheapest_healthy()\` returns None and the decoration never runs. **Closing DQbench requires a new rule for uniform-heavy blocking** — separate followup.

## What this PR does NOT do

- **Doesn't close the DQbench gap** — that needs a uniform-heavy-blocking rule, separate work.
- **Doesn't auto-disable LLM on datasets where it hurts** (e.g. DBLP-ACM). Could be a follow-up: signal from postflight whether LLM helped (e.g. agreement rate with base scorer) and learn over time via Tier 4 memory.
- **Doesn't change LLMRefitPolicy** (PR #112's option B). That's still the meta-config policy; this is the per-pair scoring layer.

## Test status

- 94/94 targeted tests pass (policy + controller + facade)
- 1805 broad regression tests pass, 3 skipped, 0 failures
- Existing \`rule_enable_llm_scorer\` unit tests still pass (function still defined, just not in DEFAULT_RULES)
- 3 new controller-integration tests for \`_maybe_decorate_with_llm_scorer\` (with key + borderline → fires; lowered threshold → bounds track; no key → silent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)