### PR TITLE
ci: add ci-required summary job for matrix-stable branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -749,3 +749,53 @@ jobs:
             **/pyproject.toml
       - run: uv sync --all-packages
       - run: uv run pyright
+
+  # Single required-status-check for branch protection. Branch ruleset
+  # references `ci-required` (stable name) instead of the matrix-instance
+  # check names (`python (goldenmatch)`, `rust_pgrx (15)`, ...) which
+  # change per-row and can't be matched by GitHub's exact-name required
+  # status check rule.
+  #
+  # `if: always()` lets the job fire even when upstream jobs are skipped
+  # by the `changes` path filter — a doc-only PR with all code jobs
+  # skipped should still merge.
+  #
+  # The check inside fails the summary when an upstream conclusion is
+  # `failure` or `cancelled`. `skipped` and `success` both pass. Avoids
+  # the trap where `needs:` default behaviour blocks the summary when
+  # any upstream was skipped.
+  ci-required:
+    needs:
+      - changes
+      - python
+      - python_skipped_lanes
+      - python_postgres
+      - synthetic_benchmarks
+      - benchmark_runner_smoke
+      - typescript
+      - web_ui_e2e
+      - rust
+      - dbt
+      - action
+      - rust_pgrx
+      - duckdb_extensions
+      - pyright
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verify no upstream job failed or was cancelled
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS_JSON"
+          # Use jq to inspect each upstream's `result`. `success` and
+          # `skipped` both pass; anything else (`failure`, `cancelled`)
+          # fails the summary.
+          BAD=$(echo "$NEEDS_JSON" | jq -r '[.[] | select(.result != "success" and .result != "skipped") | .result] | join(",")')
+          if [ -n "$BAD" ]; then
+            echo "::error::upstream job(s) failed or were cancelled: $BAD"
+            exit 1
+          fi
+          echo "all required upstream jobs passed or were skipped"


### PR DESCRIPTION
Follow-up to PR #180. Solves the BLOCKED-merge problem on PRs whose status checks include matrix jobs.

## The bug

PR #180 enabled branch protection with required status checks: \`python\`, \`rust_pgrx\`, \`typescript\`, \`CodeQL\`, \`changes\`. The actual check rows register with the matrix-row suffix (\`python (goldenmatch)\`, \`rust_pgrx (15)\`, etc), so GitHub's exact-name match for \`python\` and \`rust_pgrx\` never finds a passing check. Every PR ends up \`mergeStateStatus: BLOCKED\` even with everything green.

PR #180 itself is currently blocked by this exact problem — meta.

## The fix

Standard pattern: add one summary job (\`ci-required\`) that \`needs:\` every code-running job in ci.yml. The summary's name is stable across matrix changes, so the ruleset can reference it once and not break when we add/rename matrix rows.

\`\`\`yaml
ci-required:
  needs: [changes, python, python_skipped_lanes, python_postgres, ...]
  if: always()
  runs-on: ubuntu-latest
  timeout-minutes: 1
  steps:
    - run: |
        BAD=$(echo "$NEEDS_JSON" | jq -r '[.[] | select(.result != "success" and .result != "skipped") | .result] | join(",")')
        [ -z "$BAD" ] || (echo "::error::upstream failed/cancelled: $BAD"; exit 1)
\`\`\`

Two non-obvious bits worth flagging:

1. **\`if: always()\`** — so the summary still fires when the \`changes\` path filter skips downstream jobs (doc-only PRs).
2. **\`needs.*.result\` inspection via jq** — without this the default \`needs:\` behaviour would block the summary if any upstream was \`skipped\`. The jq filter treats \`skipped\` and \`success\` as both passing; only \`failure\` and \`cancelled\` fail the summary.

## Follow-up after this lands

Update the branch ruleset:
- **Remove:** \`python\`, \`rust_pgrx\` (matrix names that don't match real checks)
- **Add:** \`ci-required\` (single stable-named gate)
- **Optionally keep:** \`changes\`, \`typescript\`, \`CodeQL\` — these match real job names, but they're now redundant since \`ci-required\` covers them all. Simpler to require only \`ci-required\`.

After that, PR #180 should flip from BLOCKED to mergeable.

## Test plan

- [x] YAML lint passes (\`python -c "import yaml; yaml.safe_load(...)"\`)
- [ ] CI on this PR shows the new \`ci-required\` check appearing and passing
- [ ] After merge + ruleset update, PR #180 becomes mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)