### PR TITLE
fix(security): CodeQL sweep — SSRF, path/log injection, stack-trace leaks

### DIFF
--- a/packages/python/goldencheck/goldencheck/a2a/server.py
+++ b/packages/python/goldencheck/goldencheck/a2a/server.py
@@ -200,7 +200,9 @@ async def _handle_tasks_send(request: web.Request) -> web.Response:
         })
 
     except Exception as exc:
-        logger.exception("Task %s failed", task_id)
+        # %r quotes the value, which escapes any control chars in task_id
+        # that would otherwise corrupt structured log lines.
+        logger.exception("Task %r failed", task_id)
         _tasks[task_id]["state"] = "failed"
         _tasks[task_id]["error"] = str(exc)
         return web.json_response(
@@ -292,13 +294,19 @@ async def _handle_tasks_send_subscribe(request: web.Request) -> web.StreamRespon
             await response.write(completed_event.encode("utf-8"))
 
     except Exception as exc:
-        logger.exception("Task %s failed", task_id)
+        # %r quotes the value, which escapes any control chars in task_id
+        # that would otherwise corrupt structured log lines.
+        logger.exception("Task %r failed", task_id)
         _tasks[task_id]["state"] = "failed"
         _tasks[task_id]["error"] = str(exc)
+        # Send only a sanitised first-line message on the SSE wire; the
+        # full traceback already went to the logger above. Stack traces
+        # leaking to clients can expose internal paths / library versions.
+        wire_msg = (str(exc).splitlines()[0][:200]) if str(exc) else "internal error"
         error_event = _sse_encode("task-status", {
             "id": task_id,
             "state": "failed",
-            "error": str(exc),
+            "error": wire_msg,
         })
         await response.write(error_event.encode("utf-8"))
 

--- a/packages/python/goldencheck/goldencheck/engine/reader.py
+++ b/packages/python/goldencheck/goldencheck/engine/reader.py
@@ -10,14 +10,20 @@ logger = logging.getLogger(__name__)
 SUPPORTED_EXTENSIONS = {".csv", ".parquet", ".xlsx", ".xls"}
 
 def read_file(path: Path) -> pl.DataFrame:
-    path = Path(path)
+    # Normalise the path early so symlink-and-`..` traversal can't smuggle
+    # access to unexpected locations through downstream Polars / openpyxl
+    # readers. `path` is a trusted-config / CLI value, but the normalisation
+    # is cheap insurance against accidental traversal in API callers.
+    path = Path(path).resolve()
     ext = path.suffix.lower()
     if ext not in SUPPORTED_EXTENSIONS:
         raise ValueError(f"Unsupported file format: {ext}. Supported: {', '.join(sorted(SUPPORTED_EXTENSIONS))}")
     if not path.exists():
-        raise FileNotFoundError(f"File not found: {path}")
+        raise FileNotFoundError(f"File not found: {path.name}")
 
-    logger.info("Reading %s (%s)", path, ext)
+    # Log basename only — full paths can carry control characters /
+    # newlines that pollute structured logs (CodeQL py/log-injection).
+    logger.info("Reading %s (%s)", path.name, ext)
 
     if path.stat().st_size == 0:
         raise ValueError("File has no data rows. Nothing to profile.")

--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -352,8 +352,10 @@ def scan_file(
     if baseline is not None:
         from goldencheck.drift import run_drift_checks
         if baseline.source_filename and baseline.source_filename != path.name:
+            # %r quotes both values so YAML-supplied filename can't smuggle
+            # newlines / control chars into structured logs.
             logger.warning(
-                "Baseline source '%s' doesn't match scan file '%s'",
+                "Baseline source %r doesn't match scan file %r",
                 baseline.source_filename, path.name,
             )
         drift_findings = run_drift_checks(sample, baseline)

--- a/packages/python/goldencheck/goldencheck/semantic/classifier.py
+++ b/packages/python/goldencheck/goldencheck/semantic/classifier.py
@@ -60,13 +60,22 @@ def load_type_defs(
     # Layer 2: domain types (override/extend base)
     domain_defs: dict[str, TypeDef] = {}
     if domain:
-        domain_path = Path(__file__).parent / "domains" / f"{domain}.yaml"
-        if not domain_path.exists():
-            available = list_available_domains()
+        # Path-traversal defense: the `domain` arg is user-supplied; constructing
+        # `Path(...) / domain / f"{domain}.yaml"` would let `domain="../../etc/passwd"`
+        # escape the domains directory. Restrict to the allowlist of installed
+        # domain packs and resolve+verify the final path stays inside `domains/`.
+        available = list_available_domains()
+        if domain not in available:
             raise ValueError(
                 f"Unknown domain: '{domain}'. "
                 f"Available: {', '.join(available) if available else 'none'}"
             )
+        domains_root = (Path(__file__).parent / "domains").resolve()
+        domain_path = (domains_root / f"{domain}.yaml").resolve()
+        # Guard against symlink shenanigans and weird YAML names that
+        # somehow made it past the allowlist check.
+        if domains_root not in domain_path.parents:
+            raise ValueError(f"Unsafe domain path: '{domain}'")
         domain_defs = _load_yaml_types(domain_path)
 
     # Layer 3: user custom types

--- a/packages/python/goldencheck/goldencheck/server.py
+++ b/packages/python/goldencheck/goldencheck/server.py
@@ -1,8 +1,10 @@
 """REST API server for GoldenCheck — scan files via HTTP."""
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
+import socket
 import tempfile
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -15,6 +17,42 @@ from goldencheck.models.finding import Severity
 logger = logging.getLogger(__name__)
 
 __all__ = ["run_server", "GoldenCheckHandler"]
+
+
+def _validate_remote_url(url: str) -> tuple[bool, str]:
+    """Validate that a URL is safe to fetch from a public-facing endpoint.
+
+    Returns ``(ok, reason)``. Rejects:
+
+    - schemes other than http/https (defangs ``file://``, ``gopher://``, etc.)
+    - hostnames that resolve to private / loopback / link-local / reserved
+      IPs (defangs SSRF into cloud metadata services, internal networks,
+      and localhost callbacks)
+    - hostnames that fail DNS resolution
+
+    Caller-controlled URLs go through this filter before any I/O happens.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return False, f"unsupported URL scheme: {parsed.scheme!r}"
+    if not parsed.hostname:
+        return False, "URL has no hostname"
+    try:
+        infos = socket.getaddrinfo(parsed.hostname, None)
+    except OSError as e:
+        return False, f"DNS resolution failed: {e}"
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            return False, f"refusing private/internal IP {ip}"
+    return True, ""
 
 
 class GoldenCheckHandler(BaseHTTPRequestHandler):
@@ -94,11 +132,22 @@ class GoldenCheckHandler(BaseHTTPRequestHandler):
             self._json_response({"error": "Missing 'url' field"}, status=400)
             return
 
+        # SSRF guard: reject non-HTTP(S) schemes, private/internal IPs, and
+        # unresolvable hostnames before issuing any network I/O. Otherwise an
+        # attacker JSON could reach `file:///etc/passwd`, the cloud metadata
+        # service at 169.254.169.254, or any host on the operator's intranet.
+        ok, reason = _validate_remote_url(url)
+        if not ok:
+            self._json_response({"error": f"URL rejected: {reason}"}, status=400)
+            return
+
         domain = data.get("domain")
 
         with tempfile.NamedTemporaryFile(suffix=".csv", delete=False, mode="wb") as tmp:
             try:
-                resp = urllib.request.urlopen(url, timeout=30)
+                # noqa S310 (audit_url): URL is filtered above by
+                # _validate_remote_url; scheme + IP-class are both whitelisted.
+                resp = urllib.request.urlopen(url, timeout=30)  # noqa: S310
                 tmp.write(resp.read())
             except Exception as e:
                 self._json_response({"error": f"Failed to download: {e}"}, status=400)

--- a/packages/python/goldenmatch/tests/benchmarks/run_llm_budget_bench.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_llm_budget_bench.py
@@ -96,7 +96,9 @@ api_key = os.environ.get("OPENAI_API_KEY")
 if not api_key:
     print("ERROR: No OPENAI_API_KEY found.")
     sys.exit(1)
-print(f"API key loaded: {api_key[:10]}...{api_key[-4:]}")
+# Just confirm presence; don't echo any portion of the key. Even masked
+# prefixes can leak provider/account info in screenshots.
+print(f"API key loaded (length={len(api_key)})")
 
 df, gt = load_abt_buy()
 print(f"Loaded: {df.height} records, {len(gt)} ground truth pairs\n")

--- a/packages/python/goldenpipe/goldenpipe/api/server.py
+++ b/packages/python/goldenpipe/goldenpipe/api/server.py
@@ -1,10 +1,13 @@
 """FastAPI REST API for GoldenPipe."""
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from fastapi import FastAPI
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
 
 from goldenpipe.engine.registry import StageRegistry
 from goldenpipe.engine.resolver import Resolver, WiringError
@@ -45,7 +48,9 @@ def create_app() -> FastAPI:
             plan = Resolver.resolve(config, reg)
             return {"valid": True, "stages": [s.name for s in plan.stages]}
         except (WiringError, KeyError) as e:
-            return {"valid": False, "error": str(e)}
+            # Only the message line goes on the wire; never the traceback.
+            logger.exception("Pipeline wiring failed")
+            return {"valid": False, "error": str(e).splitlines()[0][:200]}
 
     @app.post("/run")
     def run_pipeline(req: RunRequest):

--- a/packages/typescript/goldencheck/src/core/engine/notifier.ts
+++ b/packages/typescript/goldencheck/src/core/engine/notifier.ts
@@ -102,6 +102,21 @@ export async function sendWebhook(
     top_findings: topFindings,
   };
 
+  // Webhook URL is operator-supplied config but can flow in from config
+  // files / env vars; validate that it's actually a remote http(s) URL so
+  // a misconfigured `file://` or `gopher://` URL can't be used to read
+  // local files or hit internal services.
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      console.warn(`Webhook URL must be http(s), got ${parsed.protocol}`);
+      return;
+    }
+  } catch {
+    console.warn(`Webhook URL is not a valid URL: skipping notify`);
+    return;
+  }
+
   try {
     await fetch(url, {
       method: "POST",

--- a/packages/typescript/goldenflow/src/node/api/server.ts
+++ b/packages/typescript/goldenflow/src/node/api/server.ts
@@ -16,9 +16,26 @@ function sanitizePath(raw: string): string {
 
 const VERSION = "0.1.0";
 
+/** Strip stack / errno / syscall fields from objects + Error instances so
+ *  unauthenticated callers don't see internal paths / library versions. */
+function sanitiseForWire(data: unknown): unknown {
+  if (data instanceof Error) {
+    return { error: data.message };
+  }
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(data)) {
+      if (k === "stack" || k === "errno" || k === "syscall") continue;
+      out[k] = v;
+    }
+    return out;
+  }
+  return data;
+}
+
 function jsonResponse(res: ServerResponse, status: number, data: unknown): void {
   res.writeHead(status, { "Content-Type": "application/json" });
-  res.end(JSON.stringify(data));
+  res.end(JSON.stringify(sanitiseForWire(data)));
 }
 
 async function readBody(req: IncomingMessage): Promise<string> {

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -349,10 +349,26 @@ async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknow
   return parsed as Record<string, unknown>;
 }
 
+/** See `src/node/api/server.ts::sanitiseForWire` for rationale. */
+function sanitiseForWire(data: unknown): unknown {
+  if (data instanceof Error) {
+    return { error: data.message };
+  }
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(data)) {
+      if (k === "stack" || k === "errno" || k === "syscall") continue;
+      out[k] = v;
+    }
+    return out;
+  }
+  return data;
+}
+
 function sendJson(res: ServerResponse, status: number, data: unknown): void {
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json");
-  res.end(JSON.stringify(data));
+  res.end(JSON.stringify(sanitiseForWire(data)));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/typescript/goldenmatch/src/node/api/server.ts
+++ b/packages/typescript/goldenmatch/src/node/api/server.ts
@@ -137,10 +137,29 @@ async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknow
   }
 }
 
+/** Strip internal Error fields (stack, errno, syscall, code) before
+ *  serialising to the wire. Otherwise a thrown Error becomes a JSON
+ *  blob with its full V8 stack trace, exposing internal file paths
+ *  and library versions to unauthenticated clients. */
+function sanitiseForWire(data: unknown): unknown {
+  if (data instanceof Error) {
+    return { error: data.message };
+  }
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(data)) {
+      if (k === "stack" || k === "errno" || k === "syscall") continue;
+      out[k] = v;
+    }
+    return out;
+  }
+  return data;
+}
+
 function sendJson(res: ServerResponse, status: number, data: unknown): void {
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json");
-  res.end(JSON.stringify(data));
+  res.end(JSON.stringify(sanitiseForWire(data)));
 }
 
 function asRowArray(v: unknown, label: string): Row[] {


### PR DESCRIPTION
## Summary

Triage of all 90 open CodeQL alerts on main. **90 → 25 open** (the remaining 25 will be 10-ish after CodeQL re-scans this PR, since 15 of them target lines my fixes already touched).

## Real fixes

- **Critical SSRF** in `goldencheck.server` `/scan` endpoint — scheme allowlist + DNS resolution + private/loopback/link-local IP block before `urlopen`.
- **Path-traversal** in `goldencheck.semantic.classifier` — domain arg now allowlisted, post-resolve containment check.
- **Path-injection + log-injection** in `goldencheck.engine.reader` — resolve path early, log basename only.
- **Log-injection** in `goldencheck.{engine.scanner, a2a.server}` — `%r` quoting on user-controllable values.
- **Stack-trace exposure** (TS + Python) — `sanitiseForWire` helper in TS API/A2A servers strips `stack`/`errno`/`syscall`. Python side: only `str(exc).splitlines()[0][:200]` goes on the wire; tracebacks stay in logs.
- **File-access-to-HTTP** in `goldencheck-ts` webhook notifier — validate URL is http(s) before `fetch`.
- **Credential prefix logging** in `run_llm_budget_bench.py` — stopped echoing first/last chars of `OPENAI_API_KEY`.

## Dismissed (with rationale per alert)

- 46 OSSF Scorecards governance alerts (`PinnedDependenciesID`, `TokenPermissionsID`, etc) — repo-policy noise
- 4 trusted-config path-injection in `*/config/loader.py` — in-process YAML loaders, same pattern as `MemoryStore`/`IdentityStore`
- 7 overly-large-range — bounded Unicode codepoint ranges in an emoji regex (false positive)
- 7 insecure-temporary-file in `*/examples/` — single-user demo scripts
- 1 clear-text-logging at `boost.py:474` — `provider` is a name like "openai", not credentials

## Test plan

- [x] 567 (goldencheck) + 136 (goldenpipe) passing, 0 regressions
- [x] TS typecheck clean on goldenmatch + goldenflow + goldencheck
- [ ] CI green

## Follow-up issue to file after merge

Remaining ~10 medium-severity regex/sanitization alerts: `js/regex/missing-regexp-anchor` × 2, `js/polynomial-redos` × 2, `py/redos` × 1, `js/incomplete-sanitization` × 1, `js/incomplete-multi-character-sanitization` × 1, plus 2 `py/insecure-temporary-file` in non-example code (`*.testing*` paths). Focused pass when there's time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)