### PR TITLE
release(goldenmatch): v1.14.0 — controller telemetry visible from every surface

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-05-11
+
+This release ships the full v1.7-v1.12 AutoConfigController surface to every user-facing entry point in the suite. No algorithm changes vs 1.13.0 — same DQbench / DBLP-ACM / Febrl3 / NCVR numbers — but you can now read what the controller decided from every interface (web, TUI, CLI, REST, MCP, A2A, Postgres, DuckDB) and round-trip the committed config (including Path Y negative-evidence) through SQL.
+
+### Fixed
+
+- **AgentSession default path now actually runs the AutoConfigController** (PR #169). `deduplicate(config=None)` / `match_sources(config=None)` were building a config from the legacy `select_strategy()` heuristic and passing it explicitly to `dedupe_df`/`match_df`, which suppressed the zero-config controller path. `last_telemetry` ended up `None` for the case it was meant to capture. Default path now calls `dedupe_df(df)` / `match_df(df_a, df_b)` with no config so the controller fires. Explicit-config calls explicitly clear `last_telemetry` to prevent stale-blob leaks across calls on the same session. `select_strategy()` still runs but only for the `reasoning` payload, not to back the actual matching config. Hard-asserting tests landed alongside the fix.
+
 ### Added — AutoConfigController surface-parity arc
 
 Six PRs (#156-#159 + #161; #160 added CI lanes) bring every user-facing entry point up to speed with the v1.7-v1.12 AutoConfigController / IndicatorContext / NegativeEvidence work. Before this arc, controller decisions were observable only by reading `result.postflight_report.controller_history` in Python. Now every surface returns the same JSON shape (`stop_reason`, `health`, refit decisions, indicator column priors, committed `negative_evidence`) via `goldenmatch.web.controller_telemetry.serialize_telemetry`.

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.13.0"
+__version__ = "1.14.0"
 
 # ── High-level API (convenience functions) ────────────────────────────────
 from goldenmatch._api import (

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.13.0"
+version = "1.14.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Cuts ``goldenmatch`` v1.14.0. Materializes the [Unreleased] section in CHANGELOG.md as [1.14.0] - 2026-05-11 and bumps both ``pyproject.toml`` and ``__init__.py`` to 1.14.0 (per the version-sync invariant noted in CLAUDE.md).

## What's in this release

- **The full v1.7-v1.12 controller surface, visible from every interface** — web ControllerPanel, TUI Controller tab + ``Ctrl+A``, CLI ``goldenmatch autoconfig``, REST ``/autoconfig`` + ``/controller/telemetry``, MCP ``auto_configure`` + ``controller_telemetry``, A2A ``autoconfig`` + ``controller_telemetry``, Postgres ``goldenmatch_autoconfig`` + ``gm_telemetry`` + ``goldenmatch_dedupe_full``, DuckDB UDF equivalents.
- **AgentSession default path actually runs the controller** (#169). The bug PR #161 left behind: ``deduplicate(config=None)`` / ``match_sources(config=None)`` were passing a legacy heuristic config explicitly, which suppressed the controller. Now fixed.
- **Single shared telemetry serializer** at ``goldenmatch.web.controller_telemetry.serialize_telemetry``. One parser, reused everywhere.
- **CI coverage** for the previously-unverified pgrx + DuckDB UDF surface (PR #160).
- **MCP Registry auto-sync** keeps the registry in lockstep with PyPI on every release (PR #165 + #167).

## No algorithm changes

Same DQbench / DBLP-ACM / Febrl3 / NCVR / DQbench numbers as 1.13.0. The committed benchmark numbers in the README and ``docs/reproducing-benchmarks.md`` remain valid.

## Release plan after merge

1. Cut a GitHub release with tag ``v1.14.0`` against the merge commit.
2. ``publish-goldenmatch.yml`` fires → PyPI gets 1.14.0.
3. ``publish-mcp.yml`` fires off the same ``release: published`` event → MCP Registry listing flips 1.13.0 → 1.14.0. With #167's tag-driven version source, no race against the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)