### PR TITLE
feat(cli): surface AutoConfigController telemetry; add autoconfig cmd

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/cli/_controller_render.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/_controller_render.py
@@ -1,0 +1,361 @@
+"""Rich rendering of AutoConfigController telemetry for the CLI.
+
+Mirrors the web ControllerPanel and TUI ControllerTab: stop_reason,
+ComplexityProfile health, committed matchkeys with Path Y NE indicator,
+indicator column priors, refit decisions trace.
+
+The two entry points:
+
+- ``capture_controller_state()`` reads ``_LAST_CONTROLLER_RUN`` off the
+  ContextVar and returns ``(profile, history)`` or ``(None, None)``. Call
+  this immediately after ``auto_configure_df`` / ``auto_configure`` /
+  ``run_dedupe(... auto_config=True)`` returns.
+- ``render_controller_panel(...)`` returns a renderable Rich Panel; print
+  it to stderr in your command's success path.
+
+Why stderr: keeps stdout clean for downstream piping (``goldenmatch dedupe
+... | jq``, etc.). Aligns with how the existing ``dedupe`` command
+already routes preview output via ``err_console``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import Group, RenderableType
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+_HEALTH_STYLES = {
+    "green": "bold green",
+    "yellow": "bold yellow",
+    "red": "bold red",
+}
+
+_STOP_REASON_HINTS = {
+    "green": "iteration produced a GREEN profile",
+    "converged": "profile distance to prior iteration fell below epsilon",
+    "budget_iterations": "max-iteration budget reached before GREEN",
+    "budget_time": "wall-clock budget exhausted",
+    "policy_satisfied": "policy left current config in place on non-green profile",
+    "policy_no_progress": "policy proposed identical config twice in a row",
+    "oscillating": "same (config, rule) pair repeated within a 4-iteration window",
+    "cancelled": "cancelled (KeyboardInterrupt)",
+}
+
+
+def capture_controller_state() -> tuple[Any, Any]:
+    """Read controller state off the autoconfig ContextVar.
+
+    Returns ``(profile, history)``; both are ``None`` when the controller
+    didn't run on the current thread (e.g. user passed ``--config``).
+    """
+    try:
+        from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+    except Exception:
+        return None, None
+    state = _LAST_CONTROLLER_RUN.get()
+    if state is None:
+        return None, None
+    return state[0], state[1]
+
+
+def _health_verdict(profile: Any) -> str | None:
+    if profile is None:
+        return None
+    try:
+        return profile.health().value
+    except Exception:
+        return None
+
+
+def _stop_reason(history: Any) -> str | None:
+    if history is None:
+        return None
+    sr = getattr(history, "stop_reason", None)
+    return sr.value if sr is not None else None
+
+
+def _header(profile: Any, history: Any) -> Text:
+    txt = Text()
+    verdict = _health_verdict(profile)
+    if verdict:
+        txt.append(f"health · {verdict}", style=_HEALTH_STYLES.get(verdict, ""))
+    reason = _stop_reason(history)
+    if reason:
+        if txt:
+            txt.append("    ")
+        txt.append(f"stop · {reason.replace('_', ' ')}", style="bold")
+        hint = _STOP_REASON_HINTS.get(reason)
+        if hint:
+            txt.append(f"  ({hint})", style="dim")
+    if history is not None:
+        elapsed = getattr(history, "elapsed", None)
+        if elapsed is not None:
+            try:
+                ms = elapsed.total_seconds() * 1000.0
+                txt.append(f"    elapsed · {ms:.0f}ms", style="dim")
+            except Exception:
+                pass
+        drift = getattr(history, "full_vs_sample_drift", None)
+        if drift is not None:
+            txt.append(f"    drift · {drift:.2f}", style="dim")
+    return txt
+
+
+def _committed_matchkeys(committed_config: Any) -> RenderableType | None:
+    if committed_config is None:
+        return None
+    try:
+        matchkeys = committed_config.get_matchkeys()
+    except Exception:
+        return None
+    if not matchkeys:
+        return None
+    table = Table(
+        show_header=True,
+        header_style="bold cyan",
+        title="committed matchkeys",
+        title_style="bold cyan",
+        title_justify="left",
+        box=None,
+        padding=(0, 1),
+    )
+    table.add_column("name", style="cyan")
+    table.add_column("type")
+    table.add_column("threshold", justify="right")
+    table.add_column("fields", overflow="fold")
+    table.add_column("path Y")
+    for mk in matchkeys:
+        threshold = (
+            f"{mk.threshold:.2f}" if mk.threshold is not None else "—"
+        )
+        fields = ", ".join(
+            f"{f.column or f.field}"
+            + (f"·{f.scorer}" if f.scorer else "")
+            for f in mk.fields
+        )
+        ne = getattr(mk, "negative_evidence", None) or []
+        ne_marker = (
+            Text(f"{len(ne)} NE", style="bold magenta") if ne else Text("—", style="dim")
+        )
+        table.add_row(mk.name, mk.type or "—", threshold, fields, ne_marker)
+    return table
+
+
+def _negative_evidence(committed_config: Any) -> RenderableType | None:
+    if committed_config is None:
+        return None
+    try:
+        matchkeys = committed_config.get_matchkeys()
+    except Exception:
+        return None
+    rows: list[tuple[str, str, str, str, str]] = []
+    for mk in matchkeys:
+        for nf in getattr(mk, "negative_evidence", None) or []:
+            rows.append((
+                mk.name,
+                nf.field,
+                nf.scorer,
+                f"{nf.threshold:.2f}",
+                f"-{nf.penalty:.2f}",
+            ))
+    if not rows:
+        return None
+    table = Table(
+        show_header=True,
+        header_style="bold magenta",
+        title="negative evidence (path Y)",
+        title_style="bold magenta",
+        title_justify="left",
+        box=None,
+        padding=(0, 1),
+    )
+    table.add_column("matchkey")
+    table.add_column("field")
+    table.add_column("scorer")
+    table.add_column("threshold", justify="right")
+    table.add_column("penalty", justify="right", style="magenta")
+    for r in rows:
+        table.add_row(*r)
+    return table
+
+
+def _profile_strip(profile: Any) -> RenderableType | None:
+    if profile is None:
+        return None
+    cells: list[tuple[str, str]] = []
+    scoring = getattr(profile, "scoring", None)
+    if scoring is not None:
+        cells.append(("pairs", _num(getattr(scoring, "n_pairs_scored", 0))))
+        cells.append(("above thr", _pct(getattr(scoring, "mass_above_threshold", 0))))
+        cells.append(("borderline", _pct(getattr(scoring, "mass_in_borderline", 0))))
+    blocking = getattr(profile, "blocking", None)
+    if blocking is not None:
+        cells.append(("blocks", _num(getattr(blocking, "n_blocks", 0))))
+        cells.append(("p99 block", _num(getattr(blocking, "block_sizes_p99", 0))))
+    cluster = getattr(profile, "cluster", None)
+    if cluster is not None:
+        cells.append(("clusters", _num(getattr(cluster, "n_clusters", 0))))
+        cells.append(("transitivity", _pct(getattr(cluster, "transitivity_rate", 0))))
+    if not cells:
+        return None
+    table = Table(
+        show_header=False,
+        title="complexity profile",
+        title_style="bold cyan",
+        title_justify="left",
+        box=None,
+        padding=(0, 1),
+    )
+    table.add_column(style="cyan")
+    table.add_column(style="bold")
+    for label, value in cells:
+        table.add_row(label, value)
+    return table
+
+
+def _decision_trace(history: Any) -> RenderableType | None:
+    if history is None:
+        return None
+    rows: list[tuple[str, str, str, str]] = []
+    for entry in getattr(history, "entries", []):
+        if entry.decision is None:
+            continue
+        rows.append((
+            str(entry.iteration),
+            entry.decision.rule_name,
+            _truncate(entry.decision.rationale, 80),
+            f"{int(getattr(entry, 'wall_clock_ms', 0) or 0)}ms",
+        ))
+    if not rows:
+        return None
+    table = Table(
+        show_header=True,
+        header_style="bold cyan",
+        title="refit decisions",
+        title_style="bold cyan",
+        title_justify="left",
+        box=None,
+        padding=(0, 1),
+    )
+    table.add_column("iter", justify="right")
+    table.add_column("rule")
+    table.add_column("rationale", overflow="fold")
+    table.add_column("wall", justify="right", style="dim")
+    for r in rows:
+        table.add_row(*r)
+    return table
+
+
+def _column_priors(profile: Any) -> RenderableType | None:
+    if profile is None:
+        return None
+    data_profile = getattr(profile, "data", None)
+    priors = getattr(data_profile, "column_priors", None) or {}
+    rows: list[tuple[str, float, float]] = []
+    for col, p in priors.items():
+        identity = float(getattr(p, "identity_score", 0.0))
+        corruption = float(getattr(p, "corruption_score", 0.0))
+        if identity == 0.0 and corruption == 0.0:
+            continue
+        rows.append((col, identity, corruption))
+    if not rows:
+        return None
+    rows.sort(key=lambda r: (-r[1], -r[2]))
+    table = Table(
+        show_header=True,
+        header_style="bold cyan",
+        title="indicator column priors",
+        title_style="bold cyan",
+        title_justify="left",
+        box=None,
+        padding=(0, 1),
+    )
+    table.add_column("column")
+    table.add_column("identity", justify="right")
+    table.add_column("corruption", justify="right")
+    for col, identity, corruption in rows:
+        table.add_row(col, f"{identity:.2f}", f"{corruption:.2f}")
+    return table
+
+
+def render_controller_panel(
+    *,
+    profile: Any,
+    history: Any,
+    committed_config: Any,
+    verbose: bool = False,
+) -> Panel:
+    """Build the Rich Panel rendered by ``dedupe`` / ``match`` / ``autoconfig``.
+
+    Always shows the header + committed matchkeys + NE table (Path Y is
+    headline information). ``verbose`` adds the complexity profile strip,
+    full decision trace, and indicator column priors — useful for debugging
+    auto-config decisions, noisy by default.
+    """
+    parts: list[RenderableType] = []
+    parts.append(_header(profile, history))
+    mks = _committed_matchkeys(committed_config)
+    if mks is not None:
+        parts.append(mks)
+    ne = _negative_evidence(committed_config)
+    if ne is not None:
+        parts.append(ne)
+    if verbose:
+        for renderable in (
+            _profile_strip(profile),
+            _decision_trace(history),
+            _column_priors(profile),
+        ):
+            if renderable is not None:
+                parts.append(renderable)
+    return Panel(
+        Group(*parts),
+        title="[bold yellow]AutoConfig controller[/]",
+        title_align="left",
+        border_style="yellow",
+    )
+
+
+def render_short_status(*, profile: Any, history: Any, committed_config: Any) -> str:
+    """One-line plain-text summary (no Rich markup, no ANSI). For logs."""
+    bits: list[str] = []
+    verdict = _health_verdict(profile)
+    if verdict:
+        bits.append(f"health={verdict}")
+    reason = _stop_reason(history)
+    if reason:
+        bits.append(f"stop={reason}")
+    if history is not None:
+        decisions = [e for e in getattr(history, "entries", []) if e.decision is not None]
+        bits.append(f"iterations={len(decisions)}")
+    if committed_config is not None:
+        try:
+            matchkeys = committed_config.get_matchkeys()
+            ne_count = sum(len(getattr(mk, "negative_evidence", None) or []) for mk in matchkeys)
+            bits.append(f"matchkeys={len(matchkeys)}")
+            if ne_count:
+                bits.append(f"path_y_ne={ne_count}")
+        except Exception:
+            pass
+    return " ".join(bits) or "controller unavailable"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _truncate(s: str, max_len: int) -> str:
+    return s if len(s) <= max_len else s[: max_len - 1] + "…"
+
+
+def _num(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def _pct(v: float) -> str:
+    return f"{v * 100:.1f}%"

--- a/packages/python/goldenmatch/goldenmatch/cli/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/autoconfig.py
@@ -1,0 +1,144 @@
+"""`goldenmatch autoconfig` — run AutoConfigController and report what it picked.
+
+Equivalent of the web UI's "Auto-configure" button and the TUI's Ctrl+A
+binding: profiles the input data, runs the iterative refit loop, and
+prints the committed config + telemetry. Does NOT run the pipeline.
+
+Two modes:
+
+  * Default — prints the committed config as YAML on stdout and the
+    controller telemetry panel on stderr. Pipe stdout to a file to save:
+    ``goldenmatch autoconfig data.csv > goldenmatch.yml``
+  * ``--out PATH`` — writes the YAML to ``PATH`` instead of stdout.
+    Useful when you want both the panel and the file in one run.
+
+The telemetry panel is the same one ``dedupe`` shows after a zero-config
+run, so debugging "why did auto-config decide X?" doesn't require running
+the full pipeline.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+err_console = Console(stderr=True)
+out_console = Console()
+
+
+def autoconfig_cmd(
+    files: list[str] = typer.Argument(
+        ..., help="Input files as path or path:source_name"
+    ),
+    out: str | None = typer.Option(
+        None, "--out", "-o", help="Write committed config to this path instead of stdout."
+    ),
+    domain: str | None = typer.Option(
+        None, "--domain", help="Pin a domain rulebook (electronics, software, …) instead of auto-detecting.",
+    ),
+    show_controller: bool = typer.Option(
+        True,
+        "--show-controller/--hide-controller",
+        help="Render the controller telemetry panel on stderr.",
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Include indicator priors + decision trace in the panel."),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress all stderr output (panel + status messages)."),
+) -> None:
+    """Run auto-configuration on input files and print/write the committed config."""
+    from goldenmatch.cli._controller_render import (
+        capture_controller_state,
+        render_controller_panel,
+        render_short_status,
+    )
+    from goldenmatch.cli.dedupe import _parse_file_source
+
+    parsed = [_parse_file_source(f) for f in files]
+
+    if not quiet:
+        err_console.print(f"[yellow]Auto-configuring from {len(parsed)} file(s)…[/yellow]")
+
+    try:
+        cfg = _run_autoconfig(parsed, domain=domain)
+    except Exception as exc:
+        err_console.print(f"[red]autoconfig failed:[/red] {exc}")
+        raise typer.Exit(code=1)
+
+    profile, history = capture_controller_state()
+
+    # Render telemetry on stderr so stdout stays clean for piping.
+    if show_controller and not quiet:
+        err_console.print(render_controller_panel(
+            profile=profile,
+            history=history,
+            committed_config=cfg,
+            verbose=verbose,
+        ))
+    elif not quiet:
+        # Even with the panel hidden, emit a one-line status so the user
+        # can see in CI logs whether the controller succeeded.
+        err_console.print(render_short_status(
+            profile=profile,
+            history=history,
+            committed_config=cfg,
+        ))
+
+    # Serialize the committed config to YAML and emit on stdout or to --out.
+    yaml_blob = _config_to_yaml(cfg)
+    if out:
+        out_path = Path(out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(yaml_blob, encoding="utf-8")
+        if not quiet:
+            err_console.print(f"[green]Wrote config to[/green] {out_path}")
+    else:
+        # No Rich markup here — stdout is meant to be piped to a YAML file.
+        # The print() bypasses Rich's renderer.
+        print(yaml_blob, end="")
+
+
+def _run_autoconfig(
+    parsed_files: list[tuple[str, str]],
+    *,
+    domain: str | None,
+):
+    """Invoke ``auto_configure`` with optional domain pin.
+
+    ``auto_configure`` (file-based) doesn't accept a domain_config today.
+    When a domain is requested, we round-trip through ``auto_configure_df``
+    to attach a ``DomainConfig`` before the controller starts.
+    """
+    from goldenmatch.core.autoconfig import auto_configure
+    if domain is None:
+        return auto_configure(parsed_files)
+
+    import polars as pl
+
+    from goldenmatch.config.schemas import DomainConfig
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    dfs = []
+    for path, _src in parsed_files:
+        p = Path(path)
+        if p.suffix.lower() in (".xlsx", ".xls"):
+            df = pl.read_excel(p, engine="openpyxl")
+        elif p.suffix.lower() == ".parquet":
+            df = pl.read_parquet(p)
+        else:
+            df = pl.read_csv(p, encoding="utf8-lossy", infer_schema_length=10000, ignore_errors=True)
+        dfs.append(df)
+    combined = pl.concat(dfs, how="diagonal") if len(dfs) > 1 else dfs[0]
+    return auto_configure_df(combined, domain_config=DomainConfig(enabled=True, mode=domain))
+
+
+def _config_to_yaml(cfg) -> str:
+    """Serialize ``GoldenMatchConfig`` to YAML using Pydantic + PyYAML.
+
+    Pydantic's ``model_dump(mode="json")`` gives us the wire shape; PyYAML
+    dumps it with stable key order. ``exclude_none=True`` keeps the output
+    compact — unset fields don't appear.
+    """
+    import yaml
+
+    blob = cfg.model_dump(mode="json", exclude_none=True)
+    return yaml.safe_dump(blob, sort_keys=False, default_flow_style=False)

--- a/packages/python/goldenmatch/goldenmatch/cli/dedupe.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/dedupe.py
@@ -98,10 +98,20 @@ def dedupe_cmd(
     llm_provider: str | None = typer.Option(None, "--llm-provider", help="LLM provider: auto, anthropic, or openai"),
     llm_max_labels: int = typer.Option(500, "--llm-max-labels", help="Max pairs to label with LLM"),
     backend: str | None = typer.Option(None, "--backend", help="Processing backend: default, ray, duckdb"),
+    show_controller: bool = typer.Option(
+        True,
+        "--show-controller/--hide-controller",
+        help="Render AutoConfigController telemetry (stop_reason, decisions, Path Y) when auto-config ran. No-op for runs with an explicit --config.",
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress output"),
 ) -> None:
     """Run deduplication on one or more input files."""
+    # Telemetry captured if/when auto_configure runs in this command. Stays
+    # None on the explicit-config path; the panel is suppressed in that case.
+    _ctrl_profile: object = None
+    _ctrl_history: object = None
+    _ctrl_committed_config: object = None
     # Parse file:source pairs
     parsed_files = [_parse_file_source(f) for f in files]
 
@@ -129,10 +139,15 @@ def dedupe_cmd(
         if not project or "matchkeys" not in (project or {}):
             # Auto-configure from input files
             try:
+                from goldenmatch.cli._controller_render import capture_controller_state
                 from goldenmatch.core.autoconfig import auto_configure
                 if not quiet:
                     console.print("[yellow]No config file - auto-detecting column types...[/yellow]")
                 cfg = auto_configure(parsed_files)
+                # Pull controller telemetry off the ContextVar set by
+                # auto_configure_df. None on legacy paths that bypass it.
+                _ctrl_profile, _ctrl_history = capture_controller_state()
+                _ctrl_committed_config = cfg
                 if not quiet:
                     console.print("[green]Auto-config complete. Launching TUI for review...[/green]")
             except Exception as exc:
@@ -253,6 +268,23 @@ def dedupe_cmd(
         if not quiet:
             console.print(f"[red]Runtime error:[/red] {exc}")
         raise typer.Exit(code=3)
+
+    # Show AutoConfigController telemetry before the report. We only render
+    # when the controller actually ran in this command (i.e., auto-config
+    # path) — explicit --config skips this entirely.
+    if (
+        show_controller
+        and not quiet
+        and _ctrl_history is not None
+        and _ctrl_committed_config is not None
+    ):
+        from goldenmatch.cli._controller_render import render_controller_panel
+        err_console.print(render_controller_panel(
+            profile=_ctrl_profile,
+            history=_ctrl_history,
+            committed_config=_ctrl_committed_config,
+            verbose=verbose,
+        ))
 
     # Print report
     if not quiet and results.get("report"):

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -12,6 +12,7 @@ from rich.table import Table
 
 from goldenmatch import __version__
 from goldenmatch.cli.agent_serve import agent_serve_cmd
+from goldenmatch.cli.autoconfig import autoconfig_cmd
 from goldenmatch.cli.compare import compare_clusters_cmd
 from goldenmatch.cli.dedupe import dedupe_cmd
 from goldenmatch.cli.demo import demo_cmd
@@ -93,6 +94,7 @@ app = typer.Typer(
     callback=_callback,
 )
 
+app.command("autoconfig", help="Run AutoConfigController on input files; print the committed config + telemetry without running the pipeline.")(autoconfig_cmd)
 app.command("dedupe", help="Run deduplication on one or more files.")(dedupe_cmd)
 app.command("match", help="Match a target file against reference files.")(match_cmd)
 app.command("sync", help="Sync database table, match new records against existing.")(sync_cmd)

--- a/packages/python/goldenmatch/tests/test_cli_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_cli_autoconfig.py
@@ -1,0 +1,102 @@
+"""Tests for the `goldenmatch autoconfig` CLI command + controller panel
+rendering used by `dedupe`'s zero-config path.
+
+The CLI's stderr is the controller panel + status messages; stdout is the
+serialized config (intended for ``> goldenmatch.yml``). Both are asserted
+separately.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+from goldenmatch.cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def cli_csv(tmp_path: Path) -> Path:
+    """A small but non-trivial CSV: 3 columns with clear identity / fuzz signals.
+
+    The first_name column has within-record case noise (corruption signal),
+    email is a clean identity anchor, last_name has typo-driven variants.
+    """
+    path = tmp_path / "data.csv"
+    pl.DataFrame({
+        "first_name": ["John", "john", "Jane", "JOHN", "Bob", "Robert"],
+        "last_name": ["Smith", "Smith", "Doe", "Smyth", "Jones", "Brown"],
+        "email": [
+            "john@ex.com", "john@ex.com", "jane@t.com",
+            "john@ex.com", "bob@t.com", "robert@t.com",
+        ],
+    }).write_csv(path)
+    return path
+
+
+def test_autoconfig_emits_yaml_on_stdout(cli_csv: Path):
+    """Zero options → committed config goes to stdout, ready to pipe to a file."""
+    result = runner.invoke(app, ["autoconfig", str(cli_csv), "--quiet"])
+    assert result.exit_code == 0, result.stderr
+    # Stdout is the YAML body — must look like a goldenmatch config.
+    assert "matchkeys:" in result.stdout
+    # Real config has at least one matchkey with a real name and type.
+    assert "name:" in result.stdout
+    # No Rich markup on stdout (we use bare print(), not console).
+    assert "[bold" not in result.stdout
+
+
+def test_autoconfig_panel_renders_on_stderr(cli_csv: Path):
+    """Non-quiet mode prints the controller panel to stderr."""
+    result = runner.invoke(app, ["autoconfig", str(cli_csv)])
+    assert result.exit_code == 0, result.stderr
+    # Panel title is "AutoConfig controller"; stop_reason line surfaces a
+    # health verdict. Don't assert the specific verdict — auto-config on
+    # 6 rows can legitimately end up YELLOW or RED.
+    assert "AutoConfig controller" in result.stderr
+    assert "stop ·" in result.stderr
+    assert "health ·" in result.stderr
+
+
+def test_autoconfig_out_flag_writes_file_and_suppresses_stdout(
+    cli_csv: Path, tmp_path: Path,
+):
+    """``--out`` writes the YAML to a file and stdout stays empty."""
+    out_path = tmp_path / "out.yml"
+    result = runner.invoke(app, [
+        "autoconfig", str(cli_csv), "--out", str(out_path), "--quiet",
+    ])
+    assert result.exit_code == 0, result.stderr
+    assert out_path.exists()
+    body = out_path.read_text(encoding="utf-8")
+    assert "matchkeys:" in body
+    # ``--out`` short-circuits the stdout YAML dump. (Some library deps
+    # print incidental messages to stdout — assert the YAML body isn't
+    # there rather than insisting on empty.)
+    assert "matchkeys:" not in result.stdout
+
+
+def test_autoconfig_hide_controller_silences_panel(cli_csv: Path):
+    """``--hide-controller`` swaps the panel for a one-line status."""
+    result = runner.invoke(app, [
+        "autoconfig", str(cli_csv), "--hide-controller",
+    ])
+    assert result.exit_code == 0, result.stderr
+    assert "AutoConfig controller" not in result.stderr
+    # The short-status line uses ``health=...`` / ``stop=...`` format.
+    assert "health=" in result.stderr
+    assert "stop=" in result.stderr
+
+
+def test_autoconfig_verbose_includes_decisions(cli_csv: Path):
+    """``--verbose`` adds the refit decisions table to the panel."""
+    result = runner.invoke(app, ["autoconfig", str(cli_csv), "--verbose"])
+    assert result.exit_code == 0, result.stderr
+    # On a 6-row dataset the controller may or may not refit, so don't
+    # assert the table content — just confirm the verbose-only header
+    # appears at all when there's any decision to render. (Smoke test;
+    # if the harness ever stops emitting decisions on this fixture, this
+    # test should be updated rather than masking the regression.)
+    assert "complexity profile" in result.stderr or "indicator column priors" in result.stderr


### PR DESCRIPTION
## Summary

Third companion to #156 (web) and #157 (TUI). CLI was the last surface where v1.7-v1.12 controller output was invisible.

## What's new

- ``goldenmatch autoconfig <files>`` — new subcommand. Runs controller, prints committed config to stdout (pipe to ``> goldenmatch.yml``), telemetry panel to stderr. No pipeline run. ``--out PATH``, ``--domain``, ``--verbose``, ``--hide-controller``.
- ``goldenmatch dedupe`` zero-config path captures ``_LAST_CONTROLLER_RUN`` and renders the panel before the cluster report. ``--show-controller / --hide-controller`` toggle.
- New ``goldenmatch/cli/_controller_render.py`` shared helper: ``capture_controller_state()``, ``render_controller_panel()`` (Rich Panel with health badge, stop_reason hint, committed matchkeys, Path Y NE table), ``render_short_status()``.

## What's NOT touched

``goldenmatch match`` requires explicit ``--config`` — no controller code path. ``incremental`` / ``pprl`` / ``evaluate`` same or out of scope.

## Files

- New: ``cli/_controller_render.py``, ``cli/autoconfig.py``, ``tests/test_cli_autoconfig.py``
- Modified: ``cli/dedupe.py``, ``cli/main.py``

## Test plan

- [x] ``pytest tests/test_cli_autoconfig.py`` — 5/5 pass
- [x] ``pytest tests/test_cli_dedupe.py tests/test_cli_match.py`` — 15/15 still pass
- [x] ``ruff check`` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)