### PR TITLE
docs(claude-md): session learnings from controller-telemetry arc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,9 @@ A `continue-on-error: true` step that exits non-zero still flips the parent job'
 
 ## pypistats.org throttling
 pypistats `/api/packages/<pkg>/recent` 429s aggressively on unauthenticated bursts. Any script hitting it needs retry+backoff plus inter-request sleep (~1.5s). `scripts/suite_download_badges.py` is the reference implementation — preserves the prior badge value when throttled so the workflow exits 0.
+
+## MCP Registry vs mcp-marketplace.io
+Official registry is `registry.modelcontextprotocol.io` (suite is listed at `io.github.benzsevern/{goldenmatch,goldencheck,goldenflow,goldenpipe,infermap}`). `mcp-marketplace.io` is a third-party aggregator and does NOT list this suite. Maintainer dashboard for the official registry uses `io.github.X/Y` package identifiers + Approved/Remote/Edit buttons — that's the screenshot you'll see, not the marketplace site. `publish-mcp.yml` auto-syncs all five listings on `release: published`; `workflow_dispatch` with `package=all` force-refreshes without re-tagging.
+
+## Publish workflows: read version from git tag, not PyPI
+`publish-mcp.yml` and the per-package `publish-<pkg>.yml` workflows both fire off `release: published`. If the MCP sync queries PyPI for the version, it races against the parallel PyPI publish and reads the prior version → registry returns 400 "cannot publish duplicate version". Always derive version from the git tag (`${TAG##*-v}`, then `${V#v}`) for release events and from `pyproject.toml` for `workflow_dispatch`. PR #167 has the canonical pattern.

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -282,9 +282,13 @@ dqbench run all                                  # Compare against other tools
 
 ## Publishing
 
+CI auto-publishes via `.github/workflows/publish-goldenflow.yml` (PR #166) on `release: published` for `goldenflow-v*` tags. The MCP Registry listing auto-syncs off the same event via `publish-mcp.yml`. Manual fallback:
+
 ```bash
 python -m build && source .testing/.env && python -m twine upload dist/*
 ```
+
+- **Version source**: `pyproject.toml` `[project] version` is canonical. `goldenflow/__init__.py:__version__` MUST match. They drifted in v1.1.x (pyproject=1.1.2, `__init__`=1.1.1) and shipped that way — fixed in 1.1.5. Bumping a release means touching both atomically.
 
 ## Remote MCP Server
 

--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -17,6 +17,7 @@ Root CLAUDE.md owns: branch/merge SOP, GitHub auth dance, Rust + pgrx, PostgreSQ
 - **Release tags:** Python = `v1.x.y` (triggers `publish-goldenmatch.yml` → PyPI). TypeScript = `goldenmatch-js-v0.x.y` (triggers `publish-goldenmatch-js.yml` → npm). Never push an unprefixed version tag for TS.
 
 ## Testing
+- `CliRunner(mix_stderr=False)` errors on click ≥8.3 (currently installed) with `TypeError: unexpected keyword argument 'mix_stderr'`. Drop the kwarg — default already routes stderr separately; `result.stderr` is still accessible.
 - **TypeScript:** `cd packages/goldenmatch-js && npx vitest run` — 478 tests currently. Full check: `npx tsc --noEmit && npx vitest run && npm run build`
 - TS parity check: `tests/parity/` — add new parity cases when porting any new scorer or algorithm
 - `pytest --tb=short` from project root — all tests must pass after every change
@@ -105,6 +106,7 @@ Root CLAUDE.md owns: branch/merge SOP, GitHub auth dance, Rust + pgrx, PostgreSQ
 - LLM+embedding benchmark: `python tests/benchmarks/run_llm_budget_bench.py` (requires OPENAI_API_KEY)
 
 ## Code Patterns
+- **Cross-surface controller telemetry uses ONE serializer**: `goldenmatch.web.controller_telemetry.serialize_telemetry(profile, history, committed_config, source, run_name, recorded_at)`. Every v1.7-v1.12 surface (web `/api/v1/controller/telemetry`, TUI Controller tab, CLI `goldenmatch autoconfig`, REST `/autoconfig`, MCP `auto_configure` tool, A2A `autoconfig` skill, SQL `goldenmatch_autoconfig_telemetry()`, Rust bridge `autoconfig()`) delegates here. SQL bridge + DuckDB UDFs fall back to a minimal hand-rolled blob (`{available, source, stop_reason, health}`) when `goldenmatch[web]` extra isn't installed. Capture telemetry by reading `goldenmatch.core.autoconfig._LAST_CONTROLLER_RUN.get()` post-`auto_configure_df()` — returns `(profile, history)` or `None`.
 - **Pydantic typed-accessor pattern for Optional invariants.** `MatchkeyConfig.threshold` / `MatchkeyField.scorer`/`weight`/`field` are typed Optional at the Pydantic level (YAML round-trip) but guaranteed non-None for `weighted`/`fuzzy` matchkey types post-validation. Pattern (PR #151): keep the field Optional, add a `@property` accessor (`fuzzy_threshold`, `fuzzy_scorer`, `fuzzy_weight`, `resolved_field`) that raises `ValueError` if the invariant was broken via post-construction mutation, and use the accessor at call sites that need the narrowed type. Pyright stops seeing Optional — dropped 7 `# pyright: ignore` suppressions in `scorer.py`.
 - **Pyright suppressions on multi-line imports.** `# pyright: ignore[reportMissingImports]` must sit on the `from X import (` line itself, NOT on the imported-symbol continuation line. Pyright reports the error at the `from X` column; a comment on a later line doesn't satisfy it. Bit us on `autoconfig_policy.py` (openai) and `scorer.py` (sentence_transformers) in PR #147.
 - Auto-config exact matchkeys: `col_type in ("zip","geo")` NEVER backs an exact matchkey (blocking signal, not identity claim). Exact matchkeys require `cardinality_ratio >= 0.5`. Skipped columns still flow into `build_blocking()`.


### PR DESCRIPTION
## Summary

Four short additions to CLAUDE.md files capturing learnings from the v1.7-v1.12 surface-parity arc + MCP Registry work (PRs #156-167).

## Where

| File | Additions |
|---|---|
| ``CLAUDE.md`` (root) | MCP Registry vs mcp-marketplace.io; publish-workflow race + tag-driven version source |
| ``packages/python/goldenmatch/CLAUDE.md`` | Cross-surface telemetry serializer location; ``CliRunner(mix_stderr=False)`` removed in click ≥8.3 |
| ``packages/python/goldenflow/CLAUDE.md`` | pyproject + __init__ version-sync invariant; auto-publish flow via #166 |

3 files, 12 insertions. Each addition is a single-line concept; no verbose explanations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)