### PR TITLE
chore(badges): add OpenSSF Scorecard; drop Colab + Discussions + MCP Marketplace

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+name: OpenSSF Scorecard
+# Runs the OpenSSF Scorecard on a schedule and on default-branch pushes,
+# publishing results to the public scorecard.dev dashboard. The README badge
+# pulls its number from the dashboard endpoint — without this workflow the
+# badge would show "No data" forever.
+#
+# Read-only by default: `id-token: write` is needed for SLSA attestation,
+# `security-events: write` is needed to upload the SARIF to GitHub's Security
+# tab. No code or config is modified.
+
+on:
+  branch_protection_rule:  # rule changes trigger re-evaluation
+  schedule:
+    - cron: '37 13 * * 1'   # Mondays 13:37 UTC — off-peak slot
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for SARIF upload to the Security tab.
+      security-events: write
+      # Required for OIDC token retrieval used by Scorecard's signing step.
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # `publish_results: true` makes the score visible at
+          # https://scorecard.dev/viewer/?uri=github.com/<owner>/<repo>
+          # which is what the README badge points to. Required for the
+          # badge to ever flip from "No data" to a real number.
+          publish_results: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload artifact
+        # Keep the raw SARIF as an artifact for 30 days so failed-criteria
+        # diffs are inspectable across runs.
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 <!-- Quality / proof -->
 [![CI](https://github.com/benzsevern/goldenmatch/actions/workflows/ci.yml/badge.svg)](https://github.com/benzsevern/goldenmatch/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/benzsevern/goldenmatch/graph/badge.svg)](https://codecov.io/gh/benzsevern/goldenmatch)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/benzsevern/goldenmatch/badge)](https://scorecard.dev/viewer/?uri=github.com/benzsevern/goldenmatch)
 [![DQBench ER](https://img.shields.io/badge/DQBench%20ER-95.30-d4a017)](https://github.com/benzsevern/dqbench)
 [![DBLP-ACM F1](https://img.shields.io/badge/DBLP--ACM%20F1-97.2%25-d4a017)](packages/python/goldenmatch/README.md#benchmarks)
 
@@ -32,10 +33,8 @@
 [![Wiki](https://img.shields.io/badge/wiki-github-d4a017)](https://github.com/benzsevern/goldenmatch/wiki)
 [![Web UI](https://img.shields.io/badge/web%20ui-FastAPI%20%2B%20React-d4a017?logo=react&logoColor=white)](https://github.com/benzsevern/goldenmatch/wiki/Web-UI)
 [![Smithery MCP](https://img.shields.io/badge/MCP-smithery-6e40c9)](https://smithery.ai/servers/benzsevern/goldenmatch)
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/benzsevern/goldenmatch/blob/main/packages/python/goldenmatch/scripts/gpu_colab_notebook.ipynb)
 
 <!-- Activity -->
-[![GitHub Discussions](https://img.shields.io/github/discussions/benzsevern/goldenmatch?color=d4a017&logo=github&label=discussions)](https://github.com/benzsevern/goldenmatch/discussions)
 [![Last commit](https://img.shields.io/github/last-commit/benzsevern/goldenmatch?color=d4a017&label=last%20commit)](https://github.com/benzsevern/goldenmatch/commits/main)
 
 </div>

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -31,6 +31,7 @@
 <!-- Ecosystem -->
 [![Docs](https://img.shields.io/badge/docs-github.io-d4a017)](https://benzsevern.github.io/goldenmatch/)
 [![Smithery MCP](https://img.shields.io/badge/MCP-smithery-6e40c9)](https://smithery.ai/servers/benzsevern/goldenmatch)
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-io.github.benzsevern%2Fgoldenmatch-0ea5e9)](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.benzsevern/goldenmatch)
 
 </div>
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -19,6 +19,7 @@
 <!-- Quality -->
 [![CI](https://github.com/benzsevern/goldenmatch/actions/workflows/ci.yml/badge.svg)](https://github.com/benzsevern/goldenmatch/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/benzsevern/goldenmatch/graph/badge.svg)](https://codecov.io/gh/benzsevern/goldenmatch)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/benzsevern/goldenmatch/badge)](https://scorecard.dev/viewer/?uri=github.com/benzsevern/goldenmatch)
 [![DQBench ER](https://img.shields.io/badge/DQBench%20ER-95.30-d4a017?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjZmZmIj48Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSI4Ii8+PC9zdmc+)](https://github.com/benzsevern/dqbench)
 [![F1: 96.4%](https://img.shields.io/badge/DBLP--ACM%20F1-96.4%25%20zero--config-d4a017)](#benchmarks)
 
@@ -30,8 +31,6 @@
 <!-- Ecosystem -->
 [![Docs](https://img.shields.io/badge/docs-github.io-d4a017)](https://benzsevern.github.io/goldenmatch/)
 [![Smithery MCP](https://img.shields.io/badge/MCP-smithery-6e40c9)](https://smithery.ai/servers/benzsevern/goldenmatch)
-[![MCP Marketplace](https://img.shields.io/badge/MCP-marketplace-0ea5e9)](https://mcp-marketplace.io/)
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/benzsevern/goldenmatch/blob/main/scripts/gpu_colab_notebook.ipynb)
 
 </div>
 


### PR DESCRIPTION
## Summary

Trim and refresh README badges. Follow-up to the v1.7-v1.12 surface-parity arc documentation in #162.

## Added

**OpenSSF Scorecard** — security-posture signal (signed releases, branch protection, dep-update tooling). New `.github/workflows/scorecard.yml` runs weekly + on default-branch pushes and publishes results to scorecard.dev so the badge has data.

```
[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/benzsevern/goldenmatch/badge)](https://scorecard.dev/viewer/?uri=github.com/benzsevern/goldenmatch)
```

## Dropped

- **Colab notebook** — the notebook is buried at `packages/python/goldenmatch/scripts/gpu_colab_notebook.ipynb`; badge wasn't pulling its weight. Re-add when we promote the notebook in the README body.
- **GitHub Discussions** — overlaps with `Last commit` + `GitHub stars` as activity signals; drops dilution without losing a unique trust dimension.
- **MCP Marketplace** — verified the linked site (mcp-marketplace.io) doesn't actually list goldenmatch. Badge was misleading. Re-add once a listing exists.

## Test plan

- [x] ``.github/workflows/scorecard.yml`` parses (yaml.safe_load)
- [ ] After merge, the Scorecard workflow runs on next push to ``main`` and the badge transitions from "No data" to a numeric score (~24-48h for initial publish to scorecard.dev)
- [ ] Manual: confirm the README renders cleanly on github.com (no missing badge alt text, all rows still flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)