### PR TITLE
ci(eval): independent ER scoring via er-evaluation (workflow_dispatch)

### DIFF
--- a/.github/workflows/eval-er-evaluation.yml
+++ b/.github/workflows/eval-er-evaluation.yml
@@ -1,0 +1,101 @@
+# Independent ER scoring via Olivier Binette's er-evaluation package.
+#
+# Runs gm.dedupe_df() on a synthetic fixture, then scores the output via
+# `er_evaluation` (https://github.com/OlivierBinette/er-evaluation). Pairwise
+# precision/recall/F1, B-cubed, and cluster-level metrics, with bootstrapped
+# uncertainty estimates where the package supports them.
+#
+# Why this lane exists: our existing scale-audit uses an internal scorer
+# (goldenmatch.core.evaluate). A third-party scorer is a useful cross-check
+# that quality numbers aren't artifacts of our own measurement code.
+#
+# License note: er-evaluation is AGPL-3.0. We consume it strictly at
+# evaluation time — it never ships in any GoldenMatch artifact.
+#
+# Triggers on manual dispatch only.
+# To run: GitHub → Actions → "eval-er-evaluation" → Run workflow.
+name: eval-er-evaluation
+
+on:
+  workflow_dispatch:
+    inputs:
+      n_records:
+        description: "Synthetic fixture record count"
+        required: false
+        default: "100000"
+      dupe_rate:
+        description: "Fraction of records that are duplicates (0..1)"
+        required: false
+        default: "0.15"
+      er_evaluation_ref:
+        description: "Pin er-evaluation to a PyPI version (blank = latest)"
+        required: false
+        default: ""
+      label:
+        description: "Tag for the output filename"
+        required: false
+        default: "ad-hoc"
+
+permissions:
+  contents: read
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest  # free runner — eval is cheap enough not to need larger
+    timeout-minutes: 60
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Editable-install goldenmatch
+        run: uv pip install -e packages/python/goldenmatch
+
+      - name: Install er-evaluation + pandas
+        run: |
+          if [ -n "${{ inputs.er_evaluation_ref }}" ]; then
+            uv pip install "er-evaluation==${{ inputs.er_evaluation_ref }}" pandas
+          else
+            uv pip install er-evaluation pandas
+          fi
+
+      - name: Verify install
+        run: |
+          .venv/bin/python -c "import goldenmatch, er_evaluation; \
+            print('goldenmatch:', goldenmatch.__file__); \
+            print('er_evaluation:', er_evaluation.__file__); \
+            print('er_evaluation version:', getattr(er_evaluation, '__version__', 'unknown'))"
+
+      - name: Generate ${{ inputs.n_records }}-row fixture
+        run: |
+          mkdir -p .profile_tmp/scale_fixtures
+          .venv/bin/python scripts/scale_audit_5m_generate.py \
+            --n-records ${{ inputs.n_records }} \
+            --dupe-rate ${{ inputs.dupe_rate }} \
+            --output .profile_tmp/scale_fixtures/eval_fixture.csv
+
+      - name: Score with er-evaluation
+        run: |
+          .venv/bin/python scripts/eval_er_evaluation.py \
+            --fixture .profile_tmp/scale_fixtures/eval_fixture.csv \
+            --ground-truth .profile_tmp/scale_fixtures/eval_fixture.ground_truth.csv \
+            --output .profile_tmp/eval_er_evaluation_${{ inputs.label }}.json \
+            --summary-md "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload eval artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: eval-er-evaluation-${{ inputs.label }}
+          path: .profile_tmp/eval_er_evaluation_${{ inputs.label }}.json
+          retention-days: 90

--- a/.github/workflows/eval-er-evaluation.yml
+++ b/.github/workflows/eval-er-evaluation.yml
@@ -41,7 +41,14 @@ permissions:
 
 jobs:
   eval:
-    runs-on: ubuntu-latest  # free runner — eval is cheap enough not to need larger
+    # Benchmarking workflows default to the org's large-new-64GB runner
+    # (16c/64GB/600GB Ubuntu 24.04). Consistent shape across all benchmark
+    # lanes makes the numbers directly comparable. The free ubuntu-latest
+    # (4c/16GB) was enough for er-evaluation scoring alone, but on synthetic
+    # fixtures >= 500K the gm.dedupe_df() step would dominate the cost
+    # there; staying on the larger runner gives headroom for scaling up
+    # without editing the workflow each time.
+    runs-on: large-new-64GB
     timeout-minutes: 60
     env:
       GOLDENMATCH_AUTOCONFIG_MEMORY: "0"

--- a/scripts/eval_er_evaluation.py
+++ b/scripts/eval_er_evaluation.py
@@ -1,0 +1,262 @@
+"""Score gm.dedupe_df output against ground truth via Olivier Binette's
+``er-evaluation`` package (https://github.com/OlivierBinette/er-evaluation).
+
+Why a separate scorer
+---------------------
+
+The existing scale-audit script computes pair-based F1 via
+``goldenmatch.core.evaluate.evaluate_clusters``. ``er-evaluation`` provides
+an independent implementation (entity-centric, with bootstrapped uncertainty
+estimates) — a useful sanity check that our numbers aren't artifacts of our
+own scoring code. Also surfaces additional metrics (B-cubed, cluster-level
+error analysis) the internal scorer doesn't expose.
+
+Usage::
+
+    python scripts/eval_er_evaluation.py \\
+        --fixture .profile_tmp/scale_fixtures/synthetic_bench.csv \\
+        --ground-truth .profile_tmp/scale_fixtures/synthetic_bench.ground_truth.csv \\
+        --output .profile_tmp/eval_er_evaluation.json \\
+        --summary-md "$GITHUB_STEP_SUMMARY"
+
+The script keeps the ER pipeline (gm.dedupe_df) and the scorer
+(er_evaluation) explicitly separated; ``er_evaluation`` is consumed strictly
+at evaluation time (AGPL-3.0 — we don't redistribute it).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _build_prediction_series(clusters: dict[int, dict]) -> "pd.Series":
+    """Map row_id -> cluster_id as a pandas Series.
+
+    ``clusters`` is GoldenMatch's standard shape: ``dict[cluster_id, {"members": [row_id, ...], ...}]``.
+    er-evaluation wants a Series indexed by record id with values = cluster id.
+    """
+    import pandas as pd
+    rows: list[tuple[int, int]] = []
+    for cid, info in clusters.items():
+        for rid in info.get("members", []):
+            rows.append((int(rid), int(cid)))
+    if not rows:
+        return pd.Series(dtype="int64", name="prediction")
+    s = pd.Series({rid: cid for rid, cid in rows}, name="prediction")
+    s.index.name = "record_id"
+    return s
+
+
+def _build_reference_series(gt_path: Path) -> "pd.Series":
+    """Load ground truth ``id,cluster_id`` CSV into a pandas Series.
+
+    Mirrors ``scripts/scale_audit_5m.py::_pairs_from_ground_truth``: the
+    ground-truth CSV's ``id`` column is 1-based row order, while
+    GoldenMatch's internal ``__row_id__`` is 0-based. Subtract 1 to align.
+    """
+    import pandas as pd
+    df = pd.read_csv(gt_path)
+    df["record_id"] = df["id"].astype(int) - 1
+    s = pd.Series(df["cluster_id"].astype(int).values, index=df["record_id"], name="reference")
+    s.index.name = "record_id"
+    return s
+
+
+def _safe_call(name: str, fn, *args, **kwargs) -> tuple[Any, str | None]:
+    """Call a metric fn; return (value, None) on success, (None, err) on failure.
+
+    er-evaluation's API has shifted between releases (estimator vs direct
+    forms, different argument names). We try; if it doesn't exist or raises,
+    we log and move on rather than aborting the whole eval.
+    """
+    try:
+        return fn(*args, **kwargs), None
+    except Exception as exc:
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _resolve_metric(ee, candidates: list[str]):
+    """Return the first attribute name from ``candidates`` that exists on the
+    er_evaluation module, or None if none do.
+    """
+    for name in candidates:
+        if hasattr(ee, name):
+            return getattr(ee, name), name
+    return None, None
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fixture", type=Path, required=True,
+                    help="CSV produced by scripts/scale_audit_5m_generate.py")
+    ap.add_argument("--ground-truth", type=Path, required=True,
+                    help="Ground-truth CSV with id,cluster_id columns")
+    ap.add_argument("--output", type=Path, required=True,
+                    help="Where to write the metrics JSON")
+    ap.add_argument("--summary-md", type=Path, default=None,
+                    help="Optional path to append a Markdown summary "
+                         "(typically $GITHUB_STEP_SUMMARY)")
+    args = ap.parse_args()
+
+    if not args.fixture.exists():
+        sys.exit(f"fixture not found: {args.fixture}")
+    if not args.ground_truth.exists():
+        sys.exit(f"ground truth not found: {args.ground_truth}")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    # Import after argparse so --help works without the heavy deps.
+    import polars as pl
+    import pandas as pd
+    import goldenmatch as gm
+    import er_evaluation as ee  # pyright: ignore[reportMissingImports]
+    ee_version = getattr(ee, "__version__", "unknown")
+
+    print(f"er_evaluation version: {ee_version}")
+    print(f"Loading fixture {args.fixture}...")
+    df = pl.read_csv(args.fixture, ignore_errors=True, infer_schema_length=0)
+    if "cluster_id" in df.columns:
+        df = df.drop("cluster_id")
+    print(f"  {df.height:,} rows x {df.width} cols")
+
+    print("Running gm.dedupe_df(df) zero-config...")
+    t0 = time.perf_counter()
+    result = gm.dedupe_df(df)
+    wall_s = time.perf_counter() - t0
+    print(f"  dedupe wall: {wall_s:.1f}s, {len(result.clusters)} clusters")
+
+    print("Building predicted-cluster Series (record_id -> cluster_id)...")
+    predictions = _build_prediction_series(result.clusters)
+    print(f"  {len(predictions):,} records assigned to clusters")
+
+    print(f"Loading ground truth from {args.ground_truth}...")
+    reference = _build_reference_series(args.ground_truth)
+    print(f"  {len(reference):,} ground-truth records")
+
+    # Align indices: only score records that appear in BOTH predictions and
+    # reference. (Internal __row_id__ is 0..n-1, ground truth is also 0..n-1
+    # after the -1 shift; they should match exactly, but cheap to guard.)
+    aligned = pd.concat([predictions, reference], axis=1, join="inner")
+    pred = aligned["prediction"]
+    ref = aligned["reference"]
+    print(f"  aligned on {len(aligned):,} records")
+
+    # Try the canonical metric names first, falling back to alternates the
+    # package has used over its release history.
+    metrics: dict[str, Any] = {}
+
+    pairwise_p, name_p = _resolve_metric(ee, [
+        "pairwise_precision_estimator", "pairwise_precision",
+    ])
+    pairwise_r, name_r = _resolve_metric(ee, [
+        "pairwise_recall_estimator", "pairwise_recall",
+    ])
+    pairwise_f, name_f = _resolve_metric(ee, [
+        "pairwise_f1_estimator", "pairwise_f1",
+    ])
+    bcubed_p, name_bp = _resolve_metric(ee, [
+        "b_cubed_precision_estimator", "b_cubed_precision",
+    ])
+    bcubed_r, name_br = _resolve_metric(ee, [
+        "b_cubed_recall_estimator", "b_cubed_recall",
+    ])
+    bcubed_f, name_bf = _resolve_metric(ee, [
+        "b_cubed_f1_estimator", "b_cubed_f1",
+    ])
+    cluster_p, name_cp = _resolve_metric(ee, [
+        "cluster_precision_estimator", "cluster_precision",
+    ])
+    cluster_r, name_cr = _resolve_metric(ee, [
+        "cluster_recall_estimator", "cluster_recall",
+    ])
+
+    for label, fn, fname in [
+        ("pairwise_precision", pairwise_p, name_p),
+        ("pairwise_recall",    pairwise_r, name_r),
+        ("pairwise_f1",        pairwise_f, name_f),
+        ("b_cubed_precision",  bcubed_p,   name_bp),
+        ("b_cubed_recall",     bcubed_r,   name_br),
+        ("b_cubed_f1",         bcubed_f,   name_bf),
+        ("cluster_precision",  cluster_p,  name_cp),
+        ("cluster_recall",     cluster_r,  name_cr),
+    ]:
+        if fn is None:
+            metrics[label] = {"value": None, "error": "not available in er_evaluation"}
+            continue
+        # Most er-evaluation estimators take (predictions, reference) and
+        # return either a scalar or a (point_estimate, std_error) tuple.
+        value, err = _safe_call(label, fn, pred, ref)
+        if err is not None:
+            metrics[label] = {"value": None, "error": err, "fn": fname}
+            continue
+        if isinstance(value, tuple) and len(value) == 2:
+            metrics[label] = {
+                "value": float(value[0]),
+                "std_error": float(value[1]) if value[1] is not None else None,
+                "fn": fname,
+            }
+        else:
+            metrics[label] = {"value": float(value), "fn": fname}
+
+    # Summary statistics
+    summary_fn, _ = _resolve_metric(ee, ["summary_statistics"])
+    if summary_fn is not None:
+        summary_value, err = _safe_call("summary_statistics", summary_fn, pred)
+        if err is None and summary_value is not None:
+            # Convert pandas Series/DataFrame to dict for JSON serialization
+            try:
+                if hasattr(summary_value, "to_dict"):
+                    metrics["summary_statistics"] = summary_value.to_dict()
+                else:
+                    metrics["summary_statistics"] = dict(summary_value)
+            except Exception:
+                metrics["summary_statistics"] = str(summary_value)
+
+    report = {
+        "fixture": str(args.fixture),
+        "ground_truth": str(args.ground_truth),
+        "n_rows": df.height,
+        "n_predicted_clusters": len(result.clusters),
+        "n_aligned_records": int(len(aligned)),
+        "dedupe_wall_seconds": round(wall_s, 2),
+        "er_evaluation_version": ee_version,
+        "metrics": metrics,
+    }
+    args.output.write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {args.output}")
+    for label, m in metrics.items():
+        if isinstance(m, dict) and "value" in m and m["value"] is not None:
+            se = m.get("std_error")
+            tail = f"  (SE={se:.4f})" if se is not None else ""
+            print(f"  {label}: {m['value']:.4f}{tail}")
+        elif isinstance(m, dict) and m.get("error"):
+            print(f"  {label}: SKIPPED ({m['error']})")
+
+    if args.summary_md is not None:
+        with args.summary_md.open("a", encoding="utf-8") as f:
+            f.write(f"# eval-er-evaluation\n\n")
+            f.write(f"- fixture: `{args.fixture}` ({df.height:,} rows)\n")
+            f.write(f"- dedupe wall: **{wall_s:.1f}s**\n")
+            f.write(f"- predicted clusters: {len(result.clusters):,}\n")
+            f.write(f"- er-evaluation version: `{ee_version}`\n\n")
+            f.write("## Metrics\n\n")
+            f.write("| metric | value | std error |\n")
+            f.write("|---|---|---|\n")
+            for label, m in metrics.items():
+                if not isinstance(m, dict):
+                    continue
+                if m.get("value") is None:
+                    f.write(f"| `{label}` | n/a ({m.get('error', '?')}) | - |\n")
+                else:
+                    se = m.get("std_error")
+                    se_str = f"{se:.4f}" if se is not None else "-"
+                    f.write(f"| `{label}` | {m['value']:.4f} | {se_str} |\n")
+            f.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a new evaluation lane that scores `gm.dedupe_df()` output against ground truth using [Olivier Binette's er-evaluation](https://github.com/OlivierBinette/er-evaluation) package.

**Why a separate lane:** Existing scale-audit uses internal scoring (`goldenmatch.core.evaluate`). Third-party scorer with different implementation (entity-centric, bootstrapped uncertainty) cross-checks our F1 numbers aren't artifacts of our own measurement code. Also surfaces B-cubed + cluster-level metrics our internal scorer doesn't expose.

**Files:**
- `scripts/eval_er_evaluation.py` — runs `gm.dedupe_df` on a synthetic fixture, builds predicted/reference pandas Series (`record_id -> cluster_id`), calls er-evaluation metrics with API-version fallback, emits JSON + Markdown summary
- `.github/workflows/eval-er-evaluation.yml` — `workflow_dispatch` only, runs on free `ubuntu-latest`. Inputs: `n_records`, `dupe_rate`, `er_evaluation_ref` (pin version), `label`

**License:** er-evaluation is AGPL-3.0. Consumed only at evaluation time in a workflow runner; never ships in any goldenmatch artifact. Workflow installs via pip in the runner's venv.

## Test plan

- [ ] Workflow validates (lint passes, shows up under Actions)
- [ ] Dispatch with `n_records=10000` (smoke test, ~3 min): expect JSON artifact + step summary with pairwise P/R/F1, B-cubed, cluster metrics
- [ ] Verify er-evaluation API resolution: if a metric isn't available in the installed version, it's marked as such in the JSON (no crash)
- [ ] After dispatch lands, compare pairwise F1 against `scripts/scale_audit_5m.py`'s internal F1 on the same fixture — should agree within bootstrapping noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)