### PR TITLE
fix(scale-audit): pass _skip_finalize=True to match production dedupe_df path

### DIFF
--- a/scripts/scale_audit.py
+++ b/scripts/scale_audit.py
@@ -382,7 +382,17 @@ def run_audit(
             with _StageTimer("auto_configure", result, process):
                 # The zero-config controller path — same one
                 # `goldenmatch dedupe customers.csv` exercises with no flags.
-                config = auto_configure_df(df)
+                #
+                # _skip_finalize=True matches the production dedupe_df()
+                # path (see goldenmatch/_api.py: dedupe_df calls
+                # auto_configure_df with _skip_finalize=True so the
+                # controller's _finalize step doesn't run a redundant
+                # full-data pipeline that the immediately-following
+                # run_dedupe_df call repeats. Without this flag the audit
+                # double-counts a full pipeline run in the auto_configure
+                # stage, inflating measured wall by ~2× and giving a
+                # numbers that don't match what real users see.
+                config = auto_configure_df(df, _skip_finalize=True)
             _write_snapshot(result, out_path)
 
             with _StageTimer("run_dedupe", result, process):


### PR DESCRIPTION
**The Round 3 numbers (43 min for 1M) were ~2× the production wall.** Found while reading cProfile output for the wall-time attack.

## The bug

\`scripts/scale_audit.py\` calls:
\`\`\`python
config = auto_configure_df(df)            # default _skip_finalize=False
result = run_dedupe_df(df, config=config, auto_config=False)
\`\`\`

Without \`_skip_finalize=True\`, the controller's \`_finalize\` step runs a full goldenmatch pipeline on the entire dataset (\`run_transform + quality.scan + matchkey + block + score + cluster\`). The harness then immediately calls \`run_dedupe_df\` which runs the same full pipeline AGAIN.

## Production already handles this

\`goldenmatch._api.dedupe_df\` (the zero-config user-facing entry point) threads \`_skip_finalize=True\` specifically to prevent this duplication:

\`\`\`python
# goldenmatch/_api.py:367-372
config = _self_api.auto_configure_df(
    df,
    llm_provider=_auto_config_provider,
    llm_auto=llm_auto,
    _skip_finalize=True,
)
\`\`\`

The audit was the only caller NOT using this pattern.

## Impact on Round 3

The 43 min wall measurement was the WRONG number — real production wall is closer to 22 min.

| stage | Round 3 measured | real production |
|---|---:|---:|
| auto_configure | 22 min (includes full _finalize) | ~30 s (sample iterations only) |
| run_dedupe | 21 min | 21 min |
| **total** | **43 min** | **~22 min** |

Sample is capped at 5K rows regardless of dataset size, so iteration cost is tiny. Almost all the time was the redundant _finalize.

## Next steps

1. Land this fix.
2. Re-fire 1M scale-audit, get real production wall.
3. Update \`docs/scale-audit-2026-05.md\` Round 3 numbers (separate PR — corrects the misleading "43 min" headline).
4. Re-prioritise the wall-time attack: the only redundancy was in the audit harness; the real production codepath was already optimal w.r.t. that lever. Remaining optimization targets stay the same (\`_generalize\` vectorisation in #186, fuzzy hotpath, scoring), but the wall ceiling is half of what we thought.

## Test plan

- [x] One-line behaviour change; production path was already exercising this flag (zero new code paths).
- [ ] CI green on this PR.
- [ ] After merge: re-fire 1M run and compare wall to 43 min Round 3 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)