### PR TITLE
release(goldenflow): 1.1.5 + add publish-goldenflow.yml

### DIFF
--- a/.github/workflows/publish-goldenflow.yml
+++ b/.github/workflows/publish-goldenflow.yml
@@ -1,0 +1,47 @@
+name: Publish goldenflow to PyPI
+
+# Brings goldenflow into the same release pipeline as the rest of the suite.
+# Before this workflow goldenflow was published manually via twine, which is
+# why the MCP Registry listing drifted ahead of PyPI (someone bumped the
+# registry to 1.1.4 in advance of a release that didn't ship). Once this
+# lands and goldenflow-v1.1.5 is tagged + released, the pattern matches
+# every other package in the suite.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    # Only run for goldenflow-v* tags. The leading `-v` distinguishes from
+    # the npm-side `goldenflow-js-v*` tag pattern used by the TypeScript port.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenflow-v')
+    runs-on: ubuntu-latest
+    environment: pypi
+    defaults:
+      run:
+        working-directory: packages/python/goldenflow
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/python/goldenflow/dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.1.5 (2026-05-11)
+
+Maintenance release. No transform / API behaviour changes.
+
+### Fixed
+
+- `goldenflow/__init__.py` `__version__` was `1.1.1`, lagging behind the
+  PyPI `1.1.2` release. Both now report `1.1.5`.
+
+### Infrastructure
+
+- New `.github/workflows/publish-goldenflow.yml` mirrors the per-package
+  PyPI publish workflows used by goldenmatch / goldencheck / goldenpipe /
+  infermap. Fires on `release: published` for `goldenflow-v*` tags;
+  `workflow_dispatch` with `ref` input for retro-publish. Brings goldenflow
+  into the same release pipeline the rest of the suite uses.
+- Companion MCP Registry sync (`.github/workflows/publish-mcp.yml`,
+  added in monorepo PR #165) flips
+  `registry.modelcontextprotocol.io/v0/servers?search=io.github.benzsevern/goldenflow`
+  from 1.1.4 → 1.1.5 automatically after this release lands on PyPI.
+
 ## 1.1.0 (2026-04-03)
 
 ### New Transforms (33 new, 43 → 76 total)

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.1"
+__version__ = "1.1.5"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.1.2"
+version = "1.1.5"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Maintenance release to close the MCP Registry drift that #165's auto-sync couldn't resolve. The registry rejected goldenflow's auto-sync because the registry's latest (1.1.4) is *ahead* of PyPI's latest (1.1.2) — re-publishing 1.1.2 returned `cannot publish duplicate version`. Fix: ship a new PyPI version that exceeds 1.1.4.

## Changes

**Version bumps**
- ``pyproject.toml``: 1.1.2 → 1.1.5
- ``goldenflow/__init__.py``: 1.1.1 → 1.1.5 (was lagging pyproject.toml independently — fixed in passing)

**Infrastructure**
- New ``.github/workflows/publish-goldenflow.yml`` mirrors the per-package publish workflows already in place for goldenmatch / goldencheck / goldenpipe / infermap. Fires on ``release: published`` for ``goldenflow-v*`` tags; ``workflow_dispatch`` with ``ref`` input. Before this, goldenflow was published manually via twine — that's how the registry got ahead in the first place.

**CHANGELOG.md** entry under ``## 1.1.5 (2026-05-11)``.

## Release flow after merge

1. Tag ``goldenflow-v1.1.5`` at HEAD of main, cut a GitHub release.
2. ``publish-goldenflow.yml`` fires → PyPI gets 1.1.5.
3. ``publish-mcp.yml`` (from #165) fires off the same ``release: published`` event → registry listing for goldenflow flips 1.1.4 → 1.1.5.

After this, drift is permanently closed across all five suite packages.

## Test plan

- [x] Both YAML files parse cleanly
- [x] ``publish-mcp.yml``'s tag resolver already handles ``goldenflow-v*`` (PR #165, line 66)
- [ ] Manual after merge: tag + release; confirm PyPI 1.1.5 + registry 1.1.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)