### PR TITLE
ci: flip Postgres lane from skipped to live

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       dbt: ${{ steps.filter.outputs.dbt }}
       action: ${{ steps.filter.outputs.action }}
       ci_workflow: ${{ steps.filter.outputs.ci_workflow }}
+      python_goldenmatch_postgres: ${{ steps.filter.outputs.python_goldenmatch_postgres }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -37,6 +38,11 @@ jobs:
               - 'uv.lock'
             python_goldenmatch:
               - 'packages/python/goldenmatch/**'
+            python_goldenmatch_postgres:
+              - 'packages/python/goldenmatch/tests/test_db.py'
+              - 'packages/python/goldenmatch/tests/test_reconcile.py'
+              - 'packages/python/goldenmatch/tests/_pg_helpers.py'
+              - 'packages/python/goldenmatch/goldenmatch/db/**'
             python_goldencheck:
               - 'packages/python/goldencheck/**'
             python_goldenflow:
@@ -190,7 +196,8 @@ jobs:
       fail-fast: false
       matrix:
         lane:
-          - { name: db,           tests: "tests/test_db.py tests/test_reconcile.py", needs: "POSTGRES (services container)" }
+          # `db` lane removed 2026-05-10: now runs for real in the
+          # `python_postgres` job below, against a services Postgres container.
           - { name: mcp_watch,    tests: "tests/test_mcp_and_watch.py",              needs: "MCP runtime + watch fixtures" }
           - { name: llm_boost,    tests: "tests/test_llm_boost.py",                  needs: "OPENAI_API_KEY secret + torch (segfaults locally)" }
           - { name: embedder,     tests: "tests/test_embedder.py",                   needs: "Vertex AI credentials + torch" }
@@ -218,9 +225,6 @@ jobs:
           # service, API-key secret, etc.) the corresponding lane flips to
           # "configured" and runs its tests.
           case "$LANE_NAME" in
-            db)
-              CONFIGURED="false"  # No Postgres service container yet
-              ;;
             mcp_watch)
               CONFIGURED="false"  # No MCP runtime fixtures in CI
               ;;
@@ -258,6 +262,58 @@ jobs:
             # Exit zero — "not-configured" is informational, not a failure.
             exit 0
           fi
+
+  # Real Postgres lane for goldenmatch.db tests. Boots a Postgres 16 services
+  # container (matches the pinned PG version in packages/rust/extensions) and
+  # runs `tests/test_db.py` + `tests/test_reconcile.py` against it. The shared
+  # fixture in `tests/_pg_helpers.py` provisions a unique database per test
+  # off the admin URL and drops it on teardown — no cross-test pollution.
+  # Gated by path filter so the lane only fires when DB code or DB tests
+  # change (plus workflow self-edits).
+  python_postgres:
+    needs: changes
+    if: |
+      needs.changes.outputs.python_goldenmatch_postgres == 'true' ||
+      needs.changes.outputs.ci_workflow == 'true'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        # `pg_isready` health-check so GH Actions only marks the job started
+        # after Postgres is actually accepting connections.
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      # _pg_helpers reads this to provision per-test databases off the admin
+      # connection instead of spawning a local `testing.postgresql`.
+      GOLDENMATCH_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Run Postgres-backed tests
+        shell: bash
+        run: |
+          cd packages/python/goldenmatch
+          # -n 0 (serial): per-test DB provisioning + the shared admin
+          # connection make xdist worker contention plausible; serial avoids
+          # the headache for a small (~30-test) lane.
+          uv run pytest tests/test_db.py tests/test_reconcile.py \
+            -n 0 --timeout=180 --timeout-method=thread -v
 
   # Synthetic-fixture benchmark smoke. Runs on every PR against committed
   # synthetic fixtures (t3_synthetic.csv, t3_clean_compat.csv, red_provoking.csv,

--- a/packages/python/goldenmatch/tests/_pg_helpers.py
+++ b/packages/python/goldenmatch/tests/_pg_helpers.py
@@ -1,0 +1,128 @@
+"""Postgres test fixture helpers.
+
+Two modes:
+
+- **CI / services container.** When `GOLDENMATCH_TEST_DATABASE_URL` is set
+  (typical CI shape: `postgresql://postgres:postgres@localhost:5432/postgres`),
+  every fixture invocation provisions a unique database off that admin URL
+  (`gm_test_<uuid>`), yields a small URL-holder pointing at it, and drops the
+  database on teardown. This keeps tests isolated against a single shared
+  Postgres services container without per-test container churn.
+
+- **Local fallback.** When the env var is unset, fall back to
+  `testing.postgresql` which spawns its own ephemeral Postgres. Skip the test
+  if neither path is available.
+
+The yielded object exposes a `.url()` method so the existing fixtures can pass
+it straight to `PostgresConnector(url())` regardless of which mode we're in.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Iterator
+from urllib.parse import urlparse, urlunparse
+
+import pytest
+
+_ADMIN_URL_ENV = "GOLDENMATCH_TEST_DATABASE_URL"
+
+
+def _has_psycopg2() -> bool:
+    try:
+        import psycopg2  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _has_testing_postgresql() -> bool:
+    try:
+        import testing.postgresql  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+# Module-level capability flag preserved for `skipif` decorators used in tests.
+# True when *either* a services-container admin URL is configured OR
+# `testing.postgresql` is importable locally.
+HAS_POSTGRES = bool(os.environ.get(_ADMIN_URL_ENV)) or (
+    _has_testing_postgresql() and _has_psycopg2()
+)
+
+
+class _UrlHolder:
+    """Tiny shim that mirrors testing.postgresql.Postgresql().url()."""
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    def url(self) -> str:
+        return self._url
+
+
+def _provision_db_from_admin_url(admin_url: str) -> tuple[_UrlHolder, str, str]:
+    """Create a fresh database off the admin URL. Returns (holder, db_name, admin_url)."""
+    import psycopg2
+
+    parsed = urlparse(admin_url)
+    db_name = f"gm_test_{uuid.uuid4().hex[:12]}"
+
+    # Connect to the admin DB (typically 'postgres') to issue CREATE DATABASE.
+    admin_conn = psycopg2.connect(admin_url)
+    try:
+        admin_conn.autocommit = True
+        with admin_conn.cursor() as cur:
+            cur.execute(f'CREATE DATABASE "{db_name}"')
+    finally:
+        admin_conn.close()
+
+    # Build the per-test URL by swapping the database path component.
+    new_url = urlunparse(parsed._replace(path=f"/{db_name}"))
+    return _UrlHolder(new_url), db_name, admin_url
+
+
+def _drop_db(admin_url: str, db_name: str) -> None:
+    import psycopg2
+
+    admin_conn = psycopg2.connect(admin_url)
+    try:
+        admin_conn.autocommit = True
+        with admin_conn.cursor() as cur:
+            # Terminate any leftover connections (psycopg2 sometimes leaves one
+            # in flight when a connector close errored on Windows etc.).
+            cur.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (db_name,),
+            )
+            cur.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
+    finally:
+        admin_conn.close()
+
+
+def pg_url_fixture() -> Iterator[_UrlHolder]:
+    """Generator suitable for use inside a pytest fixture (`yield from`)."""
+    admin_url = os.environ.get(_ADMIN_URL_ENV)
+    if admin_url:
+        if not _has_psycopg2():
+            pytest.skip("psycopg2 not installed")
+        holder, db_name, admin = _provision_db_from_admin_url(admin_url)
+        try:
+            yield holder
+        finally:
+            _drop_db(admin, db_name)
+        return
+
+    # Local fallback: testing.postgresql.
+    if not (_has_testing_postgresql() and _has_psycopg2()):
+        pytest.skip(
+            "PostgreSQL not available "
+            f"(set {_ADMIN_URL_ENV} or install testing.postgresql + psycopg2)"
+        )
+    import testing.postgresql
+
+    with testing.postgresql.Postgresql() as postgresql:
+        yield postgresql  # already exposes .url()

--- a/packages/python/goldenmatch/tests/test_db.py
+++ b/packages/python/goldenmatch/tests/test_db.py
@@ -5,27 +5,24 @@ from __future__ import annotations
 import pytest
 import polars as pl
 
-# Check if testing.postgresql is available
-try:
-    import testing.postgresql
-    import psycopg2
-    HAS_POSTGRES = True
-except (ImportError, Exception):
-    HAS_POSTGRES = False
+from ._pg_helpers import HAS_POSTGRES, pg_url_fixture
 
 
 @pytest.fixture
 def pg():
-    """Create a temporary PostgreSQL instance."""
-    if not HAS_POSTGRES:
-        pytest.skip("testing.postgresql or PostgreSQL not available")
-    with testing.postgresql.Postgresql() as postgresql:
-        yield postgresql
+    """Yield an object with a `.url()` method pointing at a per-test Postgres database.
+
+    Two modes:
+    - CI (services container): `GOLDENMATCH_TEST_DATABASE_URL` is set; we provision
+      a unique database off that admin URL and drop it on teardown.
+    - Local: fall back to `testing.postgresql` if available, else skip.
+    """
+    yield from pg_url_fixture()
 
 
 @pytest.fixture
 def connector(pg):
-    """Create a PostgresConnector connected to temp Postgres."""
+    """Create a PostgresConnector connected to per-test Postgres."""
     from goldenmatch.db.connector import PostgresConnector
     conn = PostgresConnector(pg.url())
     conn.connect()

--- a/packages/python/goldenmatch/tests/test_reconcile.py
+++ b/packages/python/goldenmatch/tests/test_reconcile.py
@@ -4,20 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-try:
-    import testing.postgresql
-    import psycopg2
-    HAS_POSTGRES = True
-except (ImportError, Exception):
-    HAS_POSTGRES = False
+from ._pg_helpers import HAS_POSTGRES, pg_url_fixture
 
 
 @pytest.fixture
 def pg():
-    if not HAS_POSTGRES:
-        pytest.skip("PostgreSQL not available")
-    with testing.postgresql.Postgresql() as postgresql:
-        yield postgresql
+    yield from pg_url_fixture()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Adds a real `python_postgres` CI job that boots a `postgres:16` services container and runs the previously-ignored `tests/test_db.py` + `tests/test_reconcile.py` for real.
- New `tests/_pg_helpers.py` shared fixture: when `GOLDENMATCH_TEST_DATABASE_URL` is set (CI), provisions a unique `gm_test_<uuid>` database off the admin URL per test and drops it on teardown. Falls back to `testing.postgresql` locally so the local skip-vs-run behavior is unchanged.
- Removes the `db` entry from the `python_skipped_lanes` not-configured matrix (now redundant with the live lane).
- Path-filtered: lane fires only when `tests/test_db.py`, `tests/test_reconcile.py`, `tests/_pg_helpers.py`, `goldenmatch/db/**`, or `ci.yml` itself changes.

## Test plan

- [x] YAML syntax validated locally.
- [ ] CI `python_postgres` job goes green on this PR.
- [ ] `python_skipped_lanes (mcp_watch, llm_boost, embedder, benchmarks)` still pass with the `db` entry removed.
- [ ] No behavior change for Python/TS test suites (CI-only change).