### PR TITLE
ci(scale-audit): add --cprofile flag + workflow lane for wall-time attribution

### DIFF
--- a/.github/workflows/scale-audit.yml
+++ b/.github/workflows/scale-audit.yml
@@ -45,6 +45,14 @@ on:
         description: "abort + flush if RSS exceeds this (MB). leave blank to disable."
         required: false
         default: ""
+      cprofile:
+        description: "wrap the audit in cProfile. .prof file uploads as an artifact. ~30% wall overhead — use for time-attribution runs."
+        required: true
+        default: "off"
+        type: choice
+        options:
+          - "off"
+          - "on"
 
 # Read-only: this workflow generates synthetic data, runs an in-process
 # audit, and uploads artifacts via the actions/upload-artifact API. None
@@ -113,6 +121,10 @@ jobs:
           if [ -n "${{ inputs.rss_budget_mb }}" ]; then
             ARGS="$ARGS --rss-budget-mb ${{ inputs.rss_budget_mb }}"
           fi
+          if [ "${{ inputs.cprofile }}" = "on" ]; then
+            PROF=".profile_tmp/scale_${{ inputs.rows }}_${{ inputs.runner }}.prof"
+            ARGS="$ARGS --cprofile $PROF"
+          fi
 
           echo "running: scripts/scale_audit.py $ARGS"
           # tee so the live log streams to the workflow output AND lands
@@ -151,6 +163,7 @@ jobs:
           path: |
             .profile_tmp/scale_*.json
             .profile_tmp/scale_*.log
+            .profile_tmp/scale_*.prof
           if-no-files-found: warn
 
       - name: Capture host memory pressure on exit

--- a/scripts/scale_audit.py
+++ b/scripts/scale_audit.py
@@ -163,8 +163,13 @@ def ensure_fixture(rows: int, dupe_rate: float, fixture_dir: Path) -> Path:
 
 
 @contextmanager
-def _tracking(result: ScaleAuditResult, process: psutil.Process, enable_tracemalloc: bool = True):
-    """Wrap the whole run with optional tracemalloc + a global wall timer.
+def _tracking(
+    result: ScaleAuditResult,
+    process: psutil.Process,
+    enable_tracemalloc: bool = True,
+    cprofile_path: Path | None = None,
+):
+    """Wrap the whole run with optional tracemalloc + cProfile + a wall timer.
 
     tracemalloc retains a traceback per allocation, which on large runs
     becomes a meaningful chunk of process memory itself — defeating the
@@ -172,15 +177,30 @@ def _tracking(result: ScaleAuditResult, process: psutil.Process, enable_tracemal
     for cloud runs where we care about true RSS without the tracker's
     overhead. Stage-level peaks are still captured via psutil RSS sampling
     regardless.
+
+    ``cprofile_path`` (optional): when set, wraps the audit in
+    ``cProfile.Profile`` and dumps stats to that path on exit. cProfile's
+    overhead is ~30% wall — fine for "where does time go?" attribution
+    runs, but turn it off for memory-only / clean-wall measurements.
     """
+    import cProfile  # stdlib; lazy import keeps the no-profile path light.
+
     if enable_tracemalloc:
         tracemalloc.start()
+    profiler: cProfile.Profile | None = None
+    if cprofile_path is not None:
+        profiler = cProfile.Profile()
+        profiler.enable()
     t0 = time.perf_counter()
     rss0 = process.memory_info().rss
     try:
         yield
     finally:
         result.total_wall_seconds = time.perf_counter() - t0
+        if profiler is not None and cprofile_path is not None:
+            profiler.disable()
+            cprofile_path.parent.mkdir(parents=True, exist_ok=True)
+            profiler.dump_stats(str(cprofile_path))
         if enable_tracemalloc:
             _, tm_peak = tracemalloc.get_traced_memory()
             result.peak_tracemalloc_mb = tm_peak / 1024 / 1024
@@ -304,6 +324,7 @@ def run_audit(
     out_path: Path | None = None,
     rss_budget_mb: float | None = None,
     enable_tracemalloc: bool = True,
+    cprofile_path: Path | None = None,
 ) -> ScaleAuditResult:
     """Run one audit pass against a synthetic fixture of the given size.
 
@@ -345,7 +366,11 @@ def run_audit(
         watchdog.start()
 
     try:
-        with _tracking(result, process, enable_tracemalloc=enable_tracemalloc):
+        with _tracking(
+            result, process,
+            enable_tracemalloc=enable_tracemalloc,
+            cprofile_path=cprofile_path,
+        ):
             import polars as pl
             from goldenmatch.core.autoconfig import auto_configure_df
             from goldenmatch.core.pipeline import run_dedupe_df
@@ -468,6 +493,17 @@ def main() -> None:
         ),
     )
     ap.add_argument(
+        "--cprofile",
+        type=Path,
+        help=(
+            "wrap the audit in cProfile and dump stats to this path. "
+            "Adds ~30%% wall overhead — use for `where does time go?` "
+            "attribution runs, not for clean-wall measurements. The .prof "
+            "file can be loaded with `python -m pstats <path>` or visualised "
+            "via snakeviz / gprof2dot."
+        ),
+    )
+    ap.add_argument(
         "--summarize",
         nargs="+",
         help="aggregate previously-written JSON results into a Markdown summary on stdout",
@@ -512,6 +548,7 @@ def main() -> None:
         out_path=args.out,
         rss_budget_mb=args.rss_budget_mb,
         enable_tracemalloc=not args.no_tracemalloc,
+        cprofile_path=args.cprofile,
     )
     if args.out:
         print(f"wrote {args.out}")


### PR DESCRIPTION
First step of the wall-time attack now that Round 3 confirmed memory isn't the cliff.

## Why

Round 3 (run [25708038764](https://github.com/benzsevern/goldenmatch/actions/runs/25708038764)) showed 1M completes in 43 min / 9.98 GB peak on \`ubuntu-latest\` — comfortable on 16 GB. Wall is now the cliff, split roughly half \`auto_configure\` (22 min) and half \`run_dedupe\` (21 min). Before changing any code, we need attribution: which functions inside each stage actually burn time?

## What

- **\`--cprofile <path>\`** on \`scripts/scale_audit.py\`. Wraps the audit in \`cProfile.Profile\`; dumps stats on exit. Lazy import keeps the no-profile path light. ~30% wall overhead — fine for relative hot-spot hunting.
- **\`cprofile\` workflow input** on \`scale-audit.yml\` (\"off\" default). When \"on\", \`.profile_tmp/scale_*.prof\` joins the artifact upload glob.

## Usage

Fire workflow_dispatch with \`rows=100000\`, \`cprofile=on\`, \`tracemalloc=off\`. Artifact contains \`scale_100000_ubuntu-latest.{json,log,prof}\`. Then locally:

\`\`\`bash
python -m pstats scale_100000_ubuntu-latest.prof
# or:
snakeviz scale_100000_ubuntu-latest.prof
\`\`\`

Pick the first wall optimization target.

## Why 100K, not 1M

The hot functions don't change with row count — the relative time-share of \`score_blocks_parallel\`, \`find_fuzzy_matches\`, \`learn_blocking_rules\`, etc. is the same at 100K as at 1M. 100K runs in ~3 min on cloud which makes the attribution loop fast. We only graduate to a 1M profile if 100K's hot spots don't predict 1M's behaviour.

## Test plan

- [x] \`python scripts/scale_audit.py --help\` shows the new flag
- [x] YAML lints clean
- [ ] CI green on this PR
- [ ] First fire post-merge: \`rows=100000, cprofile=on\` → artifact includes the .prof

## Follow-ups

- (this PR's purpose) Fire a 100K profile run, analyse the .prof, open a PR targeting the #1 hot spot.
- If 100K hot spots don't match a 1M run's, fire a 1M profile (longer wall but same artifact shape).

Tracks issue #171's \"attack wall time\" step (now #1 priority per Round 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)