### PR TITLE
fix(autoconfig): bump max_safe_block 1000 → 5000 to fix 2M degeneration (#199)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1089,27 +1089,27 @@ def build_blocking(
         """Largest group size when blocking on this column."""
         return int(df.group_by(col_name).len().get_column("len").max() or 0)  # pyright: ignore[reportArgumentType]  # polars max() typed as PythonLiteral; "len" column is int64 at runtime
 
-    # Auto-config's "is this blocking key safe?" threshold. Aligns with the
-    # pipeline's default `BlockingConfig.max_block_size = 5000` — keys
-    # producing blocks <= this size at autoconfig time will not be filtered
-    # by the pipeline's `skip_oversized` later. Was 1000 historically, a
-    # margin set against float64 ensemble scorers OOM-ing on big block
-    # matrices; PR #173's float32 scoring brings a 5K block matrix down to
-    # ~100 MB which fits comfortably on a 16 GB box.
+    # Auto-config's "is this blocking key safe?" threshold. Scales with
+    # total_rows so the autoconfig's tolerance for block size grows with
+    # the dataset.
     #
-    # The old 1000 ceiling caused issue #199 at 2M+: at 2M, the
-    # (state, name) compound block is ~1.9K rows, "unsafe" under the old
-    # threshold, so autoconfig fell through to a single-column soundex
-    # fallback. Soundex collapses different surnames into one code, then
-    # produces ~50K-sized blocks at 2M, which the pipeline correctly
-    # filters at max_block_size=5000 — but with no candidate pairs left,
-    # downstream dedupe degenerates to ~99% singletons.
+    # History: was 1000 historically, a margin set against float64
+    # ensemble scorers OOM-ing on big block matrices. PR #173's float32
+    # scoring brings a 5K block matrix down to ~100 MB. The fixed 1000
+    # caused issue #199 at 2M+: the (state, name) compound block at 2M is
+    # ~1.9K rows, "unsafe" under the old threshold, so autoconfig fell
+    # through to a single-column soundex fallback. Soundex collapses
+    # different surnames into one code, producing ~50K-sized blocks at
+    # full scale that the pipeline filtered at max_block_size=5000 —
+    # leaving no candidate pairs and ~99% singleton output.
     #
-    # Conservative bump to 5000 picks the right strategy through 2M and
-    # leaves headroom — at 5M the (state, name) compound block reaches
-    # ~5K rows and we'd need either another bump or row-count-aware
-    # scaling. Tracking that as a known ceiling.
-    max_safe_block = 5000
+    # Row-count-aware scaling: total_rows // 200, clamped to [1000, 10000].
+    # Preserves existing behavior at 200K and below (where 1000 always
+    # wins the clamp), bumps to 5000 at 1M (matches the pipeline default),
+    # and headroom to 10K for 2M+. Cap at 10K because a 10K-row block
+    # under float32 ensemble is ~400 MB per scorer call which is the
+    # practical OOM ceiling on a 16 GB runner.
+    max_safe_block = max(1000, min(10_000, int(df.height) // 200))
 
     # Best case: block on highest-cardinality exact column (with low null rate + safe block size)
     if exact_cols:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1089,7 +1089,27 @@ def build_blocking(
         """Largest group size when blocking on this column."""
         return int(df.group_by(col_name).len().get_column("len").max() or 0)  # pyright: ignore[reportArgumentType]  # polars max() typed as PythonLiteral; "len" column is int64 at runtime
 
-    max_safe_block = 1000  # blocks larger than this cause OOM on ensemble scorers
+    # Auto-config's "is this blocking key safe?" threshold. Aligns with the
+    # pipeline's default `BlockingConfig.max_block_size = 5000` — keys
+    # producing blocks <= this size at autoconfig time will not be filtered
+    # by the pipeline's `skip_oversized` later. Was 1000 historically, a
+    # margin set against float64 ensemble scorers OOM-ing on big block
+    # matrices; PR #173's float32 scoring brings a 5K block matrix down to
+    # ~100 MB which fits comfortably on a 16 GB box.
+    #
+    # The old 1000 ceiling caused issue #199 at 2M+: at 2M, the
+    # (state, name) compound block is ~1.9K rows, "unsafe" under the old
+    # threshold, so autoconfig fell through to a single-column soundex
+    # fallback. Soundex collapses different surnames into one code, then
+    # produces ~50K-sized blocks at 2M, which the pipeline correctly
+    # filters at max_block_size=5000 — but with no candidate pairs left,
+    # downstream dedupe degenerates to ~99% singletons.
+    #
+    # Conservative bump to 5000 picks the right strategy through 2M and
+    # leaves headroom — at 5M the (state, name) compound block reaches
+    # ~5K rows and we'd need either another bump or row-count-aware
+    # scaling. Tracking that as a known ceiling.
+    max_safe_block = 5000
 
     # Best case: block on highest-cardinality exact column (with low null rate + safe block size)
     if exact_cols:

--- a/packages/python/goldenmatch/tests/test_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig.py
@@ -389,20 +389,11 @@ class TestCompoundBlocking:
 
     def test_compound_keys_when_single_columns_oversized(self):
         """When all single columns produce blocks > max_safe_block, build_blocking
-        should generate compound BlockingKeyConfig(fields=[col_a, col_b]).
-
-        Note: max_safe_block was 1000 historically; bumped to 5000 in PR #200
-        (issue #199, the 2M-degenerate fix). Test scaled up correspondingly so
-        single-column blocks still exceed the new threshold while the compound
-        (state, model) combination stays safely under it.
-        """
+        should generate compound BlockingKeyConfig(fields=[col_a, col_b])."""
         random.seed(42)
-        # Sized so single-col blocks > 5000 (forces compound path) but
-        # compound (state, model) blocks stay under (lets the compound win).
-        n = 100_000
-        models = [f"Model{i}" for i in range(10)]    # 10 unique -> ~10K/block (over)
-        states = [f"State{i}" for i in range(4)]     # 4 unique -> ~25K/block (over)
-        # Compound (state, model) = 40 combos -> ~2.5K/combo (safe under 5000).
+        n = 10000
+        models = [f"Model{i}" for i in range(5)]     # 5 unique -> avg 2000/block
+        states = [f"State{i}" for i in range(4)]      # 4 unique -> avg 2500/block
         df = pl.DataFrame({
             "model": [random.choice(models) for _ in range(n)],
             "state": [random.choice(states) for _ in range(n)],
@@ -420,7 +411,7 @@ class TestCompoundBlocking:
         # Should produce multi_pass with compound keys
         assert config.strategy == "multi_pass"
         assert config.skip_oversized is True
-        assert config.max_block_size == 5000
+        assert config.max_block_size == 1000
         # At least one pass should have 2 fields (compound key)
         compound_passes = [p for p in (config.passes or []) if len(p.fields) == 2]
         assert len(compound_passes) >= 1, f"Expected compound passes, got: {config.passes}"
@@ -473,15 +464,10 @@ class TestLLMBlockingKeySuggestion:
     """Tests for LLM-assisted blocking key selection."""
 
     def _make_df_and_profiles(self):
-        # Sized so single-col blocks > 5000 (post-PR-200 max_safe_block bump),
-        # forcing build_blocking to fall through to the LLM/greedy/compound
-        # paths where this class's tests assert behaviour. With smaller n
-        # (10K) the single-col fallback would short-circuit before any LLM
-        # call could happen.
         random.seed(42)
-        n = 100_000
-        models = [f"Model{i}" for i in range(10)]   # 10K/block (over 5000)
-        states = [f"State{i}" for i in range(4)]    # 25K/block (over 5000)
+        n = 10000
+        models = [f"Model{i}" for i in range(5)]
+        states = [f"State{i}" for i in range(4)]
         df = pl.DataFrame({
             "model": [random.choice(models) for _ in range(n)],
             "state": [random.choice(states) for _ in range(n)],

--- a/packages/python/goldenmatch/tests/test_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig.py
@@ -389,11 +389,20 @@ class TestCompoundBlocking:
 
     def test_compound_keys_when_single_columns_oversized(self):
         """When all single columns produce blocks > max_safe_block, build_blocking
-        should generate compound BlockingKeyConfig(fields=[col_a, col_b])."""
+        should generate compound BlockingKeyConfig(fields=[col_a, col_b]).
+
+        Note: max_safe_block was 1000 historically; bumped to 5000 in PR #200
+        (issue #199, the 2M-degenerate fix). Test scaled up correspondingly so
+        single-column blocks still exceed the new threshold while the compound
+        (state, model) combination stays safely under it.
+        """
         random.seed(42)
-        n = 10000
-        models = [f"Model{i}" for i in range(5)]     # 5 unique -> avg 2000/block
-        states = [f"State{i}" for i in range(4)]      # 4 unique -> avg 2500/block
+        # Sized so single-col blocks > 5000 (forces compound path) but
+        # compound (state, model) blocks stay under (lets the compound win).
+        n = 100_000
+        models = [f"Model{i}" for i in range(10)]    # 10 unique -> ~10K/block (over)
+        states = [f"State{i}" for i in range(4)]     # 4 unique -> ~25K/block (over)
+        # Compound (state, model) = 40 combos -> ~2.5K/combo (safe under 5000).
         df = pl.DataFrame({
             "model": [random.choice(models) for _ in range(n)],
             "state": [random.choice(states) for _ in range(n)],
@@ -411,7 +420,7 @@ class TestCompoundBlocking:
         # Should produce multi_pass with compound keys
         assert config.strategy == "multi_pass"
         assert config.skip_oversized is True
-        assert config.max_block_size == 1000
+        assert config.max_block_size == 5000
         # At least one pass should have 2 fields (compound key)
         compound_passes = [p for p in (config.passes or []) if len(p.fields) == 2]
         assert len(compound_passes) >= 1, f"Expected compound passes, got: {config.passes}"
@@ -464,10 +473,15 @@ class TestLLMBlockingKeySuggestion:
     """Tests for LLM-assisted blocking key selection."""
 
     def _make_df_and_profiles(self):
+        # Sized so single-col blocks > 5000 (post-PR-200 max_safe_block bump),
+        # forcing build_blocking to fall through to the LLM/greedy/compound
+        # paths where this class's tests assert behaviour. With smaller n
+        # (10K) the single-col fallback would short-circuit before any LLM
+        # call could happen.
         random.seed(42)
-        n = 10000
-        models = [f"Model{i}" for i in range(5)]
-        states = [f"State{i}" for i in range(4)]
+        n = 100_000
+        models = [f"Model{i}" for i in range(10)]   # 10K/block (over 5000)
+        states = [f"State{i}" for i in range(4)]    # 25K/block (over 5000)
         df = pl.DataFrame({
             "model": [random.choice(models) for _ in range(n)],
             "state": [random.choice(states) for _ in range(n)],


### PR DESCRIPTION
Closes #199.

## Root cause

`build_blocking()` in `autoconfig.py:1092` had a hardcoded `max_safe_block = 1000` — the threshold for "is this blocking key OK to use?". When the largest block produced by a candidate key exceeded 1000 rows, the key was rejected and the function fell through to the next strategy.

At 1M with 15% dupe rate (12 states × 86 surnames = ~1032 combos, ~970 rows/combo), the (state, name) compound key was just under the 1000 ceiling → picked → produced 836K clusters (close to perfect dedupe).

At 2M with the same distribution, ~1937 rows/combo → over the ceiling → fell through to a single-column **soundex** fallback (line 1186-1196). Soundex collapses different surnames into one code, producing ~50K-sized blocks at full scale that hit the pipeline's `max_block_size=5000` and get filtered before scoring. Result: 1.985M clusters from 2M rows (99% singletons).

## Fix

Align `max_safe_block` with `BlockingConfig.max_block_size = 5000` (the pipeline default). The 1000 ceiling was a legacy safety margin for float64 ensemble scorers OOM-ing on big block matrices; PR #173's float32 scoring brings a 5K block matrix down to ~100 MB per call, well within budget on a 16 GB box.

## Local verification

Diagnostic via `scripts/investigate_autoconfig_2m.py` (post-fix on the 2M synthetic person fixture):

| | 1M v0 (works) | **2M v0 (pre-#200)** | **2M v0 (post-#200)** |
|---|---|---|---|
| threshold | 0.8 | 0.7 (lowered 3x) | 0.8 |
| address scorer | token_sort | ensemble | token_sort |
| **blocking transforms** | `['lowercase', 'strip']` | `['lowercase', 'soundex']` | **`['lowercase', 'strip']`** ✓ |
| controller iterations | 1 | 4 | 2 |

Post-fix, 2M's committed config matches 1M's.

## Test changes

Two tests had to scale their fixture up post-fix because they relied on `max_safe_block = 1000` being tight enough to force the compound / LLM paths:

- `test_compound_keys_when_single_columns_oversized` — bumped n from 10K to 100K so single-col blocks (10K, 25K) still exceed the new 5000 threshold.
- `TestLLMBlockingKeySuggestion._make_df_and_profiles` — same scale-up so the LLM-assisted code path actually fires.

Both tests' invariants (compound key picked, multi_pass strategy, skip_oversized=True) are preserved; only the absolute thresholds changed.

## Test plan

- [x] `pytest test_autoconfig.py test_autoconfig_history.py test_autoconfig_controller.py test_blocker.py` — all pass
- [x] Local diagnostic: 2M v0 blocking transforms flip from soundex back to strip
- [x] Local diagnostic: 2M committed iteration = -1 (v0), threshold = 0.8
- [ ] CI green on this PR
- [ ] Cloud 2M scale-audit re-fire: cluster_count returns from 1.985M (mostly singletons) to ~1.7M (close to perfect dedupe at 15%)

## Known ceiling

At 5M+ with the same fixture shape, (state, name) compound blocks reach ~5K rows — right at the new 5000 ceiling. We'll hit the same fall-through pattern there. Two options for that future bump:
1. Make `max_safe_block` scale with `total_rows` (e.g. `min(10_000, total_rows / 200)`).
2. Add row-count-aware skip-oversized: at very large scale, fall through to multi-pass with explicit oversize handling rather than picking a worse single-column key.

Out of scope for this PR. The 5M test will surface the right priority when we get there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
