### PR TITLE
docs(future-work): add tracker file with two scale-audit deferrals

### DIFF
--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -1,0 +1,53 @@
+# Future work
+
+A long-lived index of deferred work — non-urgent items that surfaced during measurement or implementation and were intentionally not pursued. Items here should be **specific, measured, and have a clear hypothesis**. If something is just a vague idea, it doesn't belong here; it belongs in a brainstorm doc.
+
+When an item gets picked up, move it (or its outcome) out of this file. When something gets killed for good, leave a one-line note explaining why.
+
+---
+
+## Scale-audit follow-ups (Round 5+, 2026-05)
+
+### 1. Reduce fuzzy scoring wall via batched cdist / precomputed feature vectors
+
+**Where**: `goldenmatch/core/scorer.py` — `find_fuzzy_matches`, `_fuzzy_score_matrix`, downstream `rapidfuzz.process_cpp.cdist`.
+
+**What the data shows**: After PR #189 cleared the `DataFrame.filter` hotspot, these three are the new dominant cost in 1M dedupe wall:
+
+- 100K Round 4 cProfile: `rapidfuzz.cdist` 19 s tottime, `find_fuzzy_matches` 11.8 s, `_fuzzy_score_matrix` 4.8 s.
+- 1M Round 5 cProfile (pre-#189): `rapidfuzz.cdist` 89 s tottime, `find_fuzzy_matches` 45 s, `_fuzzy_score_matrix` 19 s.
+
+Post-#189 these will be a larger fraction of the (now smaller) total. A Round 6 cProfile on the new code path is the first step.
+
+**Hypothesis**: 30-50% wall reduction possible via two tactics:
+
+1. **Batched cdist** — `cdist` is called once per (block × field) tuple. At 1M with ~50K blocks × 3 fuzzy fields, that's ~150K cdist invocations, each with overhead. Batching across fields (one cdist call producing a stacked similarity tensor) trades a constant Python-side overhead for an O(fields × N²) matrix that's then sliced field-by-field. Worth it when block size > some threshold.
+2. **Precomputed feature vectors** — many string scorers (jaro-winkler, levenshtein) can be approximated by hashing into fixed-size feature vectors that allow vectorised dot-product similarity. rapidfuzz already exposes `process.cdist` with `score_cutoff` for early termination; we should make sure we're passing it (and a sane cutoff) from goldenmatch.
+
+**How to validate**: Round 6 cProfile run, then prototype the batched cdist on a 100K fixture, measure delta. Microbench first; only ship if the gain on a realistic block-size distribution is materially better than the call overhead saved.
+
+**Risk**: scorer correctness regressions. Lots of tests pin scorer behaviour at exact thresholds (e.g. autoconfig regression suite). Run the full goldenmatch test suite + DQbench adapter before merging.
+
+---
+
+### 2. `score_blocks_parallel` ThreadPool dispatch overhead
+
+**Where**: `goldenmatch/core/scorer.py:727` `_score_one_block`, `score_blocks_parallel` orchestrator.
+
+**What the data shows**: 100K Round 4 cProfile attributed **196 s cumtime** to `concurrent.futures._base.as_completed` and **164 s cumtime** to `threading.Event.wait` — about half the total wall flowed through synchronization primitives rather than actual scoring. At 1M Round 5: `threading.wait` cumtime 4,513 s (across both `_base.wait` and `Event.wait`).
+
+The 1M cumtime number is inflated because each block's I/O wait gets attributed up the stack; the actual wall cost is bounded by the sequential portion. But the call counts — 1.7M `_thread.lock.acquire` calls at 1M — suggest the per-block dispatch overhead is non-trivial when blocks are small.
+
+**Hypothesis**: 10-20% wall reduction by batching small blocks. Each block submission incurs a fixed ThreadPool overhead (~50-100 μs). At 50K blocks with average 10 members, the dispatch cost is ~3-5 s wall on its own; the actual scoring work per small block is comparable. Pre-coalesce small blocks into batches of (say) 1000 rows total before submission, score each batch in one cdist call, then post-split.
+
+**Why this isn't first**: the win is smaller than item 1 and the code change is more invasive (touches the orchestrator). Pick it up after item 1's measurement.
+
+**How to validate**: instrument `score_blocks_parallel` with explicit timing of (dispatch → wait → collect) per block; correlate with block size distribution from a real run. If small blocks (< 50 members) account for >30% of total dispatch time, the batching is worth it.
+
+---
+
+## How to add to this file
+
+- **Be specific**: include filepath:line for the code, a number from a measurement, and a hypothesis with an expected impact range.
+- **Cite the source**: link the PR / cProfile run / issue that surfaced the item. If we can't point to evidence, the item isn't ready.
+- **Pre-commit a validation plan**: how will you know it worked? "Microbench first" / "Re-run scale-audit" / "Compare cluster counts" — answer this before starting work.


### PR DESCRIPTION
New \`docs/future-work.md\` for non-urgent items with specific evidence + hypothesis. Format requires file:line, a measurement, an impact range, and a validation plan — so the file stays load-bearing instead of becoming a graveyard of vague ideas.

Seeds with two scale-audit Round 5 deferrals:
1. fuzzy scoring hotpath (find_fuzzy_matches + _fuzzy_score_matrix + rapidfuzz.cdist), 30-50% wall reduction
2. score_blocks_parallel ThreadPool dispatch overhead, 10-20% wall reduction

Both blocked on Round 6 cProfile measuring the post-#189 code path before any concrete prioritization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)