### PR TITLE
fix(ci): scale-audit upload step needs include-hidden-files: true

### DIFF
--- a/.github/workflows/scale-audit.yml
+++ b/.github/workflows/scale-audit.yml
@@ -164,6 +164,10 @@ jobs:
             .profile_tmp/scale_*.json
             .profile_tmp/scale_*.log
             .profile_tmp/scale_*.prof
+          # `.profile_tmp/` starts with a dot; without this flag, upload-artifact
+          # v4 silently skips everything under it as "hidden". Every prior
+          # scale-audit run uploaded an empty artifact because of this default.
+          include-hidden-files: true
           if-no-files-found: warn
 
       - name: Capture host memory pressure on exit


### PR DESCRIPTION
Every scale-audit workflow_dispatch run so far has produced an **empty artifact** despite the audit completing successfully. The log warning was being missed:

\`\`\`
##[warning]No files were found with the provided path:
.profile_tmp/scale_*.json
.profile_tmp/scale_*.log
.profile_tmp/scale_*.prof. No artifacts will be uploaded.
\`\`\`

## Root cause

\`actions/upload-artifact@v4\` defaults \`include-hidden-files: false\`. Our scratch directory is \`.profile_tmp/\` — starts with a dot, so v4 treats the entire tree as hidden and silently skips. Files DO exist (the workflow's "Print result summary" step prints the JSON contents from within the same directory at the same point in the run). Only the upload step can't see them.

## Fix

Set \`include-hidden-files: true\` on the upload step. The repo intentionally uses \`.profile_tmp/\` to match the suite's other \`.*\` working dirs (\`.goldenmatch/\`, \`.goldencheck/\`, \`.testing/\`); renaming would create more confusion than the four-byte flag.

## Test plan

- [x] YAML lints clean
- [ ] CI green on this PR
- [ ] After merge, fire \`scale-audit\` with \`rows=100000, cprofile=on, tracemalloc=off\` — artifact should contain \`.json\`, \`.log\`, and \`.prof\`
- [ ] Download .prof, run \`python -m pstats\` against it, unblock the wall-time attribution loop

## Lost data

The three previous successful runs (100K validation, 1M full, 100K cprofile) lost their .prof / .log artifacts to this bug. Re-running 100K cprofile costs ~$0.50 in cloud minutes; not worth recovering, just refire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)