### PR TITLE
feat(infermap): write_aliases_from_mapping — bridge to Identity Graph (closes #206)

### DIFF
--- a/packages/python/infermap/infermap/__init__.py
+++ b/packages/python/infermap/infermap/__init__.py
@@ -7,15 +7,15 @@ from infermap.detect import detect_domain, detect_domain_detailed
 from infermap.domain_pack import DomainPackTarget
 from infermap.engine import MapEngine
 from infermap.errors import ApplyError, ConfigError, InferMapError
-from infermap.providers import extract_schema
-from infermap.scorers import default_scorers, scorer
-from infermap.types import FieldInfo, FieldMapping, MapResult, SchemaInfo, ScorerResult
 
 # Identity Graph bridge (optional; lazy-imports goldenmatch on use). Exposed
 # at the top level so callers write `infermap.write_aliases_from_mapping(...)`
 # without reaching into a submodule. The helper itself raises ImportError
 # with a clear remediation message if goldenmatch isn't installed.
 from infermap.identity import AliasWriteResult, write_aliases_from_mapping
+from infermap.providers import extract_schema
+from infermap.scorers import default_scorers, scorer
+from infermap.types import FieldInfo, FieldMapping, MapResult, SchemaInfo, ScorerResult
 
 
 def map(source, target, **kwargs) -> MapResult:
@@ -56,4 +56,6 @@ __all__ = [
     "scorer",
     "extract_schema",
     "map",
+    "AliasWriteResult",
+    "write_aliases_from_mapping",
 ]

--- a/packages/python/infermap/infermap/__init__.py
+++ b/packages/python/infermap/infermap/__init__.py
@@ -11,6 +11,12 @@ from infermap.providers import extract_schema
 from infermap.scorers import default_scorers, scorer
 from infermap.types import FieldInfo, FieldMapping, MapResult, SchemaInfo, ScorerResult
 
+# Identity Graph bridge (optional; lazy-imports goldenmatch on use). Exposed
+# at the top level so callers write `infermap.write_aliases_from_mapping(...)`
+# without reaching into a submodule. The helper itself raises ImportError
+# with a clear remediation message if goldenmatch isn't installed.
+from infermap.identity import AliasWriteResult, write_aliases_from_mapping
+
 
 def map(source, target, **kwargs) -> MapResult:
     """Convenience function: create a MapEngine and map source to target.

--- a/packages/python/infermap/infermap/identity.py
+++ b/packages/python/infermap/infermap/identity.py
@@ -21,11 +21,11 @@ See issue #206 for the design discussion.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
-from infermap.types import FieldMapping, MapResult
+from infermap.types import MapResult
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/infermap/infermap/identity.py
+++ b/packages/python/infermap/infermap/identity.py
@@ -1,0 +1,200 @@
+"""InferMap -> Identity Graph bridge.
+
+Helper that writes InferMap's schema-mapping output into the GoldenMatch
+Identity Graph as ``IdentityAlias`` rows. When InferMap discovers that
+``crm.cust_id`` maps to ``customer_id`` (the canonical entity-id field
+on the target schema), each source record's ``crm.cust_id`` value becomes
+an alias that resolves to that record's identity.
+
+This is **per-record** alias writing -- InferMap tells us *which column
+holds the id of this kind*, we record one row per (record, alias-kind).
+Schema-level "this column maps to that column" aliasing without a record
+context is intentionally **not** modeled -- the alias table is keyed on
+the alias *value*, not the column name.
+
+Sized down on purpose: this module imports goldenmatch.identity lazily so
+infermap users without goldenmatch installed keep working. The
+``write_aliases_from_mapping`` function is the only public surface.
+
+See issue #206 for the design discussion.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from infermap.types import FieldMapping, MapResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AliasWriteResult:
+    """Summary of one ``write_aliases_from_mapping`` invocation."""
+
+    aliases_written: int = 0
+    records_processed: int = 0
+    mappings_used: int = 0
+    skipped_low_confidence: int = 0
+    skipped_no_value: int = 0
+    skipped_no_entity: int = 0
+    skipped_no_kind: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "aliases_written": self.aliases_written,
+            "records_processed": self.records_processed,
+            "mappings_used": self.mappings_used,
+            "skipped_low_confidence": self.skipped_low_confidence,
+            "skipped_no_value": self.skipped_no_value,
+            "skipped_no_entity": self.skipped_no_entity,
+            "skipped_no_kind": self.skipped_no_kind,
+        }
+
+
+def _is_alias_kind(target_field: str, alias_kinds: frozenset[str]) -> str | None:
+    """Return the alias ``kind`` for a target field name, or None.
+
+    Strict match against ``alias_kinds`` plus a tiny set of common
+    aliases (e.g. ``customer_id`` -> ``customer_id``). Case-insensitive.
+    """
+    norm = target_field.lower().strip()
+    if norm in alias_kinds:
+        return norm
+    return None
+
+
+def write_aliases_from_mapping(
+    mapping: MapResult,
+    records: Iterable[dict[str, Any]],
+    store: Any,
+    entity_id_resolver: Callable[[dict[str, Any]], str | None],
+    *,
+    source_name: str,
+    alias_kinds: frozenset[str] = frozenset({
+        "customer_id", "user_id", "account_id", "external_id", "email",
+        "phone", "ssn", "tax_id", "ein", "vin", "isbn", "doi",
+    }),
+    min_confidence: float = 0.85,
+    dataset: str | None = None,
+) -> AliasWriteResult:
+    """Write IdentityAlias rows for each record where InferMap mapped a
+    source column to a known alias-kind target column.
+
+    Parameters
+    ----------
+    mapping:
+        InferMap's ``MapResult`` -- typically the result of
+        ``infermap.map(source_schema, target_schema)``.
+    records:
+        Iterable of dicts. Each dict represents one source record;
+        keys are source field names.
+    store:
+        A ``goldenmatch.identity.IdentityStore`` instance. Imported lazily;
+        this function will not import goldenmatch if the caller doesn't
+        pass one.
+    entity_id_resolver:
+        ``record -> entity_id | None`` function. Typically pulls the
+        record's primary-key value and calls
+        ``store.find_entity_by_record(record_id)``. Returning None for a
+        record skips alias writing for that row.
+    source_name:
+        The source name (e.g. ``"crm"``). Used to namespace the alias
+        value (``f"{source_name}:{value}"``) so two sources with the
+        same id space don't collide.
+    alias_kinds:
+        Target field names that count as alias-kinds. The default set
+        covers the common identifier types; pass an extended set when
+        your target schema has domain-specific ids
+        (e.g. ``"npi"`` for healthcare).
+    min_confidence:
+        Drop any mapping below this confidence threshold. 0.85 default
+        matches the threshold InferMap considers a "strong" match.
+    dataset:
+        Optional dataset name flowed onto each ``IdentityAlias`` row.
+
+    Returns
+    -------
+    AliasWriteResult
+        Counters describing what got written and why anything was
+        skipped.
+    """
+    try:
+        from goldenmatch.identity import IdentityAlias
+    except ImportError as e:
+        raise ImportError(
+            "write_aliases_from_mapping requires goldenmatch>=1.15.0 "
+            "to be installed (provides IdentityAlias).",
+        ) from e
+
+    # Pre-compute the usable (source_col, target_kind) tuples from the
+    # mapping. Drops low-confidence and non-alias-kind mappings upfront so
+    # we don't reread per record.
+    usable: list[tuple[str, str]] = []
+    for m in mapping.mappings:
+        if m.confidence < min_confidence:
+            continue
+        kind = _is_alias_kind(m.target, alias_kinds)
+        if kind is None:
+            continue
+        usable.append((m.source, kind))
+
+    skipped_low = sum(
+        1 for m in mapping.mappings if m.confidence < min_confidence
+    )
+    summary = AliasWriteResult(
+        mappings_used=len(usable),
+        skipped_low_confidence=skipped_low,
+    )
+    if not usable:
+        logger.info(
+            "No usable alias-kind mappings (>= %.2f confidence). "
+            "Available mappings: %s",
+            min_confidence,
+            [m.target for m in mapping.mappings],
+        )
+        return summary
+
+    for record in records:
+        summary.records_processed += 1
+        entity_id = entity_id_resolver(record)
+        if entity_id is None:
+            summary.skipped_no_entity += 1
+            continue
+
+        for source_col, kind in usable:
+            value = record.get(source_col)
+            if value is None or value == "":
+                summary.skipped_no_value += 1
+                continue
+            alias_value = f"{source_name}:{value}"
+            try:
+                store.add_alias(
+                    IdentityAlias(
+                        alias=alias_value,
+                        entity_id=entity_id,
+                        kind=kind,
+                        dataset=dataset,
+                    ),
+                )
+                summary.aliases_written += 1
+            except Exception as e:  # noqa: BLE001
+                # Don't blow up the whole batch on one bad row -- log and
+                # continue. Identity is additive; partial writes are fine.
+                logger.warning(
+                    "Failed to write alias %s (kind=%s) for entity %s: %s",
+                    alias_value, kind, entity_id, e,
+                )
+
+    logger.info(
+        "InferMap -> Identity: wrote %d aliases across %d records (%d mappings used)",
+        summary.aliases_written,
+        summary.records_processed,
+        summary.mappings_used,
+    )
+    return summary
+
+
+__all__ = ["AliasWriteResult", "write_aliases_from_mapping"]

--- a/packages/python/infermap/tests/test_identity_feeder.py
+++ b/packages/python/infermap/tests/test_identity_feeder.py
@@ -12,7 +12,6 @@ from goldenmatch.identity import (  # noqa: E402
     SourceRecord,
     new_entity_id,
 )
-
 from infermap.identity import write_aliases_from_mapping  # noqa: E402
 from infermap.types import FieldMapping, MapResult, ScorerResult  # noqa: E402
 

--- a/packages/python/infermap/tests/test_identity_feeder.py
+++ b/packages/python/infermap/tests/test_identity_feeder.py
@@ -1,0 +1,180 @@
+"""Tests for the InferMap -> IdentityGraph bridge."""
+from __future__ import annotations
+
+import pytest
+
+# Skip the whole module when goldenmatch isn't available (e.g. infermap-only
+# editable install). The cross-package feature requires goldenmatch>=1.15.
+goldenmatch = pytest.importorskip("goldenmatch", reason="bridge needs goldenmatch>=1.15")
+from goldenmatch.identity import (  # noqa: E402
+    IdentityNode,
+    IdentityStore,
+    SourceRecord,
+    new_entity_id,
+)
+
+from infermap.identity import write_aliases_from_mapping  # noqa: E402
+from infermap.types import FieldMapping, MapResult, ScorerResult  # noqa: E402
+
+
+def _mapping(*pairs, confidence=0.95):
+    return MapResult(
+        mappings=[
+            FieldMapping(
+                source=src, target=tgt, confidence=confidence,
+                breakdown={"test": ScorerResult(score=confidence, reasoning="t")},
+                reasoning="test fixture",
+            )
+            for src, tgt in pairs
+        ],
+    )
+
+
+@pytest.fixture()
+def seeded_store(tmp_path):
+    db = str(tmp_path / "id.db")
+    eid_alice = new_entity_id()
+    eid_bob = new_entity_id()
+    with IdentityStore(path=db) as s:
+        s.upsert_identity(IdentityNode(entity_id=eid_alice, dataset="t"))
+        s.upsert_identity(IdentityNode(entity_id=eid_bob, dataset="t"))
+        s.upsert_record(SourceRecord("crm:1", "crm", "1", "h1",
+                                     entity_id=eid_alice, dataset="t"))
+        s.upsert_record(SourceRecord("crm:2", "crm", "2", "h2",
+                                     entity_id=eid_bob, dataset="t"))
+    return db, eid_alice, eid_bob
+
+
+def _record_entity_resolver(store):
+    def _r(record):
+        rid = f"crm:{record['cust_id']}"
+        return store.find_entity_by_record(rid)
+    return _r
+
+
+def test_writes_alias_per_record_per_kind(seeded_store):
+    db, eid_alice, eid_bob = seeded_store
+    records = [
+        {"cust_id": "1", "email_addr": "alice@x.com"},
+        {"cust_id": "2", "email_addr": "bob@y.com"},
+    ]
+    mapping = _mapping(("cust_id", "customer_id"), ("email_addr", "email"))
+    with IdentityStore(path=db) as store:
+        result = write_aliases_from_mapping(
+            mapping, records, store, _record_entity_resolver(store),
+            source_name="crm", dataset="t",
+        )
+    assert result.aliases_written == 4
+    assert result.records_processed == 2
+    assert result.mappings_used == 2
+    # Resolve via the store
+    with IdentityStore(path=db) as store:
+        assert store.resolve_alias("crm:1", kind="customer_id") == eid_alice
+        assert store.resolve_alias("crm:bob@y.com", kind="email") == eid_bob
+
+
+def test_low_confidence_dropped(seeded_store):
+    db, _, _ = seeded_store
+    records = [{"cust_id": "1", "email_addr": "alice@x.com"}]
+    mapping = _mapping(
+        ("cust_id", "customer_id"),
+        ("email_addr", "email"),
+        confidence=0.50,
+    )
+    with IdentityStore(path=db) as store:
+        result = write_aliases_from_mapping(
+            mapping, records, store, _record_entity_resolver(store),
+            source_name="crm", dataset="t",
+        )
+    assert result.aliases_written == 0
+    assert result.mappings_used == 0
+    assert result.skipped_low_confidence == 2
+
+
+def test_non_alias_kind_target_skipped(seeded_store):
+    """Mapping to a non-alias target column (e.g. `address`) shouldn't
+    create alias rows -- only ID-shaped targets do."""
+    db, _, _ = seeded_store
+    records = [{"cust_id": "1", "street": "123 Main"}]
+    mapping = _mapping(("cust_id", "customer_id"), ("street", "address"))
+    with IdentityStore(path=db) as store:
+        result = write_aliases_from_mapping(
+            mapping, records, store, _record_entity_resolver(store),
+            source_name="crm",
+        )
+    assert result.aliases_written == 1  # only customer_id
+    assert result.mappings_used == 1
+
+
+def test_missing_value_skipped(seeded_store):
+    db, _, _ = seeded_store
+    records = [
+        {"cust_id": "1", "email_addr": "alice@x.com"},
+        {"cust_id": "2"},  # no email_addr
+    ]
+    mapping = _mapping(("cust_id", "customer_id"), ("email_addr", "email"))
+    with IdentityStore(path=db) as store:
+        result = write_aliases_from_mapping(
+            mapping, records, store, _record_entity_resolver(store),
+            source_name="crm",
+        )
+    assert result.aliases_written == 3   # alice has both, bob has only cust_id
+    assert result.skipped_no_value == 1
+
+
+def test_missing_entity_skipped(seeded_store):
+    """Records whose entity_id_resolver returns None are skipped, not failed."""
+    db, _, _ = seeded_store
+    records = [
+        {"cust_id": "1", "email_addr": "alice@x.com"},
+        {"cust_id": "999", "email_addr": "ghost@unknown.com"},  # no identity
+    ]
+    mapping = _mapping(("cust_id", "customer_id"), ("email_addr", "email"))
+    with IdentityStore(path=db) as store:
+        result = write_aliases_from_mapping(
+            mapping, records, store, _record_entity_resolver(store),
+            source_name="crm",
+        )
+    assert result.records_processed == 2
+    assert result.aliases_written == 2  # only alice's
+    assert result.skipped_no_entity == 1
+
+
+def test_custom_alias_kinds(seeded_store):
+    """Callers can pass domain-specific alias kinds (e.g. healthcare NPI)."""
+    db, eid_alice, _ = seeded_store
+    records = [{"cust_id": "1", "provider_npi": "1234567890"}]
+    mapping = _mapping(
+        ("cust_id", "customer_id"),
+        ("provider_npi", "npi"),
+    )
+    with IdentityStore(path=db) as store:
+        result = write_aliases_from_mapping(
+            mapping, records, store, _record_entity_resolver(store),
+            source_name="crm",
+            alias_kinds=frozenset({"customer_id", "npi"}),
+        )
+    assert result.aliases_written == 2
+    with IdentityStore(path=db) as store:
+        assert store.resolve_alias("crm:1234567890", kind="npi") == eid_alice
+
+
+def test_no_goldenmatch_raises_clean_error(monkeypatch):
+    """When goldenmatch isn't importable, we raise a clear ImportError."""
+    import builtins as _builtins
+    real = _builtins.__import__
+
+    def fake(name, *args, **kwargs):
+        if name == "goldenmatch.identity":
+            raise ImportError("simulated: goldenmatch not installed")
+        return real(name, *args, **kwargs)
+
+    monkeypatch.setattr(_builtins, "__import__", fake)
+    with pytest.raises(ImportError, match="goldenmatch>=1.15.0"):
+        write_aliases_from_mapping(
+            _mapping(("cust_id", "customer_id")),
+            [{"cust_id": "1"}],
+            store=object(),
+            entity_id_resolver=lambda r: "fake-id",
+            source_name="crm",
+        )


### PR DESCRIPTION
## Summary

Closes #206. Adds the InferMap -> Identity Graph bridge as a thin helper:

\`\`\`python
infermap.write_aliases_from_mapping(
    mapping, records, store, entity_id_resolver,
    source_name=\"crm\",
)
\`\`\`

## Design decision (from issue #206)

**Per-record** alias writing, not schema-level. InferMap tells us which source column holds the id of each kind; we write one \`IdentityAlias\` row per (record, detected alias-kind). Schema-level "this column maps to that column" aliasing without a record context isn't modeled — \`identity_aliases\` is keyed on the alias *value*, not the column name.

## Behavior

- Default alias-kinds: customer_id, user_id, account_id, external_id, email, phone, ssn, tax_id, ein, vin, isbn, doi. Pass \`alias_kinds=\` to extend for domain-specific ids (e.g. npi for healthcare).
- Drops mappings below \`min_confidence=0.85\` (the "strong match" threshold).
- \`entity_id_resolver(record)\` lets callers control the lookup path.
- Returns \`AliasWriteResult\` with counters for every skip reason.
- Lazy-imports \`goldenmatch.identity\` — InferMap-only users without goldenmatch keep working. Clean \`ImportError\` if the helper is invoked without goldenmatch>=1.15.0.

## Test plan

- [x] 7 new tests (alias writing, low-confidence drop, non-alias-kind skip, missing value, missing entity, custom alias kinds, clean ImportError)
- [x] All pass locally
- [ ] CI green

## What's NOT in this PR

- No CLI changes
- No new \`infermap.map\` arguments — the helper is a separate function
- No GoldenPipe stage wiring (that's a separate follow-up if/when GoldenPipe ships InferMap orchestration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)