### PR TITLE
ci: workflow_dispatch lane for scale-audit on GitHub-hosted runners (#176)

### DIFF
--- a/.github/workflows/scale-audit.yml
+++ b/.github/workflows/scale-audit.yml
@@ -1,0 +1,156 @@
+name: scale-audit
+
+# Offload scale_audit.py to GitHub-hosted runners so we can measure
+# memory + wall on hardware sized for the row count, without taking
+# the developer machine offline for hours. workflow_dispatch only —
+# never auto-triggered. Tracks issue #176 (Round 3 memory attribution).
+
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "row count for the synthetic fixture"
+        required: true
+        default: "100000"
+        type: choice
+        options:
+          - "10000"
+          - "100000"
+          - "500000"
+          - "1000000"
+          - "2000000"
+          - "5000000"
+      runner:
+        description: "runner size. larger sizes must be enabled in repo settings before they can be selected."
+        required: true
+        default: "ubuntu-latest"
+        type: choice
+        options:
+          - "ubuntu-latest"          # 16 GB, 4-core
+          - "ubuntu-latest-8-cores"  # 32 GB
+          - "ubuntu-latest-16-cores" # 64 GB
+      dupe_rate:
+        description: "synthetic duplicate rate (0.0 - 1.0)"
+        required: false
+        default: "0.15"
+      tracemalloc:
+        description: "enable tracemalloc tracking. disable for clean RSS measurement on large runs."
+        required: true
+        default: "off"
+        type: choice
+        options:
+          - "off"
+          - "on"
+      rss_budget_mb:
+        description: "abort + flush if RSS exceeds this (MB). leave blank to disable."
+        required: false
+        default: ""
+
+jobs:
+  audit:
+    name: "scale_audit rows=${{ inputs.rows }} runner=${{ inputs.runner }}"
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Free disk space on runner
+        # The synthetic fixture at 5M is ~500 MB and Polars build assets
+        # eat a chunk too. The hosted-toolcache + dotnet bundles are dead
+        # weight for this job; drop them up front so the audit doesn't
+        # run out of disk midway through fixture generation.
+        run: |
+          df -h /
+          sudo rm -rf /opt/hostedtoolcache /usr/share/dotnet /usr/local/lib/android || true
+          df -h /
+
+      - name: Show runner memory + CPU
+        # Capture the actual runner shape so future readers of the audit
+        # log can correlate results with the hardware they ran on (the
+        # ubuntu-latest tier swaps periodically and 16 GB is not guaranteed).
+        run: |
+          echo "===memory==="
+          free -h || vm_stat || true
+          echo "===cpu==="
+          nproc || sysctl -n hw.ncpu || true
+          cat /proc/cpuinfo 2>/dev/null | head -25 || true
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Run scale audit
+        id: audit
+        run: |
+          mkdir -p .profile_tmp
+          OUT=".profile_tmp/scale_${{ inputs.rows }}_${{ inputs.runner }}.json"
+          LOG=".profile_tmp/scale_${{ inputs.rows }}_${{ inputs.runner }}.log"
+          echo "out_path=$OUT" >> $GITHUB_OUTPUT
+          echo "log_path=$LOG" >> $GITHUB_OUTPUT
+
+          ARGS="--rows ${{ inputs.rows }} --dupe-rate ${{ inputs.dupe_rate }} --out $OUT"
+          if [ "${{ inputs.tracemalloc }}" = "off" ]; then
+            ARGS="$ARGS --no-tracemalloc"
+          fi
+          if [ -n "${{ inputs.rss_budget_mb }}" ]; then
+            ARGS="$ARGS --rss-budget-mb ${{ inputs.rss_budget_mb }}"
+          fi
+
+          echo "running: scripts/scale_audit.py $ARGS"
+          # tee so the live log streams to the workflow output AND lands
+          # in the artifact. set +e so we still upload artifacts on crash.
+          set +e
+          uv run python scripts/scale_audit.py $ARGS 2>&1 | tee "$LOG"
+          AUDIT_EXIT=${PIPESTATUS[0]}
+          echo "audit exited $AUDIT_EXIT"
+          # Always succeed this step — the next steps need to run so the
+          # JSON / log artifacts get uploaded even when the run OOM-kills
+          # or panics. The "did it work?" check happens in summary below.
+          exit 0
+
+      - name: Print result summary
+        if: always()
+        run: |
+          OUT="${{ steps.audit.outputs.out_path }}"
+          LOG="${{ steps.audit.outputs.log_path }}"
+          echo "===JSON ($OUT)==="
+          if [ -f "$OUT" ]; then
+            cat "$OUT"
+          else
+            echo "(no JSON written — process may have died before first flush)"
+          fi
+          echo ""
+          echo "===log tail (last 60 lines)==="
+          if [ -f "$LOG" ]; then
+            tail -60 "$LOG"
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scale-audit-${{ inputs.rows }}-${{ inputs.runner }}-${{ github.run_id }}
+          path: |
+            .profile_tmp/scale_*.json
+            .profile_tmp/scale_*.log
+          if-no-files-found: warn
+
+      - name: Capture host memory pressure on exit
+        # If the audit OOM-killed, dmesg often has the OOM message and the
+        # MemFree number at kill-time. Surface it in the workflow log so
+        # we don't have to download the artifact to know what happened.
+        if: always()
+        run: |
+          echo "===dmesg tail (OOM diagnostics)==="
+          sudo dmesg | tail -40 || dmesg | tail -40 || echo "(dmesg unavailable)"
+          echo "===memory at exit==="
+          free -h || true

--- a/scripts/scale_audit.py
+++ b/scripts/scale_audit.py
@@ -155,22 +155,32 @@ def ensure_fixture(rows: int, dupe_rate: float, fixture_dir: Path) -> Path:
 
 
 @contextmanager
-def _tracking(result: ScaleAuditResult, process: psutil.Process):
-    """Wrap the whole run with tracemalloc + a global wall timer."""
-    tracemalloc.start()
+def _tracking(result: ScaleAuditResult, process: psutil.Process, enable_tracemalloc: bool = True):
+    """Wrap the whole run with optional tracemalloc + a global wall timer.
+
+    tracemalloc retains a traceback per allocation, which on large runs
+    becomes a meaningful chunk of process memory itself — defeating the
+    "what's the real peak?" question. Pass ``enable_tracemalloc=False``
+    for cloud runs where we care about true RSS without the tracker's
+    overhead. Stage-level peaks are still captured via psutil RSS sampling
+    regardless.
+    """
+    if enable_tracemalloc:
+        tracemalloc.start()
     t0 = time.perf_counter()
     rss0 = process.memory_info().rss
     try:
         yield
     finally:
         result.total_wall_seconds = time.perf_counter() - t0
-        _, tm_peak = tracemalloc.get_traced_memory()
-        result.peak_tracemalloc_mb = tm_peak / 1024 / 1024
+        if enable_tracemalloc:
+            _, tm_peak = tracemalloc.get_traced_memory()
+            result.peak_tracemalloc_mb = tm_peak / 1024 / 1024
+            tracemalloc.stop()
         # Final RSS is approximate peak — RSS doesn't shrink immediately on
         # Linux; close enough for a "did this fit on a 64GB box" question.
         rss_now = process.memory_info().rss
         result.peak_rss_mb = max(rss_now, rss0) / 1024 / 1024
-        tracemalloc.stop()
 
 
 def _write_snapshot(result: ScaleAuditResult, out_path: Path | None) -> None:
@@ -285,6 +295,7 @@ def run_audit(
     fixture_dir: Path | None = None,
     out_path: Path | None = None,
     rss_budget_mb: float | None = None,
+    enable_tracemalloc: bool = True,
 ) -> ScaleAuditResult:
     """Run one audit pass against a synthetic fixture of the given size.
 
@@ -326,7 +337,7 @@ def run_audit(
         watchdog.start()
 
     try:
-        with _tracking(result, process):
+        with _tracking(result, process, enable_tracemalloc=enable_tracemalloc):
             import polars as pl
             from goldenmatch.core.autoconfig import auto_configure_df
             from goldenmatch.core.pipeline import run_dedupe_df
@@ -439,6 +450,16 @@ def main() -> None:
         ),
     )
     ap.add_argument(
+        "--no-tracemalloc",
+        action="store_true",
+        help=(
+            "disable tracemalloc tracking. tracemalloc retains a traceback per "
+            "allocation, which on large runs adds non-trivial memory overhead. "
+            "Recommended for cloud-runner peak-memory measurements where psutil "
+            "RSS is the metric of interest."
+        ),
+    )
+    ap.add_argument(
         "--summarize",
         nargs="+",
         help="aggregate previously-written JSON results into a Markdown summary on stdout",
@@ -482,6 +503,7 @@ def main() -> None:
         dupe_rate=args.dupe_rate,
         out_path=args.out,
         rss_budget_mb=args.rss_budget_mb,
+        enable_tracemalloc=not args.no_tracemalloc,
     )
     if args.out:
         print(f"wrote {args.out}")


### PR DESCRIPTION
Tracks #176. Lets us track down the memory ceiling without occupying the dev box for hours per run.

## Summary

Adds `.github/workflows/scale-audit.yml` so `scripts/scale_audit.py` can run on a GitHub-hosted runner with a workflow_dispatch trigger. Inputs:

| input | purpose |
|---|---|
| `rows` | choice — 10K / 100K / 500K / 1M / 2M / 5M |
| `runner` | choice — `ubuntu-latest` (16 GB) / `ubuntu-latest-8-cores` (32 GB) / `ubuntu-latest-16-cores` (64 GB) |
| `dupe_rate` | free-form, default 0.15 |
| `tracemalloc` | on/off — off gives a cleaner RSS measurement |
| `rss_budget_mb` | optional watchdog cap before OOM |

The job frees runner disk (drops `/opt/hostedtoolcache` + `dotnet` + Android SDK), prints `free -h` + `nproc` for hardware-context-with-result correlation, streams the audit log to both stdout and an artifact file, always uploads JSON + log artifacts (even on crash, thanks to the harness's per-stage flush), and dumps `dmesg` tail + final memory state on exit so OOM diagnostics show up directly in the workflow log.

## Harness change

Also adds `--no-tracemalloc` to `scripts/scale_audit.py`. Default behaviour unchanged. Pass the flag (or set `tracemalloc=off` in the workflow input) to skip `tracemalloc.start()`. tracemalloc retains a traceback per allocation, which on a 1M run materially inflates the process working set — defeating the "what's the real peak?" question. With it off, `peak_tracemalloc_mb` stays `0.0` in the JSON (advertises no-data rather than a misleading zero); `peak_rss_mb` from psutil is still recorded.

## Test plan

- [x] `python scripts/scale_audit.py --help` lists the new flag
- [x] YAML lints locally (`yamllint .github/workflows/scale-audit.yml`)
- [ ] First fire: `rows=100000, runner=ubuntu-latest, tracemalloc=off` — validates the workflow plumbing on a fast cheap run (expected ~10 min)
- [ ] Second fire (if first is green): `rows=1000000, runner=ubuntu-latest-16-cores, tracemalloc=off` — get a real peak number on 64 GB Linux to compare against the local-machine OOM
- [ ] CI on this PR itself (no actual audit triggered by the PR; just YAML parse)

## Pre-requisite

Larger runner tiers (`ubuntu-latest-8-cores`, `ubuntu-latest-16-cores`) need to be enabled in repo settings before the workflow can actually allocate them. Without that, picking those options just hangs the job in queue forever. The `ubuntu-latest` 16 GB tier is enabled by default for public repos.

## Follow-ups (separate PRs)

- After the first 1M cloud run, write up Round 3 attribution in `docs/scale-audit-2026-05.md` based on real numbers (not local OOM artefacts)
- Wire optional `psutil.virtual_memory()` sampling into `_RSSWatchdog` so we capture system-level pressure, not just per-process RSS
- If 1M-on-64-GB-Linux passes cleanly, the next question is "what's the smallest tier 1M fits on" — useful for documenting recommended hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)