### PR TITLE
fix(agent): default path runs AutoConfigController; clear telemetry on explicit config

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/agent.py
+++ b/packages/python/goldenmatch/goldenmatch/core/agent.py
@@ -450,28 +450,48 @@ class AgentSession:
         file_path: str,
         config: Any = None,
     ) -> dict[str, Any]:
-        """Full deduplication with profiling, strategy, gating, and review queue."""
+        """Full deduplication with profiling, strategy, gating, and review queue.
+
+        When ``config`` is None, delegates to ``dedupe_df(df)`` with no config
+        so the AutoConfigController fires and produces telemetry. When
+        ``config`` is supplied, runs the explicit config and zeros
+        ``last_telemetry`` so a prior auto-config's blob can't leak into the
+        result. ``select_strategy()`` still runs for the ``reasoning`` payload
+        — that's a separate legacy heuristic-driven explanation, not the
+        controller's authoritative output.
+        """
         from goldenmatch._api import dedupe_df
 
         df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
         self.data = df
 
+        # Profile + decision are kept ONLY for the `reasoning` field; they do
+        # not back the actual dedupe config when the caller didn't pass one.
+        # See PR #169: routing the default path through dedupe_df()'s
+        # AutoConfigController gives us the v1.7-v1.12 telemetry that the
+        # legacy `_decision_to_config(decision)` heuristic does not.
         profile = profile_for_agent(df)
         decision = select_strategy(profile)
 
         if config is not None:
             cfg = config
+            # Explicit config means the controller doesn't fire; clear any
+            # cached telemetry so callers can't read a stale blob from a
+            # prior auto-config call.
+            self.last_telemetry = None
+            result = dedupe_df(df, config=cfg)
         else:
-            cfg = _decision_to_config(decision)
+            # No config -> let dedupe_df run its zero-config AutoConfigController
+            # path. The committed config comes back on result.config.
+            cfg = None
+            result = dedupe_df(df)
+            committed_cfg = getattr(result, "config", None)
+            self.last_telemetry = self._capture_telemetry(
+                committed_cfg, source="deduplicate"
+            )
+            cfg = committed_cfg
         self.config = cfg
-
-        result = dedupe_df(df, config=cfg)
         self.result = result
-
-        # Capture controller telemetry from this call (None when caller
-        # passed an explicit config and the controller didn't fire).
-        committed_cfg = getattr(result, "config", cfg)
-        self.last_telemetry = self._capture_telemetry(committed_cfg, source="deduplicate")
 
         # Gate scored pairs through review queue
         scored_pairs = result.scored_pairs or []
@@ -520,27 +540,37 @@ class AgentSession:
         file_b: str,
         config: Any = None,
     ) -> dict[str, Any]:
-        """Match two CSV sources with profiling, strategy, and gating."""
+        """Match two CSV sources with profiling, strategy, and gating.
+
+        ``config=None`` delegates to ``match_df(df_a, df_b)`` (no config) so
+        the AutoConfigController fires; explicit config clears cached
+        telemetry to prevent stale-blob leaks. Mirror of ``deduplicate``.
+        """
         from goldenmatch._api import match_df
 
         df_a = pl.read_csv(file_a, encoding="utf8-lossy", ignore_errors=True)
         df_b = pl.read_csv(file_b, encoding="utf8-lossy", ignore_errors=True)
 
-        # Profile the target (first file)
+        # Profile the target (first file) — used only for the `reasoning`
+        # payload, NOT to build the actual matching config when config is None
+        # (see deduplicate() for the rationale).
         profile = profile_for_agent(df_a)
         decision = select_strategy(profile)
 
         if config is not None:
             cfg = config
+            self.last_telemetry = None
+            result = match_df(df_a, df_b, config=cfg)
         else:
-            cfg = _decision_to_config(decision)
+            cfg = None
+            result = match_df(df_a, df_b)
+            committed_cfg = getattr(result, "config", None)
+            self.last_telemetry = self._capture_telemetry(
+                committed_cfg, source="match_sources"
+            )
+            cfg = committed_cfg
         self.config = cfg
-
-        result = match_df(df_a, df_b, config=cfg)
         self.result = result
-
-        committed_cfg = getattr(result, "config", cfg)
-        self.last_telemetry = self._capture_telemetry(committed_cfg, source="match_sources")
 
         self.reasoning = {
             "strategy": decision.strategy,

--- a/packages/python/goldenmatch/tests/test_agent.py
+++ b/packages/python/goldenmatch/tests/test_agent.py
@@ -349,12 +349,12 @@ class TestAgentSessionTelemetry:
         result = session.autoconfigure(tmp_csv)
         assert "config" in result
         assert "telemetry" in result
-        # Controller always sets these — assert presence not specific values.
+        # Controller always sets these — hard assertions (was conditional;
+        # tightened in PR #169 once the default-config bug was fixed).
         telemetry = result["telemetry"]
-        assert "available" in telemetry
-        if telemetry["available"]:
-            assert "stop_reason" in telemetry
-            assert "health" in telemetry
+        assert telemetry["available"] is True
+        assert "stop_reason" in telemetry
+        assert "health" in telemetry
 
     def test_autoconfigure_caches_telemetry_on_session(self, tmp_csv):
         """last_telemetry is set after autoconfigure for follow-up reads."""
@@ -362,14 +362,83 @@ class TestAgentSessionTelemetry:
         assert session.last_telemetry is None
         session.autoconfigure(tmp_csv)
         assert session.last_telemetry is not None
+        assert session.last_telemetry["available"] is True
 
     def test_deduplicate_default_path_captures_telemetry(self, tmp_csv):
-        """No explicit config -> controller fires -> telemetry is captured."""
+        """No explicit config -> dedupe_df runs the AutoConfigController ->
+        telemetry MUST land. Hard assertion (was conditional before #169).
+
+        Regression guard for the bug the v1.14 release fixes: prior to
+        #169, AgentSession.deduplicate built a config from select_strategy()
+        and passed it explicitly, which suppressed the controller path and
+        produced None telemetry. The fix passes no config so dedupe_df()
+        runs its zero-config controller-backed path.
+        """
         session = AgentSession()
+        result = session.deduplicate(tmp_csv)
+        assert session.last_telemetry is not None, (
+            "default-path deduplicate() must produce telemetry — if this "
+            "fires, AgentSession is bypassing the AutoConfigController again"
+        )
+        assert session.last_telemetry["available"] is True
+        assert "stop_reason" in session.last_telemetry
+        assert "health" in session.last_telemetry
+        # The result dict shape is unchanged — fix is internal.
+        assert "results" in result
+        assert "reasoning" in result
+        assert "confidence_distribution" in result
+
+    def test_match_sources_default_path_captures_telemetry(
+        self, tmp_csv, tmp_csv_b,
+    ):
+        """Mirror of test_deduplicate_default_path for match_sources."""
+        session = AgentSession()
+        session.match_sources(tmp_csv, tmp_csv_b)
+        assert session.last_telemetry is not None
+        assert session.last_telemetry["available"] is True
+
+    def test_explicit_config_does_not_leak_prior_telemetry(self, tmp_csv):
+        """Regression: after a default-path call populates last_telemetry,
+        a follow-up explicit-config call must reset it — callers reading
+        last_telemetry on an explicit-config result should not see a stale
+        blob from the prior auto-config run.
+
+        Pre-#169 behavior: explicit-config calls inherited last_telemetry
+        from a prior auto-config call because the code always called
+        `_capture_telemetry(committed_cfg, ...)` regardless of whether the
+        controller actually fired. Now last_telemetry is explicitly cleared
+        on the explicit-config branch.
+        """
+        from goldenmatch.config.schemas import (
+            BlockingConfig,
+            BlockingKeyConfig,
+            GoldenMatchConfig,
+            MatchkeyConfig,
+            MatchkeyField,
+        )
+
+        session = AgentSession()
+
+        # Step 1: populate last_telemetry via the default path.
         session.deduplicate(tmp_csv)
-        # No explicit config, dedupe_df auto-configs internally — telemetry should land.
-        # (Note: select_strategy heuristic path still wins inside AgentSession.deduplicate
-        #  today; this test documents intent. If telemetry is None here, the heuristic
-        #  path is overriding the controller — that is a known gap to address separately.)
-        if session.last_telemetry is not None:
-            assert "available" in session.last_telemetry
+        assert session.last_telemetry is not None
+        prior_telemetry = session.last_telemetry
+
+        # Step 2: explicit-config dedupe on the same session. Controller
+        # doesn't fire; last_telemetry must NOT still hold the prior blob.
+        explicit_cfg = GoldenMatchConfig(
+            matchkeys=[MatchkeyConfig(
+                name="mk", type="weighted", threshold=0.85,
+                fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+            )],
+            blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["zip"])]),
+        )
+        session.deduplicate(tmp_csv, config=explicit_cfg)
+        assert session.last_telemetry is None, (
+            f"explicit-config dedupe leaked prior auto-config telemetry: "
+            f"{session.last_telemetry!r}"
+        )
+        # Sanity: the prior_telemetry variable is still the same object the
+        # earlier call produced (we didn't mutate it; we cleared the session
+        # attribute).
+        assert prior_telemetry["available"] is True


### PR DESCRIPTION
## Summary

Closes the semantic gap that #161 left behind: ``AgentSession.deduplicate(config=None)`` and ``.match_sources(config=None)`` were still building a config from ``select_strategy()`` (the legacy heuristic) and passing it explicitly to ``dedupe_df``/``match_df``, which suppressed the v1.7+ controller's zero-config path. ``last_telemetry`` ended up ``None`` even though the call should have produced full telemetry. The conditional test (#161's coverage for this case) documented the gap rather than guarding against it.

Required before cutting v1.14.0 — that release's headline is "telemetry visible from every surface" and the agent surface was the one still cheating.

## Change

| Surface | Before | After |
|---|---|---|
| ``deduplicate(config=None)`` | called ``dedupe_df(df, config=_decision_to_config(decision))`` | calls ``dedupe_df(df)``; controller fires; ``last_telemetry`` populated |
| ``match_sources(config=None)`` | same shape, with ``match_df`` | calls ``match_df(df_a, df_b)``; same fix |
| ``deduplicate(config=X)`` / ``match_sources(config=X)`` | populated ``last_telemetry`` regardless (read from prior call's ContextVar) | explicitly clears ``last_telemetry = None`` so prior auto-config blobs don't leak |
| ``select_strategy()`` / ``_decision_to_config()`` | drove the actual config | only used for the ``reasoning`` payload + ``compare_strategies`` legacy path |

The ``reasoning`` field shape is unchanged.

## Tests

- ``test_deduplicate_default_path_captures_telemetry``: hard-asserts ``telemetry["available"] is True`` + ``stop_reason`` + ``health`` (was conditional)
- new ``test_match_sources_default_path_captures_telemetry``: match-side mirror
- new ``test_explicit_config_does_not_leak_prior_telemetry``: dedupe via default path → dedupe via explicit config; must clear telemetry
- ``test_autoconfigure_returns_config_and_telemetry``: hard-asserts available (was conditional)

## Test plan

- [x] ``pytest tests/test_agent.py`` — 37/37
- [x] ``pytest tests/{test_agent,test_mcp_controller_telemetry,test_a2a_controller_telemetry,test_api_rest_controller}.py`` — 46 pass + 4 skipped (a2a no aiohttp locally)
- [x] ``ruff check`` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)