### PR TITLE
chore(claude-md): post-quality-wave audit + trim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,15 @@ A push of a tag that points at a commit predating a workflow file's introduction
 ## pnpm vs npm flag drift
 - `pnpm pack` has no `--dry-run` flag (npm-only). pnpm always writes a `.tgz`; running plain `pnpm pack` on a CI dry-run path validates packing without publishing.
 - `pnpm publish` from CI needs `--no-git-checks` because the runner checkout state confuses pnpm's "is this the latest commit on the branch?" guard.
+
+## Stacked PR auto-closure on squash-merge
+Squash-merging PR A with `--delete-branch` auto-closes any stacked PRs targeting A's branch — `gh pr reopen` rejects with "Could not open." Recovery: rebase locally onto main (or cherry-pick only the wave's own commits if a full rebase cascades add-add conflicts), force-push, open a fresh PR. Bit the TS parity wave twice (#139→#141, #140→#142).
+
+## `gh pr merge --delete-branch` + local worktree
+Cosmetic failure: `cannot delete branch 'X' used by worktree at ...`. The remote merge succeeded; only local cleanup failed. Safe to ignore unless you're scripting on the exit code.
+
+## CI `UNSTABLE` vs failing
+A `continue-on-error: true` step that exits non-zero still flips the parent job's conclusion to FAILURE → PR `mergeStateStatus: UNSTABLE`. The PR is still mergeable; the merge button just looks scary. Don't waste time chasing UNSTABLE if you know the failing lane is opt-in.
+
+## pypistats.org throttling
+pypistats `/api/packages/<pkg>/recent` 429s aggressively on unauthenticated bursts. Any script hitting it needs retry+backoff plus inter-request sleep (~1.5s). `scripts/suite_download_badges.py` is the reference implementation — preserves the prior badge value when throttled so the workflow exits 0.

--- a/packages/python/goldencheck-types/CLAUDE.md
+++ b/packages/python/goldencheck-types/CLAUDE.md
@@ -1,0 +1,43 @@
+# goldencheck-types
+
+Shared canonical field-type registry for the Golden Suite. Producer: `packages/python/goldencheck/`. Consumers: `packages/python/goldenpipe/` (stage I/O), `packages/python/infermap/` (target schema), `packages/typescript/goldencheck-types/` (cross-language mirror over JSON wire).
+
+## Why this package exists
+The Golden Suite needs a single source of truth for "what does field type `email` mean?" — name hints, value signals, confidence thresholds. Goldencheck profiles datasets and emits these types; goldenpipe/infermap consume them. Cross-language because the TS port of goldencheck (and consumers) must produce identical types.
+
+## snake_case exception
+This package is the **single Golden Suite location where TypeScript code keeps `snake_case` field names** instead of camelCase. Reason: producer-side YAML and consumer-side JSON wire pass through unchanged, and cross-language parity with the Python sibling matters more than language-idiomatic case style. See `packages/typescript/CLAUDE.md` for the broader convention this exception lives within.
+
+Affected fields: `name_hints`, `value_signals`, `confidence_threshold`, `source_col`, `schema_version`.
+
+Any TS code that directly constructs / consumes these interfaces gets the same exception.
+
+## Layout
+```
+goldencheck_types/
+├── __init__.py     # public API: SchemaVersion, FieldType, InferredSchema, etc.
+├── types.py        # Pydantic models. snake_case enforced via Field(alias=...) where needed.
+├── loader.py       # YAML → FieldType. Single load_field_types(path) entrypoint.
+└── _domains/       # Bundled domain packs (healthcare.yml, finance.yml, ecommerce.yml)
+```
+
+## Schema versioning
+Every emitted type carries `schema_version`. Consumers MUST check this and refuse unknown versions rather than silently degrade. Bump when:
+- A new required field is added to `FieldType`
+- An enum gains a value (since old consumers won't recognize it)
+- Wire format of `value_signals` changes shape
+
+## Cross-language parity contract
+The TS mirror at `packages/typescript/goldencheck-types/` ships the same `FieldType` / `InferredSchema` interfaces. When changing this package's types:
+1. Update `packages/typescript/goldencheck-types/src/types.ts` in the same PR.
+2. Run TS typecheck: `pnpm --filter goldencheck-types typecheck`.
+3. If shape changes, bump `schema_version` and add a migration note to both packages' CHANGELOG.
+
+## Testing
+- `pytest packages/python/goldencheck-types/` from monorepo root.
+- Domain pack loader is exercised by goldencheck's own test suite (this package has no domain-pack tests of its own — that's intentional, the YAML format is validated end-to-end through goldencheck).
+
+## Gotchas
+- Don't add runtime deps beyond `pyyaml`. This package is intentionally minimal so every consumer can pull it in without dragging in numpy/polars/etc.
+- `FieldType.value_signals` is a flexible dict by design — adding too much structure here defeats the purpose of "consumer-extensible signal bag". Push back on PRs that try to tighten it.
+- Domain YAML files under `_domains/` are bundled as package data. New domain packs need a `[tool.hatch.build.targets.wheel.force-include]` entry if added.

--- a/packages/python/goldencheck/CLAUDE.md
+++ b/packages/python/goldencheck/CLAUDE.md
@@ -11,7 +11,7 @@ pip install -e ".[mcp]"          # With MCP server
 pip install -e ".[baseline]"     # With deep profiling baseline
 goldencheck baseline data.csv    # Create statistical baseline
 goldencheck scan data.csv --baseline goldencheck_baseline.yaml  # Drift detection
-pytest --tb=short -v             # Run tests (189+ passing)
+pytest --tb=short -v             # Run tests (550+ passing)
 ruff check .                     # Lint
 ruff check . --fix               # Auto-fix lint
 goldencheck data.csv --no-tui    # Scan a file (CLI output)
@@ -186,10 +186,10 @@ goldencheck scan data.csv --domain ecommerce
 - Adapter: `dqbench/adapters/goldencheck.py`
 - Run: `pip install dqbench && dqbench run goldencheck`
 
-## TypeScript Port (packages/goldencheck-js/)
+## TypeScript Port (packages/typescript/goldencheck/)
 
 ```bash
-cd packages/goldencheck-js
+cd packages/typescript/goldencheck
 npm install                      # Install deps
 npm run typecheck                # tsc --noEmit
 npm run test                     # vitest (144+ tests)

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -3,23 +3,7 @@
 Data transformation toolkit -- standardize, reshape, and normalize messy data. DQBench Transform Score: 100/100.
 
 ## Related Projects
-- **GoldenCheck:** `D:\show_case\goldencheck` -- Data validation. Has its own CLAUDE.md.
-- **GoldenMatch:** `D:\show_case\goldenmatch` -- Entity resolution. Has its own CLAUDE.md.
-- **GitHub:** `benzsevern/goldenflow`, `benzsevern/goldencheck`, `benzsevern/goldenmatch`
-
-## Branch & Merge SOP (all Golden Suite repos)
-- Feature work goes on `feature/<name>` branches, never directly to main
-- Merge via **squash merge PR** (watchers see PR activity, history stays clean)
-- PR title format: `feat: <description>` or `fix: <description>`
-- PR body: summary bullets + test plan
-- Merge when: tests pass, docs updated. Days not weeks.
-- After merge: delete remote branch
-
-## Environment
-- Windows 11, bash shell (Git Bash)
-- Python 3.12 at `C:\Users\bsevern\AppData\Local\Programs\Python\Python312\python.exe`
-- Two GitHub accounts: `benzsevern` (personal) and `benzsevern-mjh` (work)
-- MUST `gh auth switch --user benzsevern` before push, switch back to `benzsevern-mjh` after
+Sibling packages in this monorepo at `packages/python/{goldencheck,goldenmatch,goldenpipe,infermap}/`. Pre-fold history in `_archive/goldenmatch-pre-fold/`. Branch/merge SOP, GitHub auth dance, and env setup live in root CLAUDE.md.
 
 ## Commands
 

--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -6,46 +6,15 @@
 - **npm:** `goldenmatch` (TypeScript port at `packages/goldenmatch-js/`)
 - **GitHub:** `benzsevern/goldenmatch`, `benzsevern/goldenmatch-extensions`
 
-## TypeScript Port (`packages/goldenmatch-js/`)
-- **npm:** `goldenmatch` (same name, different registry from PyPI)
-- **Commands** (from `packages/goldenmatch-js/`): `npx tsc --noEmit`, `npx vitest run`, `npm run build` (tsup)
-- **Edge-safe rule:** files in `src/core/` MUST NOT import `node:*`. Node-only code lives in `src/node/`.
-- **Parity harness:** `tests/parity/scorer-ground-truth.test.ts` locks scorer output at 4-decimal tolerance against Python
-- **Strict TS:** `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` — use `!` on bounded-loop indices, conditional spread for optional props
-- **Optional peer deps:** load via `await import("pkg-name" as string)` — the `as string` cast prevents tsup from resolving at build time
-- **tsup has 5 entrypoints:** `index`, `core/index`, `node/index`, `cli`, `node/backends/score-worker` (piscina worker)
-- **PORTING_GUIDE.md** in repo root is the playbook for porting
-- **No `make*` factory functions** exist for config types — test fixtures use full literals. Required fields: `MatchkeyField` needs `field`+`transforms`+`scorer`+`weight`; `BlockingKeyConfig` needs `fields`+`transforms`; `BlockingConfig` needs `strategy`+`keys`+`maxBlockSize`+`skipOversized`
-- **Scorer names are snake_case** (same as Python): `token_sort`, `record_embedding`, `soundex_match`, `ensemble`, `exact`, `jaro_winkler`, `levenshtein`
-- **`DOMAIN_EXTRACTED_COLS`** (in `src/core/domain.ts`) has only 3 entries (`__brand__`, `__model__`, `__version__`) — Python's equivalent has 12; don't assume parity when porting domain features
-- **`import type` cycle rule:** `types.ts` imports types from `autoconfigVerify.ts`, so `autoconfigVerify.ts` must use `import type { ... }` (never runtime `import`) for any types.ts symbols
-- **`exactOptionalPropertyTypes`:** don't spread `undefined` into typed optional fields — use `...(x !== undefined ? { field: x } : {})`
-- **Vitest default timeout is 5s** — heavier integration tests (PPRL multi-level, postflight end-to-end) need `{ timeout: 15000 }`; CI concurrent load has bitten this (cost a release: goldenmatch-js v0.3.0 → v0.3.1)
+## TypeScript Port
+Lives at `packages/typescript/goldenmatch/`. See that package's CLAUDE.md for npm release flow, edge-safety rules, parity harness, and port-specific gotchas.
 
-## Branch & Merge SOP (all Golden Suite repos)
-- Feature work goes on `feature/<name>` branches, never directly to main
-- Merge via **squash merge PR** (watchers see PR activity, history stays clean)
-- PR title format: `feat: <description>` or `fix: <description>`
-- PR body: summary bullets + test plan
-- Merge when: tests pass, docs updated. Days not weeks.
-- After merge: delete remote branch
-- Commands: `gh pr create --title "..." --body "..."` then squash merge via GitHub UI or `gh pr merge --squash`
-- **Release tags:** Python = `v1.4.x` (triggers `publish.yml` → PyPI). TypeScript = `goldenmatch-js-v0.1.x` (triggers `publish-npm.yml` → npm). Never push an unprefixed version tag for TS.
-
-## Environment
-- Windows 11, bash shell (Git Bash) -- use Unix paths in scripts
+## Environment (goldenmatch-specific)
+Root CLAUDE.md owns: branch/merge SOP, GitHub auth dance, Rust + pgrx, PostgreSQL 16 portable. Goldenmatch-only quirks:
 - GCP project: `gen-lang-client-0692108803` (Vertex AI embeddings)
-- Python 3.12 at `C:\Users\bsevern\AppData\Local\Programs\Python\Python312\python.exe`
-- Project lives on D: drive: `D:\show_case\goldenmatch`
-- Two GitHub accounts: `benzsevern` (personal, for this repo) and `benzsevern-mjh` (work)
-- MUST `gh auth switch --user benzsevern` before push, switch back to `benzsevern-mjh` after
-- `gh auth switch` sometimes doesn't apply to `gh api graphql` / `gh pr create` / git push — force the right token with `GH_TOKEN=$(gh auth token --user benzsevern) gh ...`. For wiki repo push, rewrite the remote URL: `git remote set-url origin "https://benzsevern:$(gh auth token --user benzsevern)@github.com/benzsevern/goldenmatch.wiki.git"`
 - Polars `scan_csv` uses `encoding="utf8"` not `"utf-8"`
 - Polars `read_excel` needs explicit `engine="openpyxl"`
-- Rust 1.94.0 installed at `C:\Users\bsevern\.cargo\bin` -- must set `RUSTUP_HOME="C:/Users/bsevern/.rustup"` and `CARGO_HOME="C:/Users/bsevern/.cargo"` in every bash command, plus add to PATH
-- No admin privileges -- cannot install system packages (LLVM, WSL2, Developer Mode). Workarounds: `RUSTUP_WINDOWS_PATH_TYPE=hardlink` for Rust, user-dir installs for everything else
-- pgrx (Postgres extension framework) cannot build locally -- needs libclang/LLVM. Use CI (Linux) for pgrx builds/tests
-- PostgreSQL 16 portable at `C:\Users\bsevern\tools\pg16portable\pgsql`
+- **Release tags:** Python = `v1.x.y` (triggers `publish-goldenmatch.yml` → PyPI). TypeScript = `goldenmatch-js-v0.x.y` (triggers `publish-goldenmatch-js.yml` → npm). Never push an unprefixed version tag for TS.
 
 ## Testing
 - **TypeScript:** `cd packages/goldenmatch-js && npx vitest run` — 478 tests currently. Full check: `npx tsc --noEmit && npx vitest run && npm run build`
@@ -136,6 +105,8 @@
 - LLM+embedding benchmark: `python tests/benchmarks/run_llm_budget_bench.py` (requires OPENAI_API_KEY)
 
 ## Code Patterns
+- **Pydantic typed-accessor pattern for Optional invariants.** `MatchkeyConfig.threshold` / `MatchkeyField.scorer`/`weight`/`field` are typed Optional at the Pydantic level (YAML round-trip) but guaranteed non-None for `weighted`/`fuzzy` matchkey types post-validation. Pattern (PR #151): keep the field Optional, add a `@property` accessor (`fuzzy_threshold`, `fuzzy_scorer`, `fuzzy_weight`, `resolved_field`) that raises `ValueError` if the invariant was broken via post-construction mutation, and use the accessor at call sites that need the narrowed type. Pyright stops seeing Optional — dropped 7 `# pyright: ignore` suppressions in `scorer.py`.
+- **Pyright suppressions on multi-line imports.** `# pyright: ignore[reportMissingImports]` must sit on the `from X import (` line itself, NOT on the imported-symbol continuation line. Pyright reports the error at the `from X` column; a comment on a later line doesn't satisfy it. Bit us on `autoconfig_policy.py` (openai) and `scorer.py` (sentence_transformers) in PR #147.
 - Auto-config exact matchkeys: `col_type in ("zip","geo")` NEVER backs an exact matchkey (blocking signal, not identity claim). Exact matchkeys require `cardinality_ratio >= 0.5`. Skipped columns still flow into `build_blocking()`.
 - Auto-config learned blocking: gated at `total_rows >= 50_000` in `autoconfig.py`. Sample size capped at `min(total_rows // 4, 5000)` so learner has held-out rows. Below 50K, static/multi_pass is default.
 - `DedupeResult.total_records` = `dupes.height + unique.height` (golden is a rollup, NOT a separate row population). Adding golden double-counts every multi-member cluster.
@@ -328,151 +299,9 @@ Hosted on Railway, registered on Smithery:
 - `apply_corrections` reanchor builds `record_hash → list[row_id]` via `pl.concat_str` + `map_elements` (vectorized O(N)). Ambiguous re-anchors counted as `stale_ambiguous`, never silently misapplied.
 - PyPI publish: `publish-goldenmatch.yml` lives at the **monorepo root**, not under this package. Trusted publishing NOT configured — uses `PYPI_TOKEN` secret. To enable trusted publishing later, claim PyPI publisher: owner `benzsevern`, repo `goldenmatch`, workflow `publish-goldenmatch.yml`, environment `pypi`.
 
-## TS port v0.4.0 — Learning Memory parity
-- npm `goldenmatch` v0.4.0 ships full cross-language parity with Python `goldenmatch` v1.6.0. A correction written by either runtime applies identically in the other.
-- **Hash bytes are the contract.** SHA-256 truncated to 16 hex chars via Web Crypto (`crypto.subtle.digest("SHA-256", new TextEncoder().encode(s))`). UTF-8 encoding mandatory on both sides. Hash input = values only joined by `|` (NOT `<col>=<val>`). `__row_id__` excluded from `record_hash` so it survives row reordering.
-- **Edge-safety boundary.** `src/core/memory/` is edge-safe (no `node:*`); `src/node/memory/` has `SqliteMemoryStore` + the Python-API mirror (`getMemory`, `addCorrection`, `learn`, `memoryStats`) — they construct a Node-only SQLite store.
-- **`ScoredPair` shape divergence.** Memory module's `applyCorrections` takes a tuple `[a, b, score]` (matches Python). Pipeline passes the object shape. Translation isolated to `_applyMemoryPost` in `pipeline.ts` — touching it means handling both shapes.
-- **Pipeline is async post-v0.4.0.** `runDedupePipeline`, `runMatchPipeline`, `dedupe`, `match`, `dedupeFile`, `matchFile`, `runSensitivity`, `unmergeRecord`, `unmergeCluster` all return Promises. Every external caller awaits.
-- **MCP tool count is 24** (19 existing + 5 memory tools). Description literal at `src/node/mcp/server.ts:6` reads `Exposes 24 tools`. Update + assert via the existing regex test when adding more.
-- **`better-sqlite3` is an OPTIONAL peer dep.** `await import("better-sqlite3" as string)` with the `as string` cast (prevents tsup resolving at build time). Throws clear "install better-sqlite3" if missing.
-- **Cross-language parity fixtures** committed at `tests/parity/fixtures/{memory_corrections.json, memory.db, memory_apply_inputs.json}` on both Python and TS sides. Regen via `packages/python/goldenmatch/tests/parity/memory/gen_memory_fixtures.py --rebuild-db`. Determinism clamp: pinned UUIDs, pinned `created_at` (no `datetime.now()`).
-- **npm publish workflow:** `.github/workflows/publish-goldenmatch-js.yml` at MONOREPO ROOT. Trusted publishing NOT configured — uses `NPM_TOKEN` secret. Trigger pattern: `goldenmatch-js-v*` tag push OR `workflow_dispatch` with optional `ref` input. Tag MUST point at a commit that has the workflow file, otherwise the trigger doesn't fire.
+## API + Common Mistakes
 
-## API Quick Reference
-
-### dedupe_df() — DataFrame deduplication
-```python
-import goldenmatch
-
-result = goldenmatch.dedupe_df(
-    df,
-    config=None,              # GoldenMatchConfig or None
-    exact=["email"],          # exact match columns
-    fuzzy={"name": 0.85},     # fuzzy match with thresholds
-    blocking=["zip"],         # blocking keys
-    threshold=0.85,           # overall fuzzy threshold
-    llm_scorer=False,         # enable LLM for borderline pairs
-)
-```
-
-### DedupeResult fields
-```python
-result.golden          # pl.DataFrame | None — canonical records with __cluster_id__
-result.dupes           # pl.DataFrame | None — duplicate records with __row_id__
-result.unique          # pl.DataFrame | None — non-duplicate records
-result.clusters        # dict[int, dict] — {cluster_id: {"members": [row_ids], "pair_scores": {(a,b): score}}}
-result.scored_pairs    # list[tuple[int, int, float]] — all matched pairs
-result.stats           # dict — total_records, total_clusters, matched_records, match_rate
-result.total_records   # int
-result.total_clusters  # int
-result.match_rate      # float
-```
-
-### StandardizationConfig — use rules dict, NOT keyword args
-```python
-# WRONG:
-StandardizationConfig(email=["email"], phone=["phone"])
-
-# RIGHT:
-StandardizationConfig(rules={
-    "email": ["email"],
-    "phone": ["phone"],
-    "first_name": ["strip", "name_proper"],
-})
-```
-Verified: `StandardizationConfig` has a single `rules: dict[str, list[str]]` field with a model validator. Keyword args will raise a Pydantic validation error.
-
-### BlockingConfig requires `keys` field
-```python
-# keys is required even with multi_pass
-BlockingConfig(
-    strategy="multi_pass",
-    keys=[BlockingKeyConfig(fields=["email"], transforms=["lowercase"])],  # required!
-    passes=[
-        BlockingKeyConfig(fields=["email"], transforms=["lowercase"]),
-        BlockingKeyConfig(fields=["last_name"], transforms=["soundex"]),
-    ],
-)
-```
-
-### MatchkeyConfig requires `name` field
-```python
-MatchkeyConfig(
-    name="identity",       # required!
-    type="weighted",
-    threshold=0.75,
-    fields=[...],
-)
-```
-
-### Extracting pairs from clusters (correct way)
-```python
-pairs = []
-for cluster in result.clusters.values():
-    members = sorted(cluster["members"])
-    for i in range(len(members)):
-        for j in range(i + 1, len(members)):
-            pairs.append((members[i], members[j]))
-```
-
-### Multi-pass blocking for catching different dupe types
-```python
-# Pass 1: exact email (identical-email dupes)
-# Pass 2: soundex last_name (phonetic variants: Smith/Smyth)
-# Pass 3: first 3 chars of last_name (typo dupes: Johm/John)
-BlockingConfig(
-    strategy="multi_pass",
-    keys=[BlockingKeyConfig(fields=["email"], transforms=["lowercase", "strip"])],
-    passes=[
-        BlockingKeyConfig(fields=["email"], transforms=["lowercase", "strip"]),
-        BlockingKeyConfig(fields=["last_name"], transforms=["soundex"]),
-        BlockingKeyConfig(fields=["last_name"], transforms=["substring:0:3"]),
-    ],
-)
-```
-
-### Available scorers
-- `exact`: 1.0 if equal, 0.0 otherwise
-- `jaro_winkler`: best for short strings (names)
-- `levenshtein`: normalized edit distance
-- `token_sort`: handles word reordering
-- `ensemble`: weighted combination of jaro_winkler + levenshtein + token_sort + dice (best for names)
-- `dice`, `jaccard`: set-based similarity
-- `soundex_match`: phonetic matching
-- `embedding`: sentence-transformer cosine similarity
-
-### Available transforms (applied at matchkey time)
-`lowercase`, `uppercase`, `strip`, `strip_all`, `soundex`, `metaphone`, `digits_only`, `alpha_only`, `normalize_whitespace`, `token_sort`, `first_token`, `last_token`, `substring:start:end`, `qgram:n`
-
-### LLM Scorer for borderline pairs
-```python
-from goldenmatch.config.schemas import LLMScorerConfig, BudgetConfig
-
-config.llm_scorer = LLMScorerConfig(
-    enabled=True,
-    candidate_lo=0.60,    # send pairs scoring 0.60-0.90 to LLM
-    candidate_hi=0.90,
-    auto_threshold=0.90,  # auto-accept above 0.90
-    budget=BudgetConfig(max_calls=500, max_cost_usd=1.0),
-)
-# Requires OPENAI_API_KEY or ANTHROPIC_API_KEY in environment
-```
-
-## DQBench Integration
-
-GoldenMatch is benchmarked by DQBench ER category:
-- **DQBench ER Score: 95.30** (with LLM) / **77.21** (without LLM)
-- Key to high score: multi-pass blocking + ensemble scoring + standardization + LLM scorer
-- Adapter: `dqbench/adapters/goldenmatch_adapter.py`
-- Run: `pip install dqbench && dqbench run goldenmatch`
-
-## Common Mistakes
-- Using `exact=["email"]` as sole matchkey — creates oversized clusters with common emails
-- Using `auto_configure()` on synthetic data — it may produce poor configs
-- Not setting `name=` on MatchkeyConfig — it's required
-- Not providing `keys=` on BlockingConfig — it's required even with multi_pass
-- Extracting pairs from dupes DataFrame directly instead of using result.clusters
+Moved to `packages/python/goldenmatch/docs/api-quick-reference.md` (reference content, not session context). DQBench ER scores live in the package README + CHANGELOG.
 
 ## Web UI (`goldenmatch[web]`)
 

--- a/packages/python/goldenmatch/docs/api-quick-reference.md
+++ b/packages/python/goldenmatch/docs/api-quick-reference.md
@@ -1,0 +1,140 @@
+# goldenmatch API Quick Reference
+
+Practical examples for the most-used surface. Authoritative type signatures live in `goldenmatch/_api.py` and `goldenmatch/config/schemas.py`.
+
+## `dedupe_df()` — DataFrame deduplication
+
+```python
+import goldenmatch
+
+result = goldenmatch.dedupe_df(
+    df,
+    config=None,              # GoldenMatchConfig or None
+    exact=["email"],          # exact match columns
+    fuzzy={"name": 0.85},     # fuzzy match with thresholds
+    blocking=["zip"],         # blocking keys
+    threshold=0.85,           # overall fuzzy threshold
+    llm_scorer=False,         # enable LLM for borderline pairs
+)
+```
+
+## `DedupeResult` fields
+
+```python
+result.golden          # pl.DataFrame | None - canonical records with __cluster_id__
+result.dupes           # pl.DataFrame | None - duplicate records with __row_id__
+result.unique          # pl.DataFrame | None - non-duplicate records
+result.clusters        # dict[int, dict] - {cluster_id: {"members": [row_ids], "pair_scores": {(a,b): score}}}
+result.scored_pairs    # list[tuple[int, int, float]] - all matched pairs
+result.stats           # dict - total_records, total_clusters, matched_records, match_rate
+result.total_records   # int
+result.total_clusters  # int
+result.match_rate      # float
+```
+
+## `StandardizationConfig` - use rules dict, NOT keyword args
+
+```python
+# WRONG:
+StandardizationConfig(email=["email"], phone=["phone"])
+
+# RIGHT:
+StandardizationConfig(rules={
+    "email": ["email"],
+    "phone": ["phone"],
+    "first_name": ["strip", "name_proper"],
+})
+```
+
+`StandardizationConfig` has a single `rules: dict[str, list[str]]` field with a model validator. Keyword args will raise a Pydantic validation error.
+
+## `BlockingConfig` requires `keys` field
+
+```python
+# keys is required even with multi_pass
+BlockingConfig(
+    strategy="multi_pass",
+    keys=[BlockingKeyConfig(fields=["email"], transforms=["lowercase"])],  # required!
+    passes=[
+        BlockingKeyConfig(fields=["email"], transforms=["lowercase"]),
+        BlockingKeyConfig(fields=["last_name"], transforms=["soundex"]),
+    ],
+)
+```
+
+## `MatchkeyConfig` requires `name` field
+
+```python
+MatchkeyConfig(
+    name="identity",       # required!
+    type="weighted",
+    threshold=0.75,
+    fields=[...],
+)
+```
+
+## Extracting pairs from clusters (correct way)
+
+```python
+pairs = []
+for cluster in result.clusters.values():
+    members = sorted(cluster["members"])
+    for i in range(len(members)):
+        for j in range(i + 1, len(members)):
+            pairs.append((members[i], members[j]))
+```
+
+## Multi-pass blocking for catching different dupe types
+
+```python
+# Pass 1: exact email (identical-email dupes)
+# Pass 2: soundex last_name (phonetic variants: Smith/Smyth)
+# Pass 3: first 3 chars of last_name (typo dupes: Johm/John)
+BlockingConfig(
+    strategy="multi_pass",
+    keys=[BlockingKeyConfig(fields=["email"], transforms=["lowercase", "strip"])],
+    passes=[
+        BlockingKeyConfig(fields=["email"], transforms=["lowercase", "strip"]),
+        BlockingKeyConfig(fields=["last_name"], transforms=["soundex"]),
+        BlockingKeyConfig(fields=["last_name"], transforms=["substring:0:3"]),
+    ],
+)
+```
+
+## Available scorers
+
+- `exact`: 1.0 if equal, 0.0 otherwise
+- `jaro_winkler`: best for short strings (names)
+- `levenshtein`: normalized edit distance
+- `token_sort`: handles word reordering
+- `ensemble`: weighted combination of jaro_winkler + levenshtein + token_sort + dice (best for names)
+- `dice`, `jaccard`: set-based similarity
+- `soundex_match`: phonetic matching
+- `embedding`: sentence-transformer cosine similarity
+
+## Available transforms (applied at matchkey time)
+
+`lowercase`, `uppercase`, `strip`, `strip_all`, `soundex`, `metaphone`, `digits_only`, `alpha_only`, `normalize_whitespace`, `token_sort`, `first_token`, `last_token`, `substring:start:end`, `qgram:n`
+
+## LLM Scorer for borderline pairs
+
+```python
+from goldenmatch.config.schemas import LLMScorerConfig, BudgetConfig
+
+config.llm_scorer = LLMScorerConfig(
+    enabled=True,
+    candidate_lo=0.60,    # send pairs scoring 0.60-0.90 to LLM
+    candidate_hi=0.90,
+    auto_threshold=0.90,  # auto-accept above 0.90
+    budget=BudgetConfig(max_calls=500, max_cost_usd=1.0),
+)
+# Requires OPENAI_API_KEY or ANTHROPIC_API_KEY in environment
+```
+
+## Common Mistakes
+
+- Using `exact=["email"]` as sole matchkey - creates oversized clusters with common emails
+- Using `auto_configure()` on synthetic data - it may produce poor configs
+- Not setting `name=` on MatchkeyConfig - it's required
+- Not providing `keys=` on BlockingConfig - it's required even with multi_pass
+- Extracting pairs from dupes DataFrame directly instead of using result.clusters

--- a/packages/python/goldenpipe/CLAUDE.md
+++ b/packages/python/goldenpipe/CLAUDE.md
@@ -6,19 +6,6 @@ Golden Suite orchestrator -- chains GoldenCheck, GoldenFlow, GoldenMatch.
 Sibling packages live in this monorepo at `packages/python/{goldencheck,goldenflow,goldenmatch,infermap}/`. Pre-fold standalone repos lived at `D:\show_case\<name>`; their history is in `_archive/goldenmatch-pre-fold/`.
 - **GitHub:** `benzsevern/goldenmatch` (single monorepo since 2026-05-02)
 
-## Branch & Merge SOP (all Golden Suite repos)
-- Feature work goes on `feature/<name>` branches, never directly to main
-- Merge via **squash merge PR** (watchers see PR activity, history stays clean)
-- PR title format: `feat: <description>` or `fix: <description>`
-- Merge when: tests pass, docs updated. Days not weeks.
-- After merge: delete remote branch
-
-## Environment
-- Windows 11, bash shell (Git Bash)
-- Python 3.12 at `C:\Users\bsevern\AppData\Local\Programs\Python\Python312\python.exe`
-- Two GitHub accounts: `benzsevern` (personal) and `benzsevern-mjh` (work)
-- MUST `gh auth switch --user benzsevern` before push, switch back to `benzsevern-mjh` after
-
 ## Architecture
 - `goldenpipe/pipeline.py` -- Pipeline class, run() function. ONLY file that imports from tools.
 - `goldenpipe/decisions.py` -- Adaptive logic (decide_flow, decide_match). NO tool imports. Testable independently.

--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -1,0 +1,68 @@
+# goldenmatch (TypeScript)
+
+npm package `goldenmatch`. Three-wave parity port of the Python sibling at `packages/python/goldenmatch/`. Currently at **v0.7.0** (parity with Python v1.12).
+
+## Wave history
+| npm | Python parity | Headline |
+|-----|---------------|----------|
+| 0.4.0 | v1.6.0 | Learning Memory + scorer ground truth |
+| 0.5.0 | v1.7 + v1.8 | AutoConfigController, ComplexityProfile, RunHistory, StopReason telemetry |
+| 0.6.0 | v1.9 + v1.10 | 5 complexity indicators + indicator-aware refit rules; scorer selection aligned with Python |
+| 0.7.0 | v1.11 + v1.12 | NegativeEvidenceField + Path Y (exact-MK post-filter) |
+
+Each wave's spec/plan: `docs/superpowers/specs/2026-05-10-ts-parity-arc-design.md` + per-wave plans.
+
+## Commands
+```bash
+cd packages/typescript/goldenmatch
+pnpm --filter goldenmatch test      # vitest (841 tests at v0.7.0)
+pnpm --filter goldenmatch typecheck # tsc --noEmit (strict)
+pnpm --filter goldenmatch build     # tsup (5 entry points)
+npx vitest run tests/parity/        # parity-only suite
+```
+
+## Edge-safety rule
+`src/core/**` MUST NOT import `node:*`. Node-only code lives in `src/node/`. Memory backed by SQLite is `src/node/memory/`; the edge-safe interface is `src/core/memory/`. This is enforced by build separation, not by lint — verify when adding new imports.
+
+## Strict TS
+`noUncheckedIndexedAccess` + `exactOptionalPropertyTypes`. Idioms:
+- Bounded-loop indices: use `arr[i]!` after a length check.
+- Optional props: `...(x !== undefined ? { field: x } : {})` — never spread `undefined`.
+- Optional peer deps (sqlite, sentence-transformers): `await import("pkg-name" as string)` — the `as string` cast prevents tsup from resolving at build time.
+
+## Parity contract
+- **Scorer output:** 4-decimal tolerance vs Python (`tests/parity/scorer-ground-truth.test.ts`).
+- **Hash bytes:** SHA-256 truncated to 16 hex via Web Crypto. UTF-8 mandatory. Hash input = values joined by `|` (NOT `<col>=<val>`). `__row_id__` excluded from `record_hash` so corrections survive row reordering.
+- **Cross-language fixtures:** committed under `tests/parity/fixtures/`. Regen via `packages/python/goldenmatch/tests/parity/memory/gen_memory_fixtures.py --rebuild-db` and the wave-specific emitters in `packages/python/goldenmatch/scripts/emit_ts_parity_fixtures.py`. Determinism clamp: pinned UUIDs, pinned `created_at` (no `datetime.now()`).
+- **Negative-evidence parity** (v0.7.0): 6 fixture datasets exercising Path Y filtering on exact MKs + weighted-MK NE. Live in `tests/parity/negative-evidence-fixtures.json`.
+- **Controller parity** (v0.5.0): structural-only on 4 of 6 fixtures, byte-equal on 2. Python-side `ModuleNotFoundError` on polars/sklearn in the divergent 4 — TS doesn't replicate that import wart.
+
+## Public API surface (v0.7.0)
+- `dedupeFile`, `dedupe`, `matchFile`, `match` — all return Promises.
+- `autoConfigureRows` (sync, single-pass) and `autoConfigureRowsIterate` (Promise, full controller).
+- `AutoConfigController`, `RunHistory`, `ComplexityProfile`, `HealthVerdict`, `StopReason`.
+- `NegativeEvidenceField`, `applyNegativeEvidence`, `applyNegativeEvidenceToExactPairs`, `promoteNegativeEvidence`.
+- Memory mirror: `getMemory`, `addCorrection`, `learn`, `memoryStats`.
+- MCP tool count: 24 (19 base + 5 memory). Description literal at `src/node/mcp/server.ts:6` — keep in sync via the existing regex test.
+
+## Build outputs
+- tsup with 5 entry points: `index`, `core/index`, `node/index`, `cli`, `node/backends/score-worker` (piscina worker).
+- Build artifacts to `dist/` (gitignored).
+- Test count discipline: bump when adding parity datasets so future audits can diff.
+
+## Config-types invariants
+- **No `make*` factory functions** for config types — test fixtures use full literals. Required fields:
+  - `MatchkeyField`: `field` + `transforms` + `scorer` + `weight`
+  - `BlockingKeyConfig`: `fields` + `transforms`
+  - `BlockingConfig`: `strategy` + `keys` + `maxBlockSize` + `skipOversized`
+- **Scorer names are snake_case** (same as Python): `token_sort`, `record_embedding`, `soundex_match`, `ensemble`, `exact`, `jaro_winkler`, `levenshtein`.
+- **`DOMAIN_EXTRACTED_COLS`** (in `src/core/domain.ts`) has only 3 entries (`__brand__`, `__model__`, `__version__`); Python's has 12. Don't assume parity when porting domain features.
+
+## Vitest gotchas
+- Default timeout 5s. Heavier integration tests (PPRL multi-level, postflight end-to-end) need `{ timeout: 15000 }`. CI concurrent load has bitten this (cost a release: v0.3.0 → v0.3.1).
+
+## Publish workflow
+- `.github/workflows/publish-goldenmatch-js.yml` at monorepo root. Triggers on `goldenmatch-js-v*` tag or `workflow_dispatch` with `ref` input.
+- Tag MUST point at a commit that has the workflow file, otherwise the trigger doesn't fire (root CLAUDE.md "Workflow trigger ordering" gotcha).
+- Uses `NPM_TOKEN` secret. Trusted publishing not configured.
+- The tag-version-must-match-package.json check (in the workflow) means you cannot tag multiple versions at the same commit. Each release commit has its own version bump and tag.


### PR DESCRIPTION
## Summary
Post-quality-wave audit of all 18 CLAUDE.md files using \`/claude-md-management:claude-md-improver\`. Trims redundancy, fixes stale paths, fills gaps.

## Changes
- **Root CLAUDE.md** (+12 lines): stacked-PR auto-closure on squash-merge, \`gh pr merge\` worktree noise, CI UNSTABLE meaning, pypistats 429 handling.
- **goldenmatch CLAUDE.md** (505 -> 332 lines): dropped duplicated SOPs, dropped stale v0.4.0 TS-port section, moved API Quick Reference + Common Mistakes to \`packages/python/goldenmatch/docs/api-quick-reference.md\`. Added Pydantic typed-accessor pattern + pyright multi-line import suppression placement to Code Patterns.
- **goldenflow CLAUDE.md**: fixed pre-fold sibling paths, removed duplicated SOPs.
- **goldenpipe CLAUDE.md**: removed duplicated SOPs.
- **goldencheck CLAUDE.md**: fixed pre-fold TS path (\`packages/goldencheck-js\` -> \`packages/typescript/goldencheck\`), fixed test-count inconsistency.
- **NEW** \`packages/typescript/goldenmatch/CLAUDE.md\` (68 lines): TS port context at v0.7.0, three-wave parity history, edge-safety rules, strict-TS idioms, parity contract.
- **NEW** \`packages/python/goldencheck-types/CLAUDE.md\` (43 lines): snake_case TS exception, schema-version contract.

## Net effect
- 173 lines off the always-loaded goldenmatch CLAUDE.md prompt.
- 2 new package-scoped CLAUDE.mds where there was no context before.
- All stale pre-fold paths gone.

## Test plan
- [x] No code changes; doc-only PR.
- [x] Path-filter should skip most CI lanes (only \`changes\` job runs for doc-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)