### PR TITLE
feat(web): surface AutoConfigController telemetry (v1.7-v1.12) in workbench

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/web/app.py
+++ b/packages/python/goldenmatch/goldenmatch/web/app.py
@@ -20,6 +20,7 @@ def create_app(state: AppState) -> FastAPI:
 
     from goldenmatch.web.routers import autoconfig as autoconfig_router
     from goldenmatch.web.routers import compare as compare_router
+    from goldenmatch.web.routers import controller as controller_router
     from goldenmatch.web.routers import domains as domains_router
     from goldenmatch.web.routers import evaluation as evaluation_router
     from goldenmatch.web.routers import labels as labels_router
@@ -50,6 +51,7 @@ def create_app(state: AppState) -> FastAPI:
     app.include_router(match_router.router)
     app.include_router(memory_router.router)
     app.include_router(quality_router.router)
+    app.include_router(controller_router.router)
 
     if STATIC_DIR.exists() and any(STATIC_DIR.iterdir()):
         app.mount("/", StaticFiles(directory=str(STATIC_DIR), html=True), name="static")

--- a/packages/python/goldenmatch/goldenmatch/web/controller_telemetry.py
+++ b/packages/python/goldenmatch/goldenmatch/web/controller_telemetry.py
@@ -1,0 +1,292 @@
+"""Serialize AutoConfigController output (ComplexityProfile + RunHistory) into
+the JSON shape consumed by ``/api/v1/controller/telemetry`` and the workbench
+ControllerPanel.
+
+The engine's controller artifacts are frozen dataclasses with deep typed
+sub-profiles (DataProfile, BlockingProfile, ScoringProfile, ClusterProfile,
+IndicatorsProfile, …). Rather than letting FastAPI's default
+``jsonable_encoder`` walk those structures (which would surface internal
+fields like ``_version`` and ``score_histogram`` raw), we project a small,
+intentional subset that maps 1:1 to what the UI renders.
+
+Spec inputs:
+  - ``goldenmatch.core.complexity_profile.ComplexityProfile`` (v1.10 adds
+    ``IndicatorsProfile``; ``DataProfile.column_priors`` carries ColumnPrior).
+  - ``goldenmatch.core.autoconfig_history.RunHistory`` (.entries, .decisions,
+    .errors, .stop_reason, .full_vs_sample_drift, .elapsed).
+  - ``goldenmatch.config.schemas.GoldenMatchConfig`` for committed NE fields.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _health_str(profile: Any) -> str | None:
+    """Return the profile's overall health verdict as ``green|yellow|red``.
+
+    Returns None when ``profile`` is None or doesn't expose ``health()`` —
+    keeps the response schema stable when the controller never ran.
+    """
+    if profile is None:
+        return None
+    try:
+        return profile.health().value
+    except Exception:
+        return None
+
+
+def _scoring_summary(profile: Any) -> dict[str, Any] | None:
+    """Surface the scoring sub-profile signals the workbench renders.
+
+    Skip the full 20-bucket histogram — too noisy for a top-level panel. If
+    the user wants it, ``/api/v1/runs/{name}/clusters`` already lets them
+    drill down into actual pairs.
+    """
+    if profile is None or not hasattr(profile, "scoring"):
+        return None
+    s = profile.scoring
+    return {
+        "n_pairs_scored": int(getattr(s, "n_pairs_scored", 0)),
+        "candidates_compared": int(getattr(s, "candidates_compared", 0)),
+        "mass_above_threshold": float(getattr(s, "mass_above_threshold", 0.0)),
+        "mass_in_borderline": float(getattr(s, "mass_in_borderline", 0.0)),
+        "dip_statistic": float(getattr(s, "dip_statistic", 0.0)),
+    }
+
+
+def _blocking_summary(profile: Any) -> dict[str, Any] | None:
+    if profile is None or not hasattr(profile, "blocking"):
+        return None
+    b = profile.blocking
+    return {
+        "n_blocks": int(getattr(b, "n_blocks", 0)),
+        "reduction_ratio": float(getattr(b, "reduction_ratio", 0.0)),
+        "block_sizes_p50": int(getattr(b, "block_sizes_p50", 0)),
+        "block_sizes_p99": int(getattr(b, "block_sizes_p99", 0)),
+        "block_sizes_max": int(getattr(b, "block_sizes_max", 0)),
+        "oversized_block_count": int(getattr(b, "oversized_block_count", 0)),
+        "keys_used": [list(k) for k in getattr(b, "keys_used", [])],
+    }
+
+
+def _cluster_summary(profile: Any) -> dict[str, Any] | None:
+    if profile is None or not hasattr(profile, "cluster"):
+        return None
+    c = profile.cluster
+    return {
+        "n_clusters": int(getattr(c, "n_clusters", 0)),
+        "cluster_size_p50": int(getattr(c, "cluster_size_p50", 0)),
+        "cluster_size_p99": int(getattr(c, "cluster_size_p99", 0)),
+        "cluster_size_max": int(getattr(c, "cluster_size_max", 0)),
+        "transitivity_rate": float(getattr(c, "transitivity_rate", 0.0)),
+        "oversized_cluster_count": int(getattr(c, "oversized_cluster_count", 0)),
+    }
+
+
+def _column_priors(profile: Any) -> list[dict[str, Any]]:
+    """v1.10 ColumnPrior values, one row per column with a non-zero signal.
+
+    Eager indicator output — always populated when the controller ran. Used by
+    the workbench to explain WHY auto-config picked / refused certain columns
+    as identity anchors.
+    """
+    if profile is None or not hasattr(profile, "data"):
+        return []
+    data = profile.data
+    priors = getattr(data, "column_priors", None) or {}
+    out: list[dict[str, Any]] = []
+    for col, prior in priors.items():
+        identity = float(getattr(prior, "identity_score", 0.0))
+        corruption = float(getattr(prior, "corruption_score", 0.0))
+        # Skip columns with no usable signal in either direction — keeps the
+        # panel focused on columns where the controller actually had a view.
+        if identity == 0.0 and corruption == 0.0:
+            continue
+        out.append({
+            "column": col,
+            "identity_score": identity,
+            "corruption_score": corruption,
+        })
+    # Highest-identity columns first, then highest-corruption — matches how
+    # the controller prioritises them.
+    out.sort(key=lambda r: (-r["identity_score"], -r["corruption_score"]))
+    return out
+
+
+def _indicators(profile: Any) -> dict[str, Any] | None:
+    """v1.10 lazy IndicatorsProfile, when the controller computed it.
+
+    Returns None when ``indicators is None`` (the cheap path on YELLOW
+    profiles where no expensive indicator was needed).
+    """
+    ind = getattr(profile, "indicators", None) if profile else None
+    if ind is None:
+        return None
+    return {
+        "full_pop_matchkey_hit_rate": (
+            float(ind.full_pop_matchkey_hit_rate)
+            if ind.full_pop_matchkey_hit_rate is not None
+            else None
+        ),
+        "cross_blocking_overlap": (
+            float(ind.cross_blocking_overlap)
+            if ind.cross_blocking_overlap is not None
+            else None
+        ),
+    }
+
+
+def _decisions(history: Any) -> list[dict[str, Any]]:
+    """RunHistory.decisions projected into a flat ordered list for rendering.
+
+    Includes iteration index from the parent HistoryEntry so the UI can show
+    "iter 2: rule_blocking_key_swap fired because …".
+    """
+    if history is None:
+        return []
+    out: list[dict[str, Any]] = []
+    for entry in getattr(history, "entries", []):
+        if entry.decision is None:
+            continue
+        diff = entry.decision.config_diff or {}
+        # Truncate config_diff to keys+brief repr — the full diff can carry
+        # whole MatchkeyConfig objects which are too noisy for a side panel.
+        diff_summary = {k: _truncate_repr(v) for k, v in diff.items()}
+        out.append({
+            "iteration": int(entry.iteration),
+            "rule_name": entry.decision.rule_name,
+            "rationale": entry.decision.rationale,
+            "config_diff": diff_summary,
+            "wall_clock_ms": int(getattr(entry, "wall_clock_ms", 0) or 0),
+        })
+    return out
+
+
+def _truncate_repr(value: Any, max_len: int = 140) -> str:
+    """One-line ``repr`` truncated for compact UI rendering."""
+    r = repr(value)
+    return r if len(r) <= max_len else r[: max_len - 1] + "…"
+
+
+def _errors(history: Any) -> list[dict[str, Any]]:
+    if history is None:
+        return []
+    out: list[dict[str, Any]] = []
+    for entry in getattr(history, "entries", []):
+        if entry.error is None:
+            continue
+        out.append({
+            "iteration": int(entry.iteration),
+            "exception_type": entry.error.exception_type,
+            "traceback_summary": entry.error.traceback_summary,
+        })
+    return out
+
+
+def _negative_evidence(config: Any) -> list[dict[str, Any]]:
+    """v1.11+ negative-evidence fields the controller committed, per matchkey.
+
+    Exposed so the workbench's controller panel can flag "Path Y is active on
+    matchkey X via field Y (penalty Z)" — the v1.12 unlock that drove the
+    DQbench T3 improvement. Empty list when no NE fields exist on any
+    matchkey (legacy configs, or zero-config decided no anchor was strong
+    enough to back NE).
+    """
+    if config is None:
+        return []
+    out: list[dict[str, Any]] = []
+    try:
+        matchkeys = config.get_matchkeys()
+    except Exception:
+        return []
+    for mk in matchkeys:
+        ne = getattr(mk, "negative_evidence", None)
+        if not ne:
+            continue
+        for field in ne:
+            out.append({
+                "matchkey_name": mk.name,
+                "matchkey_type": mk.type,
+                "field": field.field,
+                "scorer": field.scorer,
+                "threshold": float(field.threshold),
+                "penalty": float(field.penalty),
+                "transforms": list(field.transforms or []),
+            })
+    return out
+
+
+def _committed_matchkeys_summary(config: Any) -> list[dict[str, Any]]:
+    """One-line-per-matchkey projection of the controller-committed config.
+
+    Workbench renders this so the user can see what auto-config picked
+    without having to dig into the saved YAML. Mirrors the format that
+    ``/api/v1/rules`` returns but reflects the committed (engine-side) view
+    rather than the workbench's flattened RulesPayload.
+    """
+    if config is None:
+        return []
+    out: list[dict[str, Any]] = []
+    try:
+        matchkeys = config.get_matchkeys()
+    except Exception:
+        return []
+    for mk in matchkeys:
+        out.append({
+            "name": mk.name,
+            "type": mk.type,
+            "threshold": float(mk.threshold) if mk.threshold is not None else None,
+            "fields": [
+                {
+                    "column": f.column or f.field,
+                    "scorer": f.scorer,
+                    "weight": float(f.weight) if f.weight is not None else None,
+                }
+                for f in mk.fields
+            ],
+            "has_negative_evidence": bool(mk.negative_evidence),
+        })
+    return out
+
+
+def serialize_telemetry(
+    *,
+    profile: Any,
+    history: Any,
+    committed_config: Any,
+    source: str | None,
+    run_name: str | None,
+    recorded_at: str | None,
+) -> dict[str, Any]:
+    """Build the JSON body returned by ``GET /api/v1/controller/telemetry``."""
+    elapsed_ms: float | None = None
+    drift: float | None = None
+    stop_reason: str | None = None
+    if history is not None:
+        elapsed = getattr(history, "elapsed", None)
+        if elapsed is not None:
+            elapsed_ms = elapsed.total_seconds() * 1000.0
+        drift_val = getattr(history, "full_vs_sample_drift", None)
+        drift = float(drift_val) if drift_val is not None else None
+        sr = getattr(history, "stop_reason", None)
+        stop_reason = sr.value if sr is not None else None
+
+    return {
+        "available": profile is not None or history is not None,
+        "source": source,
+        "run_name": run_name,
+        "recorded_at": recorded_at,
+        "stop_reason": stop_reason,
+        "elapsed_ms": elapsed_ms,
+        "full_vs_sample_drift": drift,
+        "health": _health_str(profile),
+        "scoring": _scoring_summary(profile),
+        "blocking": _blocking_summary(profile),
+        "cluster": _cluster_summary(profile),
+        "indicators": _indicators(profile),
+        "column_priors": _column_priors(profile),
+        "decisions": _decisions(history),
+        "errors": _errors(history),
+        "committed_matchkeys": _committed_matchkeys_summary(committed_config),
+        "negative_evidence": _negative_evidence(committed_config),
+    }

--- a/packages/python/goldenmatch/goldenmatch/web/routers/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/autoconfig.py
@@ -122,7 +122,17 @@ def _ui_safe_field(f: MatchkeyField) -> dict[str, Any]:
     }
 
 
-def _autoconfigure(project_root: Path, domain: str | None = None) -> RulesPayload:
+def _autoconfigure(
+    project_root: Path,
+    domain: str | None = None,
+) -> tuple[RulesPayload, Any, Any, Any]:
+    """Run auto_configure_df and return (payload, committed_config, profile, history).
+
+    The profile / history come off the controller's ContextVar; they're None
+    when the controller didn't run (defensive — every modern path does run it,
+    but a future change to ``auto_configure_df`` might short-circuit and we
+    don't want this to crash if telemetry is missing).
+    """
     src = project_root / "data.csv"
     if not src.exists():
         raise FileNotFoundError("source CSV (data.csv) not found in project root")
@@ -140,6 +150,15 @@ def _autoconfigure(project_root: Path, domain: str | None = None) -> RulesPayloa
         # synthesized profile with no extractions, but doesn't error.
         domain_config = DomainConfig(enabled=True, mode=domain)
     cfg = auto_configure_df(df, allow_remote_assets=False, domain_config=domain_config)
+    # auto_configure_df stashes (profile, history) on a ContextVar the engine
+    # uses to wire PostflightReport.controller_*. Pull them here so the
+    # workbench can show the same telemetry without re-running the controller.
+    from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+    _ctrl_state = _LAST_CONTROLLER_RUN.get()
+    if _ctrl_state is not None:
+        ctrl_profile, ctrl_history = _ctrl_state
+    else:
+        ctrl_profile, ctrl_history = None, None
     fields, threshold = _pick_matchkeys(cfg.get_matchkeys())
 
     # The workbench rejects matchkeys whose scorer is in {embedding, record_embedding}
@@ -160,10 +179,11 @@ def _autoconfigure(project_root: Path, domain: str | None = None) -> RulesPayloa
                 )
             ]
 
-    return RulesPayload(
+    payload = RulesPayload(
         threshold=max(0.0, min(1.0, threshold)),
         matchkeys=[MatchkeyField(**_ui_safe_field(f)) for f in safe_fields],
     )
+    return payload, cfg, ctrl_profile, ctrl_history
 
 
 @router.post("/autoconfig")
@@ -171,7 +191,7 @@ async def autoconfigure(request: Request, domain: str | None = None) -> dict:
     state = request.app.state.app_state
     loop = asyncio.get_running_loop()
     try:
-        payload = await asyncio.wait_for(
+        payload, cfg, ctrl_profile, ctrl_history = await asyncio.wait_for(
             loop.run_in_executor(_executor, lambda: _autoconfigure(state.project_root, domain=domain)),
             timeout=AUTOCONFIG_TIMEOUT_S,
         )
@@ -189,4 +209,14 @@ async def autoconfigure(request: Request, domain: str | None = None) -> dict:
 
     # Adopt the suggestion as in-memory rules so the user can preview / save.
     state.rules = payload
+    # Stash controller telemetry so /api/v1/controller/telemetry returns the
+    # latest. We overwrite even when telemetry is partially missing — better
+    # to clear stale state than show telemetry from a prior, unrelated run.
+    from datetime import UTC, datetime as _dt
+    state.last_controller_profile = ctrl_profile
+    state.last_controller_history = ctrl_history
+    state.last_controller_committed_config = cfg
+    state.last_controller_source = "autoconfig"
+    state.last_controller_run_name = None
+    state.last_controller_recorded_at = _dt.now(UTC).isoformat()
     return payload.model_dump()

--- a/packages/python/goldenmatch/goldenmatch/web/routers/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/autoconfig.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +23,7 @@ from goldenmatch.config.schemas import (
     MatchkeyField,
     RulesPayload,
 )
-from goldenmatch.core.autoconfig import auto_configure_df
+from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN, auto_configure_df
 
 router = APIRouter(prefix="/api/v1")
 
@@ -153,7 +154,6 @@ def _autoconfigure(
     # auto_configure_df stashes (profile, history) on a ContextVar the engine
     # uses to wire PostflightReport.controller_*. Pull them here so the
     # workbench can show the same telemetry without re-running the controller.
-    from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
     _ctrl_state = _LAST_CONTROLLER_RUN.get()
     if _ctrl_state is not None:
         ctrl_profile, ctrl_history = _ctrl_state
@@ -212,11 +212,10 @@ async def autoconfigure(request: Request, domain: str | None = None) -> dict:
     # Stash controller telemetry so /api/v1/controller/telemetry returns the
     # latest. We overwrite even when telemetry is partially missing — better
     # to clear stale state than show telemetry from a prior, unrelated run.
-    from datetime import UTC, datetime as _dt
     state.last_controller_profile = ctrl_profile
     state.last_controller_history = ctrl_history
     state.last_controller_committed_config = cfg
     state.last_controller_source = "autoconfig"
     state.last_controller_run_name = None
-    state.last_controller_recorded_at = _dt.now(UTC).isoformat()
+    state.last_controller_recorded_at = datetime.now(UTC).isoformat()
     return payload.model_dump()

--- a/packages/python/goldenmatch/goldenmatch/web/routers/controller.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/controller.py
@@ -1,0 +1,30 @@
+"""GET /api/v1/controller/telemetry — surface the AutoConfigController's last
+run telemetry (stop_reason, ComplexityProfile health, RunHistory decisions,
+indicator priors, committed NE fields).
+
+Populated by ``/api/v1/autoconfig`` and ``/api/v1/run`` whenever those
+endpoints actually invoke ``auto_configure_df``. When the user has been
+hand-editing rules and never triggered auto-config, this returns
+``{"available": false}`` — the workbench panel renders a neutral "run
+auto-config to see decisions" message in that case.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from goldenmatch.web.controller_telemetry import serialize_telemetry
+
+router = APIRouter(prefix="/api/v1")
+
+
+@router.get("/controller/telemetry")
+def telemetry(request: Request) -> dict:
+    state = request.app.state.app_state
+    return serialize_telemetry(
+        profile=state.last_controller_profile,
+        history=state.last_controller_history,
+        committed_config=state.last_controller_committed_config,
+        source=state.last_controller_source,
+        run_name=state.last_controller_run_name,
+        recorded_at=state.last_controller_recorded_at,
+    )

--- a/packages/python/goldenmatch/goldenmatch/web/routers/run.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/run.py
@@ -232,11 +232,10 @@ async def run_real(payload: RunRequest, request: Request) -> dict:
     _history = result.pop("_ctrl_history", None)
     _cfg = result.pop("_ctrl_config", None)
     if payload.auto_config:
-        from datetime import UTC, datetime as _dt
         state.last_controller_profile = _profile
         state.last_controller_history = _history
         state.last_controller_committed_config = _cfg
         state.last_controller_source = "run"
         state.last_controller_run_name = result.get("run_name")
-        state.last_controller_recorded_at = _dt.now(UTC).isoformat()
+        state.last_controller_recorded_at = datetime.now(UTC).isoformat()
     return result

--- a/packages/python/goldenmatch/goldenmatch/web/routers/run.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/run.py
@@ -104,12 +104,20 @@ def _execute_run(
             ),
         )
 
+    ctrl_profile: Any = None
+    ctrl_history: Any = None
     if auto_config:
         # Zero-config: call auto_configure_df *before* the pipeline so the
         # pipeline never re-invokes auto-config. Eliminates double-pipeline-run
         # when the Task 5.1 controller loop is in play (Task 5.2 fix).
-        from goldenmatch.core.autoconfig import auto_configure_df
+        from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN, auto_configure_df
         config = auto_configure_df(df)
+        # Capture controller telemetry from the ContextVar — same mechanism
+        # _api.dedupe_df uses to surface PostflightReport.controller_*. The
+        # /api/v1/controller/telemetry endpoint reads this off AppState.
+        _ctrl_state = _LAST_CONTROLLER_RUN.get()
+        if _ctrl_state is not None:
+            ctrl_profile, ctrl_history = _ctrl_state
         result = run_dedupe_df(df, config, output_clusters=True, auto_config=False)
     else:
         result = run_dedupe_df(df, config, output_clusters=True)
@@ -167,6 +175,13 @@ def _execute_run(
         "clusters_path": str(clusters_path),
         "auto_config": auto_config,
         "llm_boost": llm_boost,
+        # Internal channels — not part of the public response shape; the
+        # router pops these before returning JSON. Kept here so the worker
+        # thread can hand telemetry back to the request thread without a
+        # second contextvar dance.
+        "_ctrl_profile": ctrl_profile,
+        "_ctrl_history": ctrl_history,
+        "_ctrl_config": config,
     }
 
 
@@ -207,4 +222,21 @@ async def run_real(payload: RunRequest, request: Request) -> dict:
         raise HTTPException(status_code=400, detail=str(exc))
     except (pl.exceptions.ColumnNotFoundError, KeyError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=f"run failed: {exc}")
+
+    # Pop the internal controller telemetry channels off the result dict and
+    # stash on AppState so /api/v1/controller/telemetry can serve them. These
+    # are unset for non-auto-config runs (the user supplied rules; the
+    # controller never ran), in which case we leave state untouched so a prior
+    # auto-config session's telemetry stays visible until the next one.
+    _profile = result.pop("_ctrl_profile", None)
+    _history = result.pop("_ctrl_history", None)
+    _cfg = result.pop("_ctrl_config", None)
+    if payload.auto_config:
+        from datetime import UTC, datetime as _dt
+        state.last_controller_profile = _profile
+        state.last_controller_history = _history
+        state.last_controller_committed_config = _cfg
+        state.last_controller_source = "run"
+        state.last_controller_run_name = result.get("run_name")
+        state.last_controller_recorded_at = _dt.now(UTC).isoformat()
     return result

--- a/packages/python/goldenmatch/goldenmatch/web/state.py
+++ b/packages/python/goldenmatch/goldenmatch/web/state.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from goldenmatch.web.registry import PreviewRegistry
 
 if TYPE_CHECKING:
-    from goldenmatch.config.schemas import RulesPayload
+    from goldenmatch.config.schemas import GoldenMatchConfig, RulesPayload
 
 
 @dataclass
@@ -21,6 +21,18 @@ class AppState:
     rules: RulesPayload | None = None
     runs_dir: Path | None = None
     registry: PreviewRegistry = field(default_factory=PreviewRegistry)
+    # v1.7-v1.12 controller telemetry from the most recent zero-config call
+    # (autoconfig or auto_config=true run). Stashed here so the workbench can
+    # surface stop_reason, RunHistory decisions, ComplexityProfile health, and
+    # IndicatorContext signals without re-running the controller. Loosely typed
+    # (Any) to dodge import cycles — the serialization layer in
+    # web/controller_telemetry.py is the type-safe boundary.
+    last_controller_profile: Any = None
+    last_controller_history: Any = None
+    last_controller_committed_config: GoldenMatchConfig | None = None
+    last_controller_source: str | None = None  # "autoconfig" or "run"
+    last_controller_run_name: str | None = None  # run_name when source="run"
+    last_controller_recorded_at: str | None = None  # ISO timestamp
 
     @classmethod
     def from_project_dir(cls, project_dir: Path, runs_dir: Path | None = None) -> AppState:

--- a/packages/python/goldenmatch/tests/web/test_router_controller.py
+++ b/packages/python/goldenmatch/tests/web/test_router_controller.py
@@ -1,0 +1,47 @@
+"""GET /api/v1/controller/telemetry — surface AutoConfigController output.
+
+The endpoint is intentionally cheap: it serves whatever was stashed on
+AppState by the most recent /api/v1/autoconfig or /api/v1/run?auto_config=true.
+When no controller run has happened yet, it returns ``available=false`` and
+empty lists rather than 404 — the workbench panel renders a neutral
+"run auto-config to see decisions" state in that case.
+"""
+from __future__ import annotations
+
+
+def test_telemetry_returns_unavailable_before_any_controller_run(client):
+    resp = client.get("/api/v1/controller/telemetry")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is False
+    assert body["decisions"] == []
+    assert body["column_priors"] == []
+    assert body["negative_evidence"] == []
+    assert body["stop_reason"] is None
+    assert body["committed_matchkeys"] == []
+
+
+def test_telemetry_populated_after_autoconfig(client):
+    # Trigger auto-config so the controller runs.
+    ac = client.post("/api/v1/autoconfig")
+    assert ac.status_code == 200, ac.text
+
+    resp = client.get("/api/v1/controller/telemetry")
+    assert resp.status_code == 200
+    body = resp.json()
+    # Controller ran → telemetry is available, source labelled correctly.
+    assert body["available"] is True
+    assert body["source"] == "autoconfig"
+    assert body["recorded_at"] is not None
+    # Stop reason is one of the StopReason enum values; controller always
+    # sets it before returning. Don't pin the exact value — the heuristic
+    # path on the 3-row fixture could legitimately hit several of them.
+    assert body["stop_reason"] in {
+        "green", "converged", "budget_iterations", "budget_time",
+        "policy_satisfied", "policy_no_progress", "oscillating", "cancelled",
+    }
+    # Committed matchkeys reflect the engine config the controller picked.
+    assert isinstance(body["committed_matchkeys"], list)
+    assert len(body["committed_matchkeys"]) >= 1
+    # health verdict surfaces the controller's view of the committed config
+    assert body["health"] in {"green", "yellow", "red"}

--- a/packages/python/goldenmatch/web/frontend/src/components/ControllerPanel.tsx
+++ b/packages/python/goldenmatch/web/frontend/src/components/ControllerPanel.tsx
@@ -1,0 +1,388 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../lib/api";
+import type {
+  ControllerColumnPrior,
+  ControllerCommittedMatchkey,
+  ControllerDecision,
+  ControllerError,
+  ControllerNegativeEvidence,
+  ControllerTelemetry,
+} from "../lib/api";
+
+/** Surfaces the AutoConfigController's last-run output (v1.7-v1.12):
+ *  stop_reason, ComplexityProfile health, RunHistory decisions, indicator
+ *  column priors, and Path Y negative-evidence on the committed config.
+ *
+ *  Data source: GET /api/v1/controller/telemetry — populated by /autoconfig
+ *  and /run?auto_config=true. Polls on `refetchKey` so the workbench can
+ *  invalidate after a fresh auto-config / zero-config run.
+ */
+export function ControllerPanel({ refetchKey }: { refetchKey?: string | number }) {
+  const { data, isLoading } = useQuery<ControllerTelemetry>({
+    queryKey: ["controller-telemetry", refetchKey ?? ""],
+    queryFn: api.controllerTelemetry,
+    // Cache-warm on every workbench mount; the user almost always wants the
+    // latest after they trigger auto-config.
+    staleTime: 0,
+  });
+
+  if (isLoading) {
+    return (
+      <section className="border-t border-ink-200 pt-5 text-xs text-ink-500">
+        Loading controller telemetry…
+      </section>
+    );
+  }
+  if (!data || !data.available) {
+    return (
+      <section className="border-t border-ink-200 pt-5">
+        <p className="eyebrow mb-2">controller</p>
+        <p className="text-xs text-ink-500">
+          Run <span className="text-gold-600">Auto-configure</span> or{" "}
+          <span className="text-gold-600">Zero-config run</span> to see the
+          controller's stop reason, health verdict, and refit decisions here.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="border-t border-ink-200 pt-5 space-y-4">
+      <header className="flex items-baseline gap-3">
+        <p className="eyebrow">controller</p>
+        <HealthBadge verdict={data.health} />
+        <StopReasonBadge reason={data.stop_reason} />
+        <span className="ml-auto text-[11px] text-ink-400 font-mono">
+          {data.source === "run" && data.run_name
+            ? `via ${data.run_name}`
+            : data.source ?? ""}
+          {data.recorded_at ? ` · ${shortTs(data.recorded_at)}` : ""}
+        </span>
+      </header>
+
+      <CommittedConfig items={data.committed_matchkeys} ne={data.negative_evidence} />
+
+      <ScoringStrip data={data} />
+
+      {data.column_priors.length > 0 && (
+        <ColumnPriorsTable priors={data.column_priors} />
+      )}
+
+      {data.decisions.length > 0 && (
+        <DecisionList decisions={data.decisions} />
+      )}
+
+      {data.errors.length > 0 && (
+        <ErrorList errors={data.errors} />
+      )}
+    </section>
+  );
+}
+
+function HealthBadge({ verdict }: { verdict: ControllerTelemetry["health"] }) {
+  if (!verdict) return null;
+  const tone =
+    verdict === "green"
+      ? "bg-emerald-50 text-emerald-800 border-emerald-300"
+      : verdict === "yellow"
+        ? "bg-amber-50 text-amber-800 border-amber-300"
+        : "bg-red-50 text-red-800 border-red-300";
+  return (
+    <span
+      className={`px-2 py-0.5 text-[11px] uppercase tracking-eyebrow rounded border ${tone}`}
+      title="Overall ComplexityProfile health verdict. Red = a sub-profile (blocking, scoring, cluster, …) flagged a problem the controller couldn't repair within budget."
+    >
+      health · {verdict}
+    </span>
+  );
+}
+
+function StopReasonBadge({ reason }: { reason: ControllerTelemetry["stop_reason"] }) {
+  if (!reason) return null;
+  // Reason → one-line plain-English hover.
+  const tooltip: Record<NonNullable<ControllerTelemetry["stop_reason"]>, string> = {
+    green: "Iteration produced a GREEN profile — controller is satisfied.",
+    converged: "Profile distance to prior iteration fell below epsilon.",
+    budget_iterations: "Max-iteration budget reached before reaching GREEN.",
+    budget_time: "Wall-clock budget exhausted.",
+    policy_satisfied: "Policy returned no refit proposal; current config is acceptable on the non-green profile.",
+    policy_no_progress: "Policy proposed the same config twice in a row.",
+    oscillating: "Same (config, rule) pair repeated within a 4-iteration window.",
+    cancelled: "Run was cancelled (KeyboardInterrupt).",
+  };
+  return (
+    <span
+      className="px-2 py-0.5 text-[11px] uppercase tracking-eyebrow rounded border border-ink-200 bg-paper-100 text-ink-700"
+      title={tooltip[reason]}
+    >
+      stop · {reason.replace(/_/g, " ")}
+    </span>
+  );
+}
+
+function CommittedConfig({
+  items,
+  ne,
+}: {
+  items: ControllerCommittedMatchkey[];
+  ne: ControllerNegativeEvidence[];
+}) {
+  if (items.length === 0) return null;
+  const neByMk = new Map<string, ControllerNegativeEvidence[]>();
+  for (const n of ne) {
+    const arr = neByMk.get(n.matchkey_name) ?? [];
+    arr.push(n);
+    neByMk.set(n.matchkey_name, arr);
+  }
+  return (
+    <div>
+      <p className="eyebrow mb-2">committed config</p>
+      <ul className="space-y-2 text-xs">
+        {items.map((mk) => {
+          const neFields = neByMk.get(mk.name) ?? [];
+          return (
+            <li key={mk.name} className="card px-3 py-2">
+              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <span className="font-mono text-ink-800">{mk.name}</span>
+                <span className="text-[10px] uppercase tracking-eyebrow text-ink-500">
+                  {mk.type ?? "—"}
+                </span>
+                {mk.threshold !== null && (
+                  <span className="text-ink-500">
+                    threshold{" "}
+                    <span className="font-mono text-ink-700">
+                      {mk.threshold.toFixed(2)}
+                    </span>
+                  </span>
+                )}
+                {neFields.length > 0 && (
+                  <span
+                    className="ml-auto px-2 py-0.5 text-[10px] uppercase tracking-eyebrow rounded border border-violet-300 bg-violet-50 text-violet-800"
+                    title={`Path Y active — ${neFields.length} negative-evidence field${neFields.length === 1 ? "" : "s"} can demote this matchkey when they disagree.`}
+                  >
+                    path Y · {neFields.length} NE
+                  </span>
+                )}
+              </div>
+              <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-ink-600">
+                {mk.fields.map((f, i) => (
+                  <span key={i} className="font-mono">
+                    {f.column ?? "—"}
+                    {f.scorer ? (
+                      <span className="text-ink-400">·{f.scorer}</span>
+                    ) : null}
+                    {f.weight != null ? (
+                      <span className="text-ink-400">·w{f.weight.toFixed(1)}</span>
+                    ) : null}
+                  </span>
+                ))}
+              </div>
+              {neFields.length > 0 && (
+                <details className="mt-2 text-[11px]">
+                  <summary className="cursor-pointer text-violet-700 hover:text-violet-900">
+                    show negative-evidence fields
+                  </summary>
+                  <ul className="mt-1 pl-3 space-y-0.5">
+                    {neFields.map((nf, i) => (
+                      <li key={i} className="font-mono text-ink-600">
+                        {nf.field} · {nf.scorer} · threshold{" "}
+                        {nf.threshold.toFixed(2)} · penalty{" "}
+                        <span className="text-violet-700">
+                          -{nf.penalty.toFixed(2)}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function ScoringStrip({ data }: { data: ControllerTelemetry }) {
+  const cells: { label: string; value: string; hint: string }[] = [];
+  if (data.scoring) {
+    cells.push({
+      label: "pairs",
+      value: numShort(data.scoring.n_pairs_scored),
+      hint: "Pairs that survived blocking and got scored.",
+    });
+    cells.push({
+      label: "above thr",
+      value: pct(data.scoring.mass_above_threshold),
+      hint: "Fraction of scored pairs above the match threshold (high = controller is matching aggressively).",
+    });
+    cells.push({
+      label: "borderline",
+      value: pct(data.scoring.mass_in_borderline),
+      hint: "Fraction in the borderline band — the review queue is sized by this.",
+    });
+  }
+  if (data.blocking) {
+    cells.push({
+      label: "blocks",
+      value: numShort(data.blocking.n_blocks),
+      hint: "Number of blocks the chosen blocking strategy produced.",
+    });
+    cells.push({
+      label: "p99 block",
+      value: numShort(data.blocking.block_sizes_p99),
+      hint: "99th-percentile block size. Large p99 → blocking key is too coarse.",
+    });
+  }
+  if (data.cluster) {
+    cells.push({
+      label: "clusters",
+      value: numShort(data.cluster.n_clusters),
+      hint: "Number of clusters produced (single-record clusters included).",
+    });
+    cells.push({
+      label: "transitivity",
+      value: pct(data.cluster.transitivity_rate),
+      hint: "Fraction of cluster triangles closed — low = clusters are stitched from weak edges.",
+    });
+  }
+  if (data.full_vs_sample_drift !== null) {
+    cells.push({
+      label: "drift",
+      value: data.full_vs_sample_drift.toFixed(2),
+      hint: "L1 distance between sample profile (last iteration) and full-data profile (finalize). High = sample wasn't representative.",
+    });
+  }
+  if (data.elapsed_ms !== null) {
+    cells.push({
+      label: "elapsed",
+      value: `${Math.round(data.elapsed_ms)}ms`,
+      hint: "Wall-clock time the controller spent iterating.",
+    });
+  }
+  if (cells.length === 0) return null;
+  return (
+    <div>
+      <p className="eyebrow mb-2">complexity profile</p>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-x-4 gap-y-2 text-xs">
+        {cells.map((c) => (
+          <div key={c.label} title={c.hint}>
+            <p className="eyebrow text-ink-500">{c.label}</p>
+            <p className="num tabular-nums text-ink-800">{c.value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ColumnPriorsTable({ priors }: { priors: ControllerColumnPrior[] }) {
+  return (
+    <details>
+      <summary className="eyebrow cursor-pointer hover:text-gold-600">
+        indicator column priors · {priors.length}
+      </summary>
+      <p className="mt-1 text-[11px] text-ink-500">
+        Per-column identity / corruption signals computed eagerly by the v1.10
+        indicator pass. Higher identity = good anchor candidate. Higher
+        corruption = consider adding a normalize transform.
+      </p>
+      <div className="mt-2 overflow-auto max-h-48">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-left eyebrow text-ink-500 border-b border-ink-200/60">
+              <th className="py-1 pr-3">column</th>
+              <th className="py-1 pr-3">identity</th>
+              <th className="py-1 pr-3">corruption</th>
+            </tr>
+          </thead>
+          <tbody>
+            {priors.map((p) => (
+              <tr key={p.column} className="border-b border-ink-100/60 last:border-b-0 font-mono tabular-nums">
+                <td className="py-1 pr-3 text-ink-700">{p.column}</td>
+                <td className="py-1 pr-3 text-ink-800">{p.identity_score.toFixed(2)}</td>
+                <td className="py-1 pr-3 text-ink-800">{p.corruption_score.toFixed(2)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}
+
+function DecisionList({ decisions }: { decisions: ControllerDecision[] }) {
+  return (
+    <details>
+      <summary className="eyebrow cursor-pointer hover:text-gold-600">
+        refit decisions · {decisions.length}
+      </summary>
+      <p className="mt-1 text-[11px] text-ink-500">
+        Ordered list of rule firings from the controller's iteration loop. Each
+        rule is the controller's response to a non-green sub-profile.
+      </p>
+      <ol className="mt-2 space-y-1.5 text-xs">
+        {decisions.map((d, i) => (
+          <li key={i} className="card px-3 py-2">
+            <div className="flex flex-wrap items-baseline gap-x-3 text-[11px]">
+              <span className="font-mono text-ink-400">iter {d.iteration}</span>
+              <span className="font-mono text-gold-600">{d.rule_name}</span>
+              <span className="ml-auto text-ink-400 font-mono">
+                {d.wall_clock_ms}ms
+              </span>
+            </div>
+            <p className="mt-1 text-ink-700">{d.rationale}</p>
+            {Object.keys(d.config_diff).length > 0 && (
+              <ul className="mt-1 pl-3 text-[11px] font-mono text-ink-500">
+                {Object.entries(d.config_diff).map(([k, v]) => (
+                  <li key={k}>
+                    <span className="text-ink-700">{k}</span>: {v}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}
+
+function ErrorList({ errors }: { errors: ControllerError[] }) {
+  return (
+    <details open>
+      <summary className="eyebrow text-red-700 cursor-pointer">
+        iteration errors · {errors.length}
+      </summary>
+      <ul className="mt-2 space-y-1 text-xs">
+        {errors.map((e, i) => (
+          <li key={i} className="card px-3 py-2 border-red-300 bg-red-50/40">
+            <div className="text-[11px] font-mono text-red-700">
+              iter {e.iteration} · {e.exception_type}
+            </div>
+            <p className="mt-1 text-ink-700 whitespace-pre-wrap font-mono text-[11px]">
+              {e.traceback_summary}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
+function pct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+function numShort(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function shortTs(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}

--- a/packages/python/goldenmatch/web/frontend/src/lib/api.ts
+++ b/packages/python/goldenmatch/web/frontend/src/lib/api.ts
@@ -254,6 +254,106 @@ export type SettingsResponse = WebSettings & {
   _path: string;
 };
 
+/** AutoConfigController telemetry — mirrors web/controller_telemetry.py. */
+export type ControllerScoringSummary = {
+  n_pairs_scored: number;
+  candidates_compared: number;
+  mass_above_threshold: number;
+  mass_in_borderline: number;
+  dip_statistic: number;
+};
+
+export type ControllerBlockingSummary = {
+  n_blocks: number;
+  reduction_ratio: number;
+  block_sizes_p50: number;
+  block_sizes_p99: number;
+  block_sizes_max: number;
+  oversized_block_count: number;
+  keys_used: string[][];
+};
+
+export type ControllerClusterSummary = {
+  n_clusters: number;
+  cluster_size_p50: number;
+  cluster_size_p99: number;
+  cluster_size_max: number;
+  transitivity_rate: number;
+  oversized_cluster_count: number;
+};
+
+export type ControllerIndicators = {
+  full_pop_matchkey_hit_rate: number | null;
+  cross_blocking_overlap: number | null;
+};
+
+export type ControllerColumnPrior = {
+  column: string;
+  identity_score: number;
+  corruption_score: number;
+};
+
+export type ControllerDecision = {
+  iteration: number;
+  rule_name: string;
+  rationale: string;
+  config_diff: Record<string, string>;
+  wall_clock_ms: number;
+};
+
+export type ControllerError = {
+  iteration: number;
+  exception_type: string;
+  traceback_summary: string;
+};
+
+export type ControllerCommittedMatchkey = {
+  name: string;
+  type: string | null;
+  threshold: number | null;
+  fields: { column: string | null; scorer: string | null; weight: number | null }[];
+  has_negative_evidence: boolean;
+};
+
+export type ControllerNegativeEvidence = {
+  matchkey_name: string;
+  matchkey_type: string | null;
+  field: string;
+  scorer: string;
+  threshold: number;
+  penalty: number;
+  transforms: string[];
+};
+
+export type ControllerTelemetry = {
+  available: boolean;
+  source: "autoconfig" | "run" | null;
+  run_name: string | null;
+  recorded_at: string | null;
+  stop_reason:
+    | "green"
+    | "converged"
+    | "budget_iterations"
+    | "budget_time"
+    | "policy_satisfied"
+    | "policy_no_progress"
+    | "oscillating"
+    | "cancelled"
+    | null;
+  elapsed_ms: number | null;
+  full_vs_sample_drift: number | null;
+  health: "green" | "yellow" | "red" | null;
+  scoring: ControllerScoringSummary | null;
+  blocking: ControllerBlockingSummary | null;
+  cluster: ControllerClusterSummary | null;
+  indicators: ControllerIndicators | null;
+  column_priors: ControllerColumnPrior[];
+  decisions: ControllerDecision[];
+  errors: ControllerError[];
+  committed_matchkeys: ControllerCommittedMatchkey[];
+  negative_evidence: ControllerNegativeEvidence[];
+};
+
 const json = async <T>(resp: Response): Promise<T> => {
   if (!resp.ok) throw new Error(`${resp.status} ${await resp.text()}`);
   return resp.json() as Promise<T>;
@@ -386,6 +486,10 @@ export const api = {
     sample_n: number;
     rules?: RulesPayload;
   }): Promise<SensitivityResponse> => post<SensitivityResponse>("/api/v1/sensitivity", body),
+  controllerTelemetry: (): Promise<ControllerTelemetry> =>
+    fetch("/api/v1/controller/telemetry").then((r) =>
+      json<ControllerTelemetry>(r),
+    ),
   putSettings: (body: WebSettings): Promise<SettingsResponse> =>
     fetch("/api/v1/settings", {
       method: "PUT",

--- a/packages/python/goldenmatch/web/frontend/src/routes/Home.tsx
+++ b/packages/python/goldenmatch/web/frontend/src/routes/Home.tsx
@@ -78,6 +78,8 @@ export function Home() {
 
       {qualityQ.data && <QualityBanner data={qualityQ.data} />}
 
+      <ProvenanceCallout />
+
       <section className="mb-10 card px-5 py-4">
         <div className="flex items-baseline gap-3 mb-2">
           <p className="eyebrow">auto-run</p>
@@ -180,6 +182,59 @@ export function Home() {
         )}
       </section>
     </div>
+  );
+}
+
+/** Surfaces the four reproducible benchmark numbers + a pointer to the
+ *  reproducibility doc (PR #152) and the scale envelope guide (PR #149). The
+ *  benchmarks are the ones the README claims; this is just the receipts. */
+function ProvenanceCallout() {
+  const REPO = "https://github.com/benzsevern/goldenmatch";
+  const benchmarks: { name: string; f1: string; note: string }[] = [
+    { name: "DQbench", f1: "91.04", note: "composite, no LLM" },
+    { name: "DBLP-ACM", f1: "0.9641", note: "auto-config beats hand-tuned" },
+    { name: "Febrl3", f1: "0.9443", note: "synthetic person records" },
+    { name: "NCVR", f1: "0.9719", note: "200k NC voters sample" },
+  ];
+  return (
+    <section className="mb-6 card px-5 py-4">
+      <div className="flex items-baseline gap-3 mb-3">
+        <p className="eyebrow">benchmarks</p>
+        <p className="text-xs text-ink-500">
+          All four numbers reproducible from a fresh clone — see{" "}
+          <a
+            className="underline text-gold-600 hover:text-gold-500"
+            href={`${REPO}/blob/main/docs/reproducing-benchmarks.md`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            reproducing-benchmarks.md
+          </a>
+          .
+        </p>
+      </div>
+      <dl className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {benchmarks.map((b) => (
+          <div key={b.name}>
+            <p className="eyebrow mb-0.5">{b.name}</p>
+            <p className="num text-xl text-ink-800 tabular-nums">{b.f1}</p>
+            <p className="text-[11px] text-ink-500">{b.note}</p>
+          </div>
+        ))}
+      </dl>
+      <p className="mt-3 text-[11px] text-ink-500">
+        Picking a backend?{" "}
+        <a
+          className="underline text-gold-600 hover:text-gold-500"
+          href={`${REPO}/blob/main/docs/scale-envelope.md`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          scale envelope guide
+        </a>
+        {" "}covers Polars (&lt;500K), DuckDB (500K-50M), Ray (≥50M).
+      </p>
+    </section>
   );
 }
 

--- a/packages/python/goldenmatch/web/frontend/src/routes/Workbench.tsx
+++ b/packages/python/goldenmatch/web/frontend/src/routes/Workbench.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { api } from "../lib/api";
 import type { PydanticError, RulesPayload } from "../lib/types";
+import { ControllerPanel } from "../components/ControllerPanel";
 import { RuleEditor } from "../components/RuleEditor";
 import { RunInspector } from "../components/RunInspector";
 import { SplitPane } from "../components/SplitPane";
@@ -80,6 +81,8 @@ export function Workbench() {
       // Server adopted the suggestion as in-memory rules; sync our /rules query
       // so the user sees the canonical form on next refetch.
       qc.setQueryData(["rules"], resp);
+      // Controller telemetry was just refreshed server-side — pull the latest.
+      qc.invalidateQueries({ queryKey: ["controller-telemetry"] });
       setToast(
         `Auto-configured from data.csv — ${resp.matchkeys.length} matchkey${resp.matchkeys.length === 1 ? "" : "s"} suggested. Run preview to see results, or tweak.`,
       );
@@ -104,6 +107,11 @@ export function Workbench() {
       setErrors([]);
       setSavedRunName(resp.run_name);
       qc.invalidateQueries({ queryKey: ["project"] });
+      // Zero-config runs re-fire the controller; refresh telemetry. (User-rule
+      // runs leave AppState telemetry untouched, so this is a cheap no-op.)
+      if (resp.auto_config) {
+        qc.invalidateQueries({ queryKey: ["controller-telemetry"] });
+      }
       setToast(
         `Saved run ${resp.run_name} — ${resp.cluster_count} clusters · ${resp.total_pairs} pairs${resp.llm_boost ? " · LLM boost on" : ""}.`,
       );
@@ -184,6 +192,8 @@ export function Workbench() {
       </div>
 
       <RuleEditor rules={rules} onChange={setRules} errors={errors} />
+
+      <ControllerPanel />
 
       <section className="border-t border-ink-200 pt-5">
         <p className="eyebrow mb-3">preview</p>


### PR DESCRIPTION
## Summary

The web UI shipped in PR #85 and was unchanged through the v1.7-v1.12 controller / indicators / negative-evidence arc. This PR brings the UI up to speed with that work.

- Backend exposes the AutoConfigController's last-run output via `GET /api/v1/controller/telemetry`, populated by `/autoconfig` and `/run?auto_config=true`.
- Workbench renders the new telemetry in a `ControllerPanel`: health verdict, `StopReason`, `ComplexityProfile` sub-profile cells, `IndicatorContext` column priors, full `RunHistory` decision trace, iteration errors, and Path Y negative-evidence on the committed config.
- Home gains a `ProvenanceCallout` showing the four reproducible benchmark numbers (DQbench 91.04 / DBLP-ACM 0.9641 / Febrl3 0.9443 / NCVR 0.9719) plus links to `docs/reproducing-benchmarks.md` (#152) and `docs/scale-envelope.md` (#149).

## What's wired

| Surface | Before | After |
|---|---|---|
| Auto-config trigger | Single button, no feedback after | Same button + StopReason badge + health verdict + decision trace |
| v1.10 indicators | Invisible | Column priors table (identity / corruption scores) |
| v1.11/12 Path Y | Invisible | Per-matchkey ``path Y · N NE`` badge with expandable NE-field list |
| Benchmark provenance | No references | Home callout linking the reproducibility doc |
| Scale envelope | No references | Home callout linking the scale guide |

## Files

- New: ``goldenmatch/web/controller_telemetry.py``, ``goldenmatch/web/routers/controller.py``, ``web/frontend/src/components/ControllerPanel.tsx``, ``tests/web/test_router_controller.py``
- Modified: ``goldenmatch/web/app.py`` (router include), ``goldenmatch/web/state.py`` (telemetry fields), ``goldenmatch/web/routers/{autoconfig,run}.py`` (capture from ``_LAST_CONTROLLER_RUN``), ``web/frontend/src/lib/api.ts`` (types + client), ``web/frontend/src/routes/{Home,Workbench}.tsx``

## Deferred

- Editable NE fields inside ``RuleEditor`` (today: read-only in the controller panel). Full editing needs ``RulesPayload`` schema extension + ``_build_config`` + YAML save-path changes.
- Per-pair "demoted by negative evidence" attribution in ``ClusterDetail`` / ``PairFieldBreakdown`` — needs explainer-side telemetry that isn't wired yet.

## Test plan

- [x] ``pytest tests/web/`` — 108/108 pass (including 2 new in ``test_router_controller.py``)
- [x] ``pnpm build`` — clean (467 KB JS / 27 KB CSS)
- [x] ``pnpm vitest run`` — 12/12 pass
- [ ] Manual: trigger ``/autoconfig`` against ``web/demo/data.csv`` and confirm the ControllerPanel renders decisions, indicators, and health badge
- [ ] Manual: confirm Home ProvenanceCallout links resolve to ``main`` on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)