### PR TITLE
feat(autoconfig): auto-detect StandardizationConfig + adaptive LLM auto_threshold

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1589,6 +1589,50 @@ def _legacy_auto_configure_v0(
 
     memory_config = MemoryConfig(enabled=True) if llm_auto else None
 
+    # Auto-detect standardization rules (Change 1, 2026-05-07)
+    # When the column-profile classifier identifies a typed column (phone,
+    # email, name, address, zip, geo), emit a corresponding StandardizationConfig
+    # rule. The hand-tuned dqbench adapter does this manually; auto-config
+    # now matches it without explicit user intervention.
+    #
+    # StandardizationConfig.rules schema: {column_name: [standardizer_names]}
+    # VALID_STANDARDIZERS: email, phone, zip5, address, state, name_proper,
+    # name_upper, name_lower, strip, trim_whitespace.
+    _std_rules: dict[str, list[str]] = {}  # {col_name: [std_name, ...]}
+    _email_typed_cols: set[str] = set()  # guard: skip address detection on these
+    for _p in profiles:
+        if _p.col_type == "email":
+            _email_typed_cols.add(_p.name)
+            _std_rules[_p.name] = ["email"]
+        elif _p.col_type == "phone":
+            _std_rules[_p.name] = ["phone"]
+        elif _p.col_type == "zip":
+            _std_rules[_p.name] = ["zip5"]
+        elif _p.col_type == "geo":
+            # state-shaped columns (state_cd, province, country) → state rule
+            _cl = _p.name.lower()
+            if any(pat in _cl for pat in ("state", "province", "country")):
+                _std_rules[_p.name] = ["state"]
+        elif _p.col_type == "name":
+            # Route all name columns to name_proper (title-case + strip).
+            _std_rules[_p.name] = ["name_proper"]
+        elif _p.col_type == "address":
+            # Guard: skip if column was already typed as email (e.g. email_address)
+            if _p.name not in _email_typed_cols:
+                _std_rules[_p.name] = ["address"]
+
+    # Build the StandardizationConfig only if we detected something.
+    # Return None rather than StandardizationConfig(rules={}) to avoid passing
+    # an empty config into the pipeline.
+    _standardization = None
+    if _std_rules:
+        from goldenmatch.config.schemas import StandardizationConfig
+        _standardization = StandardizationConfig(rules=_std_rules)
+        logger.info(
+            "auto-config: StandardizationConfig auto-detected %d column rules: %s",
+            len(_std_rules), sorted(_std_rules.keys()),
+        )
+
     # Capture choices in a decisions object so a future iterative-tuning loop
     # can nudge them without re-profiling. Matchkeys and blocking strategy/
     # keys/passes all flow through decisions; non-decision runtime attributes
@@ -1615,6 +1659,7 @@ def _legacy_auto_configure_v0(
         transient_blocking=blocking,
         llm_scorer_config=llm_scorer_config,
         memory_config=memory_config,
+        standardization_config=_standardization,
     )
 
     # ── Preflight verification ──
@@ -1647,6 +1692,7 @@ def _rebuild_from_decisions(
     transient_blocking: BlockingConfig | None,
     llm_scorer_config: LLMScorerConfig | None,
     memory_config: MemoryConfig | None,
+    standardization_config: "StandardizationConfig | None" = None,
 ) -> GoldenMatchConfig:
     """Assemble a GoldenMatchConfig from decisions (+ runtime hand-offs).
 
@@ -1654,6 +1700,7 @@ def _rebuild_from_decisions(
       - `transient_blocking` carries non-decision attributes (learned_sample_size,
         learned_min_recall, skip_oversized, ...) that survive the rebuild.
       - `llm_scorer_config` / `memory_config` are runtime plumbing, not decisions.
+      - `standardization_config` is auto-detected from column types (Change 1).
 
     Splitting this out lets a future iterative-tuning loop mutate `decisions`
     and re-call `_rebuild_from_decisions` without re-running profile_columns /
@@ -1663,6 +1710,7 @@ def _rebuild_from_decisions(
     iterative-tuning hooks that may re-examine column stats without rethreading
     them through the call chain.
     """
+    from goldenmatch.config.schemas import StandardizationConfig as _StdCfg  # noqa: F401
     # Rebuild final blocking from decisions, preserving runtime-only attrs
     # (learned_sample_size, learned_min_recall, skip_oversized, etc.) from
     # the transient blocking object produced above.
@@ -1683,6 +1731,7 @@ def _rebuild_from_decisions(
         output=OutputConfig(),
         llm_scorer=llm_scorer_config,
         memory=memory_config,
+        standardization=standardization_config,
     )
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -651,11 +651,24 @@ class AutoConfigController:
             return config
         threshold = float(weighted_mk.threshold)
 
-        # Dynamic bounds: straddle the threshold with more headroom above
-        # (where pairs are more likely to be true matches worth verifying).
-        candidate_lo = max(0.0, threshold - 0.10)
-        candidate_hi = min(1.0, threshold + 0.20)
-        auto_threshold = candidate_hi
+        # Adaptive bounds (Change 2, 2026-05-07):
+        # When most of the above-threshold mass is borderline-confident (>0.5),
+        # the LLM needs to inspect those high-scoring pairs to filter false
+        # positives. Drop auto_threshold near 1.0 so the LLM sees them all.
+        # Otherwise keep the standard band centered on the matchkey threshold.
+        if sp.mass_in_borderline > 0.5:
+            # Wide-open mode: LLM inspects almost everything above threshold.
+            candidate_lo = max(0.0, threshold - 0.05)
+            candidate_hi = 0.99    # very narrow auto-accept zone
+            auto_threshold = 0.99
+            mode = "wide"
+        else:
+            # Standard mode: straddle the threshold with more headroom above
+            # (where pairs are more likely to be true matches worth verifying).
+            candidate_lo = max(0.0, threshold - 0.10)
+            candidate_hi = min(1.0, threshold + 0.20)
+            auto_threshold = candidate_hi
+            mode = "standard"
 
         from goldenmatch.config.schemas import LLMScorerConfig, BudgetConfig
         new_cfg = config.model_copy(update={
@@ -668,10 +681,11 @@ class AutoConfigController:
             ),
         })
         logger.info(
-            "auto-config: enabling LLMScorerConfig on committed config "
+            "auto-config: enabling LLMScorerConfig (mode=%s) "
             "(mass_in_borderline=%.3f, threshold=%.2f, "
-            "candidate_lo=%.2f, candidate_hi=%.2f)",
-            sp.mass_in_borderline, threshold, candidate_lo, candidate_hi,
+            "candidate_lo=%.2f, candidate_hi=%.2f, auto_threshold=%.2f)",
+            mode, sp.mass_in_borderline, threshold,
+            candidate_lo, candidate_hi, auto_threshold,
         )
         return new_cfg
 

--- a/packages/python/goldenmatch/tests/test_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig.py
@@ -1407,3 +1407,130 @@ def test_legacy_v0_skips_high_null_blocking_candidate():
         f"v0 picked sparse_id (30% null) as a blocking field; should have skipped. "
         f"Got blocking fields: {blocking_fields}"
     )
+
+
+# ============================================================
+# Change 1 (2026-05-07): auto-detect StandardizationConfig
+# ============================================================
+
+def test_v0_auto_detects_email_standardization():
+    """Email column → column gets ['email'] standardizer in rules."""
+    import polars as pl
+    from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
+    df = pl.DataFrame({
+        "customer_email": ["a@x.com", "B@X.COM", "c@y.com"] * 10,
+        "customer_name": ["alice", "bob", "carol"] * 10,
+        "city": ["nyc", "la", "sf"] * 10,
+    })
+    cfg = _legacy_auto_configure_v0(df)
+    assert cfg.standardization is not None
+    rules = cfg.standardization.rules
+    # rules = {col_name: [standardizer_names]}
+    assert "customer_email" in rules
+    assert "email" in rules["customer_email"]
+
+
+def test_v0_auto_detects_phone_standardization():
+    """Phone column → column gets ['phone'] standardizer in rules."""
+    import polars as pl
+    from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
+    df = pl.DataFrame({
+        "name": ["alice", "bob"] * 10,
+        "phone_number": ["555-1234", "(555) 5678"] * 10,
+        "city": ["nyc", "la"] * 10,
+    })
+    cfg = _legacy_auto_configure_v0(df)
+    assert cfg.standardization is not None
+    rules = cfg.standardization.rules
+    assert "phone_number" in rules
+    assert "phone" in rules["phone_number"]
+
+
+def test_v0_auto_detects_name_standardization():
+    """Name columns → each name column gets ['name_proper'] standardizer."""
+    import polars as pl
+    from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
+    df = pl.DataFrame({
+        "first_name": ["alice", "bob", "carol"] * 10,
+        "last_name": ["smith", "jones", "doe"] * 10,
+        "email": ["a@x.com", "b@y.com", "c@z.com"] * 10,
+    })
+    cfg = _legacy_auto_configure_v0(df)
+    rules = cfg.standardization.rules
+    assert "first_name" in rules
+    assert "name_proper" in rules["first_name"]
+    assert "last_name" in rules
+    assert "name_proper" in rules["last_name"]
+
+
+def test_v0_auto_detects_address_standardization():
+    """Address column → column gets ['address'] standardizer in rules."""
+    import polars as pl
+    from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
+    df = pl.DataFrame({
+        "street_address": ["123 main st", "456 oak ave"] * 10,
+        "city": ["nyc", "la"] * 10,
+        "name": ["alice", "bob"] * 10,
+    })
+    cfg = _legacy_auto_configure_v0(df)
+    rules = cfg.standardization.rules
+    assert "street_address" in rules
+    assert "address" in rules["street_address"]
+
+
+def test_v0_auto_detects_zip_standardization():
+    """Zip column → column gets ['zip5'] standardizer (VALID_STANDARDIZERS has zip5, not zip)."""
+    import polars as pl
+    from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
+    df = pl.DataFrame({
+        "name": ["alice"] * 10,
+        "billing_zip": ["10001", "10002"] * 5,
+        "city": ["nyc", "la"] * 5,
+    })
+    cfg = _legacy_auto_configure_v0(df)
+    rules = cfg.standardization.rules
+    assert "billing_zip" in rules
+    assert "zip5" in rules["billing_zip"]
+
+
+def test_v0_auto_detects_state_standardization():
+    """State-shaped geo column → column gets ['state'] standardizer."""
+    import polars as pl
+    from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
+    df = pl.DataFrame({
+        "name": ["alice"] * 10,
+        "state_cd": ["NY", "CA"] * 5,
+        "city": ["nyc", "la"] * 5,
+    })
+    cfg = _legacy_auto_configure_v0(df)
+    rules = cfg.standardization.rules
+    assert "state_cd" in rules
+    assert "state" in rules["state_cd"]
+
+
+def test_v0_no_standardization_when_no_typed_columns():
+    """Generic non-PII columns → no standardization rules."""
+    import polars as pl
+    from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
+    df = pl.DataFrame({
+        "col_0": ["x", "y"] * 10,
+        "col_1": ["a", "b"] * 10,
+    })
+    cfg = _legacy_auto_configure_v0(df)
+    # Either standardization is None, or rules dict is empty
+    assert cfg.standardization is None or not cfg.standardization.rules
+
+
+def test_v0_existing_callers_unaffected():
+    """Existing callers (DBLP-ACM-shape) still get a valid config."""
+    import polars as pl
+    from goldenmatch.core.autoconfig import _legacy_auto_configure_v0
+    df = pl.DataFrame({
+        "id": [str(i) for i in range(20)],
+        "title": [f"paper {i}" for i in range(20)],
+        "authors": [f"author_{i}" for i in range(20)],
+        "venue": ["vldb"] * 20,
+        "year": [str(2000 + i) for i in range(20)],
+    })
+    cfg = _legacy_auto_configure_v0(df)
+    assert cfg.matchkeys

--- a/packages/python/goldenmatch/tests/test_autoconfig_controller.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_controller.py
@@ -712,3 +712,69 @@ def test_decorate_with_llm_scorer_silent_no_key(monkeypatch):
     )
     out = controller._maybe_decorate_with_llm_scorer(cfg, profile)
     assert out is cfg or out.llm_scorer is None
+
+
+# ============================================================
+# Change 2 (2026-05-07): adaptive auto_threshold
+# ============================================================
+
+def test_decorate_uses_wide_mode_when_borderline_dominant(monkeypatch):
+    """When mass_in_borderline > 0.5, LLM scorer's auto_threshold drops
+    near 1.0 so the LLM inspects high-scoring pairs (the DQbench T2/T3
+    pathology where mass_above=1.0 AND mass_borderline=0.95)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    from goldenmatch.core.complexity_profile import (
+        BlockingProfile, ScoringProfile, ClusterProfile,
+    )
+    cfg = _cfg_with_threshold(0.7)
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=2000, n_cols=2),
+        blocking=BlockingProfile(reduction_ratio=0.95, n_blocks=25,
+                                  block_sizes_p99=98),
+        scoring=ScoringProfile(
+            n_pairs_scored=600, candidates_compared=80000,
+            mass_above_threshold=1.0,
+            mass_in_borderline=0.95,    # WIDE MODE TRIGGER
+            dip_statistic=0.05,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.02),
+    )
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(), budget=ControllerBudget(),
+    )
+    out = controller._maybe_decorate_with_llm_scorer(cfg, profile)
+    assert out.llm_scorer is not None
+    # Wide mode: auto_threshold close to 1.0
+    assert out.llm_scorer.auto_threshold >= 0.95
+    # candidate_lo ≈ threshold - 0.05 (tighter than standard mode's -0.10)
+    assert out.llm_scorer.candidate_lo == pytest.approx(0.65, abs=0.01)
+
+
+def test_decorate_uses_standard_mode_when_borderline_modest(monkeypatch):
+    """When mass_in_borderline is between 0.10 and 0.50, dynamic bounds
+    centered on threshold remain (existing behavior)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    from goldenmatch.core.complexity_profile import (
+        BlockingProfile, ScoringProfile, ClusterProfile,
+    )
+    cfg = _cfg_with_threshold(0.7)
+    profile = ComplexityProfile(
+        data=DataProfile(n_rows=200, n_cols=2),
+        blocking=BlockingProfile(reduction_ratio=0.95, n_blocks=10,
+                                  block_sizes_p99=20),
+        scoring=ScoringProfile(
+            n_pairs_scored=100, candidates_compared=300,
+            mass_above_threshold=0.4,
+            mass_in_borderline=0.25,    # STANDARD MODE
+            dip_statistic=0.05,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+    )
+    controller = AutoConfigController(
+        policy=HeuristicRefitPolicy(), budget=ControllerBudget(),
+    )
+    out = controller._maybe_decorate_with_llm_scorer(cfg, profile)
+    # Standard bounds: lo=0.6, hi=0.9, auto=0.9
+    assert out.llm_scorer.candidate_lo == pytest.approx(0.60)
+    assert out.llm_scorer.candidate_hi == pytest.approx(0.90)
+    assert out.llm_scorer.auto_threshold == pytest.approx(0.90)


### PR DESCRIPTION
## Summary

Two DQbench-targeted improvements bundled.

**Change 1 — Auto-detect \`StandardizationConfig\` in v0.** Column-type classification already identifies phone / email / zip / name / geo columns; emit \`StandardizationConfig(rules={...})\` from \`_legacy_auto_configure_v0\` so the pipeline normalizes formatting variations (\`\"555-1234\"\` vs \`\"(555) 1234\"\`) before scoring. Hand-tuned dqbench adapter does this manually; auto-config now matches without explicit user input.

**Change 2 — Adaptive \`auto_threshold\` in LLM scorer decoration.** When \`mass_in_borderline > 0.5\` (DQbench T2/T3 signature: every pair above threshold but most borderline-confident), drop \`auto_threshold\` to 0.99 so the LLM actually inspects high-scoring pairs instead of auto-accepting them. Standard mode (\`≤ 0.5\`) keeps existing \`threshold ± 0.10/+0.20\` bounds.

## Measured impact

| Benchmark | Before | After |
|---|---|---|
| DQbench (no LLM) | — | 62.87 |
| DQbench (with LLM) | 62.07 | **62.87** (+0.80) |
| DBLP-ACM | 0.964 | 0.964 (held) |
| Febrl3 | 0.944 | 0.944 (held) |
| NCVR | 0.972 | 0.972 (held) |

Wide-mode log line confirmed firing on T3; LLM execution time 38s vs 13s baseline. Score rise is modest because the controller still falls back to v0 + RED on T1/T2, where the LLM decorator never runs (no \`best_entry\` to decorate).

## What still blocks bigger DQbench gains

\`cheapest_healthy()\` returns None on T1/T2 because every controller iteration produces a RED profile — separate problem from standardization or LLM bounds. To unlock those tiers, the controller needs *either*:
- A way to commit a YELLOW config when no GREEN candidate exists (currently it's GREEN-or-fallback)
- Better rules that drive T1/T2 to a healthy state in the first place

Both are larger-than-this-PR changes. Ship the standardization + adaptive bounds because they're correct on their own merits and unlock T3.

## Test status

- 8 new unit tests for standardization detection (covering all rule types + the no-typed-columns guard + existing-caller invariance)
- 2 new tests for wide vs standard mode
- 1825 broad regression tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)