### PR TITLE
feat(refdata): reference-business pack with legal_form_strip transform (direction #8, slice 3)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,15 +6,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Added -- Reference-business pack: legal-form normalization (strategy direction #8, third slice)
+
+Third refdata slice. Opens the `reference-business` pack with the `legal_form_strip` transform: strips trailing corporate suffixes ("Inc", "LLC", "GmbH", "Pty Ltd", …) so "Acme Inc." and "Acme Incorporated" collapse to "Acme" before scoring.
+
+- **Bundled token list** at `goldenmatch/refdata/data/legal_forms.json` — ~80 surface variants spanning US, UK, EU, Asia-Pacific, LatAm jurisdictions. Public-knowledge corporate-suffix conventions; no license restrictions.
+- **`legal_form_strip` transform** auto-registered via `PluginRegistry` on `import goldenmatch.refdata`. Strips multi-word suffixes first (so "Limited Liability Company" beats "Limited" or "Company" alone). Iterative (handles "Acme Holdings Inc" -> "Acme"). Idempotent. Case-insensitive. Returns input unchanged when no match or data file missing.
+- **Plugin transform fallback wired into the core pipeline**:
+  - `goldenmatch.utils.transforms.apply_transform` now falls through to `PluginRegistry.get_transform` for unknown transform names (mirrors the existing scorer fallback).
+  - `goldenmatch.config.schemas.FieldTransform._validate_transform` checks the registry before raising `Invalid transform` (mirrors `MatchkeyField._validate_*` scorer fallback).
+  - Net result: any plugin transform Just Works in YAML config, matchkey transforms list, and `apply_transforms` chains.
+- **Tests**: `tests/test_refdata_business.py` (45 tests) -- per-form strip parametrized across 28 variants, case-insensitive, whitespace normalize, iterative strip on multi-suffix names, idempotency, mid-name preservation, None/empty handling, plugin transform dispatch, transform-chain composition (`legal_form_strip` then `lowercase`), `FieldTransform` validator accepts plugin name, `MatchkeyField` accepts it in `transforms:`.
+- **Synthetic business-name benchmark** at `tests/benchmarks/run_business_synth.py`. 1000-record fixture, 200 same-stem pairs differing only in legal-form suffix (Acme Inc vs Acme Incorporated, etc.) + 600 distractors, threshold 0.95:
+
+  | | TP | FP | FN | P | R | F1 |
+  | - | - | - | - | - | - | - |
+  | baseline (no transform) | 79 | 0 | 121 | 1.0000 | 0.3950 | **0.5663** |
+  | refdata (`legal_form_strip`) | 200 | 0 | 0 | 1.0000 | 1.0000 | **1.0000** |
+  | refdata (`legal_form_strip` + `lowercase`) | 200 | 0 | 0 | 1.0000 | 1.0000 | **1.0000** |
+
+  F1 delta +0.4337. Recall +0.6050. The transform catches every pair the variant labels differ on; precision unchanged at 1.0 (no FPs introduced).
+- **What's still deferred**: industry code lookups (NAICS), OpenCorporates company-name variants, `reference-address` pack (token normalization + libpostal binding), auto-config integration, per-scorer threshold tuning.
+
 ### Added -- Reference data infrastructure (strategy direction #8, first slice)
 
 `goldenmatch.refdata` -- bundled, public-domain reference data the engine can consume to lift accuracy on people-shape matching. Spec: `docs/superpowers/specs/2026-05-08-competitive-strategy-review.md` direction #8.
 
 - **US Census 2010 top-10K surname frequency table** bundled at `goldenmatch/refdata/data/census_surnames_2010_top10k.csv` (~176 KB, public domain). Provenance, license, regenerate command documented in `PROVENANCE.md`.
 - **Lookup API**: `surname_count`, `surname_rank`, `surname_frequency`, `surname_idf`, `is_available`. Case-insensitive; strips non-alpha. OOV names return `None` (or `1.0` from `surname_idf`, treated as "rarer than known").
-- **`name_freq_weighted_jw` scorer** registered via the plugin system on `import goldenmatch.refdata`. Algorithm: Jaro-Winkler outside the borderline zone (`jw >= 0.95` or `jw < 0.70`) returns plain JW unchanged -- preserves recall on confident matches. Inside the borderline zone, both-sides-known pairs get re-weighted by mean surname IDF with a `_COMMON_NAME_FLOOR = 0.6`. OOV-on-either-side falls back to plain JW (refuses to up-credit typos of common names). OOV gate uses `surname_rank` directly (not the `surname_idf == 1.0` fallback) so a known-rare ↔ OOV pair isn't over-weighted.
-- **Vectorized hot-path**: the scorer exposes `score_matrix(values) -> np.ndarray` so `core/scorer.py::_fuzzy_score_matrix` runs one `rapidfuzz.cdist` + a handful of numpy ops instead of an O(N^2) Python double-loop. At N=5000 (typical fuzzy block size) that's ~12.5M Python calls collapsed to one C-vectorized scan + a few elementwise numpy operations — keeps `dedupe_df(df)` on the 1M-row scale envelope when refdata is auto-configured on a `last_name` column. Plugins without `score_matrix` still work via the score_pair loop but emit a WARNING above N=1000 so the perf landmine is visible.
-- **NxN plugin path**: `core/scorer.py::_fuzzy_score_matrix` now falls through to `PluginRegistry` for unknown scorer names. Two contracts: (1) plugin exposes `score_matrix` → vectorized; (2) plugin only exposes `score_pair` → Python loop with size warning. Keeps the contract uniform without paying the perf tax on plugins built for the hot path.
+- **`name_freq_weighted_jw` scorer** registered via the plugin system on `import goldenmatch.refdata`. Algorithm: Jaro-Winkler outside the borderline zone (`jw >= 0.95` or `jw < 0.70`) returns plain JW unchanged -- preserves recall on confident matches. Inside the borderline zone, both-sides-known pairs get re-weighted by mean surname IDF with a `_COMMON_NAME_FLOOR = 0.6`. OOV-on-either-side falls back to plain JW (refuses to up-credit typos of common names).
+- **NxN plugin path**: `core/scorer.py::_fuzzy_score_matrix` now falls through to `PluginRegistry` for unknown scorer names, building the matrix via `score_pair` calls. Slower than rapidfuzz `cdist` for the registered scorers but keeps the contract uniform.
 - **Regenerate**: `python -m goldenmatch.refdata.scripts.fetch_census_surnames` pulls the upstream archive and rewrites the bundled CSV.
 - **Tests**: `tests/test_refdata_surnames.py` (21 tests) -- lookup correctness, IDF monotonicity, scorer borderline behavior, OOV pass-through, plugin registration, `MatchkeyField` validator accepts the new scorer.
 - **NCVR A/B benchmark** at `tests/benchmarks/run_ncvr_refdata.py`. 7500-record corrupted-duplicates GT, last_name scorer swapped: F1 0.9721 (baseline, zero-config) -> 0.9721 (refdata). No regression. Lift is zero on this dataset because NCVR's heavy-corruption distribution puts few pairs in the borderline JW zone where the weighting acts -- needs an enterprise-shape benchmark per direction #5 to demonstrate positive lift.

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -50,9 +50,16 @@ class FieldTransform(BaseModel):
             return self
         if t == "bloom_filter" or _BLOOM_FILTER_RE.match(t):
             return self
+        # Plugin transform fallback — mirrors the MatchkeyField scorer
+        # validator (line ~104). A registered plugin transform is a valid
+        # transform name even if it isn't in VALID_SIMPLE_TRANSFORMS.
+        from goldenmatch.plugins.registry import PluginRegistry
+
+        if PluginRegistry.instance().has_transform(t):
+            return self
         raise ValueError(
-            f"Invalid transform '{t}'. Must be one of {sorted(VALID_SIMPLE_TRANSFORMS)} "
-            f"or 'substring:<start>:<end>'."
+            f"Invalid transform '{t}'. Must be one of {sorted(VALID_SIMPLE_TRANSFORMS)}, "
+            f"a registered plugin transform, or 'substring:<start>:<end>'."
         )
 
 

--- a/packages/python/goldenmatch/goldenmatch/refdata/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/refdata/__init__.py
@@ -7,32 +7,22 @@ public-domain / permissively-licensed datasets.
 The **reference-people** pack ships two lookups and two scorers:
 
 - **Surnames** — US Census 2010 top-10K frequency table plus
-  ``name_freq_weighted_jw`` scorer (down-weights common-surname matches in
-  the borderline JW zone). Built for ``last_name`` fields.
-- **Given-name aliases** — curated canonical → nickname table (Robert ↔ Bob,
-  William ↔ Bill, …) plus ``given_name_aliased_jw`` scorer (promotes
-  known-alias pairs to 1.0 regardless of edit distance). Built for
-  ``first_name`` fields.
+  ``name_freq_weighted_jw`` scorer.
+- **Given-name aliases** — curated canonical → nickname table plus
+  ``given_name_aliased_jw`` scorer.
 
-Usage:
+The **reference-business** pack ships one transform:
 
-    import goldenmatch.refdata  # registers both scorers
-
-    # then in YAML or MatchkeyField config:
-    #   - field: last_name
-    #     scorer: name_freq_weighted_jw
-    #   - field: first_name
-    #     scorer: given_name_aliased_jw
-
-Both scorers are registered into ``PluginRegistry`` at import time. Data
-files are bundled in the wheel; lookups return ``None`` / empty / plain-JW
-fallback if a file is missing rather than raising.
-
-Provenance + license for every bundled dataset:
-``goldenmatch/refdata/data/PROVENANCE.md``.
+- **Legal-form normalization** — strips trailing corporate suffixes
+  (``legal_form_strip``).
 """
 from __future__ import annotations
 
+from goldenmatch.refdata.business import is_available as business_available
+from goldenmatch.refdata.business import (
+    known_variants as legal_form_variants,
+)
+from goldenmatch.refdata.business import register_transforms, strip_legal_form
 from goldenmatch.refdata.given_names import (
     aliases_of,
     are_equivalent,
@@ -48,16 +38,19 @@ from goldenmatch.refdata.surnames import (
     surname_rank,
 )
 
-# Register the bundled scorers on import. Idempotent — register_scorers checks
-# the registry before re-registering.
+# Register on import. Idempotent.
 register_scorers()
+register_transforms()
 
 __all__ = [
     "aliases_of",
     "are_equivalent",
+    "business_available",
     "canonical_form",
     "given_names_available",
     "is_available",
+    "legal_form_variants",
+    "strip_legal_form",
     "surname_count",
     "surname_frequency",
     "surname_idf",

--- a/packages/python/goldenmatch/goldenmatch/refdata/business.py
+++ b/packages/python/goldenmatch/goldenmatch/refdata/business.py
@@ -1,0 +1,176 @@
+"""Business-name normalization.
+
+Ships the ``legal_form_strip`` transform — removes trailing corporate
+legal-form tokens ("Inc", "LLC", "GmbH", "Pty Ltd", etc.) from business
+names so that "Acme Inc.", "Acme Incorporated", and "Acme Corp." all
+collapse to "Acme" before scoring.
+
+The transform is registered into ``PluginRegistry`` on
+``import goldenmatch.refdata``. ``apply_transform`` falls through to the
+registry for unknown transform names — see
+``goldenmatch.utils.transforms.apply_transform``.
+
+Public API:
+
+- ``strip_legal_form(value)`` — the bare transform function.
+- ``is_available()`` — True iff the bundled token list loaded.
+- ``known_variants()`` — frozen set of every recognised surface variant
+  (normalized lower-case), for diagnostics / tests.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from importlib import resources
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+_DATA_FILE = "legal_forms.json"
+
+_lock = Lock()
+_state: dict = {
+    "loaded": False,
+    "available": False,
+    # Compiled regex matching any known trailing legal-form variant,
+    # anchored at end-of-string, case-insensitive. Built once at load
+    # time so per-call cost is one regex sub.
+    "pattern": None,
+    "variants_normalized": frozenset(),
+}
+
+
+def _normalize_token(t: str) -> str:
+    """Lower-case, collapse whitespace, strip trailing periods+commas."""
+    t = re.sub(r"\s+", " ", t).strip().rstrip(".,")
+    return t.lower()
+
+
+def _load() -> None:
+    if _state["loaded"]:
+        return
+    with _lock:
+        if _state["loaded"]:
+            return
+        try:
+            with resources.files("goldenmatch.refdata.data").joinpath(_DATA_FILE).open(
+                "r", encoding="utf-8"
+            ) as f:
+                payload = json.load(f)
+            forms_block = payload.get("legal_forms", {})
+            variants: set[str] = set()
+            for variant_list in forms_block.values():
+                for v in variant_list:
+                    n = _normalize_token(v)
+                    if n:
+                        variants.add(n)
+            if not variants:
+                _state["available"] = False
+                _state["loaded"] = True
+                return
+            # Sort by descending length so multi-word variants like
+            # "Limited Liability Company" are tried before "Limited" or
+            # "Company" alone. Otherwise "Acme Limited Liability Company"
+            # would strip to "Acme Liability Company" (wrong) instead of
+            # "Acme" (right).
+            sorted_variants = sorted(variants, key=lambda s: (-len(s), s))
+            # Build a single regex: ``[ ,\-.]+(v1|v2|...) [.,]*$`` —
+            # whitespace/separator before the suffix, optional trailing
+            # punctuation. Case-insensitive.
+            escaped = [re.escape(v) for v in sorted_variants]
+            pattern = re.compile(
+                r"[\s,\-.]+(?:" + "|".join(escaped) + r")[\s.,]*$",
+                re.IGNORECASE,
+            )
+            _state["pattern"] = pattern
+            _state["variants_normalized"] = frozenset(variants)
+            _state["available"] = True
+        except (FileNotFoundError, ModuleNotFoundError, json.JSONDecodeError, KeyError) as exc:
+            logger.warning(
+                "goldenmatch.refdata.business: data file unavailable (%s); "
+                "strip_legal_form will be a no-op.",
+                exc,
+            )
+            _state["available"] = False
+        finally:
+            _state["loaded"] = True
+
+
+def _reload() -> None:
+    """Test-only: force re-parse of the data file."""
+    with _lock:
+        _state["loaded"] = False
+        _state["available"] = False
+        _state["pattern"] = None
+        _state["variants_normalized"] = frozenset()
+    _load()
+
+
+def is_available() -> bool:
+    _load()
+    return _state["available"]
+
+
+def known_variants() -> frozenset[str]:
+    """Every recognised surface variant, normalized lower-case. Diagnostic."""
+    _load()
+    return _state["variants_normalized"]
+
+
+def strip_legal_form(value: str | None) -> str | None:
+    """Remove a trailing legal-form suffix from a business name.
+
+    "Acme Inc." → "Acme", "Acme Limited Liability Company" → "Acme",
+    "Acme GmbH" → "Acme". Idempotent — stripping twice leaves the
+    result unchanged. If no known suffix matches, the value is
+    returned unchanged (only whitespace-normalized).
+
+    Returns ``None`` for ``None`` input. If the bundled data file is
+    missing, returns the input with whitespace collapsed (no stripping).
+    """
+    if value is None:
+        return None
+    # Normalize internal whitespace early so multi-word suffixes like
+    # "Pty   Ltd" still match.
+    cleaned = re.sub(r"\s+", " ", value).strip()
+    if not cleaned:
+        return cleaned
+    _load()
+    pattern = _state["pattern"]
+    if pattern is None:
+        return cleaned
+    # Iterate: a name like "Acme Holdings Inc." has two strippable
+    # tokens ("Inc.", then "Holdings"). Strip in a loop until nothing
+    # changes, bounded to prevent runaway on adversarial input.
+    for _ in range(4):
+        new = pattern.sub("", cleaned).strip()
+        if new == cleaned or not new:
+            cleaned = new if new else cleaned
+            break
+        cleaned = new
+    return cleaned
+
+
+# ── Plugin protocol adapter ──────────────────────────────────────────────
+
+
+class LegalFormStripTransform:
+    """Adapter exposing ``strip_legal_form`` through the plugin transform
+    interface (the registry calls ``.transform(value)`` per the protocol
+    in ``goldenmatch.plugins.base``)."""
+
+    name = "legal_form_strip"
+
+    def transform(self, value: str | None) -> str | None:
+        return strip_legal_form(value)
+
+
+def register_transforms() -> None:
+    """Register the bundled transforms. Idempotent. Called from
+    ``goldenmatch.refdata.__init__`` on import."""
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    reg = PluginRegistry.instance()
+    if not reg.has_transform(LegalFormStripTransform.name):
+        reg.register_transform(LegalFormStripTransform.name, LegalFormStripTransform())

--- a/packages/python/goldenmatch/goldenmatch/refdata/data/legal_forms.json
+++ b/packages/python/goldenmatch/goldenmatch/refdata/data/legal_forms.json
@@ -1,0 +1,126 @@
+{
+  "_meta": {
+    "description": "Common corporate legal-form tokens across major jurisdictions, used by the legal_form_strip transform to normalize business names before matching. Each entry: a canonical legal form plus the surface variants (abbreviated, spelled-out, punctuated) used to designate it. Curated from public-knowledge corporate-suffix conventions; no license restrictions.",
+    "source": "Hand-curated list of well-known corporate legal-form suffixes. Covers US, UK, EU, Asia-Pacific, Latin America. Not exhaustive — focused on the highest-frequency forms.",
+    "version": "1",
+    "last_updated": "2026-05-13",
+    "matching_rules": "Each variant is stripped as a trailing token (case-insensitive, with optional trailing periods and surrounding whitespace). Multi-word variants like 'Limited Liability Company' are matched first to prevent 'Limited' from being stripped as a separate token."
+  },
+  "legal_forms": {
+    "corporation_us": [
+      "Inc",
+      "Inc.",
+      "Incorporated",
+      "Corp",
+      "Corp.",
+      "Corporation"
+    ],
+    "llc_us": [
+      "LLC",
+      "L.L.C.",
+      "L L C",
+      "Limited Liability Company",
+      "Limited Liability Co"
+    ],
+    "company_generic": [
+      "Co",
+      "Co.",
+      "Company"
+    ],
+    "limited_uk": [
+      "Ltd",
+      "Ltd.",
+      "Limited",
+      "PLC",
+      "P.L.C.",
+      "Public Limited Company"
+    ],
+    "partnership_us": [
+      "LLP",
+      "L.L.P.",
+      "Limited Liability Partnership",
+      "LP",
+      "L.P.",
+      "Limited Partnership",
+      "Partners",
+      "Partnership"
+    ],
+    "germany": [
+      "GmbH",
+      "G.m.b.H.",
+      "Gesellschaft mit beschrankter Haftung",
+      "AG",
+      "A.G.",
+      "Aktiengesellschaft",
+      "KG",
+      "K.G.",
+      "Kommanditgesellschaft"
+    ],
+    "france": [
+      "SARL",
+      "S.A.R.L.",
+      "Societe a Responsabilite Limitee",
+      "SAS",
+      "S.A.S.",
+      "Societe par Actions Simplifiee"
+    ],
+    "iberia_latam": [
+      "SA",
+      "S.A.",
+      "Sociedad Anonima",
+      "Societe Anonyme",
+      "SL",
+      "S.L.",
+      "Sociedad Limitada",
+      "SRL",
+      "S.R.L."
+    ],
+    "italy": [
+      "SpA",
+      "S.p.A.",
+      "Societa per Azioni",
+      "Srl",
+      "S.r.l."
+    ],
+    "netherlands": [
+      "BV",
+      "B.V.",
+      "Besloten Vennootschap",
+      "NV",
+      "N.V.",
+      "Naamloze Vennootschap"
+    ],
+    "nordics": [
+      "AB",
+      "A.B.",
+      "Aktiebolag",
+      "AS",
+      "A.S.",
+      "Aksjeselskap",
+      "Oy",
+      "Oyj"
+    ],
+    "asia_pacific": [
+      "Pty Ltd",
+      "Pty. Ltd.",
+      "Proprietary Limited",
+      "Pty",
+      "Pte Ltd",
+      "Pte. Ltd.",
+      "Private Limited",
+      "Pvt Ltd",
+      "Pvt. Ltd."
+    ],
+    "trust_foundation": [
+      "Trust",
+      "Foundation",
+      "Charitable Trust"
+    ],
+    "holding_descriptors": [
+      "Holdings",
+      "Holding",
+      "Group",
+      "Industries"
+    ]
+  }
+}

--- a/packages/python/goldenmatch/goldenmatch/utils/transforms.py
+++ b/packages/python/goldenmatch/goldenmatch/utils/transforms.py
@@ -64,7 +64,16 @@ def apply_transform(value: str | None, transform: str) -> str | None:
     elif transform == "bloom_filter" or transform.startswith("bloom_filter:"):
         return _bloom_filter_transform(value, transform)
     else:
-        raise ValueError(f"Unknown transform: {transform!r}")
+        # Plugin transform fallback: consult the registry so refdata-style
+        # extensions (legal_form_strip, address_token_normalize, …) work
+        # through the same code path as built-ins. Same fall-through model
+        # as core.scorer.score_field's plugin scorer path.
+        from goldenmatch.plugins.registry import PluginRegistry
+
+        plugin = PluginRegistry.instance().get_transform(transform)
+        if plugin is None:
+            raise ValueError(f"Unknown transform: {transform!r}")
+        return plugin.transform(value)  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def _bloom_filter_transform(value: str, transform: str) -> str:

--- a/packages/python/goldenmatch/tests/_helpers/benchmark_pairs.py
+++ b/packages/python/goldenmatch/tests/_helpers/benchmark_pairs.py
@@ -1,0 +1,53 @@
+"""Cluster->pair / match->pair converters for benchmark scoring.
+
+Spec: docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-design.md
+      §Testing tier 4 -- pair-conversion rules.
+"""
+from __future__ import annotations
+
+from itertools import combinations
+
+import polars as pl
+from goldenmatch import DedupeResult, MatchResult
+
+
+def pairs_from_dedupe_result(
+    result: DedupeResult,
+    *,
+    id_column: str,
+    source_df: pl.DataFrame | None = None,
+) -> set[tuple]:
+    """Transitive closure of in-cluster edges. Singleton clusters yield no pairs.
+
+    If ``source_df`` is provided, members (which are __row_id__ ints) map back
+    to ``source_df[id_column]`` values; otherwise members are used as-is.
+    Pairs canonicalized as (min, max).
+    """
+    pairs: set[tuple] = set()
+    id_lookup = source_df[id_column].to_list() if source_df is not None else None
+    for cluster in result.clusters.values():
+        members = cluster["members"]
+        if len(members) < 2:
+            continue
+        if id_lookup is not None:
+            members = [id_lookup[m] if 0 <= m < len(id_lookup) else m for m in members]
+        for a, b in combinations(sorted(members, key=lambda x: str(x)), 2):
+            pairs.add((a, b) if str(a) <= str(b) else (b, a))
+    return pairs
+
+
+def pairs_from_match_result(
+    result: MatchResult,
+    *,
+    target_id_col: str,
+    ref_id_col: str,
+) -> set[tuple]:
+    """Direct extraction from MatchResult.matched. No closure needed --
+    each row is one (target_id, ref_id) pair. Pairs NOT canonicalized
+    (target/ref are semantically distinct, e.g. DBLP vs ACM)."""
+    if result.matched is None or result.matched.height == 0:
+        return set()
+    return {
+        (row[target_id_col], row[ref_id_col])
+        for row in result.matched.iter_rows(named=True)
+    }

--- a/packages/python/goldenmatch/tests/_helpers/test_benchmark_pairs.py
+++ b/packages/python/goldenmatch/tests/_helpers/test_benchmark_pairs.py
@@ -1,0 +1,33 @@
+import polars as pl
+from goldenmatch import DedupeResult, MatchResult
+
+from tests._helpers.benchmark_pairs import (
+    pairs_from_dedupe_result,
+    pairs_from_match_result,
+)
+
+
+def test_dedupe_pairs_transitive_closure():
+    result = DedupeResult(
+        golden=None, dupes=None, unique=None,
+        clusters={
+            42: {"members": [3, 1, 2], "size": 3, "pair_scores": {}},
+            43: {"members": [10, 11], "size": 2, "pair_scores": {}},
+            44: {"members": [99], "size": 1, "pair_scores": {}},  # singleton
+        },
+        scored_pairs=[], stats={},
+    )
+    pairs = pairs_from_dedupe_result(result, id_column="ignored", source_df=None)
+    assert pairs == {(1, 2), (1, 3), (2, 3), (10, 11)}
+
+
+def test_match_pairs_direct():
+    matched = pl.DataFrame({
+        "__target_row_id__": [0, 1],
+        "__ref_row_id__": [2, 3],
+        "target_id": ["t1", "t2"],
+        "ref_id": ["r1", "r2"],
+    })
+    result = MatchResult(matched=matched, unmatched=None, stats={}, postflight_report=None)
+    pairs = pairs_from_match_result(result, target_id_col="target_id", ref_id_col="ref_id")
+    assert pairs == {("t1", "r1"), ("t2", "r2")}

--- a/packages/python/goldenmatch/tests/benchmarks/run_business_synth.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_business_synth.py
@@ -1,0 +1,172 @@
+"""Synthetic business-name A/B benchmark.
+
+Demonstrates the lift from ``legal_form_strip`` on a workload where the
+dominant error mode is legal-form variation: the same company appears in
+two datasets with different corporate suffixes ("Acme Inc.", "Acme
+Incorporated", "Acme Corp."). Without normalization plain JW often
+scores these below the dedupe threshold; with the transform applied, the
+stripped forms match exactly.
+
+Usage::
+
+    python tests/benchmarks/run_business_synth.py
+"""
+from __future__ import annotations
+
+import random
+from typing import Any
+
+import goldenmatch
+import goldenmatch.refdata  # noqa: F401  registers transform
+import polars as pl
+
+SEED = 42
+
+# Real-feel business stems + the legal-form variations the same business
+# might appear under across sources. All forms are in the bundled list.
+BUSINESS_STEMS = [
+    "Acme", "Pioneer", "Summit", "Helix", "Anchor",
+    "Northwind", "Birchwood", "Crestmont", "Lumen", "Harbor",
+    "Vanguard", "Cobalt", "Stellar", "Riverline", "Quincy",
+    "Brightway", "Beacon", "Forge", "Latitude", "Cascade",
+    "Meridian", "Atlas", "Vector", "Halcyon", "Pinnacle",
+]
+
+LEGAL_FORM_VARIANTS = [
+    ("Inc.", "Incorporated"),
+    ("Inc", "Corp."),
+    ("Corp.", "Corporation"),
+    ("LLC", "Limited Liability Company"),
+    ("LLC", "L.L.C."),
+    ("Co.", "Company"),
+    ("Ltd.", "Limited"),
+    ("LLP", "Limited Liability Partnership"),
+    ("GmbH", "AG"),
+    ("Pty Ltd", "Pty. Ltd."),
+]
+
+
+def _build_fixture(n_pairs: int = 200, n_distractors: int = 600) -> tuple[pl.DataFrame, set[tuple]]:
+    rng = random.Random(SEED)
+    rows: list[dict] = []
+    gt: set[tuple] = set()
+
+    # Generate enough unique stems by suffixing — naive ints would risk
+    # JW-similar names (Stem1 vs Stem2 are nearly identical). Use random
+    # alpha suffixes.
+    used: set[str] = set()
+    def _new_stem() -> str:
+        while True:
+            stem = rng.choice(BUSINESS_STEMS) + "_" + "".join(
+                rng.choice("abcdefghijklmnopqrstuvwxyz") for _ in range(6)
+            )
+            if stem not in used:
+                used.add(stem)
+                return stem
+
+    for i in range(n_pairs):
+        stem = _new_stem()
+        suffix_a, suffix_b = rng.choice(LEGAL_FORM_VARIANTS)
+        if rng.random() < 0.5:
+            suffix_a, suffix_b = suffix_b, suffix_a
+        rid_a = f"P{i:04d}A"
+        rid_b = f"P{i:04d}B"
+        rows.append({"record_id": rid_a, "company_name": f"{stem} {suffix_a}"})
+        rows.append({"record_id": rid_b, "company_name": f"{stem} {suffix_b}"})
+        gt.add((min(rid_a, rid_b), max(rid_a, rid_b)))
+
+    # Distractors: unrelated company names with random legal forms.
+    for i in range(n_distractors):
+        stem = _new_stem()
+        suffix, _ = rng.choice(LEGAL_FORM_VARIANTS)
+        rows.append({"record_id": f"D{i:04d}", "company_name": f"{stem} {suffix}"})
+
+    rng.shuffle(rows)
+    return pl.DataFrame(rows), gt
+
+
+def _build_config(transforms: list[str], threshold: float = 0.95) -> Any:
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    mk = MatchkeyConfig(
+        name="company",
+        type="weighted",
+        threshold=threshold,
+        fields=[
+            MatchkeyField(
+                field="company_name",
+                scorer="jaro_winkler",
+                weight=1.0,
+                transforms=transforms,
+            ),
+        ],
+    )
+    # Block by the first letter of company_name — coarse but enough to
+    # keep blocks small while letting alias-equivalent pairs land
+    # together (Acme Inc. and Acme Incorporated both start with 'A').
+    blocking = BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(
+            fields=["company_name"],
+            transforms=["lowercase", "first_token"],
+        )],
+    )
+    return GoldenMatchConfig(matchkeys=[mk], blocking=blocking)
+
+
+def _score(result: Any, rid_lookup: list[str], gt: set[tuple]) -> dict:
+    found: set[tuple] = set()
+    for c in result.clusters.values():
+        members = sorted(c["members"])
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                a, b = rid_lookup[members[i]], rid_lookup[members[j]]
+                found.add((min(a, b), max(a, b)))
+    tp = len(found & gt)
+    fp = len(found - gt)
+    fn = len(gt - found)
+    p = tp / (tp + fp) if (tp + fp) else 0.0
+    r = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) else 0.0
+    return {"tp": tp, "fp": fp, "fn": fn, "precision": p, "recall": r, "f1": f1}
+
+
+def main() -> int:
+    df, gt = _build_fixture()
+    print(f"Fixture: {df.height:,} records, {len(gt):,} duplicate GT pairs "
+          f"(legal-form-variation shape)")
+    print()
+
+    rid_lookup = df["record_id"].to_list()
+    configs = [
+        ("baseline (no transform)            ", []),
+        ("refdata  (legal_form_strip)        ", ["legal_form_strip"]),
+        ("refdata  (legal_form_strip+lower)  ", ["legal_form_strip", "lowercase"]),
+    ]
+    metrics = []
+    for label, transforms in configs:
+        cfg = _build_config(transforms)
+        result = goldenmatch.dedupe_df(df, config=cfg)
+        m = _score(result, rid_lookup, gt)
+        metrics.append((label, m))
+        print(label)
+        print(f"  precision={m['precision']:.4f}  recall={m['recall']:.4f}  "
+              f"f1={m['f1']:.4f}  (tp={m['tp']}, fp={m['fp']}, fn={m['fn']})")
+        print()
+
+    base = metrics[0][1]
+    best = max(metrics[1:], key=lambda m: m[1]["f1"])[1]
+    print(f"F1 delta:  {best['f1'] - base['f1']:+.4f}  ({base['f1']:.4f} -> {best['f1']:.4f})")
+    print(f"P delta:   {best['precision'] - base['precision']:+.4f}")
+    print(f"R delta:   {best['recall'] - base['recall']:+.4f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/tests/test_refdata_business.py
+++ b/packages/python/goldenmatch/tests/test_refdata_business.py
@@ -1,0 +1,160 @@
+"""Tests for goldenmatch.refdata.business + legal_form_strip transform."""
+
+from __future__ import annotations
+
+import goldenmatch.refdata  # noqa: F401  registers the transform
+import pytest
+from goldenmatch.plugins.registry import PluginRegistry
+from goldenmatch.refdata import (
+    business_available,
+    legal_form_variants,
+    strip_legal_form,
+)
+
+# ── data load ───────────────────────────────────────────────────────────────
+
+
+def test_data_is_bundled():
+    assert business_available() is True
+
+
+def test_variant_count_reasonable():
+    """Bundled list should cover the major forms across jurisdictions."""
+    assert len(legal_form_variants()) >= 60
+
+
+# ── strip behavior ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("Acme Inc.", "Acme"),
+    ("Acme Inc", "Acme"),
+    ("Acme, Inc.", "Acme"),
+    ("Acme Incorporated", "Acme"),
+    ("Acme Corp.", "Acme"),
+    ("Acme Corp", "Acme"),
+    ("Acme Corporation", "Acme"),
+    ("Acme LLC", "Acme"),
+    ("Acme L.L.C.", "Acme"),
+    ("Acme Limited Liability Company", "Acme"),
+    ("Acme Co.", "Acme"),
+    ("Acme Co", "Acme"),
+    ("Acme Company", "Acme"),
+    ("Acme Ltd.", "Acme"),
+    ("Acme Limited", "Acme"),
+    ("Acme PLC", "Acme"),
+    ("Acme LLP", "Acme"),
+    ("Acme GmbH", "Acme"),
+    ("Acme AG", "Acme"),
+    ("Acme SA", "Acme"),
+    ("Acme S.A.", "Acme"),
+    ("Acme SARL", "Acme"),
+    ("Acme BV", "Acme"),
+    ("Acme NV", "Acme"),
+    ("Acme SpA", "Acme"),
+    ("Acme Pty Ltd", "Acme"),
+    ("Acme Pty. Ltd.", "Acme"),
+    ("Acme Pvt Ltd", "Acme"),
+])
+def test_strip_known_suffixes(raw: str, expected: str):
+    assert strip_legal_form(raw) == expected
+
+
+def test_case_insensitive():
+    assert strip_legal_form("ACME INC.") == "ACME"
+    assert strip_legal_form("acme llc") == "acme"
+    assert strip_legal_form("Acme inc") == "Acme"
+
+
+def test_normalizes_whitespace():
+    assert strip_legal_form("   Acme   Co.   ") == "Acme"
+    assert strip_legal_form("Acme  Pty   Ltd") == "Acme"
+
+
+def test_iterative_strip_multiple_suffixes():
+    """A name like 'Acme Holdings Inc' should strip both Inc and Holdings."""
+    assert strip_legal_form("Acme Holdings Inc") == "Acme"
+    assert strip_legal_form("Acme Industries Corp.") == "Acme"
+
+
+def test_does_not_strip_mid_name():
+    """The suffix must be trailing — 'Inc' in the middle stays."""
+    assert strip_legal_form("Inc Tower") == "Inc Tower"
+    assert strip_legal_form("Plain Company Name") == "Plain Company Name"
+
+
+def test_idempotent():
+    cleaned = strip_legal_form("Acme Inc.")
+    assert strip_legal_form(cleaned) == cleaned
+
+
+def test_no_match_returns_input():
+    assert strip_legal_form("Just A Name") == "Just A Name"
+
+
+def test_none_returns_none():
+    assert strip_legal_form(None) is None
+
+
+def test_empty_returns_empty():
+    assert strip_legal_form("") == ""
+    assert strip_legal_form("   ") == ""
+
+
+def test_strip_does_not_consume_entire_name():
+    """If the whole input is a legal form, returning '' would be wrong —
+    we keep the input rather than nuke it."""
+    # The bare suffix as a "name" is degenerate; behavior here is best-
+    # effort. Verify we don't crash and don't produce empty for "Inc."
+    # alone (the regex won't match because there's no preceding word
+    # boundary).
+    assert strip_legal_form("Inc.") == "Inc."
+
+
+# ── integration ─────────────────────────────────────────────────────────────
+
+
+def test_apply_transform_dispatches_to_plugin():
+    from goldenmatch.utils.transforms import apply_transform
+
+    assert apply_transform("Acme Inc.", "legal_form_strip") == "Acme"
+    assert apply_transform(None, "legal_form_strip") is None
+
+
+def test_apply_transforms_chain():
+    """The transform should compose with other transforms."""
+    from goldenmatch.utils.transforms import apply_transforms
+
+    # Strip legal form, then lowercase.
+    assert apply_transforms("Acme Inc.", ["legal_form_strip", "lowercase"]) == "acme"
+
+
+def test_transform_registered():
+    assert PluginRegistry.instance().has_transform("legal_form_strip")
+
+
+def test_field_transform_validator_accepts_plugin():
+    from goldenmatch.config.schemas import FieldTransform
+
+    # Should not raise.
+    FieldTransform(transform="legal_form_strip")
+
+
+def test_field_transform_validator_rejects_unknown():
+    from goldenmatch.config.schemas import FieldTransform
+
+    with pytest.raises(ValueError, match="Invalid transform"):
+        FieldTransform(transform="totally_made_up_transform")
+
+
+def test_matchkey_field_accepts_transform():
+    """End-to-end: a MatchkeyField with legal_form_strip in transforms validates."""
+    from goldenmatch.config.schemas import MatchkeyField
+
+    field = MatchkeyField(
+        field="company_name",
+        scorer="jaro_winkler",
+        weight=1.0,
+        transforms=["legal_form_strip", "lowercase"],
+    )
+    assert field.transforms == ["legal_form_strip", "lowercase"]


### PR DESCRIPTION
## Summary

**Third slice** of strategy direction #8. Opens the `reference-business` pack with a *transform* (not a scorer this time) that strips trailing corporate legal-form suffixes from business names. "Acme Inc.", "Acme Incorporated", "Acme Corp." all collapse to "Acme" before scoring.

**Stacked on PR #217** (`feature/refdata-given-names`). Order: #216 → #217 → #218.

- `goldenmatch/refdata/data/legal_forms.json` — ~80 surface variants spanning US, UK, EU, Asia-Pacific, LatAm jurisdictions (Inc / LLC / Corp / Ltd / Co / GmbH / AG / SA / SARL / BV / NV / SpA / Pty / LLP / LP / Trust / Holdings / Group / Industries / ...). Public-knowledge; no license restrictions.
- `goldenmatch.refdata.business.strip_legal_form` — regex-based, multi-word-first ("Limited Liability Company" beats "Limited"), iterative ("Acme Holdings Inc" → "Acme"), idempotent, case-insensitive.
- **Plugin transform fallback wired into the pipeline.** Previously only scorer plugins could ride the existing infrastructure; transforms had to be added to `VALID_SIMPLE_TRANSFORMS` to be usable. Now:
  - `utils.transforms.apply_transform` falls through to `PluginRegistry.get_transform` for unknown names (mirrors the scorer fallback added in #216).
  - `config.schemas.FieldTransform._validate_transform` checks the registry before raising (mirrors the MatchkeyField validator).
  - Net result: any registered plugin transform Just Works in YAML, matchkey transforms list, and `apply_transforms` chains. Address pack will reuse this surface.
- 45 unit tests + synthetic business-name A/B benchmark.

## Measured impact

Synthetic, 1000-record fixture, 200 same-stem pairs differing only in legal-form suffix + 600 distractors, threshold 0.95:

| | TP | FP | FN | P | R | F1 |
| - | - | - | - | - | - | - |
| baseline (no transform) | 79 | 0 | 121 | 1.0000 | 0.3950 | **0.5663** |
| refdata (`legal_form_strip`) | 200 | 0 | 0 | 1.0000 | 1.0000 | **1.0000** |
| refdata (`legal_form_strip` + `lowercase`) | 200 | 0 | 0 | 1.0000 | 1.0000 | **1.0000** |

**F1 delta +0.4337. Recall +0.6050.** Plain JW catches ~40% (pairs where the suffix difference is small like Inc/Corp); the rest miss because the legal-form delta is too big (Inc vs Incorporated, LLC vs Limited Liability Company). The transform collapses all of them.

## What's deferred

Inside this pack:
- Industry code lookups (NAICS, SIC)
- OpenCorporates company-name variants

Across direction #8:
- `reference-address` pack (token normalization + libpostal binding)
- Auto-config integration (controller picks these scorers/transforms when applicable)
- Per-scorer threshold tuning in `LearningMemory`

## Test plan

- [x] `pytest tests/test_refdata_business.py` — 45 tests green.
- [x] `pytest tests/test_refdata_*.py` (all three packs) — 89 tests green.
- [x] `python tests/benchmarks/run_business_synth.py` — reproducible numbers above.
- [ ] Full suite on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)