### PR TITLE
types: pyright slice expansion + MatchkeyConfig typed accessors

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -372,13 +372,19 @@ def dedupe_df(
             )
             _used_controller = True
 
+    # All branches above bind config to GoldenMatchConfig (load_config returns
+    # GoldenMatchConfig; _build_config returns GoldenMatchConfig;
+    # auto_configure_df returns GoldenMatchConfig). The Optional in the type
+    # signature is the public input contract, not a runtime state here.
+    assert config is not None, "dedupe_df: config resolution above must bind config"
+
     # Apply overrides uniformly regardless of config source
-    if backend and hasattr(config, "backend"):
+    if backend:
         config.backend = backend
-    if llm_scorer and hasattr(config, "llm_scorer"):
+    if llm_scorer:
         from goldenmatch.config.schemas import LLMScorerConfig
         config.llm_scorer = LLMScorerConfig(enabled=True)
-    if llm_auto and hasattr(config, "llm_auto"):
+    if llm_auto:
         config.llm_auto = llm_auto
 
     result = run_dedupe_df(
@@ -477,7 +483,9 @@ def match_df(
             )
             _used_controller = True
 
-    if backend and hasattr(config, "backend"):
+    assert config is not None, "match_df: config resolution above must bind config"
+
+    if backend:
         config.backend = backend
 
     result = run_match_df(target, reference, config, auto_config=False)
@@ -1033,7 +1041,7 @@ def memory_stats(path: str | None = None) -> dict:
 def _extract_pairs(result: dict) -> list:
     """Extract scored pairs from cluster pair_scores."""
     pairs = []
-    for cid, cinfo in result.get("clusters", {}).items():
+    for _cid, cinfo in result.get("clusters", {}).items():
         for (a, b), score in cinfo.get("pair_scores", {}).items():
             pairs.append((a, b, score))
     return pairs

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -112,6 +112,40 @@ class MatchkeyField(BaseModel):
                 )
         return self
 
+    # ── Typed accessors ──
+    # ``field``, ``scorer``, ``weight`` are Optional at the schema level for
+    # serialization round-trip, but the MatchkeyConfig validator guarantees
+    # they're non-None for fuzzy/weighted matchkeys. These accessors narrow
+    # the type for code paths that have already gone through that validator.
+    @property
+    def resolved_field(self) -> str:
+        """``field`` narrowed to ``str`` after MatchkeyField validation."""
+        if self.field is None:
+            raise ValueError(
+                "MatchkeyField.resolved_field accessed before field/column resolved."
+            )
+        return self.field
+
+    @property
+    def fuzzy_scorer(self) -> str:
+        """``scorer`` narrowed to ``str`` for fields inside a weighted/probabilistic matchkey."""
+        if self.scorer is None:
+            raise ValueError(
+                f"MatchkeyField (field={self.field!r}): fuzzy_scorer accessed but scorer is None. "
+                "Only fields inside weighted/probabilistic matchkeys are guaranteed to have a scorer."
+            )
+        return self.scorer
+
+    @property
+    def fuzzy_weight(self) -> float:
+        """``weight`` narrowed to ``float`` for fields inside a weighted matchkey."""
+        if self.weight is None:
+            raise ValueError(
+                f"MatchkeyField (field={self.field!r}): fuzzy_weight accessed but weight is None. "
+                "Only fields inside weighted matchkeys are guaranteed to have a weight."
+            )
+        return self.weight
+
 
 class NegativeEvidenceField(BaseModel):
     """v1.11: a field whose disagreement subtracts from a weighted matchkey's
@@ -183,6 +217,27 @@ _VALID_MK_TYPES = ("exact", "weighted", "probabilistic")
 
 
 class MatchkeyConfig(BaseModel):
+    """A matchkey: rule for declaring two records 'the same' on a field/field-set.
+
+    Per-type field invariants (enforced by ``_validate_weighted`` after init):
+
+    - ``type == "exact"``: ``fields`` populated; ``threshold`` optional (binary
+      emit at 1.0 when no negative_evidence). No per-field scorer/weight.
+    - ``type == "weighted"``: ``threshold`` REQUIRED (non-None); every field
+      has ``scorer`` AND ``weight`` REQUIRED (non-None).
+    - ``type == "probabilistic"``: every field has ``scorer`` REQUIRED. EM
+      learns the weights at runtime.
+
+    The Pydantic fields stay ``Optional`` at the schema level (so YAML
+    round-trips and ``model_dump(exclude_none=True)`` continue to work) but
+    callers in fuzzy/weighted code paths can use the typed-accessor
+    properties (``fuzzy_threshold``, plus ``MatchkeyField.fuzzy_scorer`` /
+    ``fuzzy_weight``) to consume them as ``float`` / ``str`` without
+    re-asserting non-None at every call site. The accessors assert the
+    invariant — if it fires, a caller has bypassed the validator (e.g. by
+    mutating fields post-construction) and the crash points at the bug.
+    """
+
     name: str
     type: Literal["exact", "weighted", "probabilistic"] | None = None
     comparison: str | None = None
@@ -229,6 +284,30 @@ class MatchkeyConfig(BaseModel):
                         f"Field '{f.field}' is missing it."
                     )
         return self
+
+    # ── Typed accessors ──
+    # The Pydantic field-level types stay Optional so YAML serialization keeps
+    # working unchanged, but downstream code paths that have already gone
+    # through the weighted/fuzzy branch can use these to drop the Optional
+    # without re-asserting at every call site. Each accessor enforces the
+    # invariant the validator promised — if a property raises, a caller has
+    # mutated the model after construction (or skipped validation) and the
+    # crash points at the bug.
+    @property
+    def fuzzy_threshold(self) -> float:
+        """``threshold`` narrowed to ``float`` for weighted matchkeys.
+
+        Raises ``ValueError`` if the matchkey is not weighted or threshold
+        is unset — the validator guarantees this never fires on a Pydantic-
+        validated weighted matchkey.
+        """
+        if self.threshold is None:
+            raise ValueError(
+                f"MatchkeyConfig '{self.name}' (type={self.type!r}): "
+                "fuzzy_threshold accessed but threshold is None. "
+                "Only weighted matchkeys are guaranteed to have a threshold."
+            )
+        return self.threshold
 
 
 # ── BlockingKeyConfig / BlockingConfig ──────────────────────────────────────

--- a/packages/python/goldenmatch/goldenmatch/core/_profile_helpers.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_profile_helpers.py
@@ -20,7 +20,9 @@ def hartigan_dip(scores: list[float]) -> float:
         return 0.0
     import diptest
     import numpy as np
-    return float(diptest.dipstat(np.asarray(scores)))
+    # diptest.dipstat overload returns float | tuple[float, dict]; the no-extra
+    # path returns float at runtime, but the stub union confuses pyright.
+    return float(diptest.dipstat(np.asarray(scores)))  # pyright: ignore[reportArgumentType]  # diptest stub returns union; runtime is always float in the no-pval branch
 
 
 def mass_above(scores: list[float], threshold: float) -> float:

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -667,7 +667,7 @@ def _build_learned_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Bloc
 
     scored_pairs = []
     for block in sample_blocks:
-        block_df = block.df.collect() if hasattr(block.df, 'collect') else block.df
+        block_df = block.df.collect() if isinstance(block.df, pl.LazyFrame) else block.df
         pairs = find_fuzzy_matches(block_df, score_mk)
         scored_pairs.extend(pairs)
 
@@ -774,7 +774,8 @@ def select_best_blocking_key(
         groups = df_with_key.filter(pl.col("__block_key__").is_not_null()).group_by("__block_key__").agg(
             pl.len().alias("size")
         )
-        max_size = groups["size"].max()
+        # polars Series.max() returns PythonLiteral; "size" is i64 at runtime.
+        max_size = int(groups["size"].max() or 0)  # pyright: ignore[reportArgumentType]  # polars max() typed as PythonLiteral; "size" is int64 at runtime
         group_count = groups.height
 
         logger.debug(

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -328,7 +328,7 @@ def compute_cluster_confidence(
     avg_edge = sum(scores) / len(scores)
     max_possible_edges = size * (size - 1) / 2
     connectivity = len(pair_scores) / max_possible_edges if max_possible_edges > 0 else 0.0
-    bottleneck_pair = min(pair_scores, key=pair_scores.get)
+    bottleneck_pair = min(pair_scores, key=lambda p: pair_scores[p])
 
     # Weighted confidence: weakest link matters most
     confidence = 0.4 * min_edge + 0.3 * avg_edge + 0.3 * connectivity

--- a/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
@@ -81,7 +81,7 @@ def generate_predicates(columns: list[str]) -> list[BlockingPredicate]:
     return predicates
 
 
-def _apply_predicate(value, predicate: BlockingPredicate) -> str:
+def _apply_predicate(value: object, predicate: BlockingPredicate) -> str:
     """Apply a predicate transform to a value."""
     fn = _TRANSFORM_MAP.get(predicate.transform, _TRANSFORM_MAP["exact"])
     return fn(value)

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -6,6 +6,7 @@ import logging
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 
@@ -24,7 +25,22 @@ from goldenmatch.core.standardize import apply_standardization
 from goldenmatch.core.validate import ValidationRule, validate_dataframe
 
 
-def _get_block_scorer(config):
+def _unwrap_llm_pairs(
+    result: list[tuple[int, int, float]] | tuple[list[tuple[int, int, float]], Any]
+) -> list[tuple[int, int, float]]:
+    """Narrow the LLM-scorer return type for the pipeline call site.
+
+    Both ``llm_score_pairs`` and ``llm_cluster_pairs`` return a (pairs, stats)
+    tuple when ``return_stats=True``; the pipeline never asks for that path,
+    so the runtime is always a bare list. This helper makes that explicit for
+    the type checker.
+    """
+    if isinstance(result, tuple):
+        return result[0]
+    return result
+
+
+def _get_block_scorer(config: GoldenMatchConfig):
     """Return the block scoring function based on configured backend."""
     backend = getattr(config, "backend", None)
     if backend == "ray":
@@ -166,13 +182,13 @@ def _apply_domain_extraction(
     return combined_df_tmp.lazy()
 
 
-def _apply_memory_pre(memory_store, config: GoldenMatchConfig, matchkeys: list) -> None:
+def _apply_memory_pre(memory_store: Any, config: GoldenMatchConfig, matchkeys: list) -> None:
     """Overlay learned threshold adjustments onto the matchkeys parameter.
 
     Mutates `matchkeys` in place — rebinding to a fresh list would shadow the
     parameter and the scoring loop would never see the overlay.
     """
-    if memory_store is None:
+    if memory_store is None or config.memory is None:
         return
     try:
         from goldenmatch.core.memory.learner import MemoryLearner
@@ -199,18 +215,21 @@ def _apply_memory_pre(memory_store, config: GoldenMatchConfig, matchkeys: list) 
 
 
 def _apply_memory_post(
-    memory_store,
+    memory_store: Any,
     config: GoldenMatchConfig,
     df: pl.DataFrame,
     all_pairs: list[tuple[int, int, float]],
 ):
     """Apply stored corrections to scored pairs. Returns (pairs, stats|None)."""
-    if memory_store is None:
+    if memory_store is None or config.memory is None:
         return all_pairs, None
     try:
         from goldenmatch.core.memory.corrections import apply_corrections
+        # f.field is Optional[str] at schema level but is non-None for every
+        # field that survives MatchkeyField validation; filter defensively.
         matchkey_field_names = sorted({
             f.field for mk in config.get_matchkeys() for f in mk.fields
+            if f.field is not None
         })
         return apply_corrections(
             all_pairs, memory_store, df, matchkey_field_names,
@@ -240,7 +259,7 @@ def _derive_review_queue_path(config: GoldenMatchConfig) -> str | None:
 
 
 def _enqueue_stale_pairs(
-    memory_stats,
+    memory_stats: Any,
     all_pairs: list[tuple[int, int, float]],
     config: GoldenMatchConfig,
 ) -> None:
@@ -549,7 +568,7 @@ def _run_dedupe_pipeline(
             for rc in config.validation.rules
         ]
         combined_df_tmp = combined_lf.collect()
-        valid_df, quarantine_df, val_report = validate_dataframe(combined_df_tmp, rules)
+        valid_df, quarantine_df, _val_report = validate_dataframe(combined_df_tmp, rules)
         logger.info("Validation: %d quarantined rows", quarantine_df.height)
         combined_lf = valid_df.lazy()
     else:
@@ -603,7 +622,7 @@ def _run_dedupe_pipeline(
                     if source_lookup.get(a) != source_lookup.get(b)
                 ]
             all_pairs.extend(pairs)
-            for a, b, s in pairs:
+            for a, b, _s in pairs:
                 matched_pairs.add((min(a, b), max(a, b)))
 
     logger.info("Exact matching found %d pairs", len(all_pairs))
@@ -646,7 +665,7 @@ def _run_dedupe_pipeline(
                 em_result.converged, em_result.iterations, em_result.proportion_matched,
             )
             for block in blocks:
-                block_df = block.df.collect() if hasattr(block.df, 'collect') else block.df
+                block_df = block.df.collect() if isinstance(block.df, pl.LazyFrame) else block.df
                 pairs = score_probabilistic(block_df, mk, em_result, exclude_pairs=matched_pairs)
                 if across_files_only:
                     pairs = [
@@ -654,7 +673,7 @@ def _run_dedupe_pipeline(
                         if source_lookup.get(a) != source_lookup.get(b)
                     ]
                 all_pairs.extend(pairs)
-                for a, b, s in pairs:
+                for a, b, _s in pairs:
                     matched_pairs.add((min(a, b), max(a, b)))
 
     # ── Step 3.3: CROSS-ENCODER RERANKING (optional) ──
@@ -665,12 +684,20 @@ def _run_dedupe_pipeline(
 
     # ── Step 3.4: LLM SCORER (optional) ──
     if config.llm_scorer and config.llm_scorer.enabled and all_pairs:
+        # Both LLM scorers can return (pairs, stats) when return_stats=True; the
+        # pipeline never asks for that path, so the runtime value is always
+        # list[tuple[int, int, float]]. _unwrap_pairs narrows for the type
+        # checker without changing behavior.
         if config.llm_scorer.mode == "cluster":
             from goldenmatch.core.llm_cluster import llm_cluster_pairs
-            all_pairs = llm_cluster_pairs(all_pairs, collected_df, config=config.llm_scorer)
+            all_pairs = _unwrap_llm_pairs(
+                llm_cluster_pairs(all_pairs, collected_df, config=config.llm_scorer)
+            )
         else:
             from goldenmatch.core.llm_scorer import llm_score_pairs
-            all_pairs = llm_score_pairs(all_pairs, collected_df, config=config.llm_scorer)
+            all_pairs = _unwrap_llm_pairs(
+                llm_score_pairs(all_pairs, collected_df, config=config.llm_scorer)
+            )
         # Filter to scored matches only
         all_pairs = [(a, b, s) for a, b, s in all_pairs if s > 0.5]
 
@@ -1019,7 +1046,7 @@ def _run_match_pipeline(
             for rc in config.validation.rules
         ]
         combined_df_tmp = combined_lf.collect()
-        valid_df, quarantine_df_match, val_report = validate_dataframe(combined_df_tmp, rules)
+        valid_df, quarantine_df_match, _val_report = validate_dataframe(combined_df_tmp, rules)
         logger.info("Validation: %d quarantined rows", quarantine_df_match.height)
         combined_lf = valid_df.lazy()
     else:
@@ -1075,7 +1102,7 @@ def _run_match_pipeline(
                 if (a in target_ids) != (b in target_ids)
             ]
             all_pairs.extend(pairs)
-            for a, b, s in pairs:
+            for a, b, _s in pairs:
                 matched_pairs.add((min(a, b), max(a, b)))
 
     # Phase 2: Fuzzy matchkeys (parallel block scoring)
@@ -1110,10 +1137,10 @@ def _run_match_pipeline(
                 blocking_fields=blocking_fields,
             )
             for block in blocks:
-                block_df = block.df.collect() if hasattr(block.df, 'collect') else block.df
+                block_df = block.df.collect() if isinstance(block.df, pl.LazyFrame) else block.df
                 pairs = score_probabilistic(block_df, mk, em_result, exclude_pairs=matched_pairs)
                 all_pairs.extend(pairs)
-                for a, b, s in pairs:
+                for a, b, _s in pairs:
                     matched_pairs.add((min(a, b), max(a, b)))
 
     # ── Step 4.5: CROSS-ENCODER RERANKING (optional) ──
@@ -1126,10 +1153,14 @@ def _run_match_pipeline(
     if config.llm_scorer and config.llm_scorer.enabled and all_pairs:
         if config.llm_scorer.mode == "cluster":
             from goldenmatch.core.llm_cluster import llm_cluster_pairs
-            all_pairs = llm_cluster_pairs(all_pairs, combined_df, config=config.llm_scorer)
+            all_pairs = _unwrap_llm_pairs(
+                llm_cluster_pairs(all_pairs, combined_df, config=config.llm_scorer)
+            )
         else:
             from goldenmatch.core.llm_scorer import llm_score_pairs
-            all_pairs = llm_score_pairs(all_pairs, combined_df, config=config.llm_scorer)
+            all_pairs = _unwrap_llm_pairs(
+                llm_score_pairs(all_pairs, combined_df, config=config.llm_scorer)
+            )
         all_pairs = [(a, b, s) for a, b, s in all_pairs if s > 0.5]
 
     # ── Learning Memory: post-scoring corrections overlay ──

--- a/packages/python/goldenmatch/goldenmatch/core/profile_emitter.py
+++ b/packages/python/goldenmatch/goldenmatch/core/profile_emitter.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Union
 
 from goldenmatch.core.complexity_profile import (
     BlockingProfile,
@@ -67,7 +66,7 @@ _emitter_stack: ContextVar[tuple[ProfileEmitter, ...]] = ContextVar(
 )
 
 
-def current_emitter() -> Union[ProfileEmitter, "_NullEmitter"]:
+def current_emitter() -> ProfileEmitter | _NullEmitter:
     """Return the active emitter, or the null singleton when none is set."""
     stack = _emitter_stack.get()
     return stack[-1] if stack else _NULL_EMITTER

--- a/packages/python/goldenmatch/goldenmatch/core/profile_emitter.py
+++ b/packages/python/goldenmatch/goldenmatch/core/profile_emitter.py
@@ -9,9 +9,10 @@ Spec: docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-desi
 """
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from typing import Union
 
 from goldenmatch.core.complexity_profile import (
     BlockingProfile,
@@ -51,12 +52,12 @@ class ProfileEmitter:
 class _NullEmitter:
     """Singleton no-op. Stages call ``set_*`` and the writes vanish."""
     __slots__ = ()
-    def set_blocking(self, p): pass
-    def set_scoring(self, p): pass
-    def set_cluster(self, p): pass
-    def set_data(self, p): pass
-    def set_domain(self, p): pass
-    def set_matchkey(self, p): pass
+    def set_blocking(self, p: BlockingProfile) -> None: pass
+    def set_scoring(self, p: ScoringProfile) -> None: pass
+    def set_cluster(self, p: ClusterProfile) -> None: pass
+    def set_data(self, p: DataProfile) -> None: pass
+    def set_domain(self, p: DomainProfile) -> None: pass
+    def set_matchkey(self, p: MatchkeyProfile) -> None: pass
 
 
 _NULL_EMITTER = _NullEmitter()
@@ -66,14 +67,14 @@ _emitter_stack: ContextVar[tuple[ProfileEmitter, ...]] = ContextVar(
 )
 
 
-def current_emitter():
+def current_emitter() -> Union[ProfileEmitter, "_NullEmitter"]:
     """Return the active emitter, or the null singleton when none is set."""
     stack = _emitter_stack.get()
     return stack[-1] if stack else _NULL_EMITTER
 
 
 @contextmanager
-def profile_capture() -> Iterator[ProfileEmitter]:
+def profile_capture() -> Generator[ProfileEmitter, None, None]:
     """Push a new ProfileEmitter onto the stack; pop on exit (incl. exception).
 
     Concurrency:

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -98,15 +98,16 @@ def score_pair(row_a: dict, row_b: dict, fields: list[MatchkeyField]) -> float:
     weight_sum = 0.0
 
     for f in fields:
-        # score_pair expects fully-populated MatchkeyFields; upstream config
-        # validation guarantees field/scorer/weight are non-None at call time.
-        val_a = apply_transforms(row_a.get(f.field), f.transforms)  # pyright: ignore[reportArgumentType]
-        val_b = apply_transforms(row_b.get(f.field), f.transforms)  # pyright: ignore[reportArgumentType]
-        field_score = score_field(val_a, val_b, f.scorer)  # pyright: ignore[reportArgumentType]
+        # score_pair expects fully-populated MatchkeyFields; the MatchkeyConfig
+        # validator on weighted matchkeys guarantees field/scorer/weight are
+        # non-None at call time. Typed accessors narrow the Optional fields.
+        val_a = apply_transforms(row_a.get(f.resolved_field), f.transforms)
+        val_b = apply_transforms(row_b.get(f.resolved_field), f.transforms)
+        field_score = score_field(val_a, val_b, f.fuzzy_scorer)
 
         if field_score is not None:
-            weighted_sum += field_score * f.weight  # pyright: ignore[reportOperatorIssue]
-            weight_sum += f.weight  # pyright: ignore[reportOperatorIssue]
+            weighted_sum += field_score * f.fuzzy_weight
+            weight_sum += f.fuzzy_weight
 
     if weight_sum == 0.0:
         return 0.0
@@ -788,7 +789,7 @@ def score_blocks_parallel(
             all_pairs.extend(pairs)
             for a, b, _s in pairs:
                 matched_pairs.add((min(a, b), max(a, b)))
-        _emit_scoring_profile(all_pairs, mk.threshold, candidates_compared=total_candidates)  # pyright: ignore[reportArgumentType]  # caller ensures threshold set for fuzzy matchkeys
+        _emit_scoring_profile(all_pairs, mk.fuzzy_threshold, candidates_compared=total_candidates)
         return all_pairs
 
     # Snapshot exclude_pairs so threads see a frozen copy
@@ -845,7 +846,7 @@ def score_blocks_parallel(
         "Parallel scoring: %d blocks, %d workers, %d pairs found",
         total_blocks, max_workers, len(all_pairs),
     )
-    _emit_scoring_profile(all_pairs, mk.threshold, candidates_compared=total_candidates)  # pyright: ignore[reportArgumentType]  # caller ensures threshold set for fuzzy matchkeys
+    _emit_scoring_profile(all_pairs, mk.fuzzy_threshold, candidates_compared=total_candidates)
     return all_pairs
 
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -11,6 +11,15 @@
     "packages/python/goldenmatch/goldenmatch/core/indicators.py",
     "packages/python/goldenmatch/goldenmatch/core/complexity_profile.py",
     "packages/python/goldenmatch/goldenmatch/core/scorer.py",
+    "packages/python/goldenmatch/goldenmatch/core/pipeline.py",
+    "packages/python/goldenmatch/goldenmatch/core/blocker.py",
+    "packages/python/goldenmatch/goldenmatch/core/cluster.py",
+    "packages/python/goldenmatch/goldenmatch/core/profiler.py",
+    "packages/python/goldenmatch/goldenmatch/core/learned_blocking.py",
+    "packages/python/goldenmatch/goldenmatch/core/profile_emitter.py",
+    "packages/python/goldenmatch/goldenmatch/core/_profile_helpers.py",
+    "packages/python/goldenmatch/goldenmatch/_api.py",
+    "packages/python/goldenmatch/goldenmatch/utils/transforms.py",
     "packages/python/goldenmatch/goldenmatch/config"
   ],
   "exclude": [


### PR DESCRIPTION
## Summary

- Adds fuzzy_threshold / fuzzy_scorer / fuzzy_weight / resolved_field accessor properties on MatchkeyConfig and MatchkeyField so pyright can drop Optional narrowing on the weighted/fuzzy path. The Pydantic field-level types stay Optional (YAML round-trip is unchanged); the validator already guaranteed non-None for weighted matchkeys, and the accessors enforce that contract at call time with a clear ValueError if a caller bypassed validation.
- Drops 7 pyright-ignore suppressions in core/scorer.py (5 reportArgumentType, 2 reportOperatorIssue) using the new accessors. No behavioral change for any caller going through normal Pydantic validation.
- Expands the pyright strict slice from 12 files to 21 (+9): pipeline, blocker, cluster, profiler, learned_blocking, profile_emitter, _profile_helpers, _api, utils/transforms.

## Suppression accounting

Pre-existing slice suppressions removed: 7 in scorer.py (the threshold/scorer/weight cluster).
Newly added (all documented): 1 in blocker.py (polars Series.max() on i64 column), 1 in _profile_helpers.py (diptest.dipstat union stub).
Net: -5 suppressions, +9 files in the slice.

## Files deferred from this wave

- core/probabilistic.py: 24 type holes; mostly EM-result return-type churn that requires non-mechanical reshaping. Flagged for follow-up wave.

## Runtime behavior

No change for any caller that goes through Pydantic validation. The accessor properties raise ValueError only when the matchkey was mutated post-construction (or constructed bypassing the model_validator). Mutations that would always have crashed downstream now crash earlier with a clearer message.

## Test plan

- [x] `pytest packages/python/goldenmatch/tests/` (1889 passed, 64 skipped) excluding db / mcp / embedder / benchmark suites
- [x] `pyright -p pyrightconfig.json` clean (0 errors / 0 warnings)
- [ ] CI green