### PR TITLE
fix(chunked): force Utf8 schema in scan_csv (was crashing on int-typed ZIP)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/chunked.py
+++ b/packages/python/goldenmatch/goldenmatch/core/chunked.py
@@ -179,11 +179,22 @@ class ChunkedMatcher:
         for older Polars versions that reject ``encoding=`` on the lazy
         path.
         """
+        # infer_schema_length=0 forces all columns to Utf8. Without this,
+        # scan_csv samples the first ~100 rows and may type a column as
+        # int64 (e.g. an all-numeric ZIP column whose later values are
+        # mixed-format strings). Downstream transforms like .lower() then
+        # fail on int values. The eager pl.read_csv() path didn't hit this
+        # because it scanned the whole file before inferring.
         try:
-            lf = pl.scan_csv(path, encoding="utf8-lossy", ignore_errors=True)
+            lf = pl.scan_csv(
+                path,
+                encoding="utf8-lossy",
+                ignore_errors=True,
+                infer_schema_length=0,
+            )
         except TypeError:
             # Some Polars versions don't accept encoding= on scan_csv.
-            lf = pl.scan_csv(str(path), ignore_errors=True)
+            lf = pl.scan_csv(str(path), ignore_errors=True, infer_schema_length=0)
 
         offset = 0
         while True:


### PR DESCRIPTION
## Summary

The 5M chunked dispatch ([run 25864350989](https://github.com/benzsevern/goldenmatch/actions/runs/25864350989)) crashed in 0.3s with:
\`\`\`
AttributeError: 'int' object has no attribute 'lower'
in col("zip").python_udf()
\`\`\`

Root cause: \`pl.scan_csv()\` infers schema from ~100 rows by default, so an all-numeric ZIP head gets typed as \`int64\`. Later transforms like \`lowercase\` then call \`.lower()\` on int values and crash. The pre-streaming \`pl.read_csv()\` path didn't hit this because it scanned the entire file before inferring.

Fix: pass \`infer_schema_length=0\` to \`scan_csv\` to force all columns to \`Utf8\`. Matches the pattern \`scripts/scale_audit_5m.py::_pairs_from_ground_truth\` already uses for the same reason.

## Test plan

- [x] 5 chunked tests pass locally
- [ ] CI green
- [ ] Re-dispatch 5M chunked run after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)