### PR TITLE
feat(ci): auto-sync MCP Registry listings on every PyPI publish

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,174 @@
+name: Publish to MCP Registry
+
+# Syncs the suite's server.json files to the official MCP Registry
+# (registry.modelcontextprotocol.io) so the listings stay in lockstep with PyPI.
+#
+# Triggers:
+#   - release: published — fires automatically after a PyPI publish workflow
+#     lands. Tag pattern decides which package to sync. Mirror of the
+#     `publish-<pkg>.yml` workflows' tag patterns so we re-sync exactly once
+#     per release.
+#   - workflow_dispatch — manual fire with `package` input (single name or
+#     `all`) for the initial drift-close and any later one-off refreshes.
+#
+# Auth: GitHub OIDC. The registry trusts GitHub Actions tokens for
+# `io.github.<user>/*` namespaces — no PAT, no API token, no secrets to
+# manage. Requires `id-token: write` permission scoped to the publish step.
+#
+# CLI: mcp-publisher (Go binary, installed from the latest release tarball).
+# Pin the version once the registry stabilises out of preview; for now,
+# `latest` is fine — the CLI is conservative about breaking changes.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Which package to (re-)publish to the MCP Registry"
+        required: true
+        type: choice
+        options:
+          - all
+          - goldenmatch
+          - goldencheck
+          - goldenflow
+          - goldenpipe
+          - infermap
+        default: all
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve which packages to sync on this run. Release events map a tag
+  # pattern → one package; workflow_dispatch can request all five.
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.set.outputs.packages }}
+    steps:
+      - id: set
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_PKG: ${{ inputs.package }}
+        run: |
+          set -euo pipefail
+          PKGS=()
+          if [ "$EVENT" = "release" ]; then
+            # Tag patterns mirror the PyPI publish-*.yml workflow `if:` guards.
+            # Order matters: goldencheck-types-v* is a prefix of goldencheck-v*
+            # so check the longer prefix first.
+            if   [[ "$TAG" == goldencheck-types-v* ]];  then : noop  # not on registry
+            elif [[ "$TAG" == goldencheck-v* ]];        then PKGS+=(goldencheck)
+            elif [[ "$TAG" == goldenflow-v* ]];         then PKGS+=(goldenflow)
+            elif [[ "$TAG" == goldenpipe-v* ]];         then PKGS+=(goldenpipe)
+            elif [[ "$TAG" == infermap-js-v* ]];        then : noop
+            elif [[ "$TAG" == infermap-v* ]];           then PKGS+=(infermap)
+            elif [[ "$TAG" == goldenmatch-js-v* ]];     then : noop
+            elif [[ "$TAG" == v* ]];                    then PKGS+=(goldenmatch)
+            fi
+          else
+            if [ "$DISPATCH_PKG" = "all" ]; then
+              PKGS=(goldenmatch goldencheck goldenflow goldenpipe infermap)
+            else
+              PKGS=("$DISPATCH_PKG")
+            fi
+          fi
+          if [ ${#PKGS[@]} -eq 0 ]; then
+            echo "packages=[]" >> "$GITHUB_OUTPUT"
+          else
+            json="["
+            for p in "${PKGS[@]}"; do json+="\"$p\","; done
+            json="${json%,}]"
+            echo "packages=$json" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: resolve
+    if: needs.resolve.outputs.packages != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: ${{ fromJSON(needs.resolve.outputs.packages) }}
+    permissions:
+      # Required for OIDC token retrieval (`mcp-publisher login github-oidc`).
+      # No `contents: write` — the workflow never modifies the repo.
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install mcp-publisher from the latest release tarball. The MCP
+      # Registry team ships static binaries; no Go toolchain needed in CI.
+      # Pin a version here (e.g. `v1.0.0`) once the registry exits preview.
+      - name: Install mcp-publisher
+        run: |
+          ASSET="mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"
+          curl -fSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/${ASSET}" \
+            | tar xz mcp-publisher
+          chmod +x mcp-publisher
+          ./mcp-publisher --help >/dev/null   # smoke
+
+      - name: Look up current PyPI version
+        id: pypi
+        shell: bash
+        env:
+          PKG: ${{ matrix.pkg }}
+        run: |
+          set -euo pipefail
+          V=$(curl -fsSL "https://pypi.org/pypi/${PKG}/json" | jq -r '.info.version')
+          if [ -z "$V" ] || [ "$V" = "null" ]; then
+            echo "::error::PyPI returned no version for ${PKG}"
+            exit 1
+          fi
+          echo "version=${V}" >> "$GITHUB_OUTPUT"
+
+      - name: Inject version into server.json
+        # Keep the registry-level `version` and `packages[0].version` in
+        # lockstep with PyPI. server.json's other fields (name, title,
+        # description, repository, remotes) stay whatever the file in the
+        # repo says — those are publisher-curated, not synced from PyPI.
+        shell: bash
+        env:
+          PKG: ${{ matrix.pkg }}
+          V: ${{ steps.pypi.outputs.version }}
+        run: |
+          set -euo pipefail
+          FILE="packages/python/${PKG}/server.json"
+          jq --arg v "$V" '
+            .version = $v
+            | .packages |= map(if .registryType == "pypi" then .version = $v else . end)
+          ' "$FILE" > "${FILE}.tmp"
+          mv "${FILE}.tmp" "$FILE"
+          echo "--- ${FILE} (post-injection) ---"
+          cat "$FILE"
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        working-directory: packages/python/${{ matrix.pkg }}
+        run: ../../../mcp-publisher login github-oidc
+
+      - name: Validate server.json
+        working-directory: packages/python/${{ matrix.pkg }}
+        run: ../../../mcp-publisher validate
+
+      - name: Publish to MCP Registry
+        working-directory: packages/python/${{ matrix.pkg }}
+        run: ../../../mcp-publisher publish
+
+      - name: Summary
+        if: always()
+        shell: bash
+        env:
+          PKG: ${{ matrix.pkg }}
+          V: ${{ steps.pypi.outputs.version }}
+        run: |
+          {
+            echo "## MCP Registry: ${PKG}"
+            echo ""
+            echo "- Synced version: \`${V}\`"
+            echo "- Listing: https://registry.modelcontextprotocol.io/v0/servers?search=io.github.benzsevern/${PKG}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Local CWD = package dir (e.g. `packages/python/goldencheck`); CI CWD = repo root
 ## Post-fold GitHub Actions
 Only `.github/workflows/` at the repo root runs. Workflow files left under `packages/python/<pkg>/.github/workflows/` from pre-fold repos are orphaned (silently ignored). v1.6.0 release shipped no PyPI publish until `publish-goldenmatch.yml` was added at the root.
 - `publish-goldenmatch.yml` — fires on `release: published` for `v*` tags (skips `goldenmatch-js-v*`); `workflow_dispatch` with `ref` input for retro-publish. Uses `PYPI_TOKEN` (trusted publishing not configured).
+- `publish-mcp.yml` — auto-syncs `packages/python/<pkg>/server.json` to the official MCP Registry (`registry.modelcontextprotocol.io`) after every PyPI publish. Same tag patterns as the per-package PyPI workflows. Auth via GitHub OIDC (`id-token: write`); no secrets needed. `workflow_dispatch` with `package` input (`all` / one of five) lets you force-refresh listings without re-tagging. Updating the registry directly via the web UI also works, but the workflow keeps versions in lockstep with PyPI automatically.
 
 ## Pre-fold archive
 `_archive/goldenmatch-pre-fold/` retains the standalone repo's git history. Old specs/plans under `_archive/goldenmatch-pre-fold/docs/superpowers/` are sometimes the foundation for current work — search there before assuming a feature is undesigned.

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benzsevern.github.io/goldencheck/",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "repository": {
     "url": "https://github.com/benzsevern/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benzsevern.github.io/goldenflow/",
-  "version": "1.1.4",
+  "version": "1.1.2",
   "repository": {
     "url": "https://github.com/benzsevern/goldenflow",
     "source": "github"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://benzsevern.github.io/goldenmatch/",
-  "version": "1.4.8",
+  "version": "1.13.0",
   "repository": {
     "url": "https://github.com/benzsevern/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "1.4.5",
+      "version": "1.13.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenpipe/server.json
+++ b/packages/python/goldenpipe/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenPipe",
   "description": "One command to validate, transform, and deduplicate — chain GoldenCheck + Flow + Match.",
   "websiteUrl": "https://benzsevern.github.io/goldenpipe/",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "repository": {
     "url": "https://github.com/benzsevern/goldenpipe",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenpipe",
-      "version": "1.0.6",
+      "version": "1.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/infermap/server.json
+++ b/packages/python/infermap/server.json
@@ -4,7 +4,7 @@
   "title": "InferMap",
   "description": "Map messy columns to a known schema — 7 scorers, domain dictionaries, F1 0.84. Zero config.",
   "websiteUrl": "https://benzsevern.github.io/infermap/",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "repository": {
     "url": "https://github.com/benzsevern/infermap",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "infermap",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Closes the drift between PyPI versions and the official MCP Registry (``registry.modelcontextprotocol.io``) listings for all five suite packages. Found that ``goldenmatch`` is 8-9 versions behind on the registry, others are 1 minor behind each. New workflow keeps them in lockstep automatically going forward.

## What's new

- **``.github/workflows/publish-mcp.yml``** — fires on ``release: published`` for the same tag patterns the per-package PyPI workflows match (``v*`` → goldenmatch, ``goldencheck-v*`` → goldencheck, etc.). Single matrix job per package.
- **``workflow_dispatch`` with ``package`` input** (``all`` / one of five) — manual fire for the initial drift-close and any later one-off refreshes.
- **Auth: GitHub OIDC** — ``id-token: write`` permission scoped to the publish step. Registry trusts GH Actions tokens for ``io.github.<user>/*`` namespaces. No PAT, no secret, no DNS verification.
- **5 ``server.json`` files bumped** to current PyPI versions so the on-disk default matches reality. (Workflow re-injects per run, but the right default avoids confusing diffs.)
- **``CLAUDE.md``** note documenting the new flow.

## Drift before this PR

| Package | Registry | PyPI | Drift |
|---|---|---|---|
| ``goldenmatch`` | 1.4.8 | **1.13.0** | 8-9 versions |
| ``goldencheck`` | 1.1.4 | **1.2.0** | 1 minor |
| ``goldenflow`` | 1.1.4 | **1.1.2** | registry ahead of pkg ver |
| ``goldenpipe`` | 1.0.8 | **1.1.0** | 1 minor |
| ``infermap`` | 0.3.5 | **0.4.0** | 1 minor |

Drift closes the moment a maintainer fires ``workflow_dispatch publish-mcp.yml package=all`` after this merges.

## Test plan

- [x] YAML parses cleanly (``yaml.safe_load``)
- [x] Tag-pattern resolver matches the per-package PyPI workflow ``if:`` guards (including the ``goldencheck-types-v*`` → noop case)
- [x] ``jq`` injection step bumps both ``version`` and ``packages[0].version`` (verified locally)
- [ ] After merge: fire ``workflow_dispatch`` with ``package=all`` once. Expected: all 5 listings flip to current PyPI versions in the registry within ~30s. Verifiable via `curl https://registry.modelcontextprotocol.io/v0/servers?search=io.github.benzsevern/goldenmatch`.
- [ ] After next ``release: published`` for ``v1.13.1`` (or whichever): expect publish-mcp.yml to fire automatically and bump that one package.

## Notes

- ``goldenmatch[js]`` / ``goldencheck-types`` / ``infermap-js`` aren't on the MCP Registry today (no ``server.json``). The workflow's tag resolver treats those tag patterns as no-ops so they don't accidentally trigger Python publishes. If we add npm listings later, extend the ``case`` block.
- Pin ``mcp-publisher`` to a tag (currently uses ``latest`` release tarball) once the registry exits preview — they document breaking changes are still possible.
- The ``remotes[]`` field on ``goldenmatch/server.json`` (Railway streamable-http endpoint) is preserved unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)