### PR TITLE
fix(ci): resolve MCP publish version from git tag, not PyPI lookup

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -113,29 +113,60 @@ jobs:
           chmod +x mcp-publisher
           ./mcp-publisher --help >/dev/null   # smoke
 
-      - name: Look up current PyPI version
-        id: pypi
+      - name: Resolve target version
+        # Source of truth depends on the event:
+        #
+        # - release: read from the git tag. The tag (e.g. `goldenflow-v1.1.5`)
+        #   is the canonical declaration of what's being shipped. PyPI lookup
+        #   would race against the parallel `publish-<pkg>.yml` workflow that
+        #   triggered off the same release event — the prior 1.1.5 release
+        #   hit exactly that bug (workflow saw the prior PyPI version because
+        #   the PyPI publish hadn't completed yet).
+        #
+        # - workflow_dispatch: read from pyproject.toml in the package dir.
+        #   Race-free; also lets us force-refresh listings without going
+        #   through PyPI/release.
+        id: ver
         shell: bash
         env:
           PKG: ${{ matrix.pkg }}
+          EVENT: ${{ github.event_name }}
+          TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          V=$(curl -fsSL "https://pypi.org/pypi/${PKG}/json" | jq -r '.info.version')
-          if [ -z "$V" ] || [ "$V" = "null" ]; then
-            echo "::error::PyPI returned no version for ${PKG}"
+          if [ "$EVENT" = "release" ]; then
+            # Tag patterns:
+            #   v1.13.0                  -> goldenmatch
+            #   goldencheck-v1.2.0       -> goldencheck
+            #   goldenflow-v1.1.5        -> goldenflow
+            #   goldenpipe-v1.1.0        -> goldenpipe
+            #   infermap-v0.4.0          -> infermap
+            # In every case the version is whatever follows the last `-v`
+            # (or the leading `v` for the unprefixed goldenmatch case).
+            V="${TAG##*-v}"
+            V="${V#v}"
+          else
+            # pyproject.toml is the canonical version source per package.
+            # `awk` instead of `python` so we don't need a setup-python step.
+            FILE="packages/python/${PKG}/pyproject.toml"
+            V=$(awk -F'"' '/^version[[:space:]]*=/ {print $2; exit}' "$FILE")
+          fi
+          if [ -z "$V" ] || ! echo "$V" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::could not resolve version for ${PKG} (event=${EVENT}, raw=${V})"
             exit 1
           fi
           echo "version=${V}" >> "$GITHUB_OUTPUT"
+          echo "::notice::publishing ${PKG} version ${V} (source: ${EVENT})"
 
       - name: Inject version into server.json
         # Keep the registry-level `version` and `packages[0].version` in
-        # lockstep with PyPI. server.json's other fields (name, title,
-        # description, repository, remotes) stay whatever the file in the
-        # repo says — those are publisher-curated, not synced from PyPI.
+        # lockstep with the resolved source. server.json's other fields
+        # (name, title, description, repository, remotes) stay whatever the
+        # file in the repo says — those are publisher-curated, not synced.
         shell: bash
         env:
           PKG: ${{ matrix.pkg }}
-          V: ${{ steps.pypi.outputs.version }}
+          V: ${{ steps.ver.outputs.version }}
         run: |
           set -euo pipefail
           FILE="packages/python/${PKG}/server.json"
@@ -164,7 +195,7 @@ jobs:
         shell: bash
         env:
           PKG: ${{ matrix.pkg }}
-          V: ${{ steps.pypi.outputs.version }}
+          V: ${{ steps.ver.outputs.version }}
         run: |
           {
             echo "## MCP Registry: ${PKG}"


### PR DESCRIPTION
## Summary

Fixes the race between ``publish-mcp.yml`` and the per-package ``publish-<pkg>.yml`` workflows when both fire off the same ``release: published`` event. Reproduced on the goldenflow 1.1.5 release (#166): the MCP sync hit PyPI before ``publish-goldenflow.yml`` finished, read the prior version (1.1.2), and got rejected with ``cannot publish duplicate version``. Manual ``workflow_dispatch`` after PyPI updated worked around it; this fixes it properly.

## Change

Replace the PyPI JSON API lookup with a version source picked by event type:

- **``release`` event**: parse the git tag. Two ``${...}`` expansions cover all five suite patterns:
  ```bash
  V="${TAG##*-v}"    # strip everything through the last `-v`
  V="${V#v}"         # strip leading `v` for the goldenmatch case
  ```
  | Tag | Resolved |
  |---|---|
  | ``v1.13.0`` | 1.13.0 |
  | ``goldencheck-v1.2.0`` | 1.2.0 |
  | ``goldenflow-v1.1.5`` | 1.1.5 |
  | ``goldenpipe-v1.1.0`` | 1.1.0 |
  | ``infermap-v0.4.0`` | 0.4.0 |

- **``workflow_dispatch`` event**: read ``version`` from the package's ``pyproject.toml`` via ``awk -F'"'``. Race-free; lets us force-refresh listings without going through PyPI/release.

Both paths get a regex sanity check + ``::notice::`` showing resolved version + source.

## Side effects

- Removes the only external HTTP dependency in the workflow (was ``curl pypi.org``). Faster + one fewer thing to break.
- ``workflow_dispatch`` no longer requires PyPI to be reachable from CI for the force-refresh path.

## Test plan

- [x] YAML parses cleanly (``yaml.safe_load``)
- [x] Tag parsing verified locally for all 5 patterns
- [x] ``pyproject.toml`` ``awk`` lookup verified locally for goldenflow
- [ ] Manual after merge: fire ``workflow_dispatch publish-mcp.yml package=goldenflow`` — should resolve 1.1.5 from pyproject + skip-or-succeed at the registry (registry already on 1.1.5; expect "cannot publish duplicate version" which is the *correct* protection now). To actually exercise the success path, wait for the next real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)