### PR TITLE
feat(tui): surface AutoConfigController telemetry in a Controller tab

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/tui/app.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/app.py
@@ -11,6 +11,7 @@ from textual.widgets import Footer, Header, TabbedContent, TabPane
 from goldenmatch.tui.sidebar import Sidebar
 from goldenmatch.tui.tabs.boost_tab import BoostTab
 from goldenmatch.tui.tabs.config_tab import ConfigTab
+from goldenmatch.tui.tabs.controller_tab import ControllerTab
 from goldenmatch.tui.tabs.data_tab import DataTab
 from goldenmatch.tui.tabs.export_tab import ExportTab
 from goldenmatch.tui.tabs.golden_tab import GoldenTab
@@ -233,6 +234,7 @@ class GoldenMatchApp(App):
         Binding("f1", "help", "Help"),
         Binding("f2", "save_config", "Save"),
         Binding("f5", "run_sample", "Run"),
+        Binding("ctrl+a", "auto_configure", "Auto"),
         Binding("ctrl+r", "rerun", "Re-run"),
         Binding("ctrl+s", "save_preset", "Preset"),
         Binding("ctrl+e", "quick_export", "Export"),
@@ -243,6 +245,7 @@ class GoldenMatchApp(App):
         Binding("4", "goto_tab_4", "Golden", show=False),
         Binding("5", "goto_tab_5", "Boost", show=False),
         Binding("6", "goto_tab_6", "Export", show=False),
+        Binding("7", "goto_tab_7", "Controller", show=False),
         Binding("q", "quit", "Quit"),
     ]
 
@@ -271,6 +274,8 @@ class GoldenMatchApp(App):
                         yield BoostTab()
                     with TabPane("Export", id="tab-export"):
                         yield ExportTab()
+                    with TabPane("Controller", id="tab-controller"):
+                        yield ControllerTab()
         yield Footer()
 
     def on_mount(self) -> None:
@@ -489,6 +494,71 @@ class GoldenMatchApp(App):
 
     def action_goto_tab_6(self) -> None:
         self._goto_tab("tab-export")
+
+    def action_goto_tab_7(self) -> None:
+        self._goto_tab("tab-controller")
+
+    # ── Auto-configure ────────────────────────────────────────────
+
+    def action_auto_configure(self) -> None:
+        """Run AutoConfigController on the loaded data and adopt the result.
+
+        Mirrors the web workbench's "Auto-configure" button: profiles data,
+        picks a config, captures stop_reason / decisions / indicators / NE,
+        renders them in the Controller tab. Switches focus to the Controller
+        tab so the user sees the telemetry immediately.
+        """
+        if self.engine is None:
+            self.notify("No files loaded.", severity="warning")
+            return
+        self.notify("Running auto-configure…", severity="information")
+        self._run_auto_configure_job()
+
+    @work(thread=True)
+    def _run_auto_configure_job(self) -> None:
+        if self.engine is None:
+            return
+        try:
+            config, telemetry = self.engine.auto_configure()
+            self.call_from_thread(self._on_auto_configure_complete, config, telemetry)
+        except Exception as e:
+            self.call_from_thread(
+                self.notify, f"Auto-configure error: {e}", severity="error"
+            )
+
+    def _on_auto_configure_complete(self, config, telemetry) -> None:
+        """Adopt the controller's committed config + render telemetry."""
+        self.current_config = config
+        # Refresh sidebar config summary.
+        sidebar = self.query_one(Sidebar)
+        sidebar.update_config(config)
+        # Push to the Config tab so the user can tweak from the suggestion.
+        try:
+            config_tab = self.query_one(ConfigTab)
+            if hasattr(config_tab, "set_config"):
+                config_tab.set_config(config)
+        except Exception:
+            # ConfigTab may not have a set_config; non-fatal.
+            pass
+        # Refresh export tab so save-config uses the auto-configured shape.
+        export_tab = self.query_one(ExportTab)
+        export_tab.set_config(config)
+        # Render telemetry and switch to the Controller tab.
+        controller_tab = self.query_one(ControllerTab)
+        controller_tab.update_telemetry(telemetry)
+        self._goto_tab("tab-controller")
+        # Build a one-line status surfacing what the user got.
+        n_decisions = len(getattr(telemetry.history, "entries", []) or [])
+        ne_count = sum(
+            len(getattr(mk, "negative_evidence", None) or [])
+            for mk in config.get_matchkeys()
+        )
+        suffix = f" · {ne_count} NE field{'s' if ne_count != 1 else ''}" if ne_count else ""
+        self.notify(
+            f"Auto-configured · {n_decisions} controller iteration"
+            f"{'s' if n_decisions != 1 else ''}{suffix}.",
+            severity="information",
+        )
 
     # ── Quick export ──────────────────────────────────────────────
 

--- a/packages/python/goldenmatch/goldenmatch/tui/engine.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/engine.py
@@ -6,8 +6,9 @@ No Textual dependency — pure Python + Polars.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import polars as pl
 
@@ -40,6 +41,23 @@ class EngineResult:
     stats: EngineStats
 
 
+@dataclass
+class ControllerTelemetry:
+    """v1.7-v1.12 AutoConfigController output, captured by ``auto_configure``.
+
+    Loosely typed (Any) to dodge import cycles — the consumer
+    (``tabs/controller_tab.py``) uses ``getattr`` on the inner sub-profiles.
+    Populated only when the user actually triggered auto-config from the TUI;
+    None on every cold start and after manual ConfigTab edits.
+    """
+    profile: Any = None          # ComplexityProfile
+    history: Any = None          # RunHistory
+    committed_config: Any = None # GoldenMatchConfig the controller committed
+    source: str = "auto_configure"
+    recorded_at: str | None = None
+    column_priors: dict[str, Any] = field(default_factory=dict)
+
+
 class MatchEngine:
     """Wraps the pipeline into a clean API for the TUI and preview mode."""
 
@@ -48,6 +66,7 @@ class MatchEngine:
         self._data: pl.DataFrame | None = None
         self._profile: dict | None = None
         self._last_result: EngineResult | None = None
+        self._last_telemetry: ControllerTelemetry | None = None
         self._load()
 
     def _load(self) -> None:
@@ -301,6 +320,64 @@ class MatchEngine:
             scored_pairs=all_pairs,
             stats=stats,
         )
+
+    def auto_configure(self, domain: str | None = None) -> tuple[Any, ControllerTelemetry]:
+        """Run AutoConfigController on the loaded data, capture telemetry.
+
+        Returns ``(committed_config, telemetry)``. The committed config is the
+        same shape ``ConfigTab.set_config`` accepts, so callers can apply it
+        directly. ``telemetry`` is stashed on the engine for later inspection
+        by the Controller tab.
+
+        Mirrors the web router's ``_LAST_CONTROLLER_RUN`` capture (see
+        ``web/routers/autoconfig.py``) so we surface the same stop_reason /
+        decisions / NE the workbench shows.
+        """
+        from datetime import UTC, datetime as _dt
+
+        from goldenmatch.config.schemas import DomainConfig
+        from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN, auto_configure_df
+
+        # Profile/extract priors before the controller wipes the ContextVar
+        # state — these come from the eager indicator pass and aren't on
+        # ComplexityProfile.data.column_priors until the controller publishes.
+        domain_cfg = DomainConfig(enabled=True, mode=domain) if domain else None
+        config = auto_configure_df(
+            self._data,
+            allow_remote_assets=False,
+            domain_config=domain_cfg,
+        )
+        ctrl_state = _LAST_CONTROLLER_RUN.get()
+        profile = ctrl_state[0] if ctrl_state else None
+        history = ctrl_state[1] if ctrl_state else None
+
+        # Lift column_priors off DataProfile so the tab can render without
+        # walking the frozen dataclass tree at render time.
+        priors: dict[str, Any] = {}
+        if profile is not None:
+            data_profile = getattr(profile, "data", None)
+            cp = getattr(data_profile, "column_priors", None) or {}
+            for col, p in cp.items():
+                priors[col] = {
+                    "identity_score": float(getattr(p, "identity_score", 0.0)),
+                    "corruption_score": float(getattr(p, "corruption_score", 0.0)),
+                }
+
+        telemetry = ControllerTelemetry(
+            profile=profile,
+            history=history,
+            committed_config=config,
+            source="auto_configure",
+            recorded_at=_dt.now(UTC).isoformat(),
+            column_priors=priors,
+        )
+        self._last_telemetry = telemetry
+        return config, telemetry
+
+    @property
+    def last_telemetry(self) -> ControllerTelemetry | None:
+        """Most recent controller telemetry from ``auto_configure``, if any."""
+        return self._last_telemetry
 
     def run_sample(self, config, sample_size: int = 1000) -> EngineResult:
         """Run the pipeline on a sample of the data."""

--- a/packages/python/goldenmatch/goldenmatch/tui/engine.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/engine.py
@@ -333,10 +333,16 @@ class MatchEngine:
         ``web/routers/autoconfig.py``) so we surface the same stop_reason /
         decisions / NE the workbench shows.
         """
-        from datetime import UTC, datetime as _dt
+        # Lazy imports: ``auto_configure_df`` pulls in the policy + indicator
+        # graph (heavy). Keeping the import here means ``MatchEngine.__init__``
+        # stays cheap for TUI sessions that never trigger Ctrl+A.
+        from datetime import UTC, datetime
 
         from goldenmatch.config.schemas import DomainConfig
-        from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN, auto_configure_df
+        from goldenmatch.core.autoconfig import (
+            _LAST_CONTROLLER_RUN,
+            auto_configure_df,
+        )
 
         # Profile/extract priors before the controller wipes the ContextVar
         # state — these come from the eager indicator pass and aren't on
@@ -368,7 +374,7 @@ class MatchEngine:
             history=history,
             committed_config=config,
             source="auto_configure",
-            recorded_at=_dt.now(UTC).isoformat(),
+            recorded_at=datetime.now(UTC).isoformat(),
             column_priors=priors,
         )
         self._last_telemetry = telemetry

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/controller_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/controller_tab.py
@@ -18,7 +18,6 @@ from textual.widgets import DataTable, Static
 
 from goldenmatch.tui.engine import ControllerTelemetry
 
-
 _HEALTH_COLOR = {
     "green": "#2ecc71",
     "yellow": "#d4a017",

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/controller_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/controller_tab.py
@@ -1,0 +1,330 @@
+"""Controller tab — surfaces AutoConfigController telemetry (v1.7-v1.12).
+
+Mirrors the web UI's ControllerPanel (web/frontend/src/components/
+ControllerPanel.tsx): stop_reason, health verdict, committed matchkeys,
+Path Y negative-evidence indicators, ComplexityProfile sub-profile cells,
+indicator column priors, and the RunHistory decision trace.
+
+Populated when the user runs ``Auto-configure (Ctrl+A)`` from the app.
+Empty until then.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.widgets import DataTable, Static
+
+from goldenmatch.tui.engine import ControllerTelemetry
+
+
+_HEALTH_COLOR = {
+    "green": "#2ecc71",
+    "yellow": "#d4a017",
+    "red": "#e74c3c",
+}
+
+_STOP_REASON_HINTS = {
+    "green": "Iteration produced a GREEN profile.",
+    "converged": "Profile distance to prior iteration fell below epsilon.",
+    "budget_iterations": "Max-iteration budget reached before reaching GREEN.",
+    "budget_time": "Wall-clock budget exhausted.",
+    "policy_satisfied": "Policy returned no refit; current config acceptable on non-green profile.",
+    "policy_no_progress": "Policy proposed identical config twice in a row.",
+    "oscillating": "Same (config, rule) pair repeated within a 4-iteration window.",
+    "cancelled": "Run was cancelled (KeyboardInterrupt).",
+}
+
+
+class ControllerTab(Static):
+    """AutoConfigController telemetry view."""
+
+    DEFAULT_CSS = """
+    ControllerTab {
+        height: 1fr;
+    }
+    #controller-empty {
+        padding: 2 4;
+        color: #8892a0;
+    }
+    #controller-header {
+        padding: 1 2;
+        color: #f0f0f0;
+    }
+    #committed-config {
+        padding: 0 2 1 2;
+        color: #f0f0f0;
+    }
+    #profile-strip {
+        padding: 0 2 1 2;
+        color: #f0f0f0;
+    }
+    .section-title {
+        color: #d4a017;
+        text-style: bold;
+        padding: 1 2 0 2;
+    }
+    #priors-table, #decisions-table {
+        height: auto;
+        max-height: 16;
+        margin: 0 2;
+    }
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._telemetry: ControllerTelemetry | None = None
+
+    def compose(self) -> ComposeResult:
+        with VerticalScroll():
+            yield Static(
+                "[dim]Press [bold #d4a017]Ctrl+A[/] to auto-configure from "
+                "the loaded data. Controller decisions, indicator priors, and "
+                "negative-evidence (Path Y) will appear here.[/dim]",
+                id="controller-empty",
+            )
+            yield Static("", id="controller-header")
+            yield Static("[bold #d4a017]Committed config[/]", classes="section-title")
+            yield Static("", id="committed-config")
+            yield Static("[bold #d4a017]Complexity profile[/]", classes="section-title")
+            yield Static("", id="profile-strip")
+            yield Static(
+                "[bold #d4a017]Indicator column priors[/]",
+                classes="section-title",
+                id="priors-title",
+            )
+            yield DataTable(id="priors-table")
+            yield Static(
+                "[bold #d4a017]Refit decisions[/]",
+                classes="section-title",
+                id="decisions-title",
+            )
+            yield DataTable(id="decisions-table")
+
+    def on_mount(self) -> None:
+        # Hide everything but the placeholder until the user runs auto-config.
+        for wid in ("controller-header", "committed-config", "profile-strip"):
+            self.query_one(f"#{wid}", Static).display = False
+        for wid in ("priors-title", "decisions-title"):
+            self.query_one(f"#{wid}", Static).display = False
+        priors = self.query_one("#priors-table", DataTable)
+        priors.display = False
+        priors.add_columns("Column", "Identity", "Corruption")
+        decisions = self.query_one("#decisions-table", DataTable)
+        decisions.display = False
+        decisions.add_columns("Iter", "Rule", "Rationale", "Wall (ms)")
+
+    def update_telemetry(self, telemetry: ControllerTelemetry | None) -> None:
+        """Render controller telemetry, or show the placeholder when None."""
+        empty = self.query_one("#controller-empty", Static)
+        header = self.query_one("#controller-header", Static)
+        committed = self.query_one("#committed-config", Static)
+        strip = self.query_one("#profile-strip", Static)
+        priors_title = self.query_one("#priors-title", Static)
+        priors_table = self.query_one("#priors-table", DataTable)
+        decisions_title = self.query_one("#decisions-title", Static)
+        decisions_table = self.query_one("#decisions-table", DataTable)
+
+        if telemetry is None:
+            empty.display = True
+            for widget in (header, committed, strip, priors_title, priors_table, decisions_title, decisions_table):
+                widget.display = False
+            return
+
+        self._telemetry = telemetry
+        empty.display = False
+        header.display = True
+        committed.display = True
+        strip.display = True
+
+        header.update(self._render_header(telemetry))
+        committed.update(self._render_committed(telemetry))
+        strip.update(self._render_strip(telemetry))
+
+        # Indicator priors
+        priors_table.clear()
+        if telemetry.column_priors:
+            priors_title.display = True
+            priors_table.display = True
+            for col, p in sorted(
+                telemetry.column_priors.items(),
+                key=lambda kv: (-kv[1]["identity_score"], -kv[1]["corruption_score"]),
+            ):
+                if p["identity_score"] == 0.0 and p["corruption_score"] == 0.0:
+                    continue
+                priors_table.add_row(
+                    col,
+                    f"{p['identity_score']:.2f}",
+                    f"{p['corruption_score']:.2f}",
+                )
+        else:
+            priors_title.display = False
+            priors_table.display = False
+
+        # Decisions
+        decisions = _decisions_list(telemetry.history)
+        decisions_table.clear()
+        if decisions:
+            decisions_title.display = True
+            decisions_table.display = True
+            for d in decisions:
+                decisions_table.add_row(
+                    str(d["iteration"]),
+                    d["rule_name"],
+                    _truncate(d["rationale"], 70),
+                    str(d["wall_clock_ms"]),
+                )
+        else:
+            decisions_title.display = False
+            decisions_table.display = False
+
+    def _render_header(self, t: ControllerTelemetry) -> str:
+        verdict = _health(t.profile)
+        color = _HEALTH_COLOR.get(verdict or "", "#8892a0")
+        stop = _stop_reason(t.history)
+        stop_hint = _STOP_REASON_HINTS.get(stop or "", "")
+        parts = [
+            f"[{color}]health · {verdict or 'unknown'}[/]",
+            f"stop · [bold]{stop.replace('_', ' ') if stop else 'unknown'}[/]",
+        ]
+        elapsed = _elapsed_ms(t.history)
+        if elapsed is not None:
+            parts.append(f"elapsed · [bold]{elapsed:.0f}ms[/]")
+        drift = _drift(t.history)
+        if drift is not None:
+            parts.append(f"drift · [bold]{drift:.2f}[/]")
+        if t.recorded_at:
+            parts.append(f"[dim]at {t.recorded_at[:19]}[/dim]")
+        line = "   ".join(parts)
+        if stop_hint:
+            line += f"\n[dim]{stop_hint}[/dim]"
+        return line
+
+    def _render_committed(self, t: ControllerTelemetry) -> str:
+        cfg = t.committed_config
+        if cfg is None:
+            return "[dim]No committed config available.[/dim]"
+        try:
+            matchkeys = cfg.get_matchkeys()
+        except Exception:
+            return "[dim]Could not read committed config.[/dim]"
+        if not matchkeys:
+            return "[dim]Committed config has no matchkeys.[/dim]"
+
+        lines: list[str] = []
+        for mk in matchkeys:
+            ne = getattr(mk, "negative_evidence", None) or []
+            threshold = mk.threshold if mk.threshold is not None else None
+            thr_str = f" · threshold {threshold:.2f}" if threshold is not None else ""
+            ne_badge = f" · [bold magenta]Path Y · {len(ne)} NE[/]" if ne else ""
+            lines.append(
+                f"  [#d4a017]●[/] [bold]{mk.name}[/] "
+                f"[#8892a0]({mk.type})[/]{thr_str}{ne_badge}"
+            )
+            field_bits = []
+            for f in mk.fields:
+                col = f.column or f.field or "—"
+                scorer_bit = f"·{f.scorer}" if f.scorer else ""
+                weight_bit = f"·w{f.weight:.1f}" if f.weight is not None else ""
+                field_bits.append(f"{col}{scorer_bit}{weight_bit}")
+            if field_bits:
+                lines.append(f"    [dim]{' '.join(field_bits)}[/dim]")
+            for nf in ne:
+                lines.append(
+                    f"    [magenta]NE[/] {nf.field} · {nf.scorer} · "
+                    f"threshold {nf.threshold:.2f} · "
+                    f"penalty [magenta]-{nf.penalty:.2f}[/]"
+                )
+        return "\n".join(lines)
+
+    def _render_strip(self, t: ControllerTelemetry) -> str:
+        if t.profile is None:
+            return "[dim]No profile recorded.[/dim]"
+        scoring = getattr(t.profile, "scoring", None)
+        blocking = getattr(t.profile, "blocking", None)
+        cluster = getattr(t.profile, "cluster", None)
+        cells: list[str] = []
+        if scoring is not None:
+            cells.append(f"pairs [bold]{_num(getattr(scoring, 'n_pairs_scored', 0))}[/]")
+            cells.append(f"above thr [bold]{_pct(getattr(scoring, 'mass_above_threshold', 0))}[/]")
+            cells.append(f"borderline [bold]{_pct(getattr(scoring, 'mass_in_borderline', 0))}[/]")
+        if blocking is not None:
+            cells.append(f"blocks [bold]{_num(getattr(blocking, 'n_blocks', 0))}[/]")
+            cells.append(f"p99 block [bold]{_num(getattr(blocking, 'block_sizes_p99', 0))}[/]")
+        if cluster is not None:
+            cells.append(f"clusters [bold]{_num(getattr(cluster, 'n_clusters', 0))}[/]")
+            cells.append(f"transitivity [bold]{_pct(getattr(cluster, 'transitivity_rate', 0))}[/]")
+        if not cells:
+            return "[dim]Profile sub-profiles were not populated.[/dim]"
+        return "   ".join(cells)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _health(profile: Any) -> str | None:
+    if profile is None:
+        return None
+    try:
+        return profile.health().value
+    except Exception:
+        return None
+
+
+def _stop_reason(history: Any) -> str | None:
+    if history is None:
+        return None
+    sr = getattr(history, "stop_reason", None)
+    return sr.value if sr is not None else None
+
+
+def _elapsed_ms(history: Any) -> float | None:
+    if history is None:
+        return None
+    elapsed = getattr(history, "elapsed", None)
+    if elapsed is None:
+        return None
+    try:
+        return elapsed.total_seconds() * 1000.0
+    except Exception:
+        return None
+
+
+def _drift(history: Any) -> float | None:
+    if history is None:
+        return None
+    d = getattr(history, "full_vs_sample_drift", None)
+    return float(d) if d is not None else None
+
+
+def _decisions_list(history: Any) -> list[dict]:
+    if history is None:
+        return []
+    out: list[dict] = []
+    for entry in getattr(history, "entries", []):
+        if entry.decision is None:
+            continue
+        out.append({
+            "iteration": int(entry.iteration),
+            "rule_name": entry.decision.rule_name,
+            "rationale": entry.decision.rationale,
+            "wall_clock_ms": int(getattr(entry, "wall_clock_ms", 0) or 0),
+        })
+    return out
+
+
+def _truncate(s: str, max_len: int) -> str:
+    return s if len(s) <= max_len else s[: max_len - 1] + "…"
+
+
+def _num(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def _pct(v: float) -> str:
+    return f"{v * 100:.1f}%"

--- a/packages/python/goldenmatch/tests/test_tui.py
+++ b/packages/python/goldenmatch/tests/test_tui.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from goldenmatch.tui.app import GoldenMatchApp
 from goldenmatch.tui.tabs.config_tab import ConfigTab
+from goldenmatch.tui.tabs.controller_tab import ControllerTab
 from goldenmatch.tui.tabs.export_tab import ExportTab
 from goldenmatch.tui.tabs.golden_tab import GoldenTab
 from goldenmatch.tui.tabs.matches_tab import MatchesTab
@@ -30,12 +31,12 @@ class TestTUIApp:
 
     @pytest.mark.asyncio
     async def test_tabs_exist(self, sample_csv):
-        """All six tab panes should be present."""
+        """All seven tab panes should be present (Controller added in v1.13+)."""
         app = GoldenMatchApp(files=[str(sample_csv)])
         async with app.run_test() as pilot:
             await pilot.pause()
             panes = app.query("TabPane")
-            assert len(panes) == 6
+            assert len(panes) == 7
 
     @pytest.mark.asyncio
     async def test_app_launches_without_files(self):
@@ -157,6 +158,56 @@ class TestGoldenTab:
             await pilot.pause()
             table = app.query_one("#golden-table")
             assert table.display is False
+
+
+class TestControllerTab:
+    @pytest.mark.asyncio
+    async def test_controller_tab_renders(self, sample_csv):
+        """Controller tab should render when switched to."""
+        app = GoldenMatchApp(files=[str(sample_csv)])
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tabs = app.query_one(TabbedContent)
+            tabs.active = "tab-controller"
+            await pilot.pause()
+            controller_tab = app.query_one(ControllerTab)
+            assert controller_tab is not None
+
+    @pytest.mark.asyncio
+    async def test_controller_tab_shows_placeholder_initially(self, sample_csv):
+        """Placeholder visible before any auto-configure run."""
+        app = GoldenMatchApp(files=[str(sample_csv)])
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tabs = app.query_one(TabbedContent)
+            tabs.active = "tab-controller"
+            await pilot.pause()
+            empty = app.query_one("#controller-empty")
+            assert empty.display is True
+
+    @pytest.mark.asyncio
+    async def test_controller_tab_renders_after_auto_configure(self, sample_csv):
+        """After auto_configure, telemetry fields should be visible.
+
+        Bypasses the keyboard binding to keep the test deterministic — calls
+        the engine's auto_configure synchronously and pushes the result into
+        the tab, which is what the @work-decorated action does in production
+        once the worker thread completes.
+        """
+        app = GoldenMatchApp(files=[str(sample_csv)])
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Engine is created on mount when files are provided.
+            assert app.engine is not None
+            _config, telemetry = app.engine.auto_configure()
+            controller_tab = app.query_one(ControllerTab)
+            controller_tab.update_telemetry(telemetry)
+            await pilot.pause()
+            # Placeholder hides; header surfaces.
+            empty = app.query_one("#controller-empty")
+            header = app.query_one("#controller-header")
+            assert empty.display is False
+            assert header.display is True
 
 
 class TestExportTab:


### PR DESCRIPTION
## Summary

Companion to #156 — brings the TUI to parity with the web UI on v1.7-v1.12 controller surface area.

The TUI never invoked ``auto_configure_df`` directly; this PR adds a ``MatchEngine.auto_configure()`` entry point, captures the controller's telemetry the same way #156 does on the web side, and renders it in a new ``Controller`` tab.

## What's new in the TUI

- **``Ctrl+A`` Auto-configure** — runs the controller on loaded data, adopts the committed config into ``ConfigTab`` / ``ExportTab``, switches to the Controller tab.
- **Controller tab (7th)**:
  - Header: health verdict (green/yellow/red), ``StopReason`` with one-line hint, elapsed + drift
  - Committed config: matchkeys, threshold, fields, ``Path Y · N NE`` badge per matchkey, expanded NE-field rows when present
  - Complexity profile cells (pairs, above-thr, borderline, blocks, p99 block, clusters, transitivity)
  - Indicator column priors (identity / corruption) DataTable
  - Refit decisions DataTable (iter, rule, rationale, wall-clock ms)
- ``test_tabs_exist`` bumped 6 → 7 per CLAUDE.md guidance.

## Files

- New: ``goldenmatch/tui/tabs/controller_tab.py``
- Modified: ``goldenmatch/tui/engine.py`` (``auto_configure``, ``ControllerTelemetry`` dataclass, ``last_telemetry`` property), ``goldenmatch/tui/app.py`` (new tab + ``Ctrl+A`` binding + ``@work(thread=True)`` worker), ``tests/test_tui.py`` (tab-count bump + 3 new ControllerTab cases)

## Test plan

- [x] ``pytest tests/test_tui.py`` — 21/21 pass (including 3 new)
- [ ] Manual: ``goldenmatch tui <csv>``, press ``Ctrl+A``, confirm Controller tab populates with stop_reason, decisions, priors
- [ ] Manual: with a dataset that produces NE (T2-shape voters), confirm the ``Path Y · N NE`` badge renders and the NE field rows appear under the matchkey

## Notes

- ``MatchEngine`` interface stays back-compat: ``run_sample`` / ``run_full`` unchanged. Auto-configure is opt-in via the new method + keybinding.
- ``_LAST_CONTROLLER_RUN`` ContextVar is the only coupling to the engine internals — same boundary the web routers use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)