### PR TITLE
docs(audit): Golden Suite package audit — recommend GoldenPipe v1.2 next

### DIFF
--- a/docs/superpowers/specs/2026-05-13-golden-suite-package-audit.md
+++ b/docs/superpowers/specs/2026-05-13-golden-suite-package-audit.md
@@ -86,10 +86,7 @@ GoldenPipe's `Pipeline.run()` already has the contract for adding a stage (entry
 
 These were noticed during the audit but are not the recommended bet:
 
-1. **`goldenflow` version drift.** `packages/python/goldenflow/pyproject.toml` says `1.1.6`, but `goldenflow/__init__.py` still says `1.1.5` and `CHANGELOG.md` stops at `1.1.5`. PyPI is at `1.1.5`. No `goldenflow-v1.1.6` git tag. Either:
-   - the pyproject bump was made anticipating a 1.1.6 cut that hasn't happened, **or**
-   - someone forgot to land the matching `__init__.py` bump + CHANGELOG + tag.
-   This is a 10-line fix (revert to 1.1.5, *or* add a CHANGELOG entry and cut the tag). Worth filing as an issue, not worth blocking on.
+1. **`goldenflow` 1.1.6 partly-shipped.** `pyproject.toml` and `goldenflow/__init__.py` both say `1.1.6`, but `CHANGELOG.md` stops at `1.1.5`, there is no `goldenflow-v1.1.6` git tag, and PyPI is at `1.1.5`. Real fix commit exists at `2c7b33f` (PR #174 / #175 -- "avoid Series.to_list() panic in category_auto_correct at 1M+ rows"). Action: add CHANGELOG entry, cut the `goldenflow-v1.1.6` tag, publish. Addressed in PR #208.
 
 2. **`goldensuite-mcp` is local-only.** Local version is `v0.1.0`. `pypi.org/pypi/goldensuite-mcp/json` returns `404 Not Found`. No `tests/` directory. No CHANGELOG. No publish workflow in `.github/workflows/`. The architecture is sound (and it transitively exposes the new identity tools), but the package isn't shipping. If we want the suite-MCP story to be real, this needs:
    - a publish workflow (mirror `publish-goldenmatch.yml`)

--- a/docs/superpowers/specs/2026-05-13-golden-suite-package-audit.md
+++ b/docs/superpowers/specs/2026-05-13-golden-suite-package-audit.md
@@ -1,0 +1,188 @@
+# Golden Suite Package Audit (2026-05-13)
+
+**Author:** session audit, post-Identity-Graph-v2.1 (PR #203 merged 33a2379)
+**Scope:** all non-GoldenMatch suite packages -- goldenpipe, infermap, goldencheck, goldenflow, goldensuite-mcp, dbt-goldencheck, TS ports, Rust extensions
+**Question:** What is the highest-leverage next non-GoldenMatch bet, given the v1.15 Identity Graph just shipped?
+**Constraint:** small audit, no implementation, prefer docs/spec PR over code changes.
+
+---
+
+## Executive recommendation
+
+**Attack GoldenPipe next.** Specifically: ship **GoldenPipe v1.2 -- suite orchestration for Identity Graph v2.0**.
+
+The audit confirms the hypothesis. GoldenPipe already markets itself as "Golden Suite orchestrator", already has the stage registry + entry-points machinery, and is the only package that does *not* require new product surface area to integrate Identity Graph -- just a fourth stage and a config wire-through. Every other improvement here either has lower adoption leverage (InferMap, GoldenCheck, GoldenFlow are mature standalone tools) or higher engineering cost relative to the win (goldensuite-mcp is unpublished; TS ports are healthy but not bottlenecks; Rust extensions just released).
+
+The single most evidence-laden gap: Identity Graph v2.0 landed in PR #201, ships in `goldenmatch>=1.15.0`, and is invisible from GoldenPipe + the 12 Airflow DAGs. The headline feature has no orchestration surface.
+
+---
+
+## Method
+
+For each package: read `pyproject.toml`, `README.md`, `CLAUDE.md`, the test directory, the entry-points / stage registry, and `examples/`. Cross-check with `.github/workflows/ci.yml` for which lanes run real pytest vs lint-only. Verify release state on PyPI + tags. Map every package against the eight audit questions.
+
+Hard evidence anchors (file:line cited inline below):
+- `packages/python/goldenpipe/pyproject.toml:52` -- entry-points stage registry
+- `packages/python/goldenpipe/goldenpipe/adapters/match.py:22` -- DedupeStage produces clusters/golden but not entity_id
+- `examples/airflow/*.py` -- 12 DAGs, zero `IdentityConfig` or `IdentityStore` references
+- `.github/workflows/ci.yml:155` -- dynamic per-package matrix is real
+- `packages/python/goldensuite-mcp/goldensuite_mcp/server.py:47-50` -- aggregator does transitively expose identity tools via `goldenmatch.mcp.server.TOOLS`
+
+---
+
+## Per-package scorecard
+
+| Package | Promise | Quickstart | Prod example | CI > lint | Composes w/ Identity v2 | Release/MCP/container | Verdict |
+|---|---|---|---|---|---|---|---|
+| **goldenpipe** | "Golden Suite orchestrator" | ✅ `gp.run("customers.csv")` | ✅ 4 examples; 12 Airflow DAGs (via goldenmatch direct) | ✅ 18 test files in matrix | ❌ **No identity stage, no `IdentityConfig` wiring** | ✅ PyPI 1.1.0, MCP @8250, Railway live | **Primary target.** Headline composition gap. |
+| **infermap** | "Schema mapping engine" | ✅ `infermap.map(src, tgt)` | ✅ 4 Airflow DAGs use it | ✅ 23 test files | ❌ Output doesn't feed identity dataset/source_pk hints | ✅ PyPI 0.4.0, npm parity | Solid; runner-up. |
+| **goldencheck** | "Data validation by discovery" | ✅ `goldencheck data.csv` | ✅ Airflow `quality_gate.py` | ✅ 66 test files | ❌ Not wired as identity input gate | ✅ PyPI 1.2.0, TS parity, MCP @8100, Railway live | Mature; tactical work only. |
+| **goldenflow** | "Standardize messy data" | ✅ `goldenflow transform data.csv` | ✅ Airflow DAGs use `transform_df` | ✅ 37 test files | ❌ Not wired as identity-safe preprocessor | ⚠️ `pyproject` says 1.1.6, PyPI is 1.1.5, CHANGELOG stops at 1.1.5 -- **silent local version drift** | Mature; one tiny cleanup item below. |
+| **goldensuite-mcp** | "One MCP endpoint for the suite" | ✅ `goldensuite-mcp serve` | None | ❌ **No `tests/` directory** | ✅ Transitively picks up `identity_*` tools via `goldenmatch.mcp.server.TOOLS` | ⚠️ Local **v0.1.0**, **never published to PyPI**, no CHANGELOG, no Dockerfile in CI matrix | Architecturally sound, releasing-shaped work; not the next big bet. |
+| **dbt-goldencheck** | "dbt-side sanity check + Python runner" | ✅ `dbt deps` + `run_goldencheck.py` | ⚠️ Single test macro by design | ⚠️ no dbt CI in this repo | ❌ N/A by scope | n/a | Intentionally narrow; nothing to do. |
+| **TS `goldenmatch`** | "ER toolkit (TS)" | ✅ | ✅ | ✅ vitest | ✅ ships `InMemoryIdentityStore` in 0.8.0 | ✅ npm 0.8.0 | Healthy. v2.1 follow-up = persistent SQLite backend (already scoped). |
+| **TS `infermap`** | "Schema mapping (TS)" | ✅ | ✅ | ✅ | ❌ same gap as Python sibling | ✅ npm 0.4.0 | Healthy. |
+| **TS `goldencheck-types`** | "Shared field types" | ✅ | n/a (types-only) | ✅ minimal | n/a | ✅ npm 0.1.0 | Healthy. |
+| **Rust `goldenmatch_pg`** | "pgrx extension" | ✅ tarball install per release | ✅ identity functions land in 0.4.0 | ✅ `rust_pgrx` lane PG 15/16/17 | ✅ five identity UDFs (PR #201) | ✅ tarballs on release (PR #202) | Healthy; just shipped. |
+| **Rust `goldenmatch-duckdb`** | "DuckDB UDFs" | ✅ `pip install` + `register()` | ✅ identity tests | ✅ `duckdb_extensions` lane | ✅ five identity UDFs (PR #201) | ✅ PyPI 0.3.0 (PR #202) | Healthy; just shipped. |
+
+---
+
+## Evidence: the Identity Graph composition gap
+
+Quick grep run for any identity reference outside goldenmatch:
+
+```
+$ grep -rn "identity_resolve\|IdentityStore\|goldenmatch\.identity\|identity_graph" \
+    packages/python/{goldenpipe,goldencheck,goldenflow,goldensuite-mcp,infermap}/
+(no output)
+
+$ grep -rn "IdentityStore\|IdentityConfig\|identity_resolve" examples/airflow/
+(no output)
+```
+
+Confirmed three structural gaps in the orchestrator surface:
+
+1. **No identity stage in GoldenPipe.** Entry-points at `packages/python/goldenpipe/pyproject.toml:52`:
+
+   ```toml
+   [project.entry-points."goldenpipe.stages"]
+   "goldencheck.scan" = "goldenpipe.adapters.check:ScanStage"
+   "goldenflow.transform" = "goldenpipe.adapters.flow:TransformStage"
+   "goldenmatch.dedupe" = "goldenpipe.adapters.match:DedupeStage"
+   ```
+
+   There is no `"goldenmatch.identity_resolve"` stage. A `stages/infer_schema.py` file exists but isn't even registered as a stage.
+
+2. **DedupeStage drops `IdentityConfig` on the floor.** `packages/python/goldenpipe/goldenpipe/adapters/match.py:34-54` builds a `GoldenMatchConfig` from `stage_config` *or* from upstream column contexts -- but the helper `_build_config_from_contexts` (lines 69-243) constructs `MatchkeyConfig` + `BlockingConfig` only. `IdentityConfig` is never set. Even if a user adds `identity:` to their YAML, the adapter would have to opt into propagating it.
+
+3. **Zero Airflow DAGs invoke identity.** All 12 DAGs in `examples/airflow/` use `goldenmatch.dedupe` patterns that pre-date v1.15. `golden_suite_customer_360.py` literally has the comment "Cross-source customer 360: unify identity across CRM + warehouse + support" -- but the identity surface it ships predates the durable graph and only does run-local clusters.
+
+GoldenPipe's `Pipeline.run()` already has the contract for adding a stage (entry-points + StageInfo + adapter). The work is small and tightly bounded.
+
+---
+
+## Stale items discovered
+
+These were noticed during the audit but are not the recommended bet:
+
+1. **`goldenflow` version drift.** `packages/python/goldenflow/pyproject.toml` says `1.1.6`, but `goldenflow/__init__.py` still says `1.1.5` and `CHANGELOG.md` stops at `1.1.5`. PyPI is at `1.1.5`. No `goldenflow-v1.1.6` git tag. Either:
+   - the pyproject bump was made anticipating a 1.1.6 cut that hasn't happened, **or**
+   - someone forgot to land the matching `__init__.py` bump + CHANGELOG + tag.
+   This is a 10-line fix (revert to 1.1.5, *or* add a CHANGELOG entry and cut the tag). Worth filing as an issue, not worth blocking on.
+
+2. **`goldensuite-mcp` is local-only.** Local version is `v0.1.0`. `pypi.org/pypi/goldensuite-mcp/json` returns `404 Not Found`. No `tests/` directory. No CHANGELOG. No publish workflow in `.github/workflows/`. The architecture is sound (and it transitively exposes the new identity tools), but the package isn't shipping. If we want the suite-MCP story to be real, this needs:
+   - a publish workflow (mirror `publish-goldenmatch.yml`)
+   - at minimum a smoke test that imports each sub-package and asserts `TOOLS` is non-empty
+   - a first published version
+
+3. **PR #146's per-package pytest claim verified.** All five Python packages with `tests/` directories do run real pytest in CI via the dynamic matrix at `.github/workflows/ci.yml:155`. The audit found no lint-only-disguised-as-tested package.
+
+4. **PRs #165/#166/#167's MCP/PyPI sync verified for the existing packages.** Every published Python package has a matching `.github/workflows/publish-<pkg>.yml`. `publish-mcp.yml` routes to the registry on release. The only blank in the registry routing is `goldensuite-mcp` (because it never publishes).
+
+5. **PR #201 / Identity Graph v2.0** is live (1.15.0 on PyPI, 0.8.0 on npm, 0.3.0 on PyPI for duckdb, 0.4.0 tarballs on the GH release). v2.1 hardening (PR #203) added cross-surface contract test + auto-conflict-detection + schema v2 migration.
+
+---
+
+## Top 3 next bets, ranked
+
+### Bet 1 (recommended): GoldenPipe v1.2 -- suite orchestration for Identity Graph
+
+**Why it wins:**
+- Closes the only structural gap between the headline feature (Identity Graph) and the orchestrator the suite is marketed around.
+- Tiny new surface area (one stage + one config field + one Airflow DAG + one example). Reuses existing stage registry, existing column-context plumbing, existing manifest persistence.
+- High narrative leverage: "one CLI runs InferMap -> GoldenCheck -> GoldenFlow -> GoldenMatch -> Identity Graph" becomes literally true.
+- All adjacent packages stay on their current version and need no changes.
+
+### Bet 2: InferMap-as-identity-feeder (medium)
+
+Hook InferMap's mapping output into the identity store as `IdentityAlias` rows. When InferMap maps `crm.cust_id -> customer_id`, that's exactly the alias relationship `identity_aliases` already models. Smaller win than Bet 1 because it doesn't change the user's quickstart, but it's the natural follow-up.
+
+### Bet 3: GoldenCheck quality-gate guard on identity inputs (small)
+
+Add an opt-in "identity-safe" preflight in GoldenCheck that warns when a dataset is missing a stable `source_pk` column. Closes the documented v1.15 gotcha that hash-fallback `record_id`s can collide on duplicate raw rows. Small, low-risk, but doesn't move adoption nearly as much as Bet 1.
+
+**Not recommended for now:**
+- TS port enhancements (TS v0.9 / TS persistent identity store) -- already scoped, no urgency
+- Force-graph UI -- still YAGNI per the v2 deferred list
+- Web "review queue for conflicts" tab -- valuable but smaller leverage than Bet 1
+- goldensuite-mcp release -- ship along with Bet 1, not as the headline
+
+---
+
+## Proposed first PR: spec for GoldenPipe v1.2
+
+Single committed doc, no implementation. Targets `docs/superpowers/specs/2026-05-13-goldenpipe-v1.2-identity-orchestration-design.md`.
+
+**Acceptance criteria for the v1.2 feature it specs:**
+
+1. **New stage:** `goldenmatch.identity_resolve` registered at `goldenpipe.stages` entry-point, adapter at `goldenpipe/adapters/identity.py`.
+   - `consumes=["df", "clusters", "scored_pairs"]`
+   - `produces=["entity_ids", "identity_summary", "conflicts"]`
+2. **Adapter wires `IdentityConfig`:** the existing `DedupeStage` either gains an `identity:` field on `stage_config`, or the new IdentityResolveStage takes the same dict shape as `IdentityConfig` and constructs it. Prefer the second so dedupe stays single-purpose.
+3. **One CLI path** that runs the full pipeline:
+   ```bash
+   goldenpipe run customers.csv \
+     --stages goldencheck.scan,goldenflow.transform,goldenmatch.dedupe,goldenmatch.identity_resolve \
+     --identity-path .goldenmatch/identity.db
+   ```
+4. **One production-shaped example:** `examples/airflow/golden_suite_identity_graph.py` -- daily DAG that runs the full chain, persists the identity store to S3, and surfaces `identity_summary.conflicts_flagged` as an Airflow XCom for downstream review.
+5. **One persisted run manifest** in the GoldenPipe `PipeResult.artifacts` dict: inputs, configs, quality findings, identity_store_path, conflicts_flagged count, review-queue snapshot.
+6. **Determinism test:** small fixture, two runs, byte-equal `entity_id` set, byte-equal event-log shape (modulo timestamps -- reuse the v2.1 `_strip_volatile` helper).
+7. **Docs:** "when to use GoldenPipe vs direct GoldenMatch calls" page. GoldenPipe = orchestrator + manifest + airflow-friendly. Direct = library use, embedded pipelines, real-time match-one.
+
+**Non-acceptance / explicit non-goals:**
+- No new MCP / A2A / REST surface in GoldenPipe v1.2. Use the GoldenMatch surfaces that already exist.
+- No web UI changes. The "Identities" tab in the GoldenMatch workbench is sufficient.
+- No identity-graph features that didn't already ship in v1.15 / v2.1. This is wiring, not new product.
+- No backfill DAG for retroactive entity_id stability (already deferred to v2.x).
+- No InferMap integration (Bet 2; separate PR).
+
+---
+
+## Risks / unknowns
+
+- **`DedupeStage` cluster-output coupling.** The current adapter stores `result.clusters` in `ctx.artifacts`. The new IdentityResolveStage needs `(clusters, df, scored_pairs)` -- but the dedupe adapter doesn't currently expose `scored_pairs` (the pipeline runs identity resolution inside `_run_dedupe_pipeline` already, so the artifacts are downstream of the call). Need to decide: does `goldenmatch.identity_resolve` re-run resolution (cheap if the store already has matching events / idempotent), or do we extend the DedupeStage to surface `scored_pairs` for the next stage?
+- **Stage config schema vs `GoldenMatchConfig.identity`.** Two reasonable paths: (a) the IdentityResolveStage takes `IdentityConfig` directly, or (b) it lifts `identity:` off the DedupeStage's `GoldenMatchConfig` and treats them as one logical config. (b) keeps the user's YAML simpler.
+- **goldensuite-mcp publishing as a side-effect.** If we want the new identity stage to surface via the aggregator MCP too, it does so automatically (aggregator reads `goldenmatch.mcp.server.TOOLS`). But goldensuite-mcp is unpublished, so end users still won't see it.
+- **Airflow example will need the new stage AND the v1.15 store path on shared infra** (S3 or NFS) for multi-task runs. This is a docs/runtime concern, not a code concern.
+
+---
+
+## What this session changed in the repo
+
+Just this doc and the audit branch. No code edits. No new tests. The next PR (the v1.2 spec doc) is the recommended follow-up.
+
+---
+
+## Summary
+
+**Inspected:** 7 Python packages (goldenpipe, infermap, goldencheck, goldenflow, goldensuite-mcp, goldencheck-types, dbt-goldencheck), 3 TS packages (goldenmatch, infermap, goldencheck-types), 2 Rust extensions (postgres, duckdb), all 12 Airflow DAGs, `.github/workflows/ci.yml`, all per-package CLAUDE.md files, all per-package CHANGELOG.md files, every PyPI/npm version vs local pyproject/package.json.
+
+**What changed:** This audit doc. No code.
+
+**Recommended next package:** **GoldenPipe.** Reason: GoldenMatch v1.15 shipped a headline feature (Identity Graph v2.0) that has no path through the suite orchestrator. Closing that gap is small, bounded, and immediately changes what "Golden Suite" means to a user.
+
+**Exact next PR:** committed spec at `docs/superpowers/specs/2026-05-13-goldenpipe-v1.2-identity-orchestration-design.md` per the acceptance criteria above. No implementation, no other-package changes.
+
+**Risks / unknowns:** scored_pairs coupling between dedupe and identity_resolve stages (resolvable by re-running resolution idempotently); shared-storage requirement for the SQLite identity store across Airflow tasks.

--- a/docs/superpowers/specs/2026-05-13-goldenpipe-v1.2-identity-orchestration-design.md
+++ b/docs/superpowers/specs/2026-05-13-goldenpipe-v1.2-identity-orchestration-design.md
@@ -1,0 +1,245 @@
+# GoldenPipe v1.2 — Suite Orchestration for Identity Graph
+
+**Status:** Design proposed (post-audit PR #204). No implementation yet.
+**Owner:** GoldenPipe
+**Targets:** GoldenPipe `1.1.0 -> 1.2.0`, no other-package version bumps required.
+
+---
+
+## Problem
+
+GoldenMatch v1.15 shipped the Identity Graph (PR #201, hardened in PR #203) but GoldenPipe -- the package marketed as "Golden Suite orchestrator" -- has no surface for it. The audit (PR #204) found three structural gaps:
+
+1. **No identity stage** in the stage registry. `packages/python/goldenpipe/pyproject.toml:52` registers exactly three stages: `goldencheck.scan`, `goldenflow.transform`, `goldenmatch.dedupe`.
+2. **`DedupeStage` drops `IdentityConfig` on the floor.** Even if a user puts `identity:` in their YAML, the adapter (`goldenpipe/adapters/match.py`) never propagates it -- the constructed `GoldenMatchConfig` is built from matchkeys + blocking only.
+3. **Zero Airflow DAGs invoke identity.** All 12 DAGs in `examples/airflow/` predate v1.15.
+
+The fix is small, bounded, and reuses every existing piece of GoldenPipe machinery.
+
+---
+
+## Goal
+
+A single CLI / Python / Airflow path that runs:
+
+```
+GoldenCheck.scan -> GoldenFlow.transform -> GoldenMatch.dedupe -> GoldenMatch.identity_resolve
+```
+
+…persists a run manifest including the identity store path + auto-detected conflict count, and is deterministic on a small fixture across re-runs (entity_ids stable, event log byte-equal modulo timestamps).
+
+**Non-goal:** new product surface in GoldenPipe. This is wiring, not new features.
+
+---
+
+## Design
+
+### One new stage
+
+`goldenmatch.identity_resolve` registered at the `goldenpipe.stages` entry-point.
+
+```toml
+# packages/python/goldenpipe/pyproject.toml
+[project.entry-points."goldenpipe.stages"]
+"goldencheck.scan" = "goldenpipe.adapters.check:ScanStage"
+"goldenflow.transform" = "goldenpipe.adapters.flow:TransformStage"
+"goldenmatch.dedupe" = "goldenpipe.adapters.match:DedupeStage"
+"goldenmatch.identity_resolve" = "goldenpipe.adapters.identity:IdentityResolveStage"  # NEW
+```
+
+### Adapter
+
+```python
+# packages/python/goldenpipe/goldenpipe/adapters/identity.py
+class IdentityResolveStage:
+    info = StageInfo(
+        name="goldenmatch.identity_resolve",
+        consumes=["df", "clusters"],
+        produces=["identity_summary", "identity_store_path", "conflicts"],
+    )
+
+    def validate(self, ctx):
+        # IdentityStore comes with goldenmatch>=1.15; no separate optional dep
+        from goldenmatch.identity import IdentityStore  # noqa: F401
+
+    def run(self, ctx):
+        from goldenmatch.identity import IdentityStore, resolve_clusters
+
+        stage_cfg = ctx.stage_config or {}
+        cfg = self._build_identity_config(stage_cfg, ctx)
+
+        with IdentityStore(
+            backend=cfg.backend, path=cfg.path, connection=cfg.connection,
+        ) as store:
+            summary = resolve_clusters(
+                clusters=ctx.artifacts["clusters"],
+                df=ctx.df,
+                scored_pairs=ctx.artifacts.get("scored_pairs", []),
+                matchkey_name=ctx.artifacts.get("matchkey_used"),
+                store=store,
+                run_name=ctx.run_id,
+                dataset=cfg.dataset,
+                source_pk_col=cfg.source_pk_column,
+                emit_singletons=cfg.emit_singletons,
+                weak_confidence_threshold=cfg.weak_confidence_threshold,
+            )
+
+        ctx.artifacts["identity_summary"] = summary.as_dict()
+        ctx.artifacts["identity_store_path"] = cfg.path
+        ctx.artifacts["conflicts"] = summary.conflicts_flagged
+        return StageResult(status=StageStatus.SUCCESS)
+```
+
+### Config shape
+
+Two reasonable paths. We pick (b):
+
+(a) Carry `identity:` as a field on the *DedupeStage*'s `GoldenMatchConfig` and re-use it inside IdentityResolveStage. **Rejected:** couples two stages and forces every DedupeStage caller to know about IdentityConfig.
+
+(b) IdentityResolveStage takes a dedicated `stage_config` matching `IdentityConfig`. **Chosen:** clean separation, each stage owns its own knob set, GoldenMatch's `dedupe_df()` can keep doing identity itself when called outside GoldenPipe.
+
+YAML:
+
+```yaml
+stages:
+  - use: goldencheck.scan
+  - use: goldenflow.transform
+  - use: goldenmatch.dedupe
+    with:
+      matchkeys:
+        - { name: people, type: weighted, threshold: 0.85, fields: [...] }
+      blocking:
+        strategy: static
+        keys: [{ fields: [zip] }]
+  - use: goldenmatch.identity_resolve
+    with:
+      path: .goldenmatch/identity.db
+      source_pk_column: id
+      dataset: customers
+      weak_confidence_threshold: 0.6
+```
+
+### CLI
+
+```bash
+goldenpipe run customers.csv \
+  --stages goldencheck.scan,goldenflow.transform,goldenmatch.dedupe,goldenmatch.identity_resolve \
+  --identity-path .goldenmatch/identity.db \
+  --identity-dataset customers
+```
+
+The `--identity-path` and `--identity-dataset` shortcuts populate `stage_config` for `goldenmatch.identity_resolve` when no YAML is supplied; otherwise YAML wins.
+
+### Decision logic
+
+`goldenpipe/decisions.py` already has `decide_match` to skip dedupe when nothing matchable was found. Identity resolution should follow the same logic with one addition:
+
+```python
+def decide_identity(ctx) -> Decision:
+    """Skip identity_resolve when dedupe was skipped or produced no clusters."""
+    if not ctx.artifacts.get("clusters"):
+        return Decision(skip=["goldenmatch.identity_resolve"],
+                        reason="no clusters from dedupe")
+    return Decision()
+```
+
+### Manifest persistence
+
+`PipeResult.artifacts` already collects stage outputs. The identity stage adds three keys:
+
+```python
+result.artifacts["identity_summary"]      # dict from ResolveSummary.as_dict()
+result.artifacts["identity_store_path"]   # str
+result.artifacts["conflicts"]             # int -- conflicts_flagged count
+```
+
+The existing `PipeResult.reasoning` mechanism captures *why* each stage ran. We need one new key on the manifest itself (already a dict): `manifest.artifacts["identity_store_path"]` so downstream tasks know where to read the graph.
+
+### Cross-stage data flow concern
+
+The audit raised a real wrinkle: `DedupeStage` doesn't currently surface `scored_pairs` to the next stage. Two options:
+
+1. **Extend DedupeStage** to push `scored_pairs` onto `ctx.artifacts`. Two-line change in `adapters/match.py`. Adds memory cost on large runs (~80 bytes/pair); the calling site can opt out via stage config.
+2. **Let IdentityResolveStage re-run resolution** idempotently. Already safe per the v1.15 design (`has_run_event` guard on `(run_name, kind, entity_id)`).
+
+**Chosen:** (1). Re-running resolution would double the wall-clock cost on the identity step and (more importantly) wouldn't have access to `scored_pairs` for edge-evidence richness. The 80 bytes/pair penalty is small relative to the 16 GB working set already established for 1M-row runs.
+
+---
+
+## Acceptance criteria
+
+1. **`goldenmatch.identity_resolve` stage registered** via entry-point and discoverable from `goldenpipe stages list`.
+2. **Adapter at `goldenpipe/adapters/identity.py`** takes a dict matching `IdentityConfig`, opens the store, calls `resolve_clusters`, populates `ctx.artifacts`.
+3. **DedupeStage gains scored_pairs surfacing.** One additional `ctx.artifacts["scored_pairs"]` populated when the downstream pipeline declares it'll consume them (or unconditionally if cost-benefit pans out -- benchmark in the implementation PR).
+4. **CLI accepts `--identity-path` and `--identity-dataset`** as convenience shortcuts; YAML stage config remains the canonical path.
+5. **One production-shaped Airflow DAG** at `examples/airflow/golden_suite_identity_graph.py`: daily run, identity store on shared storage (S3 + sync or NFS), emits `identity_summary.conflicts_flagged` as an XCom for the existing `golden_suite_review_worker.py` DAG to consume.
+6. **One persisted run manifest** that includes inputs, configs, GoldenCheck findings, GoldenFlow manifest, GoldenMatch clusters, identity_store_path, conflicts_flagged count, review-queue snapshot. Reuses `goldenpipe.engine.manifest.Manifest`.
+7. **Determinism test:** `tests/test_pipeline_identity.py` with a small fixture; runs the chained pipeline twice; asserts the `entity_id` set is identical and the event-log shape matches (using a volatile-stripping helper modeled after `tests/identity/test_cross_surface_contract.py:_strip_volatile`).
+8. **Docs:** new `docs/identity-graph.md` (in goldenpipe's docs dir) covering "when to use GoldenPipe's identity stage vs calling `dedupe_df(config=...identity:enabled...)` directly". Spoiler: GoldenPipe gives you the manifest + Airflow shape + multi-task XCom; direct call gives you embedded-library use.
+
+---
+
+## Out of scope
+
+The implementation PR must explicitly NOT:
+
+- Add new MCP / A2A / REST surface in GoldenPipe v1.2. The GoldenMatch surfaces already cover identity.
+- Change the web UI. The "Identities" tab in the GoldenMatch workbench is sufficient.
+- Add force-graph visualization or any v2-deferred identity feature.
+- Open InferMap-as-identity-feeder (issue #206) -- that's a separate PR.
+- Open the GoldenCheck identity preflight (issue #207) -- separate PR.
+- Backfill DAG for retroactive entity_id stability (already deferred).
+- Publish goldensuite-mcp (issue #205) -- separate concern.
+
+---
+
+## Risks
+
+1. **scored_pairs memory cost on large runs.** At 1M records / 10k clusters / ~30 pairs/cluster, that's ~24 MB of tuples on the artifacts dict. Acceptable, but worth a config flag to opt out (`stage_config: { surface_scored_pairs: false }` on DedupeStage) for very large fixed-config Airflow runs that don't use the identity stage.
+2. **Shared-storage requirement.** The SQLite identity store has to be readable+writable by every Airflow task that touches the pipeline. Existing pattern: NFS or rsync-to-S3-after-each-run. Documented in the Airflow example, not enforced by GoldenPipe.
+3. **Postgres backend story.** `IdentityConfig.backend="postgres"` works today via the connection DSN. The Airflow example should show one Postgres-backed and one SQLite-backed variant -- different scaling envelopes.
+4. **Stage-skip behavior on partial failure.** If `goldenmatch.dedupe` produces clusters but errors during golden roll-up, the cluster artifact is set but `unique`/`golden` may not be. IdentityResolveStage should validate that `clusters` is non-empty and emit `Decision(skip=...)` otherwise. Already covered in the design via `decide_identity`.
+
+---
+
+## Test plan
+
+In addition to acceptance criterion 7:
+
+- `tests/test_identity_stage.py` -- unit tests on the adapter (no end-to-end pipeline)
+- `tests/test_pipeline_identity.py` -- determinism test, two runs
+- `tests/test_cli_identity.py` -- `--identity-path` flag wiring
+- Existing parity: `tests/test_pipeline.py` must continue to pass with the new stage *omitted* from the default pipeline (we're not changing the default; the new stage is opt-in)
+
+---
+
+## Release
+
+GoldenPipe `1.1.0 -> 1.2.0`. CHANGELOG entry describes:
+- New `goldenmatch.identity_resolve` stage
+- New `IdentityConfig` propagation through `stage_config`
+- New CLI flags `--identity-path` / `--identity-dataset`
+- New Airflow DAG example
+- `DedupeStage.ctx.artifacts["scored_pairs"]` is now populated (backwards compatible -- nothing in v1.1 consumed it)
+
+No other-package version bumps required. Requires `goldenmatch>=1.15.0` (already the minimum after PR #201).
+
+---
+
+## Implementation phasing
+
+Three small PRs in this order:
+
+1. **PR A: adapter scaffold + stage registry + tests** -- the `goldenmatch.identity_resolve` stage works in isolation, run via direct `Pipeline(stages=[...])` API, with the determinism test green. No CLI, no DAG yet.
+2. **PR B: CLI shortcuts + decisions + Airflow DAG** -- builds on (A). Adds `--identity-path` flag, `decide_identity`, and `examples/airflow/golden_suite_identity_graph.py`.
+3. **PR C: docs + 1.2.0 release** -- new `docs/identity-graph.md`, CHANGELOG entry, version bump, tag, PyPI publish.
+
+Each PR is small enough to review in one sitting. Bundling them is fine if appetite is there; I'd default to three sequential merges.
+
+---
+
+## Open questions for the implementer
+
+1. **Should `decide_identity` be auto-inserted** when the pipeline includes both `goldenmatch.dedupe` and `goldenmatch.identity_resolve`, or always inserted as long as identity is in the stage list? Default: auto-insert.
+2. **Where does the `run_id` for `resolve_clusters` come from?** Today the framework generates one per pipeline run; reuse it.
+3. **PostflightReport integration:** should `identity_summary` flow back into the controller-telemetry blob that the autoconfig surface already serializes? Probably no -- they're different concerns. Add a separate `identity:` section on `PostflightReport` if needed in v1.3.

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.1.6 (2026-05-13)
+
+Bug-fix release. Resolves a panic on large datasets surfaced by the
+scale audit work.
+
+### Fixed
+
+- `category_auto_correct` panic at 1M+ rows under memory pressure (PR
+  #174 / #175). The old path called `series.to_list()` + Python
+  `Counter`, materialising one `PyString` per input row. At ~2 GB
+  measured peak RSS following a `goldenmatch.auto_configure` sample
+  run, the PyString allocations inside Polars' `to_list` path returned
+  NULL and pyo3 0.28.2 mapped that to `PanicException("PyObject pointer
+  is null")` rather than `MemoryError`. The function only ever needed
+  `n_unique` distinct values, so the rewrite uses
+  `series.value_counts()` instead -- stays in Rust, no per-row Python
+  allocation, fixes the crash on the goldenmatch scale-audit Round 2
+  1M synthetic fixture.
+
 ## 1.1.5 (2026-05-11)
 
 Maintenance release. No transform / API behaviour changes.


### PR DESCRIPTION
## Summary

Focused single-session audit answering "what is the highest-leverage next non-GoldenMatch bet?" given Identity Graph v2.0 / v1.15.0 just shipped.

**Recommendation: GoldenPipe v1.2 — suite orchestration for Identity Graph.**

## Evidence

GoldenPipe markets itself as the Golden Suite orchestrator but has zero identity stage:

- `packages/python/goldenpipe/pyproject.toml:52` — entry-points registry has `goldencheck.scan`, `goldenflow.transform`, `goldenmatch.dedupe`. No `goldenmatch.identity_resolve`.
- `packages/python/goldenpipe/goldenpipe/adapters/match.py:69-243` — `DedupeStage` builds `GoldenMatchConfig` from column contexts but never propagates `IdentityConfig`.
- All 12 Airflow DAGs in `examples/airflow/` predate v1.15 — zero `grep` hits for `IdentityStore`, `IdentityConfig`, or `identity_resolve`.

The audit doc has per-package scorecard, top-3 ranked next bets, stale items (goldenflow 1.1.6 vs 1.1.5 drift; goldensuite-mcp v0.1.0 unpublished), and acceptance criteria for the proposed GoldenPipe v1.2 spec PR.

## Test plan

- [x] No code changes — docs-only PR
- [ ] Reviewer reads the recommendation and either approves the GoldenPipe v1.2 direction or picks a different bet from the top 3

## What's next

After this merges: open a follow-up PR with `docs/superpowers/specs/2026-05-13-goldenpipe-v1.2-identity-orchestration-design.md` describing the actual feature spec (still no code yet). Implementation is a third PR after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)