### PR TITLE
feat(refdata): gate autoconfig refinements on ColumnProfile.col_type

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Changed -- Refdata autoconfig hook gates on ColumnProfile.col_type (strategy direction #8, ninth slice)
+
+Finishes the deferred slice from #8. Refdata refinements (surname scorer swap, given-name alias scorer swap, legal-form-strip, address-normalize, NAICS-normalize) now consult the profiled data shape, not just the column name. A column literally named `last_name` but holding numeric IDs, dates, or hashed identifiers no longer gets its scorer silently swapped — the swap was previously a quality regression on those shapes, hidden behind the column-name match.
+
+- **`refine_matchkey_field()`** gains an optional `col_type: str | None = None` parameter. Per-rule accept-lists: name swaps require `col_type in {"name", "multi_name"}`; company `legal_form_strip` accepts `{"name", "multi_name", "description", "string"}` (free-text company names sometimes profile as description/string); address `address_normalize` accepts `{"address", "string"}`; NAICS `naics_normalize` accepts `{"identifier", "numeric", "string", "description"}` (NAICS codes commonly land as identifier or numeric).
+- **`col_type=None` preserves the legacy name-only behavior** so callers without a profile (ad-hoc use, tests) don't change shape.
+- **Call sites in `core/autoconfig.py`** at both `build_matchkeys()` and `build_probabilistic_matchkeys()` now pass `p.col_type` from the `ColumnProfile`.
+- **Tests** in `tests/test_refdata_autoconfig.py` cover the gate firing and skipping for each refinement, the `None` backwards-compat path, and end-to-end via `build_matchkeys()` on a synthetic frame where `last_name` holds numeric data — the surname scorer should NOT fire.
+
 ### Changed -- Refdata cross-pack cleanup (strategy direction #8, eighth slice)
 
 Refactor-only PR — no behavior change to any user-facing surface. Addresses the systemic findings from the parallel review of slices #1–#7. Five refdata modules (surnames, given_names, business, addresses, industries) plus the plugin registry are touched in one coordinated change.

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -52,7 +52,10 @@ except Exception as _refdata_import_exc:  # noqa: BLE001 — see comment above
     )
 
     def _refdata_refine_matchkey_field(
-        column_name: str, scorer: str, transforms: list[str],
+        column_name: str,
+        scorer: str,
+        transforms: list[str],
+        col_type: str | None = None,
     ) -> tuple[str, list[str]]:
         return scorer, transforms
 
@@ -593,8 +596,12 @@ def build_matchkeys(
         # imported or the relevant pack's data file is missing — the
         # module-top fallback at line ~38 wires a pass-through stub for
         # that case. Lift numbers per refdata pack are in CHANGELOG
-        # entries for slices #2-#5.
-        scorer, transforms = _refdata_refine_matchkey_field(p.name, scorer, transforms)
+        # entries for slices #2-#5. ``p.col_type`` gates each refinement
+        # on the profiled data shape so a column literally named
+        # ``last_name`` but holding non-name data isn't silently swapped.
+        scorer, transforms = _refdata_refine_matchkey_field(
+            p.name, scorer, transforms, p.col_type,
+        )
 
         # Geo and zip are blocking signals, NOT identity claims. An exact
         # matchkey on a city column asserts "two records sharing a city are
@@ -1835,7 +1842,9 @@ def build_probabilistic_matchkeys(profiles: list[ColumnProfile]) -> list[Matchke
 
         # Refdata hook (mirrors build_matchkeys); see module-top fallback
         # for the unavailable-refdata case.
-        scorer, transforms = _refdata_refine_matchkey_field(p.name, scorer, transforms)
+        scorer, transforms = _refdata_refine_matchkey_field(
+            p.name, scorer, transforms, p.col_type,
+        )
 
         # Determine comparison levels based on scorer type
         if scorer == "exact":

--- a/packages/python/goldenmatch/goldenmatch/refdata/autoconfig_hooks.py
+++ b/packages/python/goldenmatch/goldenmatch/refdata/autoconfig_hooks.py
@@ -32,6 +32,14 @@ Refinements 3-5 prepend rather than replace, so the original
 ``lowercase``/``strip`` chain still runs after the refdata transform
 collapses the trailing tokens — preserves backwards compat for
 downstream blocking-key derivation.
+
+Data-shape gating: callers that have a ``ColumnProfile`` should pass
+``col_type`` so refinements only fire when the profiled data shape
+agrees with the column-name regex. A column literally named
+``last_name`` but holding numeric IDs (``col_type='numeric'``) keeps
+its caller-specified scorer — without this guard the swap silently
+degrades quality. ``col_type=None`` keeps the legacy name-only
+behavior for callers that don't have a profile (tests, ad-hoc use).
 """
 from __future__ import annotations
 
@@ -112,16 +120,35 @@ def _industries_available() -> bool:
         return False
 
 
+# col_type values (from ColumnProfile) that are compatible with each
+# refinement. The classifier sometimes routes free-text company names
+# to "description" / "string" rather than "name", and NAICS codes
+# often land as "identifier" or "numeric" — keep these accept-lists
+# permissive enough to not regress on real shapes, but tight enough
+# to reject obvious mismatches (numeric data in a column named
+# `last_name`, etc.).
+_NAME_TYPES = frozenset({"name", "multi_name"})
+_COMPANY_TYPES = frozenset({"name", "multi_name", "description", "string"})
+_ADDRESS_TYPES = frozenset({"address", "string"})
+_INDUSTRY_TYPES = frozenset({"identifier", "numeric", "string", "description"})
+
+
 def refine_matchkey_field(
     column_name: str,
     scorer: str,
     transforms: list[str],
+    col_type: str | None = None,
 ) -> tuple[str, list[str]]:
     """Return a refdata-aware ``(scorer, transforms)`` tuple.
 
     Falls back to the input on any of: refdata not imported, the
     relevant pack's data file missing, no pattern match. Safe to call
     on every column unconditionally.
+
+    ``col_type`` — when provided, gates each refinement on the profiled
+    data shape so a column literally named ``last_name`` but holding
+    non-name data (numeric IDs, dates) isn't silently degraded by a
+    scorer swap. ``None`` preserves the legacy name-only behavior.
     """
     refined_scorer = scorer
     refined_transforms = list(transforms)  # copy — don't mutate caller's list
@@ -133,7 +160,8 @@ def refine_matchkey_field(
     string_sim_scorers = {
         "jaro_winkler", "levenshtein", "token_sort", "ensemble", "dice", "jaccard",
     }
-    if scorer in string_sim_scorers:
+    name_shape_ok = col_type is None or col_type in _NAME_TYPES
+    if scorer in string_sim_scorers and name_shape_ok:
         if _LAST_NAME_RE.search(column_name) and _surnames_available():
             refined_scorer = "name_freq_weighted_jw"
         elif _FIRST_NAME_RE.search(column_name) and _given_names_available():
@@ -143,16 +171,31 @@ def refine_matchkey_field(
     # e.g. a "company_last_name" column gets both. Prepend rather than
     # append so the existing lowercase/strip chain runs after our
     # canonicalization.
-    if _COMPANY_NAME_RE.search(column_name) and _business_available():
-        if "legal_form_strip" not in refined_transforms:
-            refined_transforms.insert(0, "legal_form_strip")
+    company_shape_ok = col_type is None or col_type in _COMPANY_TYPES
+    if (
+        company_shape_ok
+        and _COMPANY_NAME_RE.search(column_name)
+        and _business_available()
+        and "legal_form_strip" not in refined_transforms
+    ):
+        refined_transforms.insert(0, "legal_form_strip")
 
-    if _ADDRESS_RE.search(column_name) and _addresses_available():
-        if "address_normalize" not in refined_transforms:
-            refined_transforms.insert(0, "address_normalize")
+    address_shape_ok = col_type is None or col_type in _ADDRESS_TYPES
+    if (
+        address_shape_ok
+        and _ADDRESS_RE.search(column_name)
+        and _addresses_available()
+        and "address_normalize" not in refined_transforms
+    ):
+        refined_transforms.insert(0, "address_normalize")
 
-    if _INDUSTRY_RE.search(column_name) and _industries_available():
-        if "naics_normalize" not in refined_transforms:
-            refined_transforms.insert(0, "naics_normalize")
+    industry_shape_ok = col_type is None or col_type in _INDUSTRY_TYPES
+    if (
+        industry_shape_ok
+        and _INDUSTRY_RE.search(column_name)
+        and _industries_available()
+        and "naics_normalize" not in refined_transforms
+    ):
+        refined_transforms.insert(0, "naics_normalize")
 
     return refined_scorer, refined_transforms

--- a/packages/python/goldenmatch/tests/test_refdata_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_refdata_autoconfig.py
@@ -143,6 +143,131 @@ def test_build_matchkeys_picks_refdata_scorer_for_last_name():
     )
 
 
+# ── col_type gating ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("non_name_type", [
+    "numeric", "date", "identifier", "email", "phone", "zip", "geo",
+])
+def test_last_name_swap_skipped_when_coltype_disagrees(non_name_type: str):
+    """A column literally named ``last_name`` but holding non-name data
+    (numeric IDs, dates, hashed identifiers) keeps the caller-specified
+    scorer — without this guard the swap silently degrades quality."""
+    scorer, _ = refine_matchkey_field(
+        "last_name", "jaro_winkler", ["lowercase"], col_type=non_name_type,
+    )
+    assert scorer == "jaro_winkler"
+
+
+@pytest.mark.parametrize("non_name_type", [
+    "numeric", "date", "identifier", "email", "phone",
+])
+def test_first_name_swap_skipped_when_coltype_disagrees(non_name_type: str):
+    scorer, _ = refine_matchkey_field(
+        "first_name", "jaro_winkler", ["lowercase"], col_type=non_name_type,
+    )
+    assert scorer == "jaro_winkler"
+
+
+def test_last_name_swap_fires_when_coltype_agrees():
+    scorer, _ = refine_matchkey_field(
+        "last_name", "jaro_winkler", ["lowercase"], col_type="name",
+    )
+    assert scorer == "name_freq_weighted_jw"
+
+
+def test_first_name_swap_fires_when_coltype_agrees():
+    scorer, _ = refine_matchkey_field(
+        "first_name", "jaro_winkler", ["lowercase"], col_type="name",
+    )
+    assert scorer == "given_name_aliased_jw"
+
+
+def test_address_normalize_skipped_when_coltype_is_numeric():
+    """A column named ``address`` whose data profiles as numeric (e.g.
+    house-number-only) doesn't get the address tokenizer."""
+    _, transforms = refine_matchkey_field(
+        "address", "token_sort", ["strip"], col_type="numeric",
+    )
+    assert "address_normalize" not in transforms
+
+
+def test_address_normalize_fires_when_coltype_is_address():
+    _, transforms = refine_matchkey_field(
+        "address", "token_sort", ["strip"], col_type="address",
+    )
+    assert transforms[0] == "address_normalize"
+
+
+def test_legal_form_strip_skipped_when_coltype_is_numeric():
+    """``company_id`` columns sometimes profile as numeric; the legal-form
+    stripper would do nothing useful and may corrupt downstream blocking."""
+    _, transforms = refine_matchkey_field(
+        "company_name", "token_sort", ["strip"], col_type="numeric",
+    )
+    assert "legal_form_strip" not in transforms
+
+
+def test_legal_form_strip_fires_on_description_shaped_companies():
+    """Free-text company names sometimes profile as ``description`` rather
+    than ``name`` — keep the refinement firing on that shape."""
+    _, transforms = refine_matchkey_field(
+        "company_name", "token_sort", ["strip"], col_type="description",
+    )
+    assert "legal_form_strip" in transforms
+
+
+def test_naics_normalize_skipped_when_coltype_is_name():
+    """A column literally named ``industry`` but holding free-text people
+    names (col_type='name') shouldn't be coerced to a NAICS code."""
+    _, transforms = refine_matchkey_field(
+        "industry", "token_sort", ["strip"], col_type="name",
+    )
+    assert "naics_normalize" not in transforms
+
+
+def test_naics_normalize_fires_when_coltype_is_identifier():
+    _, transforms = refine_matchkey_field(
+        "naics_code", "exact", ["strip"], col_type="identifier",
+    )
+    assert "naics_normalize" in transforms
+
+
+def test_coltype_none_preserves_legacy_behavior():
+    """Backwards compat: callers without a profile (tests, ad-hoc use)
+    keep the original name-only matching when col_type is omitted."""
+    scorer, transforms = refine_matchkey_field("last_name", "jaro_winkler", [])
+    assert scorer == "name_freq_weighted_jw"
+
+
+def test_build_matchkeys_skips_refdata_swap_on_mistyped_last_name():
+    """End-to-end: a column named ``last_name`` whose data is numeric
+    should NOT get the surname scorer at auto-config time."""
+    import polars as pl
+    from goldenmatch.core.autoconfig import build_matchkeys, profile_columns
+
+    df = pl.DataFrame({
+        "last_name": [str(i) for i in range(1000, 1030)],  # numeric-looking IDs
+        "city": ["NYC", "LA"] * 15,
+    })
+    profiles = profile_columns(df)
+    last_name_profile = next(p for p in profiles if p.name == "last_name")
+    # Sanity check the premise: the classifier should NOT have called
+    # this a name. If it did, the test setup is wrong (not the gate).
+    assert last_name_profile.col_type != "name", (
+        f"profiler should not classify all-numeric data as a name; "
+        f"got col_type={last_name_profile.col_type!r}"
+    )
+    matchkeys = build_matchkeys(profiles, df=df)
+    all_scorers = {
+        f.scorer for mk in matchkeys for f in mk.fields if f.scorer
+    }
+    assert "name_freq_weighted_jw" not in all_scorers, (
+        f"refdata scorer should not fire when col_type disagrees; "
+        f"got {all_scorers}"
+    )
+
+
 def test_build_matchkeys_prepends_legal_form_strip_for_company():
     """A column named 'company_name' should pick up legal_form_strip."""
     import polars as pl


### PR DESCRIPTION
## Summary

Finishes the deferred slice from strategy direction #8. The refdata auto-config hook (`refine_matchkey_field`) previously fired its scorer swap / transform prepend on column-name regex alone. A column literally named `last_name` but holding numeric IDs would silently get `name_freq_weighted_jw` — a quality regression invisible to the user.

- `refine_matchkey_field()` now takes an optional `col_type: str | None = None` parameter.
- Per-rule accept-lists gate each refinement on the profiled shape (name swaps require `name`/`multi_name`; company `legal_form_strip` allows `name`/`multi_name`/`description`/`string`; address requires `address`/`string`; NAICS requires `identifier`/`numeric`/`string`/`description`).
- `col_type=None` preserves the legacy name-only behavior so existing tests and ad-hoc callers don't change shape.
- Both call sites in `core/autoconfig.py` (`build_matchkeys` + `build_probabilistic_matchkeys`) now pass `p.col_type`.

## Test plan

- [x] `pytest tests/test_refdata_autoconfig.py` — 68 passed (includes 12 new gating tests)
- [x] `pytest tests/test_refdata_industries.py tests/test_refdata_business.py tests/test_refdata_addresses.py tests/test_refdata_surnames.py tests/test_refdata_given_names.py tests/test_autoconfig.py tests/test_plugins.py` — 325 passed, 3 skipped
- [x] `ruff check` — passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)