### PR TITLE
perf(blocker): replace df.filter(is_in([...])) with direct row indexing

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -555,7 +555,6 @@ def _build_ann_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockRes
     pairs = blocker.query(embeddings)
 
     # Group nearby records into micro-blocks using Union-Find
-    row_ids = df["__row_id__"].to_list()
     uf = UnionFind()
     for a, b in pairs:
         uf.add(a)
@@ -568,7 +567,13 @@ def _build_ann_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockRes
         if len(members) < 2:
             continue
         member_list = sorted(members)
-        block_df = df.filter(pl.col("__row_id__").is_in([row_ids[m] for m in member_list]))
+        # `members` are positions in `df` (UnionFind operates on the same
+        # indices that drive the embeddings array, which is row-aligned with
+        # df). Direct positional indexing is O(K) vs filter(is_in(...))'s
+        # O(N) per block — at 1M rows with ~50K blocks this was the dominant
+        # wall cost (50% of total via PyLazyFrame.collect; cProfile Round 5).
+        # `row_ids` lookup was redundant indirection.
+        block_df = df[member_list]
         results.append(BlockResult(
             block_key=f"ann_{min(member_list)}",
             df=block_df.lazy(),
@@ -721,12 +726,16 @@ def _build_canopy_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Block
         max_canopy_size=canopy_cfg.max_canopy_size,
     )
 
-    row_ids = df["__row_id__"].to_list()
     results: list[BlockResult] = []
     for i, members in enumerate(canopies):
         if len(members) < 2:
             continue
-        block_df = df.filter(pl.col("__row_id__").is_in([row_ids[m] for m in members]))
+        # `members` are positions in `df` — `build_canopies` returns
+        # indices into the text_values list which was built by enumerating
+        # df.iter_rows in order. Direct positional indexing is O(K) vs
+        # filter(is_in(...))'s O(N) per canopy — see ann_blocking_strategy
+        # for the cProfile attribution that drove this change.
+        block_df = df[sorted(list(members))]
         results.append(BlockResult(
             block_key=f"canopy_{i}",
             df=block_df.lazy(),

--- a/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
@@ -294,18 +294,22 @@ def apply_learned_blocks(
             ["__row_id__"] + list({p.field for p in rule.predicates})
         ).to_dicts()
 
+        # Build (block_key -> positions) instead of (block_key -> __row_id__ values).
+        # Direct positional indexing into `df` is O(K) per block; filter+is_in
+        # was O(N) per block, which dominated wall at 1M (cProfile Round 5).
+        # We enumerate `rows` so positions track df's current ordering.
         blocks: dict[str, list[int]] = {}
-        for row in rows:
+        for pos, row in enumerate(rows):
             key = _compute_block_key(row, rule.predicates)
             if key:
-                blocks.setdefault(key, []).append(row["__row_id__"])
+                blocks.setdefault(key, []).append(pos)
 
-        for block_key, member_ids in blocks.items():
-            if len(member_ids) < 2:
+        for block_key, member_positions in blocks.items():
+            if len(member_positions) < 2:
                 continue
-            if len(member_ids) > max_block_size:
+            if len(member_positions) > max_block_size:
                 continue
-            block_lf = df.filter(pl.col("__row_id__").is_in(member_ids)).lazy()
+            block_lf = df[sorted(member_positions)].lazy()
             all_blocks.append(BlockResult(
                 block_key=f"learned:{rule.key()}:{block_key}",
                 df=block_lf,


### PR DESCRIPTION
Round 5 wall-time attack target. Expected **~50% reduction in 1M run_dedupe wall** (~10 min off the 22 min corrected baseline).

## What the profile showed

The Round 5 cProfile of 1M (cloud run [25715695819](https://github.com/benzsevern/goldenmatch/actions/runs/25715695819), corrected harness from PR #187) ranked completely differently from the 100K Round 4 profile:

| metric | 100K (Round 4) | 1M (Round 5) | Δ |
|---|---:|---:|---|
| \`PyLazyFrame.collect\` tottime | 44 s | **797 s** | 18× |
| \`DataFrame.filter\` cumtime | (not in top 20) | **827 s (52% of wall)** | new #1 |
| \`rapidfuzz.cdist\` tottime | 19 s | 89 s | 4.7× |

100K's hot spots **did not predict 1M's**. At 1M a single Polars operation pattern dominates 52% of total wall.

## Root cause

Three near-identical loops in the blocking layer:

\`\`\`python
# blocker.py:571 (ANN), blocker.py:729 (canopy), learned_blocking.py:308
for members in clusters:
    block_df = df.filter(pl.col(\"__row_id__\").is_in([row_ids[m] for m in members]))
\`\`\`

At 1M rows × 50K+ blocks this is **O(N × blocks) ≈ 5×10¹⁰ ops**, each materialising a fresh LazyFrame. The 1.34M \`PyLazyFrame.collect\` calls in the profile came from here.

## Fix

Direct positional indexing — Polars supports row selection by position natively, O(K) per block.

\`\`\`python
# Before                                                 # After
df.filter(pl.col(\"__row_id__\").is_in([...]))            df[sorted(members)]
\`\`\`

- **ANN path**: \`members\` are already positions (UnionFind operates on ann_blocker.query indices). The \`row_ids[m]\` lookup was a no-op indirection — dropped.
- **Canopy path**: \`members\` are positions (build_canopies indexes text_values built in df.iter_rows order). Same fix.
- **learned_blocking.py**: \`member_ids\` was actual \`__row_id__\` values. Switched to enumerate-based positions instead so direct indexing works. Positions track df's current ordering since we enumerate the same \`rows\` list the predicate evaluator already iterates.

## Microbench (1M rows, 50K blocks of ~10 members each)

| path | per-block wall | 50K blocks |
|---|---:|---:|
| \`filter(is_in([...]))\` | 4.34 ms | 217.2 s |
| \`df[indices]\` | 0.10 ms | 5.1 s |
| **speedup** | **42.9×** | **−212 s** |

## Expected scale-audit impact at 1M

- Round 3 corrected baseline: 22 min total (1,237 s run_dedupe + 61 s auto_configure)
- After this PR: estimated ~12 min total (~10 min off run_dedupe)
- Real measurement comes from re-firing scale-audit after merge

## Test plan

- [x] \`pytest packages/python/goldenmatch/tests/\` — 1917 passed, 66 skipped (optional deps / GPU / DB)
- [x] \`test_blocker.py\`, \`test_learned_blocking.py\`, \`test_pipeline.py\` all green
- [ ] CI on this PR
- [ ] After merge: scale-audit 1M re-fire, compare wall to 22 min baseline

## Why this wasn't caught earlier

Two stacked discoveries:
1. Round 3 doubled measurement (harness missing \`_skip_finalize=True\`, fixed in #187) hid that auto_configure was already cheap.
2. Round 4's 100K profile had \`PyLazyFrame.collect\` at 18% of wall — large but not dominant. At 1M scale the call count grew 3× but per-call work grew 4×, pushing collect to 50% of wall. Without a 1M-scale profile we'd never have seen this. PR #185 (artifact include-hidden-files) and #183 (cprofile flag) made the 1M profile actually retrievable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)