### PR TITLE
perf(bench): GHA-driven zero-config bench harness

### DIFF
--- a/.github/workflows/bench-zero-config.yml
+++ b/.github/workflows/bench-zero-config.yml
@@ -1,0 +1,159 @@
+# Zero-config dedupe bench — workflow_dispatch only.
+#
+# Captures the post-controller full-df wall + per-stage breakdown + cProfile
+# top for gm.dedupe_df(df) on a synthetic fixture. Targets the polars-direct
+# backend by default (the path real users hit when not overriding `backend`).
+# Spec: docs/superpowers/specs/2026-05-15-post-controller-full-df-perf-design.md
+#
+# Triggers on manual dispatch only — paid runner (ubuntu-latest-large,
+# 8c/32GB, ~$0.16/hr). A typical 500K run is ~25 min ($0.07).
+#
+# Outputs:
+#   - bench JSON (artifact)
+#   - cProfile dump (artifact, snakeviz-friendly)
+#   - install_paths in JSON to surface the "site-packages shadowing worktree"
+#     gotcha if pip install -e ever silently fails
+#   - Headline numbers in $GITHUB_STEP_SUMMARY
+#
+# To run: GitHub → Actions → "bench-zero-config" → Run workflow.
+name: bench-zero-config
+
+on:
+  workflow_dispatch:
+    inputs:
+      n_records:
+        description: "Synthetic fixture record count"
+        required: false
+        default: "500000"
+      runs:
+        description: "Wall-only runs for the median"
+        required: false
+        default: "5"
+      dupe_rate:
+        description: "Fraction of records that are duplicates (0..1)"
+        required: false
+        default: "0.15"
+      backend:
+        description: "Override backend (blank = controller default)"
+        required: false
+        default: ""
+      label:
+        description: "Tag for the output filename (e.g. 'post-pr239', 'post-attack-a')"
+        required: false
+        default: "ad-hoc"
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest-large  # 8 vCPU / 32 GB; paid runner
+    timeout-minutes: 180  # 3 hours; 500K typical ~30 min, 1M ~90 min
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+      # Pin the autoconfig backend threshold so 500K stays on polars-direct
+      # even if scale-aware routing thresholds shift in main. Override via the
+      # `backend` input below if measuring the duckdb path deliberately.
+      GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD: "10000000"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Editable-install goldenmatch (defensive)
+        # uv sync should already install the workspace member editable, but
+        # CLAUDE.md's "shadows worktree code" gotcha cost me an audit cycle —
+        # belt and braces. Verify the import path in the bench output too.
+        run: .venv/bin/python -m pip install -e packages/python/goldenmatch
+
+      - name: Verify worktree install
+        run: |
+          .venv/bin/python -c "import goldenmatch, goldenmatch.core.pipeline; \
+            assert 'packages/python/goldenmatch' in goldenmatch.__file__, \
+              f'goldenmatch resolves to {goldenmatch.__file__} — not the worktree'; \
+            print('worktree install OK:', goldenmatch.__file__)"
+
+      - name: Generate ${{ inputs.n_records }}-row fixture
+        run: |
+          mkdir -p .profile_tmp/scale_fixtures
+          .venv/bin/python scripts/scale_audit_5m_generate.py \
+            --n-records ${{ inputs.n_records }} \
+            --dupe-rate ${{ inputs.dupe_rate }} \
+            --output .profile_tmp/scale_fixtures/synthetic_bench.csv
+
+      - name: Report fixture stats
+        run: ls -lh .profile_tmp/scale_fixtures/synthetic_bench.csv
+
+      - name: Apply backend override (if set)
+        if: ${{ inputs.backend != '' }}
+        run: echo "GOLDENMATCH_AUTOCONFIG_BACKEND=${{ inputs.backend }}" >> $GITHUB_ENV
+
+      - name: Run bench
+        run: |
+          .venv/bin/python scripts/bench_1m_zero_config.py \
+            --fixture .profile_tmp/scale_fixtures/synthetic_bench.csv \
+            --runs ${{ inputs.runs }} \
+            --output .profile_tmp/bench_${{ inputs.label }}.json \
+            --cprofile-output .profile_tmp/bench_${{ inputs.label }}.prof \
+            --ref "${{ github.sha }}"
+
+      - name: Post headline to step summary
+        if: always()
+        run: |
+          if [ ! -f .profile_tmp/bench_${{ inputs.label }}.json ]; then
+            echo "no bench output — earlier step failed" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          .venv/bin/python - <<'PY' >> $GITHUB_STEP_SUMMARY
+          import json, os
+          label = os.environ["LABEL"]
+          p = f".profile_tmp/bench_{label}.json"
+          d = json.load(open(p))
+          print(f"# bench-zero-config ({label})")
+          print()
+          print(f"- fixture: `{d['fixture']}` ({d['n_rows']:,} rows)")
+          print(f"- ref: `{d['ref']}`")
+          print(f"- runs: {d['runs']}")
+          print()
+          print("## Wall (median over runs)")
+          print()
+          print(f"**{d['wall_seconds_median']:.1f}s** ({d['wall_seconds_min']:.1f}–{d['wall_seconds_max']:.1f}s)")
+          print()
+          timings = (d.get("stage_breakdown") or {}).get("timings", {})
+          if timings:
+              print("## bench_capture stage breakdown")
+              print()
+              print("| stage | seconds |")
+              print("|---|---|")
+              for name, secs in sorted(timings.items(), key=lambda kv: -kv[1]):
+                  print(f"| `{name}` | {secs:.2f} |")
+              print()
+          top = d.get("cprofile_top") or []
+          if top:
+              print("## cProfile top 10 (cumtime)")
+              print()
+              print("| cumtime | ncalls | func |")
+              print("|---|---|---|")
+              for row in top[:10]:
+                  print(f"| {row['cumtime_s']:.2f}s | {row['ncalls']:,} | `{row['func']}` |")
+          PY
+        env:
+          LABEL: ${{ inputs.label }}
+
+      - name: Upload bench artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: bench-zero-config-${{ inputs.label }}
+          path: |
+            .profile_tmp/bench_${{ inputs.label }}.json
+            .profile_tmp/bench_${{ inputs.label }}.prof
+          retention-days: 90

--- a/scripts/bench_1m_zero_config.py
+++ b/scripts/bench_1m_zero_config.py
@@ -1,0 +1,231 @@
+"""Bench gm.dedupe_df(df) zero-config (production caller path, _skip_finalize=True).
+
+Measures:
+- 5-run median total wall (no instrumentation overhead).
+- One run wrapped in bench_capture() for per-stage attribution (from
+  goldenmatch.core.bench, added by PR #239 — replaces the prior
+  monkey-patch approach which couldn't catch ``from X import Y`` call-site
+  bindings).
+- One cProfile pass to surface cross-stage primitives (LazyFrame.collect,
+  builtins.max — the hotspots stage-level timing can't see).
+
+Per CLAUDE.md performance-audit lesson: rank stages by measured wall, not
+cProfile cumtime. cProfile is the discovery surface for primitives; per-stage
+wall (from bench_capture) is the production-realistic attribution.
+
+Usage::
+
+    python scripts/bench_1m_zero_config.py \\
+        --fixture .profile_tmp/scale_fixtures/synthetic_500000_dupe15.csv \\
+        --runs 5 \\
+        --output .profile_tmp/bench_500k.json \\
+        --cprofile-output .profile_tmp/bench_500k.prof
+"""
+from __future__ import annotations
+
+import argparse
+import cProfile
+import json
+import pstats
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+
+def load_fixture(path: Path) -> pl.DataFrame:
+    df = pl.read_csv(path, ignore_errors=True, infer_schema_length=0)
+    if "cluster_id" in df.columns:
+        df = df.drop("cluster_id")
+    return df
+
+
+def time_dedupe(df: pl.DataFrame) -> float:
+    """One bare run of gm.dedupe_df(df) — no instrumentation, just wall."""
+    import goldenmatch as gm
+    t0 = time.perf_counter()
+    _ = gm.dedupe_df(df)
+    return time.perf_counter() - t0
+
+
+def run_with_bench_capture(df: pl.DataFrame) -> tuple[float, dict[str, Any]]:
+    """One run wrapped in bench_capture() for per-stage attribution.
+
+    Pipeline-level stages (auto_configure, exact_matching, fuzzy_scoring,
+    cluster, golden, identity_resolve) populate via the bench module's
+    in-pipeline wrappers added by PR #239. Worker-thread stages add to the
+    same recorder under the recorder's lock — safe.
+    """
+    import goldenmatch as gm
+    try:
+        from goldenmatch.core.bench import bench_capture  # pyright: ignore[reportMissingImports]
+    except ImportError:
+        # Older goldenmatch versions don't have core.bench; degrade gracefully.
+        wall = time_dedupe(df)
+        return wall, {"timings": {}, "metrics": {}, "note": "core.bench unavailable"}
+
+    t0 = time.perf_counter()
+    with bench_capture() as bench:
+        _ = gm.dedupe_df(df)
+    wall = time.perf_counter() - t0
+    return wall, bench.to_dict()
+
+
+def run_with_cprofile(df: pl.DataFrame, out_path: Path) -> tuple[float, list[dict[str, Any]]]:
+    import goldenmatch as gm
+    prof = cProfile.Profile()
+    t0 = time.perf_counter()
+    prof.enable()
+    _ = gm.dedupe_df(df)
+    prof.disable()
+    wall = time.perf_counter() - t0
+    prof.dump_stats(str(out_path))
+
+    stats = pstats.Stats(prof).strip_dirs().sort_stats("cumulative")
+    raw = getattr(stats, "stats", {})
+    top: list[dict[str, Any]] = []
+    for func, entry in raw.items():
+        # entry = (cc, nc, tt, ct, callers)
+        _cc, nc, tt, ct, _callers = entry
+        filename, lineno, name = func
+        top.append({
+            "func": f"{Path(filename).name}:{lineno}:{name}",
+            "ncalls": nc,
+            "tottime_s": round(tt, 4),
+            "cumtime_s": round(ct, 4),
+        })
+    top.sort(key=lambda r: -r["cumtime_s"])
+    return wall, top[:30]
+
+
+def _verify_install(verbose: bool) -> dict[str, str]:
+    """Confirm goldenmatch resolves to the worktree, not site-packages.
+
+    Returns paths for diagnostics. The CI workflow's `pip install -e` step
+    keeps site-packages out of the picture, but local runs can silently
+    measure the wrong code (per CLAUDE.md "shadows worktree" gotcha) — this
+    surfaces it.
+    """
+    import goldenmatch
+    import goldenmatch._api
+    import goldenmatch.core.pipeline
+    paths = {
+        "goldenmatch.__file__":             str(goldenmatch.__file__),
+        "goldenmatch._api.__file__":        str(goldenmatch._api.__file__),
+        "goldenmatch.core.pipeline.__file__": str(goldenmatch.core.pipeline.__file__),
+    }
+    if verbose:
+        print("install paths:")
+        for k, v in paths.items():
+            print(f"  {k} = {v}")
+    return paths
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--fixture",
+        type=Path,
+        default=Path(".profile_tmp/scale_fixtures/synthetic_500000_dupe15.csv"),
+    )
+    ap.add_argument("--runs", type=int, default=5,
+                    help="wall-only runs for the median (default 5)")
+    ap.add_argument(
+        "--output",
+        type=Path,
+        default=Path(".profile_tmp/bench_zero_config.json"),
+    )
+    ap.add_argument(
+        "--cprofile-output",
+        type=Path,
+        default=Path(".profile_tmp/bench_zero_config.prof"),
+    )
+    ap.add_argument("--skip-cprofile", action="store_true",
+                    help="skip the cProfile pass (~20-30%% overhead)")
+    ap.add_argument("--skip-stages", action="store_true",
+                    help="skip the bench_capture() per-stage run")
+    ap.add_argument("--ref", default=None,
+                    help="git ref this bench is measuring (logged into the JSON; "
+                         "set by CI to keep results traceable)")
+    args = ap.parse_args()
+
+    if not args.fixture.exists():
+        sys.exit(f"fixture not found: {args.fixture}")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    install_paths = _verify_install(verbose=True)
+
+    print(f"Loading {args.fixture}...")
+    df = load_fixture(args.fixture)
+    print(f"  {df.height:,} rows x {df.width} cols")
+
+    # 1) Wall-only median.
+    walls: list[float] = []
+    for i in range(args.runs):
+        print(f"[wall run {i+1}/{args.runs}] starting...")
+        wall = time_dedupe(df)
+        walls.append(wall)
+        print(f"  wall={wall:.2f}s")
+
+    median = statistics.median(walls)
+    print(f"\nmedian wall ({args.runs} runs): {median:.2f}s  "
+          f"({min(walls):.2f}-{max(walls):.2f}s)")
+
+    # 2) bench_capture() per-stage run.
+    stage_dict: dict[str, Any] = {}
+    stage_wall: float | None = None
+    if not args.skip_stages:
+        print("\n[stages run] starting (bench_capture)...")
+        stage_wall, stage_dict = run_with_bench_capture(df)
+        timings = stage_dict.get("timings", {})
+        print(f"  wall={stage_wall:.2f}s  ({len(timings)} stages recorded)")
+        for name, secs in sorted(timings.items(), key=lambda kv: -kv[1]):
+            pct = 100.0 * secs / stage_wall if stage_wall else 0.0
+            print(f"  {name:<40s} {secs:>8.2f}s  ({pct:5.1f}%)")
+        metrics = stage_dict.get("metrics", {})
+        if metrics:
+            print("  metrics:")
+            for k, v in sorted(metrics.items()):
+                print(f"    {k} = {v}")
+
+    # 3) cProfile pass.
+    cprofile_top: list[dict[str, Any]] = []
+    cprofile_wall: float | None = None
+    if not args.skip_cprofile:
+        print(f"\n[cprofile run] starting (output -> {args.cprofile_output})...")
+        cprofile_wall, cprofile_top = run_with_cprofile(df, args.cprofile_output)
+        print(f"  wall={cprofile_wall:.2f}s (cProfile adds ~20-30%% overhead)")
+        print("  top 10 by cumtime:")
+        for row in cprofile_top[:10]:
+            print(f"    {row['cumtime_s']:>8.2f}s  "
+                  f"ncalls={row['ncalls']:>10d}  {row['func']}")
+
+    report = {
+        "fixture":                       str(args.fixture),
+        "ref":                           args.ref,
+        "install_paths":                 install_paths,
+        "n_rows":                        df.height,
+        "n_cols":                        df.width,
+        "runs":                          args.runs,
+        "wall_seconds_runs":             [round(w, 3) for w in walls],
+        "wall_seconds_median":           round(median, 3),
+        "wall_seconds_min":              round(min(walls), 3),
+        "wall_seconds_max":              round(max(walls), 3),
+        "stage_breakdown_wall_seconds": stage_wall,
+        "stage_breakdown":               stage_dict,    # {timings, metrics}
+        "cprofile_wall_seconds":         cprofile_wall,
+        "cprofile_top":                  cprofile_top,
+        "cprofile_dump": (
+            str(args.cprofile_output) if not args.skip_cprofile else None
+        ),
+    }
+    args.output.write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scale_audit_5m.py
+++ b/scripts/scale_audit_5m.py
@@ -119,13 +119,31 @@ def run_audit(
     poller = threading.Thread(target=_poll_rss_mb, args=(stop, peak_rss), daemon=True)
     poller.start()
 
-    print("Auto-configuring (GoldenCheck quality scan disabled — not what we're benchmarking)...")
-    config = gm.auto_configure_df(df)
+    # Build a quality-disabled config WITHOUT running auto_configure_df
+    # explicitly — that would trigger the controller's _finalize full-df run,
+    # producing a 2× full-pipeline measurement (controller finalize + caller
+    # dedupe). Instead, let gm.dedupe_df() do zero-config internally: its
+    # zero-config branch passes _skip_finalize=True so the controller only
+    # runs on samples and the caller's run is the single full-df pass.
+    #
+    # Quality-scan disable still needs to happen — pre-bake a config carrying
+    # only the quality flag + duckdb backend; let dedupe_df fill the rest via
+    # its zero-config path. Cleanest way: hand dedupe_df the bare minimum and
+    # rely on its internal auto_configure_df(_skip_finalize=True) call.
+    from goldenmatch.config.schemas import QualityConfig
+    # NOTE: GoldenMatchConfig with no matchkeys still triggers zero-config in
+    # dedupe_df only when config is None. Passing a partial config bypasses
+    # auto-config entirely. So: run dedupe_df(df) zero-config, then apply
+    # backend + quality overrides post-controller via a thin wrapper.
+    print("Running dedupe zero-config (controller skips finalize; single full-df pass)...")
+    # Pre-config quality + backend via env-style override on the controller's
+    # committed config: easiest path is to call auto_configure_df ourselves
+    # with _skip_finalize=True (no double-run), tweak, then dedupe_df.
+    config = gm.auto_configure_df(df, _skip_finalize=True)
     config.backend = "duckdb"
     if config.quality is not None:
         config.quality.mode = "disabled"
     else:
-        from goldenmatch.config.schemas import QualityConfig
         config.quality = QualityConfig(mode="disabled")
 
     print("Running dedupe (backend=duckdb)...")


### PR DESCRIPTION
## Summary

Adds a workflow_dispatch GHA bench harness for the post-controller full-df dedupe path. Used as the measurement gate for the upcoming Attacks A + B (BlockResult positional contract + cluster vectorization). Spec lives in the brainstorm worktree at `docs/superpowers/specs/2026-05-15-post-controller-full-df-perf-design.md` (gitignored).

- `.github/workflows/bench-zero-config.yml` — workflow_dispatch on `ubuntu-latest-large`. Inputs: `n_records`, `runs`, `dupe_rate`, `backend`, `label`. Verifies editable install before measuring. Pins `GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD=10000000` so 500K/1M stay on polars-direct. Posts headline to step summary; uploads JSON + cProfile dump.
- `scripts/bench_1m_zero_config.py` — runner. 5-run median wall + one `bench_capture()` per-stage run + one cProfile pass. Logs `install_paths` in the JSON to surface site-packages shadowing.
- `scripts/scale_audit_5m.py` — fixes the `auto_configure_df` + `dedupe_df(config=...)` double-run that was inflating prior cloud measurements ~2x. Now uses `_skip_finalize=True` so the full pipeline runs once.

## Test plan

- [ ] Workflow validates via "Actions" tab (lint passes, file shows up).
- [ ] Manual dispatch: `gh workflow run bench-zero-config.yml --ref main -f n_records=50000 -f runs=2 -f label=smoke-test`. Expect ~5 min run, JSON + .prof artifacts uploaded, step summary populated.
- [ ] Editable-install gate fails fast if `pip install -e` is skipped (intentional).

After merge, the perf branch (`perf/post-controller-full-df`) triggers `bench-zero-config.yml` at 500K to capture the post-#239 baseline for Attacks A + B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)