### PR TITLE
hardening: lift OpenSSF Scorecard from 4/10 to ~7/10 (mechanical fixes)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,6 +30,10 @@ on:
         type: boolean
         default: false
 
+# Locked-down by default; benchmarks job stays read-only.
+permissions:
+  contents: read
+
 jobs:
   benchmarks:
     # Datasets are gated behind repo VARS so a fork without dataset access
@@ -46,8 +50,8 @@ jobs:
       DATASETS: ${{ inputs.datasets || 'all' }}
       WITH_LLM: ${{ inputs.with_llm || false }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -119,7 +123,7 @@ jobs:
 
       - name: Upload benchmark artifacts
         if: always() && steps.prereqs.outputs.configured == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: benchmark-results-${{ github.run_id }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Locked-down by default. Individual jobs escalate as needed.
+# OpenSSF Scorecard / Token-Permissions check requires this top-level scope.
+permissions:
+  contents: read
+
 jobs:
   # Path-filter: compute which areas of the monorepo changed so downstream
   # jobs only run when relevant. Doc-only PRs (README, wiki references,
@@ -27,8 +32,8 @@ jobs:
       rust_pgrx: ${{ steps.filter.outputs.rust_pgrx }}
       duckdb_extensions: ${{ steps.filter.outputs.duckdb_extensions }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
         id: filter
         with:
           # `filters` runs against the diff between the PR head and base
@@ -150,8 +155,8 @@ jobs:
       matrix:
         pkg: ${{ fromJSON(needs.changes.outputs.python_pkgs) }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -241,8 +246,8 @@ jobs:
           - { name: embedder,     tests: "tests/test_embedder.py",                   needs: "Vertex AI credentials + torch" }
           - { name: benchmarks,   tests: "tests/test_autoconfig_benchmarks.py",      needs: "DBLP-ACM/Febrl3/NCVR datasets (gitignored)" }
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -335,8 +340,8 @@ jobs:
       # connection instead of spawning a local `testing.postgresql`.
       GOLDENMATCH_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -364,8 +369,8 @@ jobs:
     if: contains(needs.changes.outputs.python_pkgs, 'goldenmatch') || needs.changes.outputs.ci_workflow == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -412,8 +417,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -474,18 +479,18 @@ jobs:
     if: needs.changes.outputs.typescript == 'true' || needs.changes.outputs.ci_workflow == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         # Reads version from root package.json `packageManager` field.
         # That field MUST be exact semver (pnpm@9.15.0) — ranges error.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
           cache: pnpm
         # cache: pnpm requires (a) pnpm on PATH (handled above) and
         # (b) pnpm-lock.yaml committed at repo root.
       - run: pnpm install --frozen-lockfile
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: .turbo
           key: turbo-${{ github.sha }}
@@ -507,13 +512,13 @@ jobs:
     # turbo can't cover.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
           cache: pnpm
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
           cache: pip
@@ -523,7 +528,7 @@ jobs:
       - name: Build + stage frontend into wheel-include path
         run: python packages/python/goldenmatch/scripts/build_web.py
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -533,7 +538,7 @@ jobs:
         run: pnpm -C packages/python/goldenmatch/web/frontend exec playwright test
       - name: Upload Playwright trace on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: playwright-trace
           path: packages/python/goldenmatch/web/frontend/test-results
@@ -547,9 +552,9 @@ jobs:
       run:
         working-directory: packages/rust/extensions
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           workspaces: packages/rust/extensions
       - run: cargo test --workspace
@@ -560,8 +565,8 @@ jobs:
     if: needs.changes.outputs.dbt == 'true' || needs.changes.outputs.ci_workflow == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
           cache: pip
@@ -573,7 +578,7 @@ jobs:
     if: needs.changes.outputs.action == 'true' || needs.changes.outputs.ci_workflow == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - run: test -f packages/actions/goldencheck/action.yml && echo "action.yml present"
 
   # Postgres extension build + smoke test across PG 15 / 16 / 17. The pgrx
@@ -603,12 +608,12 @@ jobs:
       run:
         working-directory: packages/rust/extensions
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           workspaces: packages/rust/extensions
 
@@ -709,8 +714,8 @@ jobs:
       run:
         working-directory: packages/rust/extensions/duckdb
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
           cache: pip
@@ -740,8 +745,8 @@ jobs:
     if: needs.changes.outputs.pyright_slice == 'true' || needs.changes.outputs.ci_workflow == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
         with:
           enable-cache: true
           cache-dependency-glob: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+name: CodeQL
+
+# Static analysis (SAST) for OpenSSF Scorecard. Runs CodeQL across the
+# Python + TypeScript surfaces; Rust is skipped (CodeQL's Rust support
+# is still experimental as of this writing and the workspace already
+# uses cargo audit via the rust_pgrx CI lane).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly fresh sweep on Sunday early-morning UTC.
+    - cron: "23 7 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: "Analyze (${{ matrix.language }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # required for upload-sarif + private repos (no-op on public, kept
+      # so the workflow works identically if the repo ever flips).
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+          - javascript-typescript
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3
+        with:
+          languages: ${{ matrix.language }}
+          # Use the security-extended query suite — the default is too
+          # conservative for what we want from SAST gating.
+          queries: security-extended
+
+      - name: Autobuild
+        # Python + JS are interpreted; autobuild is a no-op but the action
+        # still expects the step in the pipeline. Keeping it explicit so
+        # the same workflow scales if we add a compiled language later.
+        uses: github/codeql-action/autobuild@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,22 +33,22 @@ jobs:
       run:
         working-directory: packages/python/goldenmatch/docs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde  # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
           working-directory: packages/python/goldenmatch/docs
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
 
       - name: Build with Jekyll
         run: bundle exec jekyll build --baseurl "/goldenmatch"
         env:
           JEKYLL_ENV: production
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: packages/python/goldenmatch/docs/_site/
 
@@ -60,4 +60,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -71,7 +71,7 @@ jobs:
             platforms: linux/amd64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       # If this is a tag push, skip jobs whose image doesn't match the tag prefix.
       # We do this with an `if:` on the steps below by comparing matrix.image to
@@ -98,17 +98,17 @@ jobs:
 
       - name: Set up QEMU
         if: steps.gate.outputs.build == 'true'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         if: steps.gate.outputs.build == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to ghcr.io
         if: steps.gate.outputs.build == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -117,7 +117,7 @@ jobs:
       - name: Compute image tags
         if: steps.gate.outputs.build == 'true'
         id: tags
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build and push
         if: steps.gate.outputs.build == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/publish-goldencheck-types-js.yml
+++ b/.github/workflows/publish-goldencheck-types-js.yml
@@ -26,13 +26,13 @@ jobs:
       run:
         working-directory: packages/typescript/goldencheck-types
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-goldencheck-types.yml
+++ b/.github/workflows/publish-goldencheck-types.yml
@@ -25,15 +25,15 @@ jobs:
       run:
         working-directory: packages/python/goldencheck-types
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: packages/python/goldencheck-types/dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldencheck.yml
+++ b/.github/workflows/publish-goldencheck.yml
@@ -25,15 +25,15 @@ jobs:
       run:
         working-directory: packages/python/goldencheck
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: packages/python/goldencheck/dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenflow.yml
+++ b/.github/workflows/publish-goldenflow.yml
@@ -32,15 +32,15 @@ jobs:
       run:
         working-directory: packages/python/goldenflow
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: packages/python/goldenflow/dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenmatch-js.yml
+++ b/.github/workflows/publish-goldenmatch-js.yml
@@ -26,13 +26,13 @@ jobs:
       run:
         working-directory: packages/typescript/goldenmatch
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-goldenmatch.yml
+++ b/.github/workflows/publish-goldenmatch.yml
@@ -26,15 +26,15 @@ jobs:
       run:
         working-directory: packages/python/goldenmatch
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           cache: pnpm
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       # Build the web frontend BEFORE the wheel build so the staged dist
@@ -50,7 +50,7 @@ jobs:
         run: python packages/python/goldenmatch/scripts/build_web.py
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: packages/python/goldenmatch/dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-goldenpipe.yml
+++ b/.github/workflows/publish-goldenpipe.yml
@@ -24,15 +24,15 @@ jobs:
       run:
         working-directory: packages/python/goldenpipe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: packages/python/goldenpipe/dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-infermap-js.yml
+++ b/.github/workflows/publish-infermap-js.yml
@@ -26,13 +26,13 @@ jobs:
       run:
         working-directory: packages/typescript/infermap
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-infermap.yml
+++ b/.github/workflows/publish-infermap.yml
@@ -25,15 +25,15 @@ jobs:
       run:
         working-directory: packages/python/infermap
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           packages-dir: packages/python/infermap/dist
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -100,7 +100,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       # Install mcp-publisher from the latest release tarball. The MCP
       # Registry team ships static binaries; no Go toolchain needed in CI.

--- a/.github/workflows/scale-audit.yml
+++ b/.github/workflows/scale-audit.yml
@@ -46,13 +46,19 @@ on:
         required: false
         default: ""
 
+# Read-only: this workflow generates synthetic data, runs an in-process
+# audit, and uploads artifacts via the actions/upload-artifact API. None
+# of those need write access to the repo.
+permissions:
+  contents: read
+
 jobs:
   audit:
     name: "scale_audit rows=${{ inputs.rows }} runner=${{ inputs.runner }}"
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 360
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Free disk space on runner
         # The synthetic fixture at 5M is ~500 MB and Polars build assets
@@ -68,12 +74,12 @@ jobs:
           df -h /
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
         with:
           enable-cache: true
 
@@ -139,7 +145,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: scale-audit-${{ inputs.rows }}-${{ inputs.runner }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46  # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -45,14 +45,14 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3
         with:
           sarif_file: results.sarif
 
       - name: Upload artifact
         # Keep the raw SARIF as an artifact for 30 days so failed-criteria
         # diffs are inspectable across runs.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/update-download-badges.yml
+++ b/.github/workflows/update-download-badges.yml
@@ -22,9 +22,9 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,91 @@
+# Security Policy
+
+## Supported Versions
+
+| Package          | Versions          |
+| ---------------- | ----------------- |
+| `goldenmatch`    | latest minor only |
+| `goldencheck`    | latest minor only |
+| `goldenflow`     | latest minor only |
+| `goldenpipe`     | latest minor only |
+| `infermap`       | latest minor only |
+| `goldenmatch-js` | latest minor only |
+| `goldenflow-js`  | latest minor only |
+| `goldencheck-js` | latest minor only |
+| `infermap-js`    | latest minor only |
+
+The monorepo at `benzsevern/goldenmatch` hosts the Golden Suite (six Python
+packages plus the TypeScript ports under `packages/typescript/`). Each
+package ships its own version stream on PyPI / npm.
+
+Security fixes ship in the next patch release of the affected package
+only. Older minor versions do not receive security backports — pin and
+upgrade.
+
+## Reporting a Vulnerability
+
+**Please do NOT open a public GitHub issue for security reports.**
+
+Use one of these private channels instead:
+
+1. **GitHub Private Security Advisory** (preferred): open one at
+   <https://github.com/benzsevern/goldenmatch/security/advisories/new>.
+   You can reference any of the Golden Suite packages from that one
+   monorepo advisory.
+2. **Email**: `ben@bensevern.dev` with `[security]` in the subject.
+
+Please include:
+
+- Which package + version is affected (e.g. `goldenmatch==1.14.0`).
+- A minimal reproducer or description of the attack surface.
+- Whether the issue is exploitable remotely or requires local access /
+  a specific data shape.
+- Your suggested severity (CVSS optional but appreciated).
+
+### Response targets (best-effort, single-maintainer project)
+
+| Stage                          | Target  |
+| ------------------------------ | ------- |
+| Acknowledge receipt            | 3 days  |
+| Triage + severity confirmation | 7 days  |
+| Fix landed on `main`           | 14 days for high/critical; best-effort otherwise |
+| PyPI / npm release with fix    | within 7 days of fix landing on `main` |
+
+These are targets, not SLAs. This is a personal open-source project
+without a paid support contract; please don't treat the timeline as a
+commitment.
+
+## Coordinated Disclosure
+
+If you intend to publish the vulnerability after a fix ships, please
+coordinate the publication date with the maintainer so users have time
+to upgrade. Credit will be given in the release notes unless you ask
+to remain anonymous.
+
+## Scope
+
+In scope:
+
+- Code execution, sandbox escape, or privilege escalation in any
+  Golden Suite package or the published CLI tools.
+- Data leakage via crash, log, or error output that should not have
+  surfaced upstream data.
+- Authentication / authorization bypass in the MCP, A2A, or REST
+  server surfaces (`goldenmatch agent-serve`, `goldenmatch serve`,
+  `goldenmatch mcp-serve`).
+- PPRL protocol weaknesses (`goldenmatch.pprl`) — e.g. bloom-filter
+  parameter choices that leak input identity beyond the documented
+  security level.
+
+Out of scope (not a vulnerability):
+
+- Resource exhaustion from passing pathologically large or adversarial
+  input to a CLI invocation under your own user account. Use a
+  resource-cgroup wrapper.
+- Issues that require an attacker to already have shell access on the
+  host running the tool.
+- Vulnerabilities in third-party dependencies — please report those to
+  the upstream project. Dependabot keeps our pinned versions current.
+- Issues in remote MCP server deployments (`*.up.railway.app`) — these
+  are demo environments without uptime guarantees; report the
+  underlying code issue, not the deployment.

--- a/scripts/_pin_actions.py
+++ b/scripts/_pin_actions.py
@@ -1,0 +1,75 @@
+"""One-shot helper to pin GitHub Actions references to SHAs.
+
+Reads each `.github/workflows/*.yml` file and rewrites every
+`uses: <repo>@<tag>` line to `uses: <repo>@<sha>  # <tag>` using the
+SHA mapping below. Run once; the file is not part of CI.
+
+Discarded after the scorecard hardening PR lands — kept only so the
+mapping is reproducible if Dependabot ever needs a fresh round of pins.
+"""
+from __future__ import annotations
+import re
+from pathlib import Path
+
+# repo@tag  ->  sha (from `gh api repos/<repo>/commits/<tag>`, 2026-05-11)
+PIN_MAP: dict[str, str] = {
+    "actions/cache@v4":                                "0057852bfaa89a56745cba8c7296529d2fc39830",
+    "actions/checkout@v4":                             "34e114876b0b11c390a56381ad16ebd13914f8d5",
+    "actions/configure-pages@v5":                      "983d7736d9b0ae728b81ab479565c72886d7745b",
+    "actions/deploy-pages@v4":                         "d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e",
+    "actions/setup-node@v4":                           "49933ea5288caeca8642d1e84afbd3f7d6820020",
+    "actions/setup-python@v5":                         "a26af69be951a213d495a4c3e4e4022e16d87065",
+    "actions/upload-artifact@v4":                      "ea165f8d65b6e75b540449e92b4886f43607fa02",
+    "actions/upload-pages-artifact@v3":                "56afc609e74202658d3ffba0e8f6dda462b719fa",
+    "astral-sh/setup-uv@v3":                           "caf0cab7a618c569241d31dcd442f54681755d39",
+    "dorny/paths-filter@v3":                           "d1c1ffe0248fe513906c8e24db8ea791d46f8590",
+    "dtolnay/rust-toolchain@stable":                   "29eef336d9b2848a0b548edc03f92a220660cdb8",
+    "pnpm/action-setup@v4":                            "b906affcce14559ad1aafd4ab0e942779e9f58b1",
+    "pypa/gh-action-pypi-publish@release/v1":          "cef221092ed1bacb1cc03d23a2d87d1d172e277b",
+    "ruby/setup-ruby@v1":                              "6aaa311d81eba98ae12eaffbcb63296ace0efcde",
+    "Swatinem/rust-cache@v2":                          "e18b497796c12c097a38f9edb9d0641fb99eee32",
+    "docker/build-push-action@v6":                     "10e90e3645eae34f1e60eeb005ba3a3d33f178e8",
+    "docker/login-action@v3":                          "c94ce9fb468520275223c153574b00df6fe4bcc9",
+    "docker/metadata-action@v5":                       "c299e40c65443455700f0fdfc63efafe5b349051",
+    "docker/setup-buildx-action@v3":                   "8d2750c68a42422c14e847fe6c8ac0403b4cbd6f",
+    "docker/setup-qemu-action@v3":                     "c7c53464625b32c7a7e944ae62b3e17d2b600130",
+    "github/codeql-action/upload-sarif@v3":            "7fd177fa680c9881b53cdab4d346d32574c9f7f4",
+    "github/codeql-action/init@v3":                    "7fd177fa680c9881b53cdab4d346d32574c9f7f4",
+    "github/codeql-action/analyze@v3":                 "7fd177fa680c9881b53cdab4d346d32574c9f7f4",
+    "ossf/scorecard-action@v2.4.0":                    "62b2cac7ed8198b15735ed49ab1e5cf35480ba46",
+}
+
+WORKFLOWS = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+
+
+def pin_line(line: str) -> str:
+    # Match `<indent>- uses: <repo>@<tag>` (with or without surrounding whitespace).
+    m = re.match(r"^(\s*-?\s*uses:\s*)([^@\s]+)@([^\s#]+)(.*)$", line)
+    if not m:
+        return line
+    prefix, repo, tag, tail = m.groups()
+    key = f"{repo}@{tag}"
+    sha = PIN_MAP.get(key)
+    if not sha:
+        return line  # unknown action, leave alone (will need PIN_MAP update)
+    # If tail already contains a `#` comment, keep only the trailing whitespace removed
+    tail = tail.rstrip()
+    return f"{prefix}{repo}@{sha}  # {tag}{tail}\n"
+
+
+def main() -> int:
+    changed = 0
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        original = path.read_text(encoding="utf-8")
+        out_lines = [pin_line(line) for line in original.splitlines(keepends=True)]
+        new = "".join(out_lines)
+        if new != original:
+            path.write_text(new, encoding="utf-8")
+            print(f"pinned {path.name}")
+            changed += 1
+    print(f"\n{changed} workflow file(s) modified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Mechanical wins flagged by [the scorecard report](https://api.scorecard.dev/projects/github.com/benzsevern/goldenmatch). The hard checks need non-engineering investments and stay at 0 — split out in the **Out of scope** section below.

## What this PR lifts

| Scorecard check | Before | After | Mechanism |
|---|---:|---:|---|
| Security-Policy | 0 | 10 | `SECURITY.md` at repo root |
| Token-Permissions | 0 | 10 | Top-level `permissions:` on `ci`, `benchmarks`, `scale-audit` (others already had them) |
| Pinned-Dependencies | 0 | 10 | All 22 action refs pinned to SHA via `scripts/_pin_actions.py` |
| SAST | 0 | 10 | New `.github/workflows/codeql.yml` (python + js/ts, security-extended) |
| Maintained | 0 | 0 → 10 over time | No-op, time-based; 90-day floor |

Expected score: **4/10 → ~7-8/10**. The remaining lift to 9-10 isn't realistic for a solo-maintained repo without paying for a CII Best Practices application and onboarding external contributors.

## Files

- **`SECURITY.md`** — disclosure channel (GitHub Private Security Advisory + email), supported-versions policy, response targets, in/out-of-scope split. Covers all Golden Suite packages from the one monorepo advisory.
- **`.github/workflows/codeql.yml`** — runs on push to main, every PR, and weekly cron. Python + JS/TS matrix. Rust skipped — CodeQL Rust is experimental and the workspace already uses cargo audit via the rust_pgrx lane.
- **All workflow files** — 22 action refs pinned to commit SHA with `# v<tag>` comments. SHAs resolved via `gh api repos/<repo>/commits/<tag>` on 2026-05-11. Dependabot's existing github-actions ecosystem entry will keep them fresh.
- **`ci.yml`, `benchmarks.yml`, `scale-audit.yml`** — added top-level `permissions: contents: read`. Other workflows already had permissions blocks (kept as-is — they were already correct).
- **`scripts/_pin_actions.py`** — one-shot helper retained for reproducibility if a future bulk re-pin is needed. Not part of CI.

## Out of scope (cannot fix in a PR)

| Check | Why not |
|---|---|
| Code-Review | Solo dev — no approved reviews on recent commits. Two-account self-review is theater; not worth the workflow friction. |
| Contributors | Needs >2 distinct contributors from >1 org. By definition external. |
| Branch-Protection | Repo Settings → Branches manual click. Recommend: require PR before merge, require linear history, require status checks (CI + CodeQL + Scorecard). |
| CII-Best-Practices | OpenSSF best-practices.coreinfrastructure.org application + multi-week back-and-forth. Bureaucratic, low engineering value. |
| Fuzzing | Needs OSS-Fuzz integration. Real work, low value for this codebase shape. |
| Vulnerabilities | 5 GHSAs in transitive deps. Dependabot will surface PRs. |

## Test plan

- [x] `python -c "import yaml; ..."` on every workflow file — all 18 parse clean
- [x] All SHA pins verified via `gh api repos/<X>/<Y>/commits/<tag>` against the docked refs in `scripts/_pin_actions.py`
- [ ] CI green on this PR (most lanes will skip per path filters)
- [ ] Post-merge: next Scorecard run on `main` shows the score lift

## Follow-ups

1. **Manual**: Configure branch protection on `main` in repo Settings → Branches.
2. **Watch the next Scorecard run**: confirm the new score lands at expected ~7-8.
3. If `Vulnerabilities` stays at 5, audit the GHSAs and bump dep versions as Dependabot proposes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)