### PR TITLE
docs: AutoConfigController surface-parity arc (PRs #156-#161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ flowchart LR
 - **97.2% F1 on DBLP-ACM out of the box** for entity resolution. [DQBench ER score: 95.30](https://github.com/benzsevern/dqbench).
 - **Learning Memory** — corrections persist across runs and re-anchor across row reorders, so the system stops needing the same correction twice (GoldenMatch v1.6.0; off by default).
 - **Privacy-preserving record linkage** — match across organizations without sharing raw data (PPRL, 92.4% F1 on FEBRL4).
-- **AI-native by design** — every package ships an MCP server, a REST API, and an A2A agent surface. 35+ MCP tools across the suite.
+- **AI-native by design** — every package ships an MCP server, a REST API, and an A2A agent surface. 36+ MCP tools across the suite, including `auto_configure` + `controller_telemetry` for v1.7-v1.12 introspection.
+- **AutoConfigController visible everywhere** (v1.7-v1.12 surface-parity arc) — web `ControllerPanel`, TUI `Ctrl+A`, CLI `goldenmatch autoconfig`, REST `/autoconfig` + `/controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDFs, MCP/A2A telemetry tools. One JSON shape across every interface.
 - **Polyglot parity** — Python and TypeScript implementations track the same scorer outputs to 4-decimal precision via a parity harness.
 - **Production paths** — Postgres sync, daemon mode, lineage tracking, review queues, dbt integration, GitHub Actions, and a Rust extension layer for Postgres / DuckDB.
 

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,60 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Added — AutoConfigController surface-parity arc
+
+Six PRs (#156-#159 + #161; #160 added CI lanes) bring every user-facing entry point up to speed with the v1.7-v1.12 AutoConfigController / IndicatorContext / NegativeEvidence work. Before this arc, controller decisions were observable only by reading `result.postflight_report.controller_history` in Python. Now every surface returns the same JSON shape (`stop_reason`, `health`, refit decisions, indicator column priors, committed `negative_evidence`) via `goldenmatch.web.controller_telemetry.serialize_telemetry`.
+
+**Web UI** (PR #156)
+- New `ControllerPanel` in Workbench surfaces stop_reason badge, health verdict, complexity profile cells, indicator column priors, refit decision trace, and `Path Y · N NE` indicator on committed matchkeys.
+- New `GET /api/v1/controller/telemetry` endpoint populated by `/autoconfig` and `/run?auto_config=true`.
+- Home gains a `ProvenanceCallout` linking `docs/reproducing-benchmarks.md` + `docs/scale-envelope.md` with the four reproducible numbers.
+
+**TUI** (PR #157)
+- New `Controller` tab (7th tab) showing the same telemetry the web panel shows.
+- New `Ctrl+A` binding triggers async auto-configure; result adopted into ConfigTab + ExportTab; switches to Controller tab on completion.
+- `MatchEngine.auto_configure(domain=None)` captures `_LAST_CONTROLLER_RUN` and exposes telemetry on `engine.last_telemetry`.
+
+**CLI** (PR #158)
+- New `goldenmatch autoconfig <files>` subcommand. Prints committed config to stdout (pipe to `> goldenmatch.yml`); telemetry panel to stderr. Flags: `--out PATH`, `--domain`, `--verbose`, `--hide-controller`.
+- `goldenmatch dedupe` zero-config path captures `_LAST_CONTROLLER_RUN` and renders the same panel before the cluster report (`--show-controller` / `--hide-controller`).
+- New shared `goldenmatch.cli._controller_render` module with Rich Panel + one-line `render_short_status` for log scraping.
+
+**SQL extensions** (PR #159)
+- Bridge (Rust/pyo3) gains `DedupeResult.telemetry_json`, `autoconfig()` returning `(committed_config_json, telemetry_json)`, and `dedupe_full()` accepting the full Pydantic `GoldenMatchConfig` JSON (unlocks `negative_evidence` from SQL).
+- Postgres: new `goldenmatch_autoconfig`, `goldenmatch_autoconfig_telemetry`, `goldenmatch_dedupe_full`, `goldenmatch_dedupe_full_telemetry`, `gm_telemetry`. New JSONB column `goldenmatch._jobs.last_telemetry_json` (added via `ALTER TABLE ... IF NOT EXISTS` for in-place upgrade).
+- DuckDB: parallel UDFs registered on every `register(con)`.
+
+**CI** (PR #160)
+- New `rust_pgrx` lane (matrix: PG 15/16/17) — cargo pgrx install + psql smoke covering the new v1.7-v1.12 surface.
+- New `duckdb_extensions` lane — runs the DuckDB UDF Python tests that the main `python` matrix doesn't pick up.
+
+**Agent / programmatic surfaces** (PR #161)
+- `AgentSession.autoconfigure(file_path)` returns `{config, telemetry}`; `deduplicate` / `match_sources` cache `last_telemetry`.
+- REST API (`goldenmatch serve`): new `POST /autoconfig` (with optional `records` body override) + `GET /controller/telemetry`.
+- MCP: `auto_configure` tool rewired off the legacy `select_strategy` heuristic onto the controller. New `controller_telemetry` tool. `agent_deduplicate` / `agent_match_sources` embed telemetry inline.
+- A2A: 10 → 12 skills (added `autoconfig` + `controller_telemetry`). `deduplicate` / `match` skills embed telemetry in their wire result.
+
+**Cross-surface telemetry shape** (single source of truth at `goldenmatch.web.controller_telemetry.serialize_telemetry`)
+
+```json
+{
+  "available": true,
+  "source": "autoconfig",
+  "stop_reason": "green",
+  "health": "green",
+  "elapsed_ms": 1234.5,
+  "full_vs_sample_drift": 0.12,
+  "scoring": {"n_pairs_scored": 4421, "mass_above_threshold": 0.087},
+  "blocking": {"n_blocks": 312, "reduction_ratio": 0.94},
+  "cluster": {"n_clusters": 1820, "transitivity_rate": 0.99},
+  "column_priors": [{"column": "email", "identity_score": 0.95, "corruption_score": 0.0}],
+  "decisions": [{"iteration": 1, "rule_name": "...", "rationale": "...", "wall_clock_ms": 234}],
+  "committed_matchkeys": [{"name": "exact_email", "has_negative_evidence": true}],
+  "negative_evidence": [{"matchkey_name": "exact_email", "field": "phone", "penalty": 0.5}]
+}
+```
+
 ## [1.13.0] - 2026-05-11
 
 This is a release-plumbing wave: typed-accessor API additions, PyPI metadata refresh, and contributor-facing quality improvements. **No DQbench / Febrl3 / NCVR / DBLP-ACM number changes** — algorithm is unchanged this wave.

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -111,8 +111,9 @@ npm install goldenmatch
 - **PPRL auto-configuration** — profiles your data and picks optimal fields, bloom filter parameters, and threshold
 
 ### Integration
-- **REST API + MCP Server** — 30 tools for matching, explaining, reviewing, data quality, and transforms
-- **A2A Agent** — 10 skills for AI-to-AI autonomous entity resolution
+- **REST API + MCP Server** — 31 tools for matching, explaining, reviewing, data quality, transforms, and AutoConfigController telemetry
+- **A2A Agent** — 12 skills for AI-to-AI autonomous entity resolution (incl. `autoconfig` + `controller_telemetry`)
+- **AutoConfigController telemetry visible from every surface** (v1.7-v1.12 surface-parity arc, PRs #156-#161) — web ControllerPanel, TUI Controller tab (`Ctrl+A`), CLI `goldenmatch autoconfig`, REST `POST /autoconfig` + `GET /controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDF equivalents, MCP/A2A telemetry tools. Every surface returns the same JSON shape (`stop_reason`, `health`, refit decisions, indicator column priors, `negative_evidence` / Path Y).
 - **Database sync** — incremental Postgres matching with persistent ANN index
 - **Enterprise connectors** — Snowflake, Databricks, BigQuery, HubSpot, Salesforce
 - **DuckDB backend** — out-of-core processing for 10M+ records without Spark

--- a/packages/python/goldenmatch/docs/agent.md
+++ b/packages/python/goldenmatch/docs/agent.md
@@ -66,14 +66,16 @@ Add to `claude_desktop_config.json`:
 
 ---
 
-## Agent Capabilities (10 Skills)
+## Agent Capabilities (12 Skills)
 
 | Skill | What It Does |
 |-------|-------------|
 | `analyze_data` | Profile columns, detect domain, recommend matching strategy |
-| `configure` | Generate optimal YAML config from data analysis |
-| `deduplicate` | Full pipeline with confidence-gated output and reasoning |
-| `match` | Cross-source matching with intelligent strategy selection |
+| `configure` | Generate optimal YAML config from data analysis (legacy heuristic path) |
+| `autoconfig` | **v1.7-v1.12**: run AutoConfigController; return committed config + telemetry (stop_reason, decisions, NE / Path Y) |
+| `controller_telemetry` | **v1.7-v1.12**: surface controller telemetry from the most recent call (stateless A2A dispatch → returns inline note pointing callers at `autoconfig` / `deduplicate` inline telemetry) |
+| `deduplicate` | Full pipeline with confidence-gated output, reasoning, and **telemetry** (v1.7+) |
+| `match` | Cross-source matching with intelligent strategy selection and **telemetry** (v1.7+) |
 | `explain` | Natural language explanation for any pair or cluster |
 | `review` | Present borderline matches for approval |
 | `compare_strategies` | Run multiple approaches, report metrics |
@@ -197,11 +199,22 @@ for strategy, metrics in comparison.items():
 
 # Match two sources
 matches = session.match_sources("new_customers.csv", "master.csv")
+
+# v1.7-v1.12: explicit AutoConfigController invocation
+autoconf = session.autoconfigure("customers.csv")
+print(autoconf["telemetry"]["stop_reason"])     # e.g. "green"
+print(autoconf["telemetry"]["health"])          # e.g. "green"
+for decision in autoconf["telemetry"]["decisions"]:
+    print(f"iter {decision['iteration']}: {decision['rule_name']}")
+
+# Telemetry is also cached on `deduplicate` / `match_sources` calls
+session.deduplicate("customers.csv")
+print(session.last_telemetry)                    # same shape as autoconfigure's telemetry
 ```
 
 ---
 
-## MCP Tools (13 Agent-Level)
+## MCP Tools (14 Agent-Level)
 
 | Tool | Description |
 |------|-------------|

--- a/packages/python/goldenmatch/docs/api-quick-reference.md
+++ b/packages/python/goldenmatch/docs/api-quick-reference.md
@@ -2,6 +2,26 @@
 
 Practical examples for the most-used surface. Authoritative type signatures live in `goldenmatch/_api.py` and `goldenmatch/config/schemas.py`.
 
+## `AgentSession.autoconfigure()` — run controller; return config + telemetry (v1.7-v1.12)
+
+```python
+from goldenmatch import AgentSession
+
+session = AgentSession()
+result = session.autoconfigure("customers.csv")
+# result["config"]:    GoldenMatchConfig as JSON-safe dict
+# result["telemetry"]: stop_reason, health, decisions, NE fields, column_priors
+# session.last_telemetry is set; also persists after deduplicate / match_sources
+
+# Same JSON shape exposed by:
+# - web   GET /api/v1/controller/telemetry
+# - CLI   goldenmatch autoconfig (stderr panel)
+# - REST  POST /autoconfig  +  GET /controller/telemetry
+# - MCP   auto_configure tool result
+# - A2A   autoconfig skill result
+# - SQL   goldenmatch_autoconfig_telemetry() / gm_telemetry()
+```
+
 ## `dedupe_df()` — DataFrame deduplication
 
 ```python

--- a/packages/python/goldenmatch/docs/cli.md
+++ b/packages/python/goldenmatch/docs/cli.md
@@ -6,12 +6,37 @@ nav_order: 5
 
 # CLI Reference
 
-GoldenMatch provides 23 CLI commands via `goldenmatch <command>`. All commands support `--help`.
+GoldenMatch provides 24 CLI commands via `goldenmatch <command>`. All commands support `--help`.
 
 ```bash
 pip install goldenmatch
 goldenmatch --version
 ```
+
+---
+
+## autoconfig
+
+Run AutoConfigController and print the committed config + telemetry. Does not run the pipeline — useful for piping into a YAML file or inspecting what auto-config would decide before committing to a full run.
+
+```bash
+# Print YAML config to stdout, telemetry panel to stderr
+goldenmatch autoconfig customers.csv
+
+# Save the config to disk; panel still goes to stderr
+goldenmatch autoconfig customers.csv --out goldenmatch.yml
+
+# Pin a domain rulebook
+goldenmatch autoconfig products.csv --domain electronics
+
+# Include indicator priors + decision trace in the panel
+goldenmatch autoconfig customers.csv --verbose
+
+# CI-friendly: swap the rich panel for a one-line status string
+goldenmatch autoconfig customers.csv --hide-controller
+```
+
+The panel surfaces the controller's `stop_reason`, health verdict, complexity profile cells, indicator column priors (with `--verbose`), refit decisions, and `Path Y · N NE` indicators on committed matchkeys. Same JSON shape the web UI's `/api/v1/controller/telemetry` endpoint returns.
 
 ---
 
@@ -34,6 +59,13 @@ goldenmatch dedupe products.csv --config config.yaml --llm-scorer
 
 # With anomaly detection
 goldenmatch dedupe customers.csv --anomalies
+
+# Zero-config path: render the controller telemetry panel before the report
+# (default ON when auto-config fires; suppressed automatically with --config)
+goldenmatch dedupe customers.csv  # panel surfaces stop_reason, health, decisions, Path Y NE
+
+# Hide the controller panel (useful in CI logs)
+goldenmatch dedupe customers.csv --hide-controller
 
 # Preview changes before writing
 goldenmatch dedupe customers.csv --preview

--- a/packages/python/goldenmatch/docs/llms.txt
+++ b/packages/python/goldenmatch/docs/llms.txt
@@ -3,12 +3,17 @@
 > Entity resolution toolkit — deduplicate records and match across datasets using fuzzy, probabilistic, and LLM-powered scoring.
 
 ## Interfaces
-- MCP Server: `goldenmatch mcp-serve` (13 agent tools + 17 data tools + 5 memory tools = 35 total)
-- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (35 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
-- A2A Server: `goldenmatch agent-serve --port 8200` (10 skills)
-- CLI: `goldenmatch dedupe`, `goldenmatch match`, `goldenmatch memory ...`, + more
-- Python API: `import goldenmatch` -- `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, `add_correction()`, `learn()`, `memory_stats()`, `get_memory()`, ~106 exports
-- REST API: `goldenmatch serve` on port 8000
+- MCP Server: `goldenmatch mcp-serve` (14 agent tools + 17 data tools + 5 memory tools = 36 total)
+- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (36 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- A2A Server: `goldenmatch agent-serve --port 8200` (12 skills)
+- CLI: `goldenmatch dedupe`, `goldenmatch autoconfig`, `goldenmatch match`, `goldenmatch memory ...`, + more
+- Python API: `import goldenmatch` -- `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, `AgentSession.autoconfigure()`, `add_correction()`, `learn()`, `memory_stats()`, `get_memory()`, ~106 exports
+- REST API: `goldenmatch serve` on port 8000 (incl. `POST /autoconfig`, `GET /controller/telemetry`)
+- SQL: Postgres extension + DuckDB UDFs at `packages/rust/extensions/` (`goldenmatch_autoconfig`, `goldenmatch_dedupe_full`, `gm_telemetry`)
+
+## AutoConfigController telemetry (v1.7-v1.12, cross-surface)
+
+Every interface above returns the same JSON shape from `goldenmatch.web.controller_telemetry.serialize_telemetry`: `{stop_reason, health, scoring, blocking, cluster, column_priors, decisions, committed_matchkeys, negative_evidence}`. Write one parser, reuse across web / TUI / CLI / SQL / MCP / A2A / REST.
 
 ## Install
 - `pip install goldenmatch`

--- a/packages/python/goldenmatch/docs/mcp.md
+++ b/packages/python/goldenmatch/docs/mcp.md
@@ -206,7 +206,30 @@ Normalize phone numbers (E.164), dates (ISO), categorical spelling, and Unicode.
 "Normalize the phone and date formats in my data"
 ```
 
-In addition, 13 **agent-level tools** are available for autonomous operation (analyze_data, auto_configure, agent_deduplicate, agent_match_sources, agent_explain_pair, agent_explain_cluster, agent_review_queue, agent_approve_reject, agent_compare_strategies, suggest_pprl, scan_quality, fix_quality, run_transforms). See [ER Agent](agent) for details.
+In addition, 14 **agent-level tools** are available for autonomous operation (analyze_data, auto_configure, controller_telemetry, agent_deduplicate, agent_match_sources, agent_explain_pair, agent_explain_cluster, agent_review_queue, agent_approve_reject, agent_compare_strategies, suggest_pprl, scan_quality, fix_quality, run_transforms). See [ER Agent](agent) for details.
+
+### AutoConfigController telemetry (v1.7-v1.12)
+
+`auto_configure` was rewired in PR #161 to invoke the v1.7+ AutoConfigController instead of the legacy `select_strategy` heuristic. It now returns:
+
+```json
+{
+  "config": { "...": "full GoldenMatchConfig" },
+  "telemetry": {
+    "available": true,
+    "stop_reason": "green",
+    "health": "green",
+    "decisions": [...],
+    "column_priors": [...],
+    "committed_matchkeys": [...],
+    "negative_evidence": [...]
+  }
+}
+```
+
+`agent_deduplicate` and `agent_match_sources` both include a `telemetry` field in their result dict so the host LLM can see `stop_reason`, refit decisions, and Path Y negative-evidence without a second call.
+
+The standalone `controller_telemetry` tool surfaces a per-session limitation note (MCP dispatch is stateless, so it can't recall a prior call's telemetry — use the inline telemetry from `auto_configure` / `agent_deduplicate` instead).
 
 ### Learning Memory tools (v1.6.0)
 

--- a/packages/python/goldenmatch/docs/python-api.md
+++ b/packages/python/goldenmatch/docs/python-api.md
@@ -700,6 +700,54 @@ New v1.5.0 kwargs on `auto_configure_df`:
 
 The returned config carries `config._preflight_report: PreflightReport` (underscore — private-by-convention but stable across v1.5.x).
 
+### Controller telemetry (v1.7-v1.12)
+
+`auto_configure_df` runs the AutoConfigController, which writes `(profile, history)` to a ContextVar (`goldenmatch.core.autoconfig._LAST_CONTROLLER_RUN`). Callers can read it post-call:
+
+```python
+from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN, auto_configure_df
+
+cfg = auto_configure_df(df)
+profile, history = _LAST_CONTROLLER_RUN.get()  # ComplexityProfile, RunHistory
+print(history.stop_reason)            # StopReason enum
+print(profile.health())                # HealthVerdict enum
+for entry in history.entries:
+    if entry.decision:
+        print(f"iter {entry.iteration}: {entry.decision.rule_name}")
+```
+
+Or via the cross-surface serializer (single JSON shape used by web / CLI / SQL / MCP / A2A):
+
+```python
+from goldenmatch.web.controller_telemetry import serialize_telemetry
+
+telemetry = serialize_telemetry(
+    profile=profile,
+    history=history,
+    committed_config=cfg,
+    source="my_app",
+    run_name=None,
+    recorded_at=None,
+)
+# telemetry["stop_reason"], telemetry["health"], telemetry["decisions"], ...
+```
+
+### AgentSession.autoconfigure (v1.7-v1.12)
+
+For agent-style sessions, `AgentSession` exposes the same surface as a single call:
+
+```python
+from goldenmatch import AgentSession
+
+session = AgentSession()
+result = session.autoconfigure("customers.csv")
+# {"config": {...}, "telemetry": {"stop_reason": "green", "health": "green", ...}}
+
+# `deduplicate` / `match_sources` also cache telemetry for follow-up reads.
+session.deduplicate("customers.csv")
+print(session.last_telemetry)  # same shape as result["telemetry"]
+```
+
 ---
 
 ## Verification (v1.5.0)

--- a/packages/python/goldenmatch/docs/rest-api.md
+++ b/packages/python/goldenmatch/docs/rest-api.md
@@ -34,6 +34,8 @@ The server loads data, runs initial matching, and exposes endpoints on the speci
 | `GET` | `/reviews` | Review queue (borderline pairs) |
 | `GET` | `/reviews/decisions` | List completed review decisions |
 | `POST` | `/reviews/decide` | Approve or reject a pair |
+| `POST` | `/autoconfig` | Run AutoConfigController; return committed config + telemetry |
+| `GET` | `/controller/telemetry` | Last autoconfig's telemetry (stop_reason, health, decisions, NE fields) |
 
 ---
 
@@ -226,6 +228,54 @@ explanation = client.explain(42, 108)
 
 # Get review queue
 reviews = client.reviews()
+```
+
+---
+
+## AutoConfigController telemetry (v1.7-v1.12)
+
+Two endpoints expose what the controller decides and why. Same JSON shape as the workbench `GET /api/v1/controller/telemetry`, the CLI `goldenmatch autoconfig` output, and the SQL `goldenmatch_autoconfig_telemetry()` function — write a parser once and reuse across surfaces.
+
+### POST /autoconfig
+
+Runs `auto_configure_df` and returns the committed config + telemetry.
+
+```bash
+# Re-profile the server's currently-loaded data
+curl -X POST http://localhost:8080/autoconfig
+
+# Or override with a different dataset
+curl -X POST http://localhost:8080/autoconfig \
+    -H "content-type: application/json" \
+    -d '{"records": [{"name": "Alice", "email": "a@x.com"}, ...]}'
+```
+
+```json
+{
+  "config": { "...": "full GoldenMatchConfig JSON" },
+  "telemetry": {
+    "available": true,
+    "source": "rest_autoconfig",
+    "stop_reason": "green",
+    "health": "green",
+    "elapsed_ms": 234.5,
+    "scoring": {"n_pairs_scored": 4421, "mass_above_threshold": 0.087},
+    "blocking": {"n_blocks": 312, "reduction_ratio": 0.94},
+    "cluster": {"n_clusters": 1820, "transitivity_rate": 0.99},
+    "column_priors": [{"column": "email", "identity_score": 0.95, "corruption_score": 0.0}],
+    "decisions": [{"iteration": 1, "rule_name": "...", "rationale": "..."}],
+    "committed_matchkeys": [{"name": "exact_email", "has_negative_evidence": true}],
+    "negative_evidence": [{"matchkey_name": "exact_email", "field": "phone", "penalty": 0.5}]
+  }
+}
+```
+
+### GET /controller/telemetry
+
+Returns the cached telemetry from the most recent `POST /autoconfig` call without re-running the controller. Before any autoconfig call:
+
+```json
+{"available": false, "source": null}
 ```
 
 ---

--- a/packages/python/goldenmatch/docs/sql-duckdb.md
+++ b/packages/python/goldenmatch/docs/sql-duckdb.md
@@ -111,6 +111,40 @@ SELECT goldenmatch_explain(
 );
 ```
 
+### AutoConfig and controller telemetry (v1.7-v1.12)
+
+```sql
+-- Run AutoConfigController on a table; get committed config JSON.
+SELECT goldenmatch_autoconfig('customers');
+
+-- Same call, but returns the controller telemetry blob (stop_reason,
+-- health, decisions, indicator priors, committed NE).
+SELECT goldenmatch_autoconfig_telemetry('customers');
+
+-- Run dedupe with a *full* GoldenMatchConfig JSON. Unlike the slim
+-- `goldenmatch_dedupe_table` kwargs, this accepts `negative_evidence`
+-- (Path Y) and every other Pydantic field.
+SELECT goldenmatch_dedupe_full('customers', '{
+    "matchkeys": [
+        {"name": "exact_email", "type": "exact",
+         "fields": [{"field": "email", "transforms": ["lowercase"]}],
+         "negative_evidence": [
+             {"field": "phone", "scorer": "exact",
+              "transforms": ["digits_only"], "threshold": 0.5, "penalty": 0.5}
+         ]}
+    ]
+}');
+
+-- Job pipeline: gm_run captures controller telemetry into in-memory state.
+SELECT gm_configure('cust_job', '{"exact": ["email"]}');
+SELECT gm_run('cust_job', 'customers');
+SELECT gm_telemetry('cust_job');   -- last run's telemetry JSON
+```
+
+The telemetry JSON shape is identical across the DuckDB UDFs, the Postgres extension, the CLI `goldenmatch autoconfig`, and the web `/api/v1/controller/telemetry` endpoint — parse once, reuse everywhere.
+
+---
+
 ### Pipeline management
 
 ```sql

--- a/packages/python/goldenmatch/docs/sql-postgres.md
+++ b/packages/python/goldenmatch/docs/sql-postgres.md
@@ -106,6 +106,41 @@ SELECT goldenmatch.goldenmatch_match_tables(
 );
 ```
 
+### AutoConfig and controller telemetry (v1.7-v1.12)
+
+```sql
+-- Run AutoConfigController; get the committed config as JSON.
+SELECT goldenmatch.goldenmatch_autoconfig('customers');
+
+-- Same call, but return the telemetry blob (stop_reason, health,
+-- decisions, indicator priors, committed NE) instead of the config.
+SELECT goldenmatch.goldenmatch_autoconfig_telemetry('customers');
+
+-- Run dedupe with a *full* GoldenMatchConfig JSON. This is the only
+-- code path that supports `negative_evidence` (Path Y) from SQL —
+-- the slim kwargs accepted by `goldenmatch_dedupe_table` can't express it.
+SELECT goldenmatch.goldenmatch_dedupe_full('customers', '{
+    "matchkeys": [
+        {
+            "name": "exact_email",
+            "type": "exact",
+            "fields": [{"field": "email", "transforms": ["lowercase"]}],
+            "negative_evidence": [
+                {"field": "phone", "scorer": "exact",
+                 "transforms": ["digits_only"], "threshold": 0.5, "penalty": 0.5}
+            ]
+        }
+    ]
+}');
+
+-- Job pipeline: telemetry from the most-recent `gm_run` persists on the job row.
+SELECT goldenmatch.gm_configure('cust_job', '{"exact": ["email"]}');
+SELECT goldenmatch.gm_run('cust_job', 'customers');
+SELECT goldenmatch.gm_telemetry('cust_job');   -- last run's telemetry JSON
+```
+
+The telemetry JSON shape is identical to the web `/api/v1/controller/telemetry`, CLI `goldenmatch autoconfig`, and DuckDB `goldenmatch_autoconfig_telemetry` outputs — write one parser, reuse everywhere.
+
 ### Pair scoring and explanation
 
 ```sql

--- a/packages/python/goldenmatch/docs/tui.md
+++ b/packages/python/goldenmatch/docs/tui.md
@@ -15,9 +15,9 @@ goldenmatch interactive customers.csv --config config.yaml
 
 ---
 
-## 6 Tabs
+## 7 Tabs
 
-The TUI has 6 tabs, accessible via keyboard shortcuts `1` through `6`.
+The TUI has 7 tabs, accessible via keyboard shortcuts `1` through `7`.
 
 ### Tab 1: Data
 
@@ -68,14 +68,27 @@ Output options:
 - Export lineage JSON
 - Generate HTML report
 
+### Tab 7: Controller (v1.7-v1.12)
+
+AutoConfigController telemetry from the most recent `Ctrl+A` invocation:
+- Health verdict badge (green / yellow / red)
+- `StopReason` with one-line hover explanation
+- Committed matchkeys with `Path Y · N NE` indicator + expandable NE field rows
+- Complexity profile cells (pairs, above-threshold, borderline, blocks, p99, clusters, transitivity)
+- Indicator column priors table (identity / corruption scores)
+- Refit decisions table (iter / rule / rationale / wall-clock)
+
+Same JSON shape as the web `/api/v1/controller/telemetry` endpoint and the CLI `goldenmatch autoconfig` output.
+
 ---
 
 ## Keyboard shortcuts
 
 | Key | Action |
 |-----|--------|
-| `1`--`6` | Jump to tab (Data, Config, Matches, Golden, Boost, Export) |
+| `1`--`7` | Jump to tab (Data, Config, Matches, Golden, Boost, Export, Controller) |
 | `F5` | Run the pipeline |
+| `Ctrl+A` | **Auto-configure**: run AutoConfigController; adopt config; switch to Controller tab |
 | `?` | Show all keyboard shortcuts |
 | `Ctrl+E` | Export results |
 | `Left`/`Right` | Adjust threshold (Matches tab) |


### PR DESCRIPTION
## Summary

Documentation catch-up for the six-PR surface-parity arc:
- #156 web UI · #157 TUI · #158 CLI · #159 Postgres + DuckDB extensions · #160 CI lanes · #161 MCP + A2A + REST + AgentSession

Every entry point now returns AutoConfigController telemetry in the same JSON shape; the docs needed to catch up to the code.

## What's updated

| File | What changed |
|---|---|
| ``CHANGELOG.md`` | New ``[Unreleased]`` section per-surface; cross-surface telemetry JSON shape spelled out |
| ``README.md`` (package + root) | Bumped A2A 10→12 skills, MCP 35→36 tools; arc-summary feature line |
| ``docs/cli.md`` | New ``goldenmatch autoconfig`` section; ``--show-controller / --hide-controller`` flags on ``dedupe`` |
| ``docs/rest-api.md`` | ``POST /autoconfig`` + ``GET /controller/telemetry`` with example payloads |
| ``docs/mcp.md`` | 13→14 agent tools; ``auto_configure`` rewired note; ``controller_telemetry`` tool |
| ``docs/agent.md`` | 10→12 skills table; Python example for ``AgentSession.autoconfigure`` |
| ``docs/sql-postgres.md`` | AutoConfig + telemetry section, full ``negative_evidence`` example |
| ``docs/sql-duckdb.md`` | Parallel section for DuckDB UDFs |
| ``docs/tui.md`` | 6→7 tabs (Controller); ``Ctrl+A`` binding |
| ``docs/python-api.md`` | Controller telemetry sub-section; ``AgentSession.autoconfigure`` example |
| ``docs/api-quick-reference.md`` | ``AgentSession.autoconfigure`` entry with cross-surface routing |
| ``docs/llms.txt`` | AI-discovery surface inventory updated |

## Test plan

- [x] CHANGELOG renders cleanly (preview)
- [x] Doc-only PR — should hit only the ``changes`` lane in CI per the path filter
- [ ] Manual: confirm Jekyll build still passes (the package docs site builds on `gh-pages`)
- [ ] Manual: confirm `llms.txt` round-trips through `llms-full.txt` generation (separate job, not on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)