### PR TITLE
docs(claude-md): trim stale '1M OOM in-memory' note per scale-audit Round 3

### DIFF
--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -86,7 +86,7 @@ Root CLAUDE.md owns: branch/merge SOP, GitHub auth dance, Rust + pgrx, PostgreSQ
 - Blocking key choice dominates fuzzy performance — coarse keys create huge blocks
 - 1M exact dedupe: ~7.8s. 100K fuzzy (name+zip): ~12.8s via pipeline
 - Scale curve: 7,823 rec/s at 100K records on laptop (fuzzy + exact + golden)
-- 1M records: OOM in-memory — use DuckDB backend or chunked processing for >500K records
+- 1M records (scale-audit Round 3, 2026-05-11): ~43 min wall on a GitHub `ubuntu-latest` (4-core, 16 GB) runner, 9.98 GB peak RSS, 836K clusters, no OOM. Roughly split half auto_configure + half run_dedupe. The older "1M OOMs in-memory" note was driven by tracemalloc traceback storage + Windows file-cache pressure, not by goldenmatch's working set. Default (Linux, tracemalloc off) fits comfortably in 16 GB through 1M. Wall is now the cliff, not memory — use DuckDB backend or chunked processing for 5M+ if wall becomes unacceptable, not for memory reasons.
 
 ## Accuracy Strategy
 - Structured data (names, addresses, bibliographic): fuzzy matching alone → 97.2% F1. No embeddings or LLM needed.


### PR DESCRIPTION
The CLAUDE.md guidance flagged 1M as a memory cliff:
\`\`\`
- 1M records: OOM in-memory — use DuckDB backend or chunked processing for >500K records
\`\`\`

Scale-audit Round 3 (cloud run [25708038764](https://github.com/benzsevern/goldenmatch/actions/runs/25708038764)) showed this is no longer the case:

| stage | wall | peak RSS |
|---|---:|---:|
| read_csv | 0.15 s | 433 MB |
| auto_configure | 22 min | 6.9 GB |
| run_dedupe | 21 min | 7.6 GB |
| **total** | **43 min** | **9.98 GB** |

836K clusters, no OOM, no watchdog trip (10 GB peak vs 14.5 GB threshold). Ran on a GitHub-hosted \`ubuntu-latest\` (4-core, 16 GB).

The local Windows OOM that drove the original note was caused by tracemalloc traceback storage + Polars Rust arenas + Windows file-cache pressure on the 100 MB CSV — not goldenmatch's working set. With tracemalloc off on Linux, 1M fits comfortably in 16 GB.

Updated wording:
- Restates the 1M result with hardware context.
- Notes the previous OOM was tracemalloc + Windows + page-cache.
- Reframes DuckDB / chunked processing as a **wall-time** mitigation for 5M+, not a memory mitigation.

## Follow-ups

- Round 3 detail will land in \`docs/scale-audit-2026-05.md\` once PR #173 (Round 2 section) merges first — they share the same doc and stacking the docs would conflict.
- Wall-time attack (the actual cliff now) is the next workstream — \`auto_configure\` 22 min and \`run_dedupe\` 21 min are roughly equal cost targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)