### PR TITLE
feat(goldenpipe): v1.2 PR A — IdentityResolveStage

### DIFF
--- a/packages/python/goldenpipe/goldenpipe/adapters/identity.py
+++ b/packages/python/goldenpipe/goldenpipe/adapters/identity.py
@@ -1,0 +1,132 @@
+"""GoldenMatch Identity Graph adapter -- v1.2.
+
+Runs ``goldenmatch.identity.resolve_clusters`` after the dedupe stage to
+populate a durable identity graph. Reuses cluster + scored_pairs artifacts
+from DedupeStage. Idempotent: replaying the same ``run_id`` is a no-op.
+
+Spec: ``docs/superpowers/specs/2026-05-13-goldenpipe-v1.2-identity-orchestration-design.md``
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from goldenpipe.models.context import (
+    Decision,
+    PipeContext,
+    StageResult,
+    StageStatus,
+)
+from goldenpipe.models.stage import StageInfo
+
+logger = logging.getLogger(__name__)
+
+try:
+    from goldenmatch.identity import IdentityStore, resolve_clusters
+
+    HAS_IDENTITY = True
+except ImportError:
+    HAS_IDENTITY = False
+    IdentityStore = None  # type: ignore[assignment,misc]
+    resolve_clusters = None  # type: ignore[assignment]
+
+
+_DEFAULT_PATH = ".goldenmatch/identity.db"
+
+
+class IdentityResolveStage:
+    info = StageInfo(
+        name="goldenmatch.identity_resolve",
+        produces=["identity_summary", "identity_store_path", "conflicts"],
+        consumes=["df", "clusters"],
+    )
+    rollback = None
+
+    def validate(self, ctx: PipeContext) -> None:
+        if not HAS_IDENTITY:
+            raise RuntimeError(
+                "goldenmatch.identity not available. "
+                "Identity Graph ships in goldenmatch>=1.15.0 -- "
+                "upgrade with `pip install --upgrade goldenmatch`."
+            )
+
+    def run(self, ctx: PipeContext) -> StageResult:
+        if not ctx.artifacts.get("clusters"):
+            # decide_identity normally short-circuits us; this guard handles
+            # callers who skip the decision logic and run the stage directly.
+            return StageResult(
+                status=StageStatus.SKIPPED,
+                decision=Decision(
+                    skip=["goldenmatch.identity_resolve"],
+                    reason="no clusters from dedupe -- nothing to resolve",
+                ),
+            )
+
+        stage_cfg = dict(ctx.stage_config or {})
+        run_name = (
+            stage_cfg.pop("run_name", None)
+            or ctx.metadata.get("run_id")
+            or uuid.uuid4().hex
+        )
+        db_path = stage_cfg.get("path", _DEFAULT_PATH)
+        dataset = stage_cfg.get("dataset")
+        source_pk_col = stage_cfg.get("source_pk_column")
+        emit_singletons = stage_cfg.get("emit_singletons", True)
+        weak_threshold = stage_cfg.get("weak_confidence_threshold", 0.6)
+        backend = stage_cfg.get("backend", "sqlite")
+        connection = stage_cfg.get("connection")
+
+        # Resolve scored_pairs upstream if DedupeStage surfaced them; identity
+        # still works without them (edges just won't include score info).
+        scored_pairs = ctx.artifacts.get("scored_pairs", [])
+        matchkey_name = ctx.artifacts.get("matchkey_used")
+
+        store_kwargs: dict[str, Any] = {"backend": backend, "path": db_path}
+        if connection is not None:
+            store_kwargs["connection"] = connection
+
+        try:
+            with IdentityStore(**store_kwargs) as store:
+                summary = resolve_clusters(
+                    ctx.artifacts["clusters"],
+                    ctx.df,
+                    scored_pairs,
+                    matchkey_name,
+                    store,
+                    run_name=run_name,
+                    dataset=dataset,
+                    source_pk_col=source_pk_col,
+                    emit_singletons=emit_singletons,
+                    weak_confidence_threshold=weak_threshold,
+                )
+        except Exception as e:
+            logger.warning("Identity resolution failed: %s", e)
+            return StageResult(status=StageStatus.FAILED, error=str(e))
+
+        ctx.artifacts["identity_summary"] = summary.as_dict()
+        ctx.artifacts["identity_store_path"] = db_path
+        ctx.artifacts["conflicts"] = summary.conflicts_flagged
+        logger.info(
+            "Identity graph: %d created, %d absorbed, %d merged, %d conflicts",
+            summary.created,
+            summary.absorbed_records,
+            summary.merged,
+            summary.conflicts_flagged,
+        )
+        return StageResult(status=StageStatus.SUCCESS)
+
+
+def decide_identity(ctx: PipeContext) -> Decision:
+    """Skip identity_resolve when dedupe was skipped or produced no clusters.
+
+    The pipeline driver calls this between stages. Returning ``skip=[]`` lets
+    the stage run; populating ``skip`` excludes it.
+    """
+    clusters = ctx.artifacts.get("clusters")
+    if not clusters:
+        return Decision(
+            skip=["goldenmatch.identity_resolve"],
+            reason="no clusters from dedupe -- skipping identity resolution",
+        )
+    return Decision()

--- a/packages/python/goldenpipe/goldenpipe/adapters/match.py
+++ b/packages/python/goldenpipe/goldenpipe/adapters/match.py
@@ -63,6 +63,19 @@ class DedupeStage:
             ctx.artifacts["dupes"] = result.dupes
         if hasattr(result, "stats"):
             ctx.artifacts["match_stats"] = result.stats
+        # Surface scored_pairs for downstream stages (v1.2 IdentityResolveStage).
+        # Memory cost ~80 B/pair; cheap relative to clusters/df already held.
+        # No-op for callers that don't consume it.
+        if hasattr(result, "scored_pairs"):
+            ctx.artifacts["scored_pairs"] = result.scored_pairs
+        # Surface the first matchkey name so IdentityResolveStage can attach it
+        # to evidence edges. The matchkey list is available on the config or
+        # the result -- prefer the result for accuracy after auto-config.
+        mks = getattr(result, "matchkeys", None) or (
+            config.get_matchkeys() if "config" in locals() else None
+        )
+        if mks:
+            ctx.artifacts["matchkey_used"] = mks[0].name
         return StageResult(status=StageStatus.SUCCESS)
 
 

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -53,6 +53,7 @@ Author = "https://bensevern.dev"
 "goldencheck.scan" = "goldenpipe.adapters.check:ScanStage"
 "goldenflow.transform" = "goldenpipe.adapters.flow:TransformStage"
 "goldenmatch.dedupe" = "goldenpipe.adapters.match:DedupeStage"
+"goldenmatch.identity_resolve" = "goldenpipe.adapters.identity:IdentityResolveStage"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/python/goldenpipe/tests/test_identity_stage.py
+++ b/packages/python/goldenpipe/tests/test_identity_stage.py
@@ -1,0 +1,222 @@
+"""Tests for GoldenPipe v1.2 IdentityResolveStage.
+
+Three layers:
+
+  1. Unit: stage adapter in isolation against pre-built artifacts.
+  2. Skip behavior: decide_identity / direct-run guard short-circuit on
+     empty clusters.
+  3. Determinism: two end-to-end runs through the dedupe + identity
+     stages produce the same entity_id set and an equivalent event log.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from goldenpipe.adapters.identity import (
+    HAS_IDENTITY,
+    IdentityResolveStage,
+    decide_identity,
+)
+from goldenpipe.models.context import PipeContext, StageStatus
+
+pytestmark = pytest.mark.skipif(
+    not HAS_IDENTITY,
+    reason="requires goldenmatch>=1.15.0 (Identity Graph)",
+)
+
+
+def _cluster(members, score=0.95):
+    pair_scores = {}
+    ms = list(members)
+    for i, a in enumerate(ms):
+        for b in ms[i + 1 :]:
+            pair_scores[(min(a, b), max(a, b))] = score
+    return {
+        "members": ms,
+        "size": len(ms),
+        "oversized": False,
+        "pair_scores": pair_scores,
+        "confidence": score,
+        "bottleneck_pair": (ms[0], ms[1]) if len(ms) >= 2 else None,
+        "cluster_quality": "strong",
+    }
+
+
+def _people_df(extra_row: bool = False):
+    rows = [
+        {"__row_id__": 0, "__source__": "crm", "id": "1",
+         "name": "Alice Smith", "email": "a@x.com"},
+        {"__row_id__": 1, "__source__": "crm", "id": "2",
+         "name": "Alyce Smith", "email": "a@x.com"},
+        {"__row_id__": 2, "__source__": "crm", "id": "3",
+         "name": "Bob Jones",   "email": "b@y.com"},
+    ]
+    if extra_row:
+        rows.append({"__row_id__": 3, "__source__": "crm", "id": "4",
+                     "name": "Alise Smith", "email": "a@x.com"})
+    return pl.DataFrame(rows)
+
+
+# ── 1. Unit ─────────────────────────────────────────────────────────────
+
+
+def test_stage_writes_summary_and_path(tmp_path: Path):
+    db = str(tmp_path / "identity.db")
+    df = _people_df()
+    ctx = PipeContext(
+        df=df,
+        artifacts={
+            "clusters": {0: _cluster([0, 1]), 1: _cluster([2])},
+            "scored_pairs": [(0, 1, 0.95)],
+            "matchkey_used": "people_fuzzy",
+        },
+        stage_config={"path": db, "source_pk_column": "id", "dataset": "u"},
+    )
+    stage = IdentityResolveStage()
+    stage.validate(ctx)
+    result = stage.run(ctx)
+
+    assert result.status == StageStatus.SUCCESS
+    summary = ctx.artifacts["identity_summary"]
+    assert summary["created"] == 2
+    assert summary["records_upserted"] == 3
+    assert ctx.artifacts["identity_store_path"] == db
+    assert ctx.artifacts["conflicts"] == summary["conflicts_flagged"]
+
+
+def test_stage_propagates_weak_threshold(tmp_path: Path):
+    """weak_confidence_threshold from stage_config reaches resolve_clusters."""
+    db = str(tmp_path / "weak.db")
+    df = _people_df()
+    weak_cluster = _cluster([0, 1, 2], score=0.45)
+    weak_cluster["confidence"] = 0.45
+    ctx = PipeContext(
+        df=df,
+        artifacts={
+            "clusters": {0: weak_cluster},
+            "scored_pairs": [(0, 1, 0.95), (1, 2, 0.41), (0, 2, 0.94)],
+        },
+        stage_config={"path": db, "source_pk_column": "id",
+                      "weak_confidence_threshold": 0.9},
+    )
+    IdentityResolveStage().run(ctx)
+    assert ctx.artifacts["conflicts"] >= 1
+
+
+# ── 2. Skip behavior ────────────────────────────────────────────────────
+
+
+def test_decide_identity_skips_when_no_clusters():
+    ctx = PipeContext(df=pl.DataFrame(), artifacts={})
+    decision = decide_identity(ctx)
+    assert "goldenmatch.identity_resolve" in decision.skip
+    assert "no clusters" in decision.reason
+
+
+def test_decide_identity_runs_when_clusters_exist():
+    ctx = PipeContext(df=pl.DataFrame(), artifacts={"clusters": {0: _cluster([0])}})
+    decision = decide_identity(ctx)
+    assert decision.skip == []
+
+
+def test_stage_skips_when_clusters_missing(tmp_path: Path):
+    ctx = PipeContext(df=_people_df(), artifacts={})  # no clusters
+    result = IdentityResolveStage().run(ctx)
+    assert result.status == StageStatus.SKIPPED
+    assert result.decision is not None
+    assert "goldenmatch.identity_resolve" in result.decision.skip
+
+
+# ── 3. Determinism across runs ──────────────────────────────────────────
+
+
+def test_two_runs_produce_stable_entity_ids(tmp_path: Path):
+    """Run 1 mints identities. Run 2 with one extra record absorbs it
+    into the existing identity rather than minting fresh IDs."""
+    from goldenmatch.identity import IdentityStore, find_by_record
+
+    db = str(tmp_path / "stable.db")
+
+    # Run 1
+    ctx1 = PipeContext(
+        df=_people_df(),
+        artifacts={
+            "clusters": {0: _cluster([0, 1]), 1: _cluster([2])},
+            "scored_pairs": [(0, 1, 0.95)],
+            "matchkey_used": "people_fuzzy",
+        },
+        stage_config={"path": db, "source_pk_column": "id", "dataset": "stable"},
+        metadata={"run_id": "demo-r1"},
+    )
+    IdentityResolveStage().run(ctx1)
+
+    with IdentityStore(path=db) as s:
+        alice = find_by_record(s, "crm:1")
+        assert alice is not None
+        alice_eid_r1 = alice.node.entity_id
+
+    # Run 2 -- adds crm:4 to Alice's cluster
+    ctx2 = PipeContext(
+        df=_people_df(extra_row=True),
+        artifacts={
+            "clusters": {0: _cluster([0, 1, 3]), 1: _cluster([2])},
+            "scored_pairs": [(0, 1, 0.95), (0, 3, 0.93), (1, 3, 0.92)],
+            "matchkey_used": "people_fuzzy",
+        },
+        stage_config={"path": db, "source_pk_column": "id", "dataset": "stable"},
+        metadata={"run_id": "demo-r2"},
+    )
+    IdentityResolveStage().run(ctx2)
+
+    with IdentityStore(path=db) as s:
+        # Alice's entity_id is stable across the two runs.
+        alice_r2 = find_by_record(s, "crm:1")
+        assert alice_r2.node.entity_id == alice_eid_r1
+        # New record landed on the same identity (absorb).
+        new_rec = find_by_record(s, "crm:4")
+        assert new_rec.node.entity_id == alice_eid_r1
+
+
+def test_replay_same_run_id_is_idempotent(tmp_path: Path):
+    """Two runs with the same metadata['run_id'] don't double-emit events."""
+    from goldenmatch.identity import IdentityStore
+    from goldenmatch.identity import history as identity_history
+
+    db = str(tmp_path / "idem.db")
+
+    def _run():
+        ctx = PipeContext(
+            df=_people_df(),
+            artifacts={
+                "clusters": {0: _cluster([0, 1])},
+                "scored_pairs": [(0, 1, 0.95)],
+                "matchkey_used": "mk",
+            },
+            stage_config={"path": db, "source_pk_column": "id"},
+            metadata={"run_id": "idem-run"},
+        )
+        IdentityResolveStage().run(ctx)
+
+    _run()
+    _run()  # replay -- should be a no-op for event emission
+
+    with IdentityStore(path=db) as s:
+        eid = s.find_entity_by_record("crm:1")
+        events = identity_history(s, eid)
+        # `created` event guarded by has_run_event -> still 1
+        created = [e for e in events if e["kind"] == "created"]
+        assert len(created) == 1
+
+
+def test_entry_point_registered():
+    """The stage is discoverable via the goldenpipe.stages entry-point."""
+    import importlib.metadata as md
+
+    eps = md.entry_points().select(group="goldenpipe.stages")
+    names = {e.name for e in eps}
+    assert "goldenmatch.identity_resolve" in names, (
+        f"identity_resolve missing from entry-points: {names}"
+    )

--- a/packages/python/goldenpipe/tests/test_identity_stage.py
+++ b/packages/python/goldenpipe/tests/test_identity_stage.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import polars as pl
 import pytest
-
 from goldenpipe.adapters.identity import (
     HAS_IDENTITY,
     IdentityResolveStage,


### PR DESCRIPTION
## Summary

First of three planned PRs for **GoldenPipe v1.2** per the design spec merged in PR #204 (`docs/superpowers/specs/2026-05-13-goldenpipe-v1.2-identity-orchestration-design.md`).

Adds a new pipeline stage `goldenmatch.identity_resolve` that takes the cluster output of the existing `goldenmatch.dedupe` stage and persists it into a durable identity graph via `goldenmatch.identity.resolve_clusters` (v1.15+).

## Changes

- **New `IdentityResolveStage`** at `packages/python/goldenpipe/goldenpipe/adapters/identity.py`. Stage config dict matches `IdentityConfig` shape.
- **DedupeStage surfaces two new artifacts**: `scored_pairs` (from `DedupeResult.scored_pairs`) and `matchkey_used`. Backwards compatible — nothing in v1.1 consumed either.
- **New `decide_identity(ctx)`** short-circuits when no clusters exist.
- **Entry-point registered** at `goldenpipe.stages`.

## What's NOT in this PR (deferred to v1.2 PR B / PR C)

- CLI `--identity-path` / `--identity-dataset` shortcuts
- Airflow DAG example
- Public docs (`docs/identity-graph.md`)
- CHANGELOG entry + v1.2.0 version bump

## Test plan

- [x] 8 new tests: unit + skip behavior + two-run determinism + same-run idempotency + entry-point registration
- [x] Full goldenpipe suite: **132 passing, 3 skipped, 0 regressions**
- [ ] CI green

## Acceptance criteria addressed

From the design spec, PR A covers items 1-3 (stage registered + adapter + scored_pairs surfacing) and item 7 (determinism test). Items 4 (CLI), 5 (Airflow DAG), 6 (manifest), and 8 (docs) come in PR B / PR C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)