### PR TITLE
fix(ci): drop phantom raha_repo gitlink that broke OpenSSF Scorecard checkout

### DIFF
--- a/packages/python/goldencheck/.gitignore
+++ b/packages/python/goldencheck/.gitignore
@@ -4,6 +4,14 @@ __pycache__/
 dist/
 build/
 .venv/
+
+# raha benchmark dataset (developer-managed local clone, see docs/benchmarks.md).
+# We deliberately do NOT vendor this — `git clone https://github.com/BigDaMa/raha.git`
+# into the path below to enable the detection benchmark. Tracked here so the
+# clone doesn't get auto-committed as a phantom submodule again (the prior
+# accidental gitlink without a .gitmodules entry was breaking OpenSSF Scorecard
+# checkout on every push).
+benchmarks/datasets/raha_repo/
 .env
 *.csv
 *.parquet


### PR DESCRIPTION
## Summary

OpenSSF Scorecard has been failing on every push to `main` since the pre-fold consolidation, blocked at `actions/checkout`:

\`\`\`
fatal: No url found for submodule path 'packages/python/goldencheck/benchmarks/datasets/raha_repo' in .gitmodules
\`\`\`

The repo carries a mode-`160000` (gitlink / submodule pointer) entry at that path but has no \`.gitmodules\` file declaring its URL. Almost certainly the result of someone running \`git add\` on a \`git clone\`-ed raha directory — git auto-converted the embedded \`.git/\` into a submodule gitlink, but nobody authored the matching \`.gitmodules\` entry.

## Fix

- \`git rm --cached packages/python/goldencheck/benchmarks/datasets/raha_repo\` — drops the orphan gitlink from the index. No working-tree side effects; if you have a local raha clone there it stays put.
- Add \`benchmarks/datasets/raha_repo/\` to \`packages/python/goldencheck/.gitignore\` so a future \`git add\` of a local raha clone doesn't recreate the same phantom-submodule situation.

## Why this is safe

Raha is intentionally a **developer-managed local clone**. The docs already tell users to clone it themselves:

- \`packages/python/goldencheck/docs/benchmarks.md\`: \`git clone https://github.com/BigDaMa/raha.git benchmarks/raha_repo\`
- \`packages/python/goldencheck/docs/wiki/Benchmarks.md\`: same instruction

The only code reference is in \`benchmarks/detection_benchmark.py\` which reads from the path — works the same whether the directory was created by a clone or by a phantom gitlink.

## Test plan

- [x] \`git ls-files --stage packages/python/goldencheck/benchmarks/datasets/raha_repo\` returns empty after the commit (the gitlink is gone)
- [x] \`.gitignore\` rejects future \`git add\` attempts on the path
- [ ] First post-merge push triggers Scorecard — should produce the first green run on this repo since the fold

## Out of scope

Re-running the failed historical Scorecard runs. They'll naturally re-green on the next merge. Optionally we could trigger a rerun via \`gh run rerun\` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)