### PR TITLE
feat(autoconfig): rule_uniform_heavy_blocking + structural-rule reordering

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -384,6 +384,97 @@ def rule_blocking_key_swap(
     return new_cfg, decision
 
 
+def rule_uniform_heavy_blocking(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> "tuple[GoldenMatchConfig, PolicyDecision] | None":
+    """Fires when blocking creates many candidates but scoring can't separate
+    matches from non-matches — signature of over-coarse blocking on a
+    low-discriminating key.
+
+    Distinct from rule_blocking_too_coarse (which fires on p99 outlier — a
+    SKEWED distribution): this fires on UNIFORM-large blocks where every
+    pair scores high but most are false positives. T2 & T3 of DQbench fit:
+    blocking on `(city, product_category)` or `service_day` groups records
+    that share a category/date but aren't the same entity.
+
+    Signature:
+      - candidates_compared > n_rows (more than 1 comparison per row on average)
+      - mass_above_threshold > 0.5 (>50% of pairs "match")
+      - mass_in_borderline > 0.5 (>50% are borderline-confidence)
+      - avg block size > 30 (uniform-heavy, not just two big tail blocks)
+
+    Action: switch to a higher-cardinality identity-bearing column
+    (text or id-like, cardinality_ratio in [0.3, 0.95]) not currently
+    in blocking — typically a name/email field.
+    """
+    bp = profile.blocking
+    sp = profile.scoring
+    dp = profile.data
+    n_rows = dp.n_rows
+
+    if bp.n_blocks == 0 or n_rows == 0:
+        return None
+    avg_block = n_rows / bp.n_blocks
+    if avg_block < 30:
+        return None  # blocks already small enough — different pathology
+    if sp.candidates_compared < n_rows:
+        return None  # not enough candidates to characterize as over-coarse
+    if sp.mass_above_threshold < 0.5:
+        return None  # not the "everything matches" signature
+    if sp.mass_in_borderline < 0.5:
+        return None  # if matches are confident, they may be real
+
+    if current.blocking is None:
+        return None
+    used = _existing_blocking_fields(current)
+
+    # Find a high-cardinality identity-bearing column not already in blocking.
+    # Prefer email > name > text > id-like; cardinality 0.3-0.95 (selective but not unique)
+    priority_map = {"email": 0, "name": 1, "text": 2, "id-like": 3}
+    candidates: list[tuple[int, float, str, str]] = []  # (priority, -ratio, col, col_type)
+    for col, ratio in dp.cardinality_ratio.items():
+        if col in used:
+            continue
+        if not (0.3 <= ratio <= 0.95):
+            continue
+        col_type = dp.column_types.get(col, "unknown")
+        if col_type in priority_map:
+            prio = priority_map[col_type]
+            candidates.append((prio, -ratio, col, col_type))
+    if not candidates:
+        return None
+    candidates.sort()
+    new_field = candidates[0][2]
+    new_type = candidates[0][3]
+
+    # Replace blocking with single key on the selected high-cardinality field
+    new_blocking = current.blocking.model_copy(update={
+        "strategy": "static",
+        "keys": [BlockingKeyConfig(
+            fields=[new_field],
+            transforms=["lowercase", "strip"],
+        )],
+        "passes": [],  # drop multi-pass; the new key is selective enough
+    })
+    new_cfg = current.model_copy(update={"blocking": new_blocking})
+    decision = PolicyDecision(
+        rule_name="uniform_heavy_blocking",
+        rationale=(
+            f"avg_block_size={avg_block:.1f} (uniform-heavy: p99/avg ratio "
+            f"low) with mass_above={sp.mass_above_threshold:.2f} and "
+            f"mass_borderline={sp.mass_in_borderline:.2f} — blocking "
+            f"creates ambiguous candidates. Switching to "
+            f"{new_field!r} ({new_type}, cardinality "
+            f"{dp.cardinality_ratio[new_field]:.2f})"
+        ),
+        config_diff={
+            "blocking.strategy": "static",
+            "blocking.keys[0].fields": [new_field],
+        },
+    )
+    return new_cfg, decision
+
+
 def rule_blocking_field_null_heavy(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> "tuple[GoldenMatchConfig, PolicyDecision] | None":
@@ -629,15 +720,16 @@ def rule_enable_llm_scorer(
 
 
 DEFAULT_RULES = [
-    rule_blocking_field_null_heavy,   # structural null-rate guard (runs first)
-    rule_blocking_singleton_trap,     # catches __title_key__-style traps before blocking_too_coarse
-    rule_blocking_too_coarse,
-    rule_unimodal_scoring,
-    rule_low_reduction_ratio,
-    rule_low_transitivity,
-    rule_no_matches,
-    rule_blocking_key_swap,           # iter-1+ fallback when threshold/block loosening didn't help
-    rule_recall_gap_suspected,        # probe-based recall signal
+    rule_blocking_field_null_heavy,   # structural: high-null blocking field (runs first)
+    rule_blocking_singleton_trap,     # structural: candidates_compared == 0
+    rule_blocking_key_swap,           # structural: mass_above==0 with prior decision (Fix 1: was pos 8)
+    rule_blocking_too_coarse,         # structural: p99 outlier (skewed distribution)
+    rule_uniform_heavy_blocking,      # structural: uniform-large blocks (Fix 2: new rule)
+    rule_unimodal_scoring,            # tuning: dip statistic low
+    rule_low_reduction_ratio,         # structural: too-tight blocking
+    rule_low_transitivity,            # tuning: transitivity low (Fix 1: demoted from pos 6)
+    rule_no_matches,                  # tuning: nothing matches
+    rule_recall_gap_suspected,        # tuning: random pair probe high OR over-tight signature
     # NOTE: rule_enable_llm_scorer is intentionally NOT in DEFAULT_RULES.
     # LLM scorer decoration happens post-iteration via
     # AutoConfigController._maybe_decorate_with_llm_scorer(), which runs once

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -418,7 +418,8 @@ def test_default_rules_list_has_five_entries():
     # Updated to 10 after rule_enable_llm_scorer was added (2026-05-07)
     # Reverted to 9: rule_enable_llm_scorer moved out of DEFAULT_RULES into
     # AutoConfigController._maybe_decorate_with_llm_scorer (post-iteration decoration)
-    assert len(DEFAULT_RULES) == 9
+    # Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1)
+    assert len(DEFAULT_RULES) == 10
 
 
 def test_heuristic_policy_with_default_rules_fires_on_red_blocking():
@@ -597,9 +598,10 @@ def test_default_rules_now_has_six_entries():
     """Singleton-trap rule is added to DEFAULT_RULES.
     Updated to 7 after rule_blocking_key_swap was added (2026-05-07).
     Updated to 10 after rule_enable_llm_scorer was added (2026-05-07).
-    Reverted to 9: rule_enable_llm_scorer moved to post-iteration decoration."""
+    Reverted to 9: rule_enable_llm_scorer moved to post-iteration decoration.
+    Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 9
+    assert len(DEFAULT_RULES) == 10
 
 
 def test_singleton_trap_runs_before_blocking_too_coarse():
@@ -809,20 +811,24 @@ def test_rule_key_swap_returns_none_when_no_text_field_in_matchkey():
 def test_default_rules_now_has_seven_entries():
     """Adding rule_blocking_key_swap brings the count to 7.
     Updated to 10 after rule_enable_llm_scorer was added (2026-05-07).
-    Reverted to 9: rule_enable_llm_scorer moved to post-iteration decoration."""
+    Reverted to 9: rule_enable_llm_scorer moved to post-iteration decoration.
+    Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 9
+    assert len(DEFAULT_RULES) == 10
 
 
-def test_rule_key_swap_is_after_rule_no_matches():
-    """rule_no_matches gets first crack on iter 0 (it lowers threshold first);
-    rule_blocking_key_swap is the iter-1+ fallback when that didn't help."""
+def test_rule_key_swap_is_before_rule_no_matches():
+    """Fix 1: rule_blocking_key_swap fires BEFORE rule_no_matches (and
+    rule_low_transitivity). When blocking is fundamentally wrong (mass_above==0),
+    the structural fix (swap key) must take priority over tuning rules (lower threshold).
+    The old behavior was iter-1+ fallback AFTER no_matches; now it fires earlier as a
+    structural check, with history.decisions guard ensuring iter-0 safety."""
     from goldenmatch.core.autoconfig_rules import (
         DEFAULT_RULES, rule_no_matches, rule_blocking_key_swap,
     )
     idx_no_matches = DEFAULT_RULES.index(rule_no_matches)
     idx_swap = DEFAULT_RULES.index(rule_blocking_key_swap)
-    assert idx_no_matches < idx_swap
+    assert idx_swap < idx_no_matches, "key_swap must run before no_matches (structural before tuning)"
 
 
 def test_rule_key_swap_drops_derived_column_exact_matchkey():
@@ -1123,11 +1129,12 @@ def test_rule_null_heavy_does_not_fire_on_low_null_field():
 
 
 def test_default_rules_now_has_nine_entries():
-    """Adding rule_blocking_field_null_heavy and rule_recall_gap_suspected brings the count to 9.
+    """Adding rule_blocking_field_null_heavy and rule_recall_gap_suspected brought the count to 9.
+    Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     (rule_enable_llm_scorer was moved out of DEFAULT_RULES into
     AutoConfigController._maybe_decorate_with_llm_scorer post-iteration decoration.)"""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 9
+    assert len(DEFAULT_RULES) == 10
 
 
 def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_last():
@@ -1256,12 +1263,12 @@ def test_rule_enable_llm_scorer_does_not_fire_when_already_enabled(monkeypatch):
     assert out is None
 
 
-def test_default_rules_now_has_nine_entries():
-    """rule_enable_llm_scorer was moved out of DEFAULT_RULES into
-    AutoConfigController._maybe_decorate_with_llm_scorer (post-iteration
-    decoration), bringing count back to 9."""
+def test_default_rules_now_has_ten_entries():
+    """rule_uniform_heavy_blocking was added (Fix 2) and rule_blocking_key_swap
+    was reordered (Fix 1), bringing the count to 10.
+    (rule_enable_llm_scorer remains outside DEFAULT_RULES as post-iteration decoration.)"""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 9
+    assert len(DEFAULT_RULES) == 10
 
 
 def test_rule_enable_llm_scorer_not_in_default_rules():
@@ -1284,3 +1291,223 @@ def test_llm_api_key_helper_reads_openai_or_anthropic(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-test")
     assert _llm_api_key_available()
+
+
+# ============================================================
+# rule_uniform_heavy_blocking (added 2026-05-07)
+# ============================================================
+
+from goldenmatch.core.autoconfig_rules import rule_uniform_heavy_blocking
+
+
+def test_rule_uniform_heavy_blocking_fires_on_t2_signature():
+    """T2-like: 25 blocks × avg 80 records, mass_above=1.0, mass_borderline=0.95.
+    Should propose switch to a high-cardinality identity column."""
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="m", type="weighted", threshold=0.7,
+            fields=[MatchkeyField(field="customer_name", scorer="ensemble",
+                                   weight=1.0, transforms=["lowercase"])],
+        )],
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            keys=[BlockingKeyConfig(fields=["city", "product_category"],
+                                     transforms=["lowercase"])],
+            passes=[
+                BlockingKeyConfig(fields=["city", "product_category"], transforms=["lowercase"]),
+                BlockingKeyConfig(fields=["product_category"], transforms=["lowercase"]),
+            ],
+            max_block_size=5000, skip_oversized=False,
+        ),
+    )
+    profile = ComplexityProfile(
+        data=DataProfile(
+            n_rows=2000, n_cols=8,
+            column_types={
+                "city": "geo", "product_category": "text",
+                "customer_email": "email", "customer_name": "name",
+                "phone_number": "phone", "billing_zip": "zip",
+                "customer_id": "id-like", "order_total": "numeric",
+            },
+            cardinality_ratio={
+                "city": 0.05, "product_category": 0.02,
+                "customer_email": 0.95, "customer_name": 0.85,
+                "phone_number": 0.85, "billing_zip": 0.20,
+                "customer_id": 0.99, "order_total": 0.50,
+            },
+        ),
+        blocking=BlockingProfile(
+            keys_used=[["city", "product_category"]], n_blocks=25,
+            total_comparisons=79767, reduction_ratio=0.96,
+            block_sizes_p50=80, block_sizes_p95=98, block_sizes_p99=98,
+            block_sizes_max=98,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=598, candidates_compared=79767,
+            mass_above_threshold=1.0, mass_in_borderline=0.9465,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.021),
+        matchkey=MatchkeyProfile(per_field={
+            "customer_name": FieldStats(0.85, 0.0, 12),
+        }),
+    )
+    out = rule_uniform_heavy_blocking(profile, cfg, RunHistory())
+    assert out is not None
+    new_cfg, decision = out
+    assert decision.rule_name == "uniform_heavy_blocking"
+    # Should pick customer_email or customer_name (high-cardinality identity)
+    # customer_email (0.95) is excluded by cardinality ceiling; customer_name (0.85) should win
+    new_field = new_cfg.blocking.keys[0].fields[0]
+    assert new_field in {"customer_email", "customer_name"}
+    # Multi-pass dropped
+    assert len(new_cfg.blocking.passes or []) == 0
+
+
+def test_rule_uniform_heavy_blocking_does_not_fire_when_blocks_small():
+    """When avg block size < 30, this rule doesn't fire (different pathology)."""
+    cfg = _config_with_blocking()
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=2000, n_cols=4),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=500, total_comparisons=1000,
+            reduction_ratio=0.99, block_sizes_p99=5,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=500, candidates_compared=1000,
+            mass_above_threshold=1.0, mass_in_borderline=0.6,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.5),
+    )
+    out = rule_uniform_heavy_blocking(profile, cfg, RunHistory())
+    assert out is None
+
+
+def test_rule_uniform_heavy_blocking_does_not_fire_when_few_candidates():
+    """When candidates_compared < n_rows, blocking is too tight, not too loose."""
+    cfg = _config_with_blocking()
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=2000, n_cols=4),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=20, total_comparisons=500,
+            reduction_ratio=0.95, block_sizes_p99=100,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=500, candidates_compared=500,  # < n_rows
+            mass_above_threshold=1.0, mass_in_borderline=0.6,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.5),
+    )
+    out = rule_uniform_heavy_blocking(profile, cfg, RunHistory())
+    assert out is None
+
+
+def test_rule_uniform_heavy_blocking_does_not_fire_when_mass_above_low():
+    """When most pairs DON'T match, this isn't the over-coarse pathology."""
+    cfg = _config_with_blocking()
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=2000, n_cols=4,
+                          cardinality_ratio={"a": 0.01, "name": 0.85}),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=20, total_comparisons=80000,
+            reduction_ratio=0.96, block_sizes_p99=100,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=100, candidates_compared=80000,
+            mass_above_threshold=0.1,  # below 0.5
+            mass_in_borderline=0.6,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.5),
+    )
+    out = rule_uniform_heavy_blocking(profile, cfg, RunHistory())
+    assert out is None
+
+
+def test_rule_uniform_heavy_blocking_does_not_fire_when_mass_borderline_low():
+    """When mass_in_borderline < 0.5, matches are confident — may be real matches."""
+    cfg = _config_with_blocking()
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=2000, n_cols=4,
+                          cardinality_ratio={"a": 0.01, "name": 0.85},
+                          column_types={"a": "text", "name": "name"}),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=20, total_comparisons=80000,
+            reduction_ratio=0.96, block_sizes_p99=100,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=100, candidates_compared=80000,
+            mass_above_threshold=0.9,
+            mass_in_borderline=0.2,  # below 0.5 — confident matches
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.5),
+    )
+    out = rule_uniform_heavy_blocking(profile, cfg, RunHistory())
+    assert out is None
+
+
+def test_rule_uniform_heavy_blocking_returns_none_when_no_alternate_field():
+    """No high-cardinality identity-bearing field available → don't fire."""
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="m", type="weighted", threshold=0.7,
+            fields=[MatchkeyField(field="city", scorer="exact",
+                                   weight=1.0, transforms=["lowercase"])],
+        )],
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            keys=[BlockingKeyConfig(fields=["city"], transforms=["lowercase"])],
+            max_block_size=5000, skip_oversized=False,
+        ),
+    )
+    profile = ComplexityProfile(
+        data=DataProfile(
+            n_rows=2000, n_cols=2,
+            column_types={"city": "geo", "state": "geo"},
+            cardinality_ratio={"city": 0.05, "state": 0.01},
+        ),
+        blocking=BlockingProfile(
+            keys_used=[["city"]], n_blocks=25,
+            total_comparisons=79767, reduction_ratio=0.96,
+            block_sizes_p99=98,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=598, candidates_compared=79767,
+            mass_above_threshold=1.0, mass_in_borderline=0.95,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.021),
+    )
+    out = rule_uniform_heavy_blocking(profile, cfg, RunHistory())
+    assert out is None
+
+
+# ── Ordering tests for Fix 1 + Fix 2 ────────────────────────────────────────
+
+
+def test_default_rules_order_blocking_key_swap_before_low_transitivity():
+    """Fix 1 — when blocking is fundamentally wrong (mass_above=0), swap
+    the key BEFORE tuning the threshold. Otherwise low_transitivity fires
+    iteration after iteration, lowering threshold uselessly."""
+    from goldenmatch.core.autoconfig_rules import (
+        DEFAULT_RULES, rule_blocking_key_swap, rule_low_transitivity,
+    )
+    idx_swap = DEFAULT_RULES.index(rule_blocking_key_swap)
+    idx_lt = DEFAULT_RULES.index(rule_low_transitivity)
+    assert idx_swap < idx_lt
+
+
+def test_default_rules_uniform_heavy_after_blocking_too_coarse():
+    """rule_blocking_too_coarse handles skewed (p99 outlier);
+    rule_uniform_heavy_blocking handles uniform-large. Both target
+    structural blocking issues; uniform-heavy comes after the more
+    specific p99-outlier check."""
+    from goldenmatch.core.autoconfig_rules import (
+        DEFAULT_RULES, rule_blocking_too_coarse, rule_uniform_heavy_blocking,
+    )
+    idx_too_coarse = DEFAULT_RULES.index(rule_blocking_too_coarse)
+    idx_uniform = DEFAULT_RULES.index(rule_uniform_heavy_blocking)
+    assert idx_too_coarse < idx_uniform
+
+
+def test_default_rules_now_has_ten_entries_final():
+    """Fix 1 (reorder) + Fix 2 (new rule) → 10 rules total."""
+    from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
+    assert len(DEFAULT_RULES) == 10


### PR DESCRIPTION
## Summary

Diagnostic of DQbench's 62.07 zero-config score revealed three distinct pathologies that the existing rule set wasn't handling correctly. This PR addresses two of them; the third (over-permissive scoring on borderline-rich distributions) needs a different layer.

## What's in here

### Fix 1 — Reorder DEFAULT_RULES so structural fixes win over tuning fixes

\`rule_blocking_key_swap\` moved from position 8 → 3 (ahead of \`rule_low_transitivity\`). On DQbench T1 (timestamp blocking, mass_above=0, transitivity=0.265), the old order had \`rule_low_transitivity\` fire repeatedly to lower threshold — a tuning action that doesn't fix the structurally-wrong blocking key. With the new order, \`rule_blocking_key_swap\` fires on iter 1+ once a prior decision has been recorded, addressing the structural issue. \`rule_low_transitivity\` demoted to position 8.

### Fix 2 — Add \`rule_uniform_heavy_blocking\`

DQbench T2 has 25 blocks of avg 80 records (uniform-heavy, not skewed), \`mass_above_threshold=1.0\` and \`mass_in_borderline=0.95\`. None of the existing 9 rules fire because the signature doesn't match: \`rule_blocking_too_coarse\` needs a p99 outlier (skewed); \`rule_blocking_key_swap\` needs \`mass_above==0\`. New rule detects the over-coarse-uniform case and switches to a high-cardinality identity-bearing column (priority email > name > text > id-like, cardinality 0.3–0.95).

\`DEFAULT_RULES\` grows from 9 to 10 entries.

## Measured impact

**No regression on unit benchmarks:**
| Dataset | F1 (held) |
|---|---|
| DBLP-ACM | 0.964 |
| Febrl3 | 0.944 |
| NCVR | 0.972 |

**DQbench score unchanged** at 62.07 (no LLM and with LLM both). The rules now fire correctly:
- **T1**: iter 0 \`low_transitivity\`, iter 1 \`blocking_key_swap\` (the improvement)
- **T2**: iter 0 \`uniform_heavy_blocking\` fires (new rule works), proposes \`customer_email\` blocking. Iter 1 \`blocking_key_swap\` then fires because \`customer_email\` is too selective for the synthetic data. Downstream chain commits to \`website_url\` blocking — same F1 as before.
- **T3**: avg_block=3.8, doesn't trigger uniform_heavy (correctly — different pathology than T2)

The downstream cascade on T2 lands at the same committed F1 because the *score gap* between zero-config and hand-tuned (62.07 vs 95.30) is rooted in two things this PR doesn't address:
1. **Standardization rules** — the hand-tuned adapter enables \`StandardizationConfig\` with phone/email/name/address normalization that's critical for DQbench's synthetic formatting variations. The controller's v0 heuristic doesn't infer these.
2. **Per-pair LLM scoring on the right band** — DQbench has \`mass_above=1.0\` and \`mass_borderline=0.95\` simultaneously, so every pair lands above the matchkey threshold. The LLM scorer's auto_threshold gate auto-accepts pairs above its upper bound; with no real \"high confidence\" tier, the LLM never gets to filter false positives.

These are the natural followups; this PR ships the rule plumbing without those gains being measurable yet.

## Test status

- 104 targeted tests pass (policy + controller + facade)
- 1815 broad regression tests pass, 3 skipped, 0 failures
- 5 new unit tests for \`rule_uniform_heavy_blocking\`
- 2 new ordering invariant tests (\`blocking_key_swap before low_transitivity\`, \`uniform_heavy after blocking_too_coarse\`)
- Test count assertion bumped 9 → 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)