### PR TITLE
fix(autoconfig): pick_committed falls back to v0 in precision-collapsed regime (#195)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -495,6 +495,19 @@ class AutoConfigController:
         best_entry = dataclasses.replace(best_entry, profile=_stamped_profile)
         if best_entry.iteration >= 0 and best_entry.iteration < len(history.entries):
             history.entries[best_entry.iteration] = best_entry
+        elif best_entry.iteration < 0:
+            # v0 virtual entry (iteration=-1) lives at the END of
+            # history.entries (appended above after the iteration loop).
+            # Find it by attribute and replace in-place so downstream
+            # consumers of history.pick_committed() see the column_priors-
+            # stamped profile. Without this, a v0 commit (PR #197 fix for
+            # issue #195) leaves an unstamped profile in history and any
+            # caller that re-runs pick_committed() gets a profile with no
+            # column_priors / no indicators populated.
+            for _i, _e in enumerate(history.entries):
+                if _e.iteration == best_entry.iteration:
+                    history.entries[_i] = best_entry
+                    break
 
         committed_health = best_entry.profile.health()
         iter_label = "v0" if best_entry.iteration == -1 else str(best_entry.iteration)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
@@ -154,7 +154,31 @@ class RunHistory:
             if (precision_collapse_floor is not None
                     and verdict == HealthVerdict.RED
                     and sp.mass_above_threshold > precision_collapse_floor):
+                # Precision-collapsed regime ("everything matches"). Within
+                # this regime, `-sep` is mechanically biased toward lower
+                # thresholds: a lower threshold narrows the borderline band,
+                # which mechanically increases sep without the model actually
+                # separating anything better. Tiebreaking on -sep then makes
+                # the controller commit whichever iteration lowered the
+                # threshold most, even when nothing's being merged on the
+                # real data.
+                #
+                # Fix: in the collapsed regime, neutralise sep (set tiebreaker
+                # to 0.0) so the lex order falls through to iteration. v0
+                # (iteration=-1) wins among collapsed candidates, which is
+                # the right "safest fallback" behaviour — at worst we commit
+                # the user's input config and emit a warning, instead of a
+                # threshold-lowered variant that produces a degenerate
+                # dedupe on the real data.
+                #
+                # See issue #195 / scale-audit 2M-degeneration for the bug
+                # this addresses: at 2M, low_transitivity fired 3x lowering
+                # threshold 0.80 -> 0.65; precision_collapse_floor demoted
+                # all entries to rank=3; the pre-fix tiebreaker picked the
+                # most-lowered iteration; downstream pipeline produced 2,570
+                # clusters vs the ~145K v0 would have produced.
                 rank = 3
+                return (rank, 0.0, e.iteration)
             return (rank, -sep, e.iteration)
 
         return min(survivors, key=key)

--- a/packages/python/goldenmatch/tests/test_autoconfig_history.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_history.py
@@ -463,6 +463,39 @@ def test_pick_committed_precision_floor_demotes_collapsed_red():
     assert best.iteration == 1
 
 
+def test_pick_committed_collapsed_regime_prefers_earliest_iteration():
+    """Regression for issue #195: in the precision-collapsed regime (all
+    entries demoted to rank=3 by precision_collapse_floor), the lex
+    tiebreaker should be iteration order, NOT -mass_separation.
+
+    Lower thresholds mechanically narrow the borderline band; tiebreaking
+    on -sep in the collapsed regime mechanically picks the most
+    threshold-lowered iteration even when it doesn't actually separate
+    matches better on the real data. Picking the earliest iteration
+    (v0 = iteration -1) is the safest fallback.
+
+    This test pins all entries above the floor with rising mass_separation;
+    pre-fix, iter=3 would have won (largest sep, smallest -sep). Post-fix,
+    iter=-1 wins (earliest).
+    """
+    from goldenmatch.core.autoconfig_history import RunHistory
+    h = RunHistory()
+    # All collapsed (mass_above > 0.9) — all get rank=3 demotion.
+    # Mass-borderline decreases with iteration so sep increases — pre-fix
+    # this would have made iter=3 win.
+    h.entries.append(_make_red_entry_with_mass(-1, mass_above=1.0, mass_borderline=0.96))
+    h.entries.append(_make_red_entry_with_mass(0,  mass_above=1.0, mass_borderline=0.96))
+    h.entries.append(_make_red_entry_with_mass(1,  mass_above=1.0, mass_borderline=0.95))
+    h.entries.append(_make_red_entry_with_mass(2,  mass_above=1.0, mass_borderline=0.93))
+    h.entries.append(_make_red_entry_with_mass(3,  mass_above=1.0, mass_borderline=0.88))
+    best = h.pick_committed(precision_collapse_floor=0.9)
+    assert best is not None
+    assert best.iteration == -1, (
+        f"collapsed regime should fall back to earliest iteration (v0 = -1); "
+        f"got iteration={best.iteration}"
+    )
+
+
 def test_pick_committed_precision_floor_default_is_off():
     """Default behavior preserves v1.9 lex-key ranking (no demotion)."""
     from goldenmatch.core.autoconfig_history import RunHistory

--- a/scripts/investigate_autoconfig_2m.py
+++ b/scripts/investigate_autoconfig_2m.py
@@ -92,6 +92,26 @@ def dump_config(label: str, rows: int) -> None:
         msg = f"  - {d}".encode("ascii", "replace").decode("ascii")
         print(msg)
     print()
+    print("per-entry ranking stats (the pick_committed() input):")
+    print("  iter | health  | mass_above | mass_borderline | sep   | -sep   | (rank, -sep, iter) lex_key")
+    if history:
+        from goldenmatch.core.autoconfig_history import HealthVerdict
+        for e in history.entries:
+            sp = e.profile.scoring
+            verdict = e.profile.health()
+            rank = {HealthVerdict.GREEN: 0, HealthVerdict.YELLOW: 1, HealthVerdict.RED: 2}[verdict]
+            sep = sp.mass_above_threshold - sp.mass_in_borderline
+            if verdict == HealthVerdict.RED and sp.mass_above_threshold > 0.9:
+                rank = 3
+            key_tuple = (rank, -sep, e.iteration)
+            print(
+                f"  {e.iteration:>4} | {verdict.value:7s} | {sp.mass_above_threshold:9.4f} "
+                f"| {sp.mass_in_borderline:14.4f} | {sep:5.3f} | {-sep:6.3f} | {key_tuple}",
+            )
+        committed = history.pick_committed(precision_collapse_floor=0.9)
+        if committed is not None:
+            print(f"  -> committed iteration={committed.iteration}")
+    print()
 
 
 def main() -> int:

--- a/scripts/investigate_autoconfig_2m.py
+++ b/scripts/investigate_autoconfig_2m.py
@@ -1,0 +1,109 @@
+"""Diagnostic for issue #195 — auto-config degenerates at 2M+ rows.
+
+Loads two synthetic fixtures (1M, 2M) reusing the scale-audit harness's
+fixture generator, runs `auto_configure_df(..., _skip_finalize=True)` on
+each, and prints a side-by-side summary of:
+
+  - controller history's stop_reason
+  - committed config matchkeys (type + fields + threshold)
+  - blocking rules
+  - profile health verdict
+
+The 1M run produced ~145K multi-member clusters; the 2M run produced
+~2,570. Same fixture shape, same code, dramatically different output —
+this script gets us the committed-config diff that explains it.
+
+Usage:
+    python scripts/investigate_autoconfig_2m.py
+
+Exits 0 always. Prints results to stdout.
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import polars as pl
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURE_DIR = REPO / ".profile_tmp" / "scale_fixtures"
+
+
+def ensure_fixture(rows: int, dupe_rate: float = 0.15) -> Path:
+    sys.path.insert(0, str(REPO / "packages" / "python" / "goldenmatch"))
+    from tests.generate_synthetic import generate  # type: ignore[import-not-found]
+
+    FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+    path = FIXTURE_DIR / f"synthetic_{rows}_dupe{int(dupe_rate*100):02d}.csv"
+    if not path.exists():
+        print(f"[fixture] generating {rows:,} rows -> {path.name}", file=sys.stderr)
+        generate(path, n_records=rows, dupe_rate=dupe_rate)
+    return path
+
+
+def dump_config(label: str, rows: int) -> None:
+    from goldenmatch.core.autoconfig import auto_configure_df, _LAST_CONTROLLER_RUN
+
+    fp = ensure_fixture(rows)
+    df = pl.read_csv(fp, encoding="utf8-lossy", ignore_errors=True)
+
+    t0 = time.perf_counter()
+    cfg = auto_configure_df(df, _skip_finalize=True)
+    elapsed = time.perf_counter() - t0
+
+    state = _LAST_CONTROLLER_RUN.get()
+    history = state[1] if state is not None else None
+    profile = state[0] if state is not None else None
+
+    print()
+    print(f"=== {label} (rows={rows:,}) ===")
+    print(f"auto_configure wall: {elapsed:.2f} s")
+    print(f"stop_reason:         {getattr(history, 'stop_reason', None)}")
+    print(f"profile.health():    {profile.health().value if profile else None}")
+    print(f"iterations recorded: {len(history.decisions) if history else 0}")
+    print()
+    print("matchkeys:")
+    for mk in cfg.matchkeys or []:
+        print(f"  - type={mk.type}")
+        if mk.type == "weighted":
+            print(f"    threshold={mk.threshold}")
+            for f in mk.fields or []:
+                print(f"    field={f.field} scorer={f.scorer} weight={f.weight}")
+        elif mk.type == "exact":
+            for f in mk.fields or []:
+                print(f"    field={f.field}")
+        elif mk.type == "fuzzy":
+            print(f"    field={mk.field} threshold={mk.threshold} scorer={mk.scorer}")
+    print()
+    print("blocking:")
+    blk = getattr(cfg, "blocking", None)
+    if blk is None:
+        print("  (none)")
+    else:
+        print(f"  strategy={getattr(blk, 'strategy', None)}")
+        for k in (getattr(blk, "keys", None) or []):
+            print(f"  key: field={getattr(k, 'field', None)} transforms={getattr(k, 'transforms', None)}")
+    print()
+    print("controller history.decisions (first 5):")
+    for d in (history.decisions if history else [])[:5]:
+        # repr may contain non-cp1252 chars (e.g. unicode arrows from rule
+        # rationales). Encode-safe on Windows terminals via ASCII fallback.
+        msg = f"  - {d}".encode("ascii", "replace").decode("ascii")
+        print(msg)
+    print()
+
+
+def main() -> int:
+    for label, rows in [("1M-baseline", 1_000_000), ("2M-degenerate", 2_000_000)]:
+        try:
+            dump_config(label, rows)
+        except BaseException as exc:
+            import traceback
+            print(f"[error] {label}: {type(exc).__name__}: {exc}", file=sys.stderr)
+            traceback.print_exc()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #195.

## Bug

In `pick_committed()`, when `precision_collapse_floor` demotes all entries to rank=3 ("everything matches" pathology), the `-sep` tiebreaker is mechanically biased toward iterations that lowered threshold most. Lower threshold → narrower borderline → higher sep → wins lex. Commit policy rewards threshold lowering even when nothing is actually being separated better.

At 2M on the synthetic fixture: pre-fix committed iter=3 (threshold 0.7, ensemble address scorer) instead of v0 (threshold 0.8, token_sort). Downstream pipeline produced 2,570 multi-member clusters at 2M vs ~145K at 1M (57x drop for 2x rows).

## Fix

In `pick_committed()` lex-key: when collapsed-regime demotion fires, neutralise `-sep` tiebreaker to 0.0. Iteration order takes over; v0 (iteration=-1) wins. Outside collapsed regime: unchanged.

## Diagnostic

`scripts/investigate_autoconfig_2m.py` reproduces the bug. Local verification: committed iteration flipped from 3 (pre-fix) to -1 (post-fix, = v0).

## Tests

- 189/189 autoconfig + autoconfig_history + autoconfig_controller tests pass
- 23/23 autoconfig_regressions + pipeline tests pass
- New regression: test_pick_committed_collapsed_regime_prefers_earliest_iteration
- Cloud 2M re-fire after merge will validate downstream cluster count returns to ~1.7M

🤖 Generated with [Claude Code](https://claude.com/claude-code)
