### PR TITLE
feat(extensions): SQL surface for AutoConfigController telemetry + full-config dedupe

### DIFF
--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -4,10 +4,101 @@
 //! and returns the result as Rust types.
 
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyAnyMethods, PyDict};
 
 use crate::convert;
 use crate::error::BridgeError;
+
+/// Best-effort serialisation of an AutoConfigController `(profile, history,
+/// committed_config)` triple into the JSON shape consumed by the SQL layer.
+///
+/// Reuses `goldenmatch.web.controller_telemetry.serialize_telemetry` so the
+/// shape is identical to what the FastAPI server returns at
+/// `/api/v1/controller/telemetry`. That module is part of the optional `web`
+/// extra; if it isn't importable we fall back to a hand-rolled minimal blob
+/// so the SQL surface never crashes on environments that didn't install
+/// `goldenmatch[web]`.
+fn serialize_controller_telemetry<'py>(
+    py: Python<'py>,
+    profile: Bound<'py, PyAny>,
+    history: Bound<'py, PyAny>,
+    committed_config: Bound<'py, PyAny>,
+    source: &str,
+) -> Result<String, BridgeError> {
+    let json_mod = py.import("json")?;
+
+    // Try the web helper first — it's the source of truth for telemetry shape.
+    if let Ok(helper_mod) = py.import("goldenmatch.web.controller_telemetry") {
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("profile", profile)?;
+        kwargs.set_item("history", history)?;
+        kwargs.set_item("committed_config", committed_config)?;
+        kwargs.set_item("source", source)?;
+        kwargs.set_item("run_name", py.None())?;
+        kwargs.set_item("recorded_at", py.None())?;
+        let blob = helper_mod.call_method("serialize_telemetry", (), Some(&kwargs))?;
+        let json_str: String = json_mod.call_method1("dumps", (blob,))?.extract()?;
+        return Ok(json_str);
+    }
+
+    // Fallback: minimal hand-rolled telemetry surfacing stop_reason + health.
+    // Keeps the SQL contract usable when goldenmatch[web] isn't installed.
+    let minimal = PyDict::new(py);
+    minimal.set_item("available", !profile.is_none() || !history.is_none())?;
+    minimal.set_item("source", source)?;
+    if !history.is_none() {
+        if let Ok(sr) = history.getattr("stop_reason") {
+            if !sr.is_none() {
+                let value: String = sr.getattr("value")?.extract()?;
+                minimal.set_item("stop_reason", value)?;
+            }
+        }
+    }
+    if !profile.is_none() {
+        if let Ok(verdict) = profile.call_method0("health") {
+            let value: String = verdict.getattr("value")?.extract()?;
+            minimal.set_item("health", value)?;
+        }
+    }
+    let json_str: String = json_mod.call_method1("dumps", (minimal,))?.extract()?;
+    Ok(json_str)
+}
+
+/// Capture `_LAST_CONTROLLER_RUN` ContextVar and serialise it. Returns `None`
+/// when the controller didn't run in the current call (e.g. an explicit
+/// config was passed to `dedupe_df`).
+fn capture_controller_telemetry<'py>(
+    py: Python<'py>,
+    committed_config: Bound<'py, PyAny>,
+    source: &str,
+) -> Result<Option<String>, BridgeError> {
+    let autoconfig_mod = py.import("goldenmatch.core.autoconfig")?;
+    let ctx_var = autoconfig_mod.getattr("_LAST_CONTROLLER_RUN")?;
+    let state = ctx_var.call_method0("get")?;
+    if state.is_none() {
+        return Ok(None);
+    }
+    let profile = state.get_item(0)?;
+    let history = state.get_item(1)?;
+    let json = serialize_controller_telemetry(py, profile, history, committed_config, source)?;
+    Ok(Some(json))
+}
+
+/// Convert a JSON-serialised `GoldenMatchConfig` into the corresponding
+/// Python object via `GoldenMatchConfig.model_validate_json(...)`.
+///
+/// Accepts the full Pydantic shape (multiple matchkeys, `negative_evidence`,
+/// `blocking`, `standardization`, `golden_rules`, ...) instead of the slim
+/// `exact/fuzzy/blocking/threshold` kwargs the older `dedupe()` accepts.
+fn build_full_config<'py>(
+    py: Python<'py>,
+    config_json: &str,
+) -> Result<Bound<'py, PyAny>, BridgeError> {
+    let schemas_mod = py.import("goldenmatch.config.schemas")?;
+    let gm_config_cls = schemas_mod.getattr("GoldenMatchConfig")?;
+    let cfg = gm_config_cls.call_method1("model_validate_json", (config_json,))?;
+    Ok(cfg)
+}
 
 /// Result of a dedupe operation, returned as JSON strings for the extension
 /// layer to parse and convert to SQL tuples.
@@ -18,6 +109,26 @@ pub struct DedupeResult {
     pub clusters_json: String,
     /// Stats as JSON object
     pub stats_json: String,
+    /// AutoConfigController telemetry (stop_reason, decisions, health verdict,
+    /// committed NE fields). ``None`` when an explicit config was supplied
+    /// and the controller never ran on this call. Shape mirrors the web
+    /// ``/api/v1/controller/telemetry`` endpoint so callers can reuse the
+    /// same parsers.
+    pub telemetry_json: Option<String>,
+}
+
+/// Result of `autoconfig()`: the committed config + controller telemetry.
+///
+/// Mirrors `goldenmatch autoconfig` CLI: stdout-equivalent is the YAML/JSON
+/// config; stderr-equivalent is the telemetry blob.
+pub struct AutoConfigResult {
+    /// Committed `GoldenMatchConfig` serialised as JSON (Pydantic model_dump).
+    /// Suitable to round-trip back into `dedupe_full()` or stored on a Postgres
+    /// `_jobs` row / DuckDB pipeline state.
+    pub config_json: String,
+    /// Controller telemetry — same shape as `DedupeResult.telemetry_json`.
+    /// Always populated (the controller always runs); never `None`.
+    pub telemetry_json: String,
 }
 
 /// A scored pair from deduplication.
@@ -120,10 +231,131 @@ pub fn dedupe(rows_json: &str, config_json: &str) -> Result<DedupeResult, Bridge
             }
         };
 
+        // If the slim-kwargs path ended up triggering auto-config (i.e. the
+        // caller didn't pass enough kwargs to bypass it), `_LAST_CONTROLLER_RUN`
+        // will be populated. Pull the committed config off `result.config`
+        // for the NE section of the telemetry blob.
+        let committed_cfg = result
+            .getattr("config")
+            .ok()
+            .filter(|c| !c.is_none())
+            .unwrap_or_else(|| py.None().into_bound(py));
+        let telemetry_json =
+            capture_controller_telemetry(py, committed_cfg, "dedupe").unwrap_or(None);
+
         Ok(DedupeResult {
             golden_json,
             clusters_json,
             stats_json,
+            telemetry_json,
+        })
+    })
+}
+
+/// Deduplicate a table's data with a *full* `GoldenMatchConfig` JSON.
+///
+/// Unlike `dedupe()`, which only forwards `exact`/`fuzzy`/`blocking`/`threshold`
+/// kwargs, this accepts the full Pydantic config shape — including
+/// `negative_evidence` (Path Y), per-matchkey `comparison`/`scorer`/`weight`,
+/// `standardization` rules, `golden_rules`, etc. Use this when the SQL caller
+/// wants to express anything that doesn't fit the slim shape.
+pub fn dedupe_full(rows_json: &str, config_json: &str) -> Result<DedupeResult, BridgeError> {
+    crate::init()?;
+
+    Python::with_gil(|py| {
+        let gm = py.import("goldenmatch")?;
+        let json_mod = py.import("json")?;
+
+        let df = convert::json_to_polars_df(py, rows_json)?;
+        let cfg = build_full_config(py, config_json)?;
+
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("config", cfg)?;
+        let result = gm.call_method("dedupe_df", (df,), Some(&kwargs))?;
+
+        let golden_json = if let Ok(golden) = result.getattr("golden") {
+            if !golden.is_none() {
+                Some(convert::polars_df_to_json(
+                    py,
+                    &golden.into_pyobject(py).unwrap().unbind(),
+                )?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let stats = result.getattr("stats")?;
+        let stats_json: String = json_mod.call_method1("dumps", (stats,))?.extract()?;
+
+        let clusters = result.getattr("clusters")?;
+        let clusters_json: String = {
+            let str_repr: String = clusters.call_method0("__str__")?.extract()?;
+            match json_mod.call_method1("dumps", (clusters,)) {
+                Ok(j) => j.extract()?,
+                Err(_) => str_repr,
+            }
+        };
+
+        // dedupe_full passes its own config in, so re-use it for NE display.
+        // Re-fetch from result.config in case the engine swapped in an
+        // augmented copy (e.g. policy refit applied at the controller layer).
+        let committed_cfg = result
+            .getattr("config")
+            .ok()
+            .filter(|c| !c.is_none())
+            .unwrap_or_else(|| py.None().into_bound(py));
+        let telemetry_json =
+            capture_controller_telemetry(py, committed_cfg, "dedupe_full").unwrap_or(None);
+
+        Ok(DedupeResult {
+            golden_json,
+            clusters_json,
+            stats_json,
+            telemetry_json,
+        })
+    })
+}
+
+/// Run AutoConfigController on the input rows and return the committed config
+/// plus telemetry. Does NOT run the dedupe pipeline.
+///
+/// SQL-surface equivalent of the CLI `goldenmatch autoconfig <files>`.
+/// Callers typically pipe the returned `config_json` into a follow-up
+/// `dedupe_full()` call, or store it on a Postgres `_jobs` row.
+pub fn autoconfig(rows_json: &str) -> Result<AutoConfigResult, BridgeError> {
+    crate::init()?;
+
+    Python::with_gil(|py| {
+        let df = convert::json_to_polars_df(py, rows_json)?;
+        let autoconfig_mod = py.import("goldenmatch.core.autoconfig")?;
+        let cfg = autoconfig_mod.call_method1("auto_configure_df", (df,))?;
+
+        // Read controller telemetry off the ContextVar set by auto_configure_df.
+        let ctx_var = autoconfig_mod.getattr("_LAST_CONTROLLER_RUN")?;
+        let state = ctx_var.call_method0("get")?;
+        let telemetry_json = if state.is_none() {
+            // Defensive: every modern auto_configure_df path sets this.
+            "{\"available\": false, \"source\": \"autoconfig\"}".to_string()
+        } else {
+            let profile = state.get_item(0)?;
+            let history = state.get_item(1)?;
+            serialize_controller_telemetry(py, profile, history, cfg.clone(), "autoconfig")?
+        };
+
+        // Dump the committed config to JSON via Pydantic. `model_dump(mode="json",
+        // exclude_none=True)` matches what the CLI `autoconfig` writes to disk.
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("mode", "json")?;
+        kwargs.set_item("exclude_none", true)?;
+        let cfg_dict = cfg.call_method("model_dump", (), Some(&kwargs))?;
+        let json_mod = py.import("json")?;
+        let config_json: String = json_mod.call_method1("dumps", (cfg_dict,))?.extract()?;
+
+        Ok(AutoConfigResult {
+            config_json,
+            telemetry_json,
         })
     })
 }

--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
@@ -86,6 +86,28 @@ def register(con: duckdb.DuckDBPyConnection) -> None:
         ["VARCHAR"], "VARCHAR",
     )
 
+    # AutoConfig + telemetry (v1.7-v1.12 surface)
+    con.create_function(
+        "goldenmatch_autoconfig",
+        lambda table_name: _autoconfig_table(con, table_name),
+        ["VARCHAR"], "VARCHAR",
+    )
+    con.create_function(
+        "goldenmatch_autoconfig_telemetry",
+        lambda table_name: _autoconfig_telemetry_table(con, table_name),
+        ["VARCHAR"], "VARCHAR",
+    )
+    con.create_function(
+        "goldenmatch_dedupe_full",
+        lambda table_name, config_json: _dedupe_full_table(con, table_name, config_json),
+        ["VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+    con.create_function(
+        "gm_telemetry",
+        lambda name: _gm_telemetry(con, name),
+        ["VARCHAR"], "VARCHAR",
+    )
+
 
 # ── Implementation ──────────────────────────────────────────────────────
 
@@ -236,6 +258,10 @@ def _gm_run(con: duckdb.DuckDBPyConnection, job_name: str, table_name: str) -> s
     else:
         job["golden"] = []
 
+    # Capture controller telemetry (v1.7-v1.12). Stays None when the caller
+    # supplied an explicit config and dedupe_df bypassed auto-config.
+    job["telemetry"] = _capture_telemetry(getattr(result, "config", None))
+
     job["status"] = "completed"
     return json.dumps(result.stats)
 
@@ -262,6 +288,128 @@ def _gm_drop(con: duckdb.DuckDBPyConnection, job_name: str) -> str:
     if job_name in state["jobs"]:
         del state["jobs"][job_name]
     return f"Job '{job_name}' dropped"
+
+
+def _gm_telemetry(con: duckdb.DuckDBPyConnection, job_name: str) -> str:
+    """Return the most-recent run's controller telemetry for a job.
+
+    Returns the unavailable sentinel when the job hasn't run, used an
+    explicit config (controller never fired), or was created on an older
+    install that didn't capture telemetry.
+    """
+    state = _get_state(con)
+    if job_name not in state["jobs"]:
+        return json.dumps({"available": False, "error": f"Job '{job_name}' not found"})
+    telemetry = state["jobs"][job_name].get("telemetry")
+    if telemetry is None:
+        return json.dumps({"available": False})
+    return telemetry
+
+
+# ── AutoConfig + telemetry (v1.7-v1.12) ──────────────────────────────────
+
+
+def _autoconfig_table(con: duckdb.DuckDBPyConnection, table_name: str) -> str:
+    """Run AutoConfigController on a DuckDB table; return committed config JSON."""
+    cfg = _run_autoconfig(con, table_name)
+    return json.dumps(cfg.model_dump(mode="json", exclude_none=True))
+
+
+def _autoconfig_telemetry_table(
+    con: duckdb.DuckDBPyConnection, table_name: str,
+) -> str:
+    """Run AutoConfigController and return the telemetry JSON.
+
+    Re-runs the controller. For a single-shot autoconfig+telemetry flow,
+    call ``goldenmatch_autoconfig`` once, store the result, and use the
+    paired telemetry from the same call site in Python — but the SQL
+    surface is two functions because DuckDB UDFs can only return scalars.
+    """
+    from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+    cfg = _run_autoconfig(con, table_name)
+    state = _LAST_CONTROLLER_RUN.get()
+    if state is None:
+        return json.dumps({"available": False, "source": "autoconfig"})
+    profile, history = state
+    return _serialize_telemetry(profile, history, cfg, source="autoconfig")
+
+
+def _dedupe_full_table(
+    con: duckdb.DuckDBPyConnection, table_name: str, config_json: str,
+) -> str:
+    """Deduplicate using a full GoldenMatchConfig JSON (supports NE / Path Y)."""
+    from goldenmatch import dedupe_df
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    _validate_table_name(table_name)
+    cursor = con.cursor()
+    df = cursor.sql(f"SELECT * FROM {table_name}").pl()
+    cursor.close()
+
+    cfg = GoldenMatchConfig.model_validate_json(config_json)
+    result = dedupe_df(df, config=cfg)
+    if result.golden is not None:
+        return result.golden.write_json()
+    return json.dumps(result.stats)
+
+
+def _run_autoconfig(con: duckdb.DuckDBPyConnection, table_name: str):
+    """Shared helper: read table, run auto_configure_df, return the config."""
+    from goldenmatch.core.autoconfig import auto_configure_df
+    _validate_table_name(table_name)
+    cursor = con.cursor()
+    df = cursor.sql(f"SELECT * FROM {table_name}").pl()
+    cursor.close()
+    return auto_configure_df(df)
+
+
+def _capture_telemetry(committed_config) -> Optional[str]:
+    """Read the AutoConfigController ContextVar and serialise to JSON.
+
+    Returns ``None`` when the controller didn't run on the current thread
+    (the typical signal that the caller passed an explicit config).
+    """
+    try:
+        from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+        state = _LAST_CONTROLLER_RUN.get()
+    except Exception:
+        return None
+    if state is None:
+        return None
+    profile, history = state
+    return _serialize_telemetry(profile, history, committed_config, source="gm_run")
+
+
+def _serialize_telemetry(profile, history, committed_config, *, source: str) -> str:
+    """Delegate to ``goldenmatch.web.controller_telemetry`` when available.
+
+    Falls back to a minimal hand-rolled JSON when the ``[web]`` extra isn't
+    installed so the SQL contract still resolves to something parseable.
+    """
+    try:
+        from goldenmatch.web.controller_telemetry import serialize_telemetry
+        return json.dumps(serialize_telemetry(
+            profile=profile,
+            history=history,
+            committed_config=committed_config,
+            source=source,
+            run_name=None,
+            recorded_at=None,
+        ))
+    except Exception:
+        # Minimal fallback — surface at least stop_reason + health.
+        out: dict = {"available": profile is not None or history is not None, "source": source}
+        try:
+            if history is not None and getattr(history, "stop_reason", None) is not None:
+                out["stop_reason"] = history.stop_reason.value
+        except Exception:
+            pass
+        try:
+            if profile is not None:
+                out["health"] = profile.health().value
+        except Exception:
+            pass
+        return json.dumps(out)
 
 
 # Global pipeline state (shared across all UDF calls)

--- a/packages/rust/extensions/duckdb/tests/test_autoconfig_telemetry.py
+++ b/packages/rust/extensions/duckdb/tests/test_autoconfig_telemetry.py
@@ -1,0 +1,108 @@
+"""Tests for the v1.7-v1.12 AutoConfig + telemetry surface.
+
+Covers the four new UDFs registered by ``goldenmatch_duckdb.functions.register``:
+
+  - ``goldenmatch_autoconfig(table)`` returns committed config JSON
+  - ``goldenmatch_autoconfig_telemetry(table)`` returns telemetry JSON
+  - ``goldenmatch_dedupe_full(table, config_json)`` runs the full pipeline
+    with a `GoldenMatchConfig` JSON (supports `negative_evidence`)
+  - ``gm_telemetry(job)`` returns the last `gm_run` telemetry for a job
+
+These mirror the Postgres `goldenmatch_*` / `gm_*` functions and the
+CLI's `goldenmatch autoconfig` subcommand.
+"""
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pytest
+
+from goldenmatch_duckdb.functions import register
+
+
+@pytest.fixture
+def con():
+    c = duckdb.connect()
+    register(c)
+    # Small but non-trivial fixture: clear identity column (email), within-
+    # column case noise (first_name), typo variants (last_name).
+    c.sql("""
+        CREATE TABLE contacts AS
+        SELECT * FROM (VALUES
+            ('John', 'Smith', 'john@ex.com'),
+            ('john', 'Smith', 'john@ex.com'),
+            ('JOHN', 'Smyth', 'john@ex.com'),
+            ('Jane', 'Doe', 'jane@t.com'),
+            ('Bob', 'Jones', 'bob@t.com'),
+            ('Robert', 'Brown', 'robert@t.com')
+        ) AS t(first_name, last_name, email)
+    """)
+    return c
+
+
+class TestAutoconfig:
+    def test_returns_committed_config_json(self, con):
+        """``goldenmatch_autoconfig`` returns a parseable JSON config."""
+        result = con.sql("SELECT goldenmatch_autoconfig('contacts')").fetchone()[0]
+        assert isinstance(result, str)
+        config = json.loads(result)
+        # Real config has matchkeys (could be `match_settings.matchkeys` or
+        # top-level `matchkeys` depending on schema version — accept either).
+        has_matchkeys = (
+            "matchkeys" in config
+            or ("match_settings" in config and "matchkeys" in (config["match_settings"] or {}))
+        )
+        assert has_matchkeys, f"no matchkeys in committed config: {config}"
+
+    def test_telemetry_surfaces_stop_reason(self, con):
+        """``goldenmatch_autoconfig_telemetry`` includes a StopReason value."""
+        result = con.sql(
+            "SELECT goldenmatch_autoconfig_telemetry('contacts')"
+        ).fetchone()[0]
+        telemetry = json.loads(result)
+        assert telemetry["available"] is True
+        # Controller always sets stop_reason; allow any valid enum value.
+        valid = {
+            "green", "converged", "budget_iterations", "budget_time",
+            "policy_satisfied", "policy_no_progress", "oscillating", "cancelled",
+        }
+        assert telemetry["stop_reason"] in valid, telemetry
+
+
+class TestDedupeFull:
+    def test_runs_with_committed_config(self, con):
+        """``goldenmatch_dedupe_full`` accepts the JSON ``autoconfig`` returns."""
+        config_json = con.sql(
+            "SELECT goldenmatch_autoconfig('contacts')"
+        ).fetchone()[0]
+        # Round-trip: feed the auto-config output straight into dedupe_full.
+        # Expect either golden records JSON or stats JSON — both parse.
+        result = con.sql(
+            "SELECT goldenmatch_dedupe_full('contacts', ?)",
+            params=[config_json],
+        ).fetchone()[0]
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        # Golden records emit as a list; stats fall through to a dict.
+        assert isinstance(parsed, (list, dict))
+
+
+class TestGmTelemetry:
+    def test_unavailable_before_run(self, con):
+        """``gm_telemetry`` returns the unavailable sentinel on a fresh job."""
+        con.sql(
+            "SELECT gm_configure('j1', ?)",
+            params=[json.dumps({"exact": ["email"]})],
+        ).fetchone()
+        telemetry = json.loads(
+            con.sql("SELECT gm_telemetry('j1')").fetchone()[0]
+        )
+        assert telemetry["available"] is False
+
+    def test_telemetry_unknown_job(self, con):
+        """``gm_telemetry`` on a job that doesn't exist also returns unavailable."""
+        telemetry = json.loads(
+            con.sql("SELECT gm_telemetry('does-not-exist')").fetchone()[0]
+        )
+        assert telemetry["available"] is False

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.1.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.1.0.sql
@@ -9,8 +9,13 @@ CREATE TABLE IF NOT EXISTS goldenmatch._jobs (
     config_json JSONB NOT NULL,
     created_at TIMESTAMPTZ DEFAULT now(),
     last_run_at TIMESTAMPTZ,
-    status TEXT DEFAULT 'configured'
+    status TEXT DEFAULT 'configured',
+    -- v1.7-v1.12: most-recent run's AutoConfigController telemetry. NULL when
+    -- the job used an explicit config (controller didn't fire) or hasn't run.
+    last_telemetry_json JSONB
 );
+-- ALTER for upgrades from extension installs that pre-date the telemetry column.
+ALTER TABLE goldenmatch._jobs ADD COLUMN IF NOT EXISTS last_telemetry_json JSONB;
 
 CREATE TABLE IF NOT EXISTS goldenmatch._pairs (
     job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
@@ -180,3 +185,54 @@ CREATE FUNCTION "goldenmatch_match"(
 STRICT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'goldenmatch_match_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- AutoConfig + controller telemetry (v1.7-v1.12)
+-- ══════════════════════════════════════════════════════════════════════
+
+-- Run AutoConfigController on a table and return the committed GoldenMatchConfig
+-- as JSON. Pipe the output into goldenmatch_dedupe_full to apply it.
+CREATE FUNCTION "goldenmatch_autoconfig"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_wrapper';
+
+-- Same as above but returns the controller telemetry blob (stop_reason,
+-- decisions, health, indicator priors, committed NE).
+CREATE FUNCTION "goldenmatch_autoconfig_telemetry"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_telemetry_wrapper';
+
+-- Deduplicate a table with a *full* GoldenMatchConfig JSON (supports
+-- negative_evidence / Path Y, per-matchkey scorers, standardization, etc.).
+CREATE FUNCTION "goldenmatch_dedupe_full"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_wrapper';
+
+-- Same as above but returns the controller telemetry from that run.
+CREATE FUNCTION "goldenmatch_dedupe_full_telemetry"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_telemetry_wrapper';
+
+-- Retrieve the telemetry from the most recent gm_run of a named job.
+-- Returns '{"available":false}' for jobs that haven't run or used an
+-- explicit config.
+CREATE FUNCTION "gm_telemetry"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_telemetry_wrapper';

--- a/packages/rust/extensions/postgres/src/pipeline.rs
+++ b/packages/rust/extensions/postgres/src/pipeline.rs
@@ -136,8 +136,53 @@ pub fn gm_run(job_name: String, table_name: String) -> String {
         });
     }
 
+    // Persist controller telemetry on the job row (NULL when explicit config).
+    if let Some(ref telemetry) = result.telemetry_json {
+        let update = format!(
+            "UPDATE goldenmatch._jobs SET last_telemetry_json = '{}'::jsonb, last_run_at = now() WHERE name = '{}'",
+            telemetry.replace('\'', "''"),
+            escaped
+        );
+        Spi::connect(|mut client| {
+            let _ = client.update(&update, None, None);
+        });
+    } else {
+        let update = format!(
+            "UPDATE goldenmatch._jobs SET last_telemetry_json = NULL, last_run_at = now() WHERE name = '{}'",
+            escaped
+        );
+        Spi::connect(|mut client| {
+            let _ = client.update(&update, None, None);
+        });
+    }
+
     set_job_status(&job_name, "completed");
     result.stats_json
+}
+
+/// Return the controller telemetry from the most recent `gm_run` of a job.
+///
+/// Returns `'{"available":false}'` if the job hasn't run or the run used an
+/// explicit config (controller never fired).
+#[pg_extern]
+pub fn gm_telemetry(job_name: String) -> String {
+    let query = format!(
+        "SELECT coalesce(last_telemetry_json::text, '{{\"available\":false}}') \
+         FROM goldenmatch._jobs WHERE name = '{}'",
+        job_name.replace('\'', "''")
+    );
+
+    Spi::connect(|client| {
+        let result = client
+            .select(&query, None, None)
+            .unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+        for row in result {
+            if let Ok(Some(json)) = row.get::<String>(1) {
+                return json;
+            }
+        }
+        "{\"available\":false}".to_string()
+    })
 }
 
 /// List all configured jobs.

--- a/packages/rust/extensions/postgres/src/quick.rs
+++ b/packages/rust/extensions/postgres/src/quick.rs
@@ -159,3 +159,89 @@ pub fn goldenmatch_match(
         Err(e) => pgrx::error!("goldenmatch: {}", e),
     }
 }
+
+// ── AutoConfig + telemetry (v1.7-v1.12 surface) ────────────────────────
+
+/// Run AutoConfigController on a table and return the committed config JSON.
+///
+/// Pipe the output into `goldenmatch_dedupe_full(table, <result>)` to run the
+/// pipeline with the auto-configured shape. The committed config is the same
+/// `GoldenMatchConfig` JSON the CLI `goldenmatch autoconfig` would write to
+/// disk, including any `negative_evidence` (Path Y) fields the controller
+/// added.
+///
+/// To inspect what the controller decided, pair with `goldenmatch_autoconfig_telemetry()`
+/// — the two functions share the same telemetry blob; this one returns only
+/// the config payload.
+///
+/// ```sql
+/// SELECT goldenmatch_autoconfig('customers');
+/// ```
+#[pg_extern]
+pub fn goldenmatch_autoconfig(table_name: String) -> String {
+    let rows_json =
+        spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+    match goldenmatch_bridge::api::autoconfig(&rows_json) {
+        Ok(result) => result.config_json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Run AutoConfigController and return the telemetry JSON (stop_reason,
+/// health verdict, refit decisions, indicator column priors, committed NE).
+///
+/// Same shape as the web UI's `/api/v1/controller/telemetry` endpoint.
+/// Run alongside `goldenmatch_autoconfig()` when you want to inspect WHY the
+/// controller picked what it did — typical SQL pattern is:
+///
+/// ```sql
+/// WITH cfg AS (SELECT goldenmatch_autoconfig('customers') AS json),
+///      tel AS (SELECT goldenmatch_autoconfig_telemetry('customers') AS json)
+/// SELECT (SELECT json FROM cfg) AS config, (SELECT json FROM tel) AS telemetry;
+/// ```
+///
+/// Note: this re-runs the controller. For a single-shot variant that
+/// returns both, persist the result of one call to a temp table.
+#[pg_extern]
+pub fn goldenmatch_autoconfig_telemetry(table_name: String) -> String {
+    let rows_json =
+        spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+    match goldenmatch_bridge::api::autoconfig(&rows_json) {
+        Ok(result) => result.telemetry_json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Deduplicate a Postgres table using a *full* `GoldenMatchConfig` JSON.
+///
+/// Unlike `goldenmatch_dedupe_table`, which forwards only the slim
+/// `exact`/`fuzzy`/`blocking`/`threshold` keys, this accepts the full
+/// Pydantic shape — including `negative_evidence` (Path Y), per-matchkey
+/// `comparison` / `scorer` / `weight`, `standardization`, `golden_rules`,
+/// and so on. Use this when you've already obtained a committed config from
+/// `goldenmatch_autoconfig()` and want to apply it unchanged.
+#[pg_extern]
+pub fn goldenmatch_dedupe_full(table_name: String, config_json: String) -> String {
+    let rows_json =
+        spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+    match goldenmatch_bridge::api::dedupe_full(&rows_json, &config_json) {
+        Ok(result) => result.golden_json.unwrap_or_else(|| result.stats_json),
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Deduplicate a table with the full config and return the controller telemetry.
+///
+/// Useful for the "auto-configure once, run with telemetry, store both" flow
+/// without re-running the controller.
+#[pg_extern]
+pub fn goldenmatch_dedupe_full_telemetry(table_name: String, config_json: String) -> String {
+    let rows_json =
+        spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+    match goldenmatch_bridge::api::dedupe_full(&rows_json, &config_json) {
+        Ok(result) => result
+            .telemetry_json
+            .unwrap_or_else(|| "{\"available\":false}".to_string()),
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}


### PR DESCRIPTION
## Summary

Final piece of the v1.7-v1.12 surface-parity arc. Brings the Postgres pgrx + DuckDB UDF extensions (vendored at ``packages/rust/extensions/``) up to speed alongside #156 (web), #157 (TUI), #158 (CLI).

The standalone ``benzsevern/goldenmatch-extensions`` repo where this was first staged is archived and read-only — re-applying the diff at the monorepo path here.

## What's new

### Bridge (``packages/rust/extensions/bridge``)
- ``DedupeResult.telemetry_json`` — controller stop_reason, decisions, health verdict, NE fields. Same JSON shape as web ``/api/v1/controller/telemetry``.
- ``autoconfig(rows_json)`` → ``AutoConfigResult { config_json, telemetry_json }``. SQL-layer equivalent of ``goldenmatch autoconfig`` CLI.
- ``dedupe_full(rows_json, config_json)`` — accepts a full Pydantic ``GoldenMatchConfig`` JSON, unlocking ``negative_evidence`` / Path Y from SQL.
- Telemetry serialisation delegates to ``goldenmatch.web.controller_telemetry`` when ``[web]`` extra is installed; minimal hand-rolled fallback otherwise.

### Postgres
- ``goldenmatch_autoconfig(table)``, ``goldenmatch_autoconfig_telemetry(table)``
- ``goldenmatch_dedupe_full(table, config_json)``, ``goldenmatch_dedupe_full_telemetry(...)``
- ``gm_telemetry(job_name)`` reading from ``goldenmatch._jobs.last_telemetry_json`` (new JSONB column, added via ``ALTER TABLE ... IF NOT EXISTS`` for in-place upgrade).
- ``gm_run`` now persists telemetry on the job row.

### DuckDB
- Parallel ``goldenmatch_autoconfig``, ``goldenmatch_autoconfig_telemetry``, ``goldenmatch_dedupe_full``, ``gm_telemetry`` UDFs registered on every ``register(con)``.
- ``_gm_run`` captures ``_LAST_CONTROLLER_RUN`` into the in-process job state.

## Test plan

- [x] DuckDB: ``pytest packages/rust/extensions/duckdb/tests/`` — 16/16 pass (5 new + 11 existing)
- [ ] Postgres bridge + pgrx: rely on CI's ``rust`` lane and multi-PG matrix (15/16/17). Local Rust toolchain on dev box is broken (partial rustup install), couldn't ``cargo build`` here.

## Notes

The standalone ``goldenmatch-extensions`` repo was archived after the fold. This work was first staged there (commit ``3490237``) before the archive was discovered; the diff is identical, just re-applied under the monorepo path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)