### PR TITLE
chore(meta): point package urls at the monorepo

### DIFF
--- a/packages/python/goldencheck-types/pyproject.toml
+++ b/packages/python/goldencheck-types/pyproject.toml
@@ -8,6 +8,12 @@ dependencies = ["pyyaml>=6.0"]
 [project.optional-dependencies]
 dev = ["pytest>=8.0"]
 
+[project.urls]
+Homepage = "https://github.com/benzsevern/goldenmatch"
+Repository = "https://github.com/benzsevern/goldenmatch"
+Documentation = "https://github.com/benzsevern/goldenmatch/tree/main/packages/python/goldencheck-types#readme"
+Issues = "https://github.com/benzsevern/goldenmatch/issues"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -36,11 +36,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/benzsevern/goldencheck"
-Repository = "https://github.com/benzsevern/goldencheck"
-Issues = "https://github.com/benzsevern/goldencheck/issues"
-Documentation = "https://benzsevern.github.io/goldencheck/"
-Changelog = "https://github.com/benzsevern/goldencheck/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/benzsevern/goldenmatch"
+Repository = "https://github.com/benzsevern/goldenmatch"
+Documentation = "https://github.com/benzsevern/goldenmatch/tree/main/packages/python/goldencheck#readme"
+Issues = "https://github.com/benzsevern/goldenmatch/issues"
+Changelog = "https://github.com/benzsevern/goldenmatch/blob/main/packages/python/goldencheck/CHANGELOG.md"
 Author = "https://bensevern.dev"
 
 [project.scripts]

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -51,11 +51,11 @@ all = ["goldenflow[check,excel,db,mcp,agent,s3,gcs]"]
 goldenflow = "goldenflow.cli.main:app"
 
 [project.urls]
-Homepage = "https://github.com/benzsevern/goldenflow"
-Repository = "https://github.com/benzsevern/goldenflow"
-Issues = "https://github.com/benzsevern/goldenflow/issues"
-Documentation = "https://benzsevern.github.io/goldenflow/"
-Changelog = "https://github.com/benzsevern/goldenflow/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/benzsevern/goldenmatch"
+Repository = "https://github.com/benzsevern/goldenmatch"
+Documentation = "https://github.com/benzsevern/goldenmatch/tree/main/packages/python/goldenflow#readme"
+Issues = "https://github.com/benzsevern/goldenmatch/issues"
+Changelog = "https://github.com/benzsevern/goldenmatch/blob/main/packages/python/goldenflow/CHANGELOG.md"
 Author = "https://bensevern.dev"
 
 [tool.pytest.ini_options]

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -41,11 +41,11 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/benzsevern/goldenmatch"
-Documentation = "https://benzsevern.github.io/goldenmatch/"
-Changelog = "https://github.com/benzsevern/goldenmatch/blob/main/CHANGELOG.md"
-Author = "https://bensevern.dev"
 Repository = "https://github.com/benzsevern/goldenmatch"
+Documentation = "https://github.com/benzsevern/goldenmatch/tree/main/packages/python/goldenmatch#readme"
 Issues = "https://github.com/benzsevern/goldenmatch/issues"
+Changelog = "https://github.com/benzsevern/goldenmatch/blob/main/packages/python/goldenmatch/CHANGELOG.md"
+Author = "https://bensevern.dev"
 
 [project.optional-dependencies]
 dev = [

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -42,11 +42,11 @@ dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "pytest-aiohttp>=1.0", "httpx>=0.2
 goldenpipe = "goldenpipe.cli.main:app"
 
 [project.urls]
-Homepage = "https://github.com/benzsevern/goldenpipe"
-Repository = "https://github.com/benzsevern/goldenpipe"
-Issues = "https://github.com/benzsevern/goldenpipe/issues"
-Documentation = "https://benzsevern.github.io/goldenpipe/"
-Changelog = "https://github.com/benzsevern/goldenpipe/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/benzsevern/goldenmatch"
+Repository = "https://github.com/benzsevern/goldenmatch"
+Documentation = "https://github.com/benzsevern/goldenmatch/tree/main/packages/python/goldenpipe#readme"
+Issues = "https://github.com/benzsevern/goldenmatch/issues"
+Changelog = "https://github.com/benzsevern/goldenmatch/blob/main/packages/python/goldenpipe/CHANGELOG.md"
 Author = "https://bensevern.dev"
 
 [project.entry-points."goldenpipe.stages"]

--- a/packages/python/goldensuite-mcp/pyproject.toml
+++ b/packages/python/goldensuite-mcp/pyproject.toml
@@ -43,6 +43,7 @@ goldensuite-mcp = "goldensuite_mcp.cli:main"
 [project.urls]
 Homepage = "https://github.com/benzsevern/goldenmatch"
 Repository = "https://github.com/benzsevern/goldenmatch"
+Documentation = "https://github.com/benzsevern/goldenmatch/tree/main/packages/python/goldensuite-mcp#readme"
 Issues = "https://github.com/benzsevern/goldenmatch/issues"
 
 [tool.uv.sources]

--- a/packages/python/infermap/pyproject.toml
+++ b/packages/python/infermap/pyproject.toml
@@ -41,11 +41,11 @@ dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.6"]
 infermap = "infermap.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/benzsevern/infermap"
-Repository = "https://github.com/benzsevern/infermap"
-Issues = "https://github.com/benzsevern/infermap/issues"
-Documentation = "https://benzsevern.github.io/infermap/"
-Changelog = "https://github.com/benzsevern/infermap/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/benzsevern/goldenmatch"
+Repository = "https://github.com/benzsevern/goldenmatch"
+Documentation = "https://github.com/benzsevern/goldenmatch/tree/main/packages/python/infermap#readme"
+Issues = "https://github.com/benzsevern/goldenmatch/issues"
+Changelog = "https://github.com/benzsevern/goldenmatch/blob/main/packages/python/infermap/CHANGELOG.md"
 Author = "https://bensevern.dev"
 
 [tool.pytest.ini_options]

--- a/packages/rust/extensions/Cargo.toml
+++ b/packages/rust/extensions/Cargo.toml
@@ -12,4 +12,5 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]
-repository = "https://github.com/benzsevern/goldenmatch-extensions"
+repository = "https://github.com/benzsevern/goldenmatch"
+homepage = "https://github.com/benzsevern/goldenmatch"

--- a/packages/rust/extensions/duckdb/pyproject.toml
+++ b/packages/rust/extensions/duckdb/pyproject.toml
@@ -25,8 +25,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/benzsevern/goldenmatch-extensions"
-Repository = "https://github.com/benzsevern/goldenmatch-extensions"
+Homepage = "https://github.com/benzsevern/goldenmatch"
+Repository = "https://github.com/benzsevern/goldenmatch"
+Documentation = "https://github.com/benzsevern/goldenmatch/tree/main/packages/rust/extensions/duckdb#readme"
+Issues = "https://github.com/benzsevern/goldenmatch/issues"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]
 description = "GoldenMatch entity resolution as a PostgreSQL extension"
+repository = "https://github.com/benzsevern/goldenmatch"
+homepage = "https://github.com/benzsevern/goldenmatch"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/packages/typescript/goldencheck-types/package.json
+++ b/packages/typescript/goldencheck-types/package.json
@@ -29,5 +29,14 @@
     "vitest": "^4.1.0"
   },
   "license": "MIT",
-  "author": "Ben Severn (https://bensevern.dev)"
+  "author": "Ben Severn (https://bensevern.dev)",
+  "homepage": "https://github.com/benzsevern/goldenmatch/tree/main/packages/typescript/goldencheck-types",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/benzsevern/goldenmatch.git",
+    "directory": "packages/typescript/goldencheck-types"
+  },
+  "bugs": {
+    "url": "https://github.com/benzsevern/goldenmatch/issues"
+  }
 }

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -63,8 +63,14 @@
     "golden-record", "data-quality", "jaro-winkler", "levenshtein"
   ],
   "license": "MIT",
+  "author": "Ben Severn (https://bensevern.dev)",
+  "homepage": "https://github.com/benzsevern/goldenmatch/tree/main/packages/typescript/goldenmatch",
   "repository": {
     "type": "git",
-    "url": "https://github.com/benzsevern/goldenmatch"
+    "url": "git+https://github.com/benzsevern/goldenmatch.git",
+    "directory": "packages/typescript/goldenmatch"
+  },
+  "bugs": {
+    "url": "https://github.com/benzsevern/goldenmatch/issues"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up from PR #145 (post-fold manifest audit). Every Python `[project.urls]` block still pointed at its pre-fold standalone repo (`benzsevern/goldenflow`, `benzsevern/goldencheck`, `benzsevern/goldenpipe`, `benzsevern/infermap`, `benzsevern/goldenmatch-extensions`). Same drift on the npm `goldenmatch` and `goldencheck-types` packages and on the Rust extensions workspace. Users installing from PyPI / npm / crates would click through to archived single-package repos instead of where the code actually lives.

All URLs now point at `github.com/benzsevern/goldenmatch` (or a sub-path under it). `Documentation` lands on each package's in-tree README under `packages/<lang>/<name>/`. `Changelog` lands on the per-package `CHANGELOG.md` where one exists (Python: goldenmatch / goldenflow / goldenpipe / goldencheck / infermap; omitted for goldencheck-types, goldensuite-mcp, goldenmatch-duckdb because no per-package changelog).

Two commits:
- `chore(meta): point Python pyproject.toml urls at monorepo` -- 8 pyprojects (7 Python + the goldenmatch-duckdb extension)
- `chore(meta): point npm + cargo urls at monorepo` -- TS goldenmatch + goldencheck-types (the other 3 TS packages were already aligned); rust extensions workspace + postgres crate

Metadata only. No version bumps -- URLs refresh on next regular release. No code, dependencies, or descriptions touched.

## Test plan
- [ ] CI green (path filters should run only what's needed; no source files changed)
- [ ] Spot-check rendered PyPI sidebar after the next release of any one package