### PR TITLE
fix(ci): scale-audit workflow — free disk before installing python/uv

### DIFF
--- a/.github/workflows/scale-audit.yml
+++ b/.github/workflows/scale-audit.yml
@@ -54,6 +54,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Free disk space on runner
+        # The synthetic fixture at 5M is ~500 MB and Polars build assets
+        # eat a chunk too. dotnet + Android SDK are dead weight for this
+        # job; drop them up front. CRITICAL: do NOT touch /opt/hostedtoolcache
+        # here — actions/setup-python and astral-sh/setup-uv install into
+        # that tree, and wiping it after setup deletes the python interpreter
+        # + uv binary (which is exactly what happened on the first run,
+        # producing "uv: command not found" at the sync step).
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost || true
+          df -h /
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -63,16 +76,6 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
-
-      - name: Free disk space on runner
-        # The synthetic fixture at 5M is ~500 MB and Polars build assets
-        # eat a chunk too. The hosted-toolcache + dotnet bundles are dead
-        # weight for this job; drop them up front so the audit doesn't
-        # run out of disk midway through fixture generation.
-        run: |
-          df -h /
-          sudo rm -rf /opt/hostedtoolcache /usr/share/dotnet /usr/local/lib/android || true
-          df -h /
 
       - name: Show runner memory + CPU
         # Capture the actual runner shape so future readers of the audit


### PR DESCRIPTION
First fire of the scale-audit workflow ([run 25706669285](https://github.com/benzsevern/goldenmatch/actions/runs/25706669285)) failed at \`uv sync\` with \`uv: command not found\`.

## Root cause

Step order bug — I put "Free disk space" AFTER \`setup-python\` and \`setup-uv\`, and the cleanup did:
\`\`\`bash
sudo rm -rf /opt/hostedtoolcache ...
\`\`\`

Both actions install into \`/opt/hostedtoolcache\`. So we deleted our own toolchain right after installing it. The next step (\`uv sync\`) hit "command not found" and the run died.

## Fix

1. Move "Free disk space" to step 2 (right after checkout, before any setup-*).
2. Stop touching \`/opt/hostedtoolcache\` at all. Actual fat targets are \`/usr/share/dotnet\` and \`/usr/local/lib/android\` (multi-GB each). Adding \`/opt/ghc\` + \`/usr/local/share/boost\` as smaller wins.
3. Inline \`CRITICAL\` comment so the next edit doesn't reintroduce the bug.

## Test plan

- [ ] Merge + re-fire 100K validation run with same inputs
- [ ] If green, proceed to 1M on largest enabled runner per #176

Tracks #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)