### PR TITLE
fix(security): close 7 residual CodeQL alerts (closes #213)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/smart_ingest.py
+++ b/packages/python/goldenmatch/goldenmatch/core/smart_ingest.py
@@ -427,10 +427,17 @@ _PHONE_RE = re.compile(
 _ZIP_RE = re.compile(r"\b\d{5}(?:-\d{4})?\b")
 _NAME_RE = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3})\b")
 _ADDR_RE = re.compile(
-    r"\b\d+\s+[A-Z][a-zA-Z]+(?:\s+[A-Z]?[a-zA-Z]+)*"
+    r"\b\d+\s+[A-Z][a-zA-Z]+(?:\s+[A-Z]?[a-zA-Z]+){0,8}"
     r"\s+(?:St|Street|Ave|Avenue|Blvd|Boulevard|Dr|Drive|Rd|Road|Ln|Lane|Way|Ct|Court|Pl|Place)\b",
     re.IGNORECASE,
 )
+# Per-line input length cap fed to _ADDR_RE / _NAME_RE / _PHONE_RE / _EMAIL_RE
+# below. The unbounded `(?:...)*` in earlier addr regex could backtrack
+# polynomially on adversarially long dot/space-heavy inputs; capping the
+# repeat to {0,8} bounds the work without losing real addresses (which
+# top out at ~5 segments in the US). Lines longer than the cap below
+# fall through unmatched -- accept slight recall loss for ReDoS safety.
+_MAX_INGEST_LINE_LEN = 4096
 
 
 def extract_entities(text: str) -> pl.DataFrame:
@@ -441,6 +448,12 @@ def extract_entities(text: str) -> pl.DataFrame:
     entity_lines: list[tuple[int, str, str]] = []  # (line_no, type, value)
 
     for i, line in enumerate(lines):
+        # Bound per-line regex work. Address / name regexes can backtrack
+        # polynomially on adversarially long inputs; lines beyond the cap
+        # are far past any realistic free-text record and skipping them
+        # preserves recall on real data while neutralising ReDoS.
+        if len(line) > _MAX_INGEST_LINE_LEN:
+            continue
         for m in _EMAIL_RE.finditer(line):
             entity_lines.append((i, "email", m.group()))
         for m in _PHONE_RE.finditer(line):

--- a/packages/typescript/goldencheck/src/node/watcher.ts
+++ b/packages/typescript/goldencheck/src/node/watcher.ts
@@ -28,7 +28,10 @@ export async function watchDirectory(
   options: WatchOptions,
 ): Promise<void> {
   const interval = options.interval ?? 30_000;
-  const ext = options.pattern?.replace("*", "") ?? ".csv";
+  // `.replace("*", "")` only strips the FIRST wildcard, so `**.csv` becomes
+  // `*.csv` (still a wildcard, won't match anything via endsWith later).
+  // replaceAll strips every `*` so the trailing extension survives.
+  const ext = options.pattern?.replaceAll("*", "") ?? ".csv";
   const mtimes = new Map<string, number>();
 
   // Initial scan — record mtimes

--- a/packages/typescript/goldenflow/src/core/transforms/text.ts
+++ b/packages/typescript/goldenflow/src/core/transforms/text.ts
@@ -151,7 +151,20 @@ registerTransform(
 // ---------------------------------------------------------------------------
 
 function removeHtmlTags(values: readonly ColumnValue[]): ColumnValue[] {
-  return mapStrings(values, (s) => s.replace(/<[^>]*>/g, ""));
+  return mapStrings(values, (s) => {
+    // Single-pass `<[^>]*>` removal lets nested-tag payloads like
+    // `<<script>script>` collapse to `<script>` after one rewrite.
+    // Loop until the output stabilises so the transform is idempotent
+    // against adversarial input. Bounded by string length -- each pass
+    // strictly shrinks the input (or matches zero, ending the loop).
+    let prev: string;
+    let out = s;
+    do {
+      prev = out;
+      out = out.replace(/<[^>]*>/g, "");
+    } while (out !== prev);
+    return out;
+  });
 }
 
 registerTransform(

--- a/packages/typescript/goldenmatch/src/core/domain.ts
+++ b/packages/typescript/goldenmatch/src/core/domain.ts
@@ -45,8 +45,11 @@ const PRODUCT_SIGNATURES: readonly Signature[] = [
 ];
 
 const PERSON_SIGNATURES: readonly Signature[] = [
-  { pattern: /^first|first_name|fname/i, weight: 2 },
-  { pattern: /^last|last_name|lname|surname/i, weight: 2 },
+  // Anchor must apply to every branch in the alternation. Without the
+  // outer group, `/^first|first_name|fname/i` only anchors `first`;
+  // `first_name` and `fname` would match anywhere in the column name.
+  { pattern: /^(first|first_name|fname)/i, weight: 2 },
+  { pattern: /^(last|last_name|lname|surname)/i, weight: 2 },
   { pattern: /full_name|person_name/i, weight: 2 },
   { pattern: /email/i, weight: 2 },
   { pattern: /phone|mobile|cell/i, weight: 1 },

--- a/packages/typescript/goldenmatch/src/core/quality.ts
+++ b/packages/typescript/goldenmatch/src/core/quality.ts
@@ -95,10 +95,18 @@ export function scanQuality(
       const s = asStr(raw);
       if (s !== null) {
         distinct.add(s);
-        // Email heuristics
-        if (s.includes("@")) {
+        // Email heuristics. Cap input length to RFC 5321 maximum (254)
+        // before regex matching to neutralise the polynomial-backtracking
+        // case where `[^@\s]+\.[^@\s]+` retries every `.` split on long
+        // dot-heavy inputs.
+        if (s.includes("@") && s.length <= 254) {
           emailLike++;
           if (!EMAIL_RE.test(s)) malformedEmail++;
+        } else if (s.includes("@")) {
+          // Over-length string with `@` -- count as malformed without
+          // running the regex; saves the worst-case match.
+          emailLike++;
+          malformedEmail++;
         }
         // Date format tracking
         for (let i = 0; i < DATE_PATTERNS.length; i++) {

--- a/packages/typescript/infermap/src/core/scorers/initialism.ts
+++ b/packages/typescript/infermap/src/core/scorers/initialism.ts
@@ -24,6 +24,10 @@ export function tokenize(name: string): string[] {
   const re = /[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|\d+/g;
   for (const chunk of cleaned.split(/\s+/)) {
     if (!chunk) continue;
+    // Bound the regex input. Column/field names beyond 256 chars aren't
+    // realistic identifiers and the alternation here can backtrack
+    // polynomially on adversarially long all-caps runs.
+    if (chunk.length > 256) continue;
     const matches = chunk.match(re);
     if (!matches) continue;
     for (const m of matches) tokens.push(m.toLowerCase());


### PR DESCRIPTION
## Summary

Closes #213. Knocks out the regex / sanitization items left over after PR #212's broader security sweep. All 7 are high-severity CodeQL alerts.

## Fixes by alert

| # | Rule | File | Fix |
|---|---|---|---|
| #144 | `js/incomplete-multi-character-sanitization` | `goldenflow-ts/.../text.ts` | Loop HTML-tag removal until stable (defangs nested-tag payloads) |
| #145 | `js/incomplete-sanitization` | `goldencheck-ts/.../watcher.ts` | `replaceAll("*", "")` instead of `replace` |
| #150 | `js/polynomial-redos` | `goldenmatch-ts/.../quality.ts` | Cap email regex input to RFC max (254 chars) |
| #151 | `js/polynomial-redos` | `infermap-ts/.../initialism.ts` | Skip tokenizer chunks > 256 chars |
| #153, #154 | `js/regex/missing-regexp-anchor` | `goldenmatch-ts/.../domain.ts` | Group alternation under `^` |
| #155 | `py/redos` | `goldenmatch/.../smart_ingest.py` | Cap `_ADDR_RE` repeat to `{0,8}` + per-line `_MAX_INGEST_LINE_LEN` cap |

## Test plan

- [x] Ruff + `tsc --noEmit` clean on every changed package
- [x] 1,314 tests across the 5 changed packages, all passing
- [ ] CI green
- [ ] Post-merge CodeQL takes the queue from 7 open → 0 (or near-0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)