### PR TITLE
fix(goldenflow): avoid Series.to_list() panic in category_auto_correct at 1M+ rows (#174)

### DIFF
--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/goldenflow/transforms/auto_correct.py
+++ b/packages/python/goldenflow/goldenflow/transforms/auto_correct.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import Iterable
+from collections.abc import Iterable
 
 import polars as pl
 from rapidfuzz import fuzz

--- a/packages/python/goldenflow/goldenflow/transforms/auto_correct.py
+++ b/packages/python/goldenflow/goldenflow/transforms/auto_correct.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import Counter
+from typing import Iterable
 
 import polars as pl
 from rapidfuzz import fuzz
@@ -9,7 +10,7 @@ from goldenflow.transforms import register_transform
 
 
 def _build_canonical_map(
-    values: list[str | None],
+    value_counts: Iterable[tuple[str | None, int]],
     frequency_threshold: float = 0.05,
     match_threshold: float = 85.0,
 ) -> dict[str, str]:
@@ -18,22 +19,28 @@ def _build_canonical_map(
     1. Count case-insensitive frequencies
     2. Values above frequency_threshold are canonical candidates
     3. Low-frequency values fuzzy-matched against candidates
+
+    Takes (value, count) pairs (typically from a Polars ``value_counts``)
+    so the caller can avoid materializing N row-level Python strings on
+    large inputs — at 1M+ rows the row-level ``Series.to_list()`` can
+    trip a pyo3 panic when PyString allocation fails under memory
+    pressure (see goldenflow issue #174 / goldenmatch PR #173).
     """
     # Count case-insensitive frequencies
     lower_counts: Counter[str] = Counter()
     case_map: dict[str, Counter[str]] = {}  # lowercase -> Counter of original casings
 
-    for v in values:
+    for v, count in value_counts:
         if v is None:
             continue
         v_stripped = v.strip()
         if not v_stripped:
             continue
         low = v_stripped.lower()
-        lower_counts[low] += 1
+        lower_counts[low] += count
         if low not in case_map:
             case_map[low] = Counter()
-        case_map[low][v_stripped] += 1
+        case_map[low][v_stripped] += count
 
     total = sum(lower_counts.values())
     if total == 0:
@@ -94,9 +101,19 @@ def category_auto_correct(
 
     Identifies low-frequency values that fuzzy-match high-frequency canonical
     values and corrects them. No LLM required.
+
+    Builds the canonical map from a Polars ``value_counts`` aggregation
+    rather than ``series.to_list()`` so the work stays O(n_unique) instead
+    of O(n_rows). On large inputs this also dodges a pyo3 PanicException
+    that can fire when materializing millions of Python strings under
+    memory pressure (goldenflow issue #174).
     """
-    values = series.to_list()
-    corrections = _build_canonical_map(values, frequency_threshold, match_threshold)
+    vc = series.value_counts(sort=True)
+    # value_counts returns a 2-column DataFrame: [<series.name>, "count"].
+    # iter_rows() yields plain Python tuples; only n_unique tuples are
+    # ever produced (no per-row materialization of the source Series).
+    pairs: list[tuple[str | None, int]] = list(vc.iter_rows())
+    corrections = _build_canonical_map(pairs, frequency_threshold, match_threshold)
 
     if not corrections:
         return series

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.1.5"
+version = "1.1.6"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"

--- a/packages/python/goldenflow/tests/transforms/test_auto_correct.py
+++ b/packages/python/goldenflow/tests/transforms/test_auto_correct.py
@@ -35,11 +35,35 @@ def test_no_correction_for_distinct_values():
 
 
 def test_build_canonical_map_basic():
-    values = ["active"] * 50 + ["Active"] * 3 + ["actve"] * 2 + ["inactive"] * 40
-    corrections = _build_canonical_map(values)
+    # value_counts-style input: (distinct_value, count) pairs.
+    pairs = [("active", 50), ("Active", 3), ("actve", 2), ("inactive", 40)]
+    corrections = _build_canonical_map(pairs)
     assert corrections.get("Active") == "active"
     assert corrections.get("actve") == "active"
     assert "inactive" not in corrections  # high-freq, no correction needed
+
+
+def test_large_series_does_not_materialize_to_list():
+    """Regression for goldenflow #174.
+
+    Earlier versions called ``series.to_list()`` which, at 1M+ rows under
+    memory pressure, could trip a pyo3 PanicException
+    ("PyObject pointer is null"). The rewritten path goes through
+    ``Series.value_counts()`` so work is O(n_unique). This test exercises
+    a 200K-row mixed-casing column shape similar to the synthetic person
+    fixture that surfaced the panic and asserts the transform completes
+    without raising.
+    """
+    import random
+    random.seed(0)
+    base = ["Active", "INACTIVE", "Pending", "Cancelled", "ACTIVE", "active", "inactive"]
+    values = [random.choice(base) for _ in range(200_000)]
+    s = pl.Series("status", values)
+    result = category_auto_correct(s)
+    assert len(result) == 200_000
+    # The transform should converge "ACTIVE" / "active" to one canonical casing.
+    distinct_lower = {v.lower() for v in result.to_list() if v}
+    assert distinct_lower.issubset({"active", "inactive", "pending", "cancelled"})
 
 
 def test_preserves_nulls():


### PR DESCRIPTION
Closes #174 (the panic). **Does NOT yet make 1M end-to-end safe on 64 GB hardware** — see Verification.

## Summary

`goldenflow.transforms.auto_correct.category_auto_correct` called `series.to_list()` on its input — at 1M rows under memory pressure (~2 GB RSS already allocated by goldenmatch's `auto_configure`), the PyString allocations inside Polars' `to_list` returned NULL and pyo3 0.28.2 mapped that to `PanicException("PyObject pointer is null")` instead of raising `MemoryError`. This crashed the 1M end-to-end run after PR #173's two goldenmatch fixes unblocked everything upstream.

Replaced the row-level `to_list()` + Python `Counter` with a Polars `series.value_counts(sort=True)` aggregation. The function only ever needed n_unique distinct values + their frequencies — both come straight out of `value_counts`. New path is **O(n_unique)** instead of **O(n_rows)** in both wall and memory, and it side-steps the pyo3 boundary entirely.

## Verification — fix lands, broader scale story still has work

The 1M scale-audit run completed (836,154 clusters, no `PanicException`, JSON `failed: null`) — but the host machine (64 GB RAM, Windows 11) **hit OS-level memory pressure / OOM during the run**. Per-stage RSS measurements topped out at 4.3 GB, but those samples come from psutil-side polling at stage boundaries; the actual process working set must have been considerably higher mid-stage. Likely contributors not captured by tracemalloc + psutil sampling:

- Polars' Rust-side arena allocations (only partially visible to tracemalloc)
- tracemalloc's own per-allocation traceback storage (can multiply traced size)
- `_RSSWatchdog` daemon thread + per-stage snapshot retention
- OS file cache pressure from the 100 MB synthetic CSV

Measured per-stage (still useful as relative attribution; not a memory budget):

| stage | wall | sampled peak RSS | sampled peak heap |
|---|---:|---:|---:|
| read_csv | 0.3 s | 468 MB | 27 MB |
| auto_configure | 36 min | 4.3 GB | 1.5 GB |
| run_dedupe | 26 min | 3.1 GB | 3.0 GB |
| **total** | **62 min** | — | — |

**What this PR DOES fix:** the panic. With this change, `category_auto_correct` no longer takes a row-proportional Python-object allocation, which removes one of the two paths that was hitting the wall on this hardware.

**What this PR does NOT fix:** the system still OOMs end-to-end at 1M. Investigation continues under scale-audit Round 3 (memory attribution + reduction is now back on the priority list — see issue #171 step 4).

## Test plan

- [x] `pytest packages/python/goldenflow/tests/` — 230 passed, 5 skipped (same baseline)
- [x] New regression test `test_large_series_does_not_materialize_to_list` (200K-row mixed-casing column shape)
- [x] Refactored `test_build_canonical_map_basic` to pass `(value, count)` pairs matching the new signature
- [x] `scripts/scale_audit.py --rows 1000000` runs to script completion without `PanicException`
- [ ] 1M end-to-end run that stays under 64 GB host pressure — **NOT achieved by this PR**; tracked under Round 3
- [ ] CI green on this branch

## Version

Patch bump 1.1.5 → 1.1.6 (both `pyproject.toml` and `goldenflow/__init__.py` per the CLAUDE.md atomicity rule). Behaviour change on `auto_apply` transform at large inputs.

## Follow-ups

- Round 3 memory attribution: get a real peak-memory number (e.g. periodic `psutil.virtual_memory()` snapshots, not just per-stage `Process.memory_info()`) and identify which subsystem owns the bulk.
- Tag `goldenflow-v1.1.6` to fire the publish workflow once this lands.
- Re-run 1M after Round 3 lands a memory-bounded path; only then claim "1M end-to-end" works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)