### PR TITLE
fix(eval-benchmarks): DBLP-ACM zip extracts at root, not in DBLP-ACM/

### DIFF
--- a/.github/workflows/eval-benchmarks.yml
+++ b/.github/workflows/eval-benchmarks.yml
@@ -107,9 +107,13 @@ jobs:
           if [ ! -f "packages/python/goldenmatch/tests/benchmarks/datasets/DBLP-ACM/DBLP2.csv" ]; then
             curl -fSL -o /tmp/dblp-acm.zip https://dbs.uni-leipzig.de/file/DBLP-ACM.zip
             unzip -o /tmp/dblp-acm.zip -d /tmp/dblp-acm-extract
-            # The zip contains a top-level DBLP-ACM/ folder; copy contents
-            cp -r /tmp/dblp-acm-extract/DBLP-ACM/* \
-              packages/python/goldenmatch/tests/benchmarks/datasets/DBLP-ACM/
+            # The Leipzig zip extracts files at the root, not into a
+            # DBLP-ACM/ subdir as the original copy expected. Move the
+            # CSVs directly into the target dir.
+            cp /tmp/dblp-acm-extract/DBLP2.csv \
+               /tmp/dblp-acm-extract/ACM.csv \
+               /tmp/dblp-acm-extract/DBLP-ACM_perfectMapping.csv \
+               packages/python/goldenmatch/tests/benchmarks/datasets/DBLP-ACM/
           fi
           ls -lh packages/python/goldenmatch/tests/benchmarks/datasets/DBLP-ACM/
 


### PR DESCRIPTION
Fix for eval-benchmarks run [25942271678](https://github.com/benseverndev-oss/goldenmatch/actions/runs/25942271678). DBLP-ACM job failed at the unzip step because the Leipzig zip puts CSVs at the extract root, not inside a nested DBLP-ACM/ folder.

Febrl3 succeeded in the same run: pairwise F1 = 0.9423 ± 0.004, B-cubed F1 = 0.9782 ± 0.0015. Matches CLAUDE.md's v1.8 quoted Febrl3 = 0.9443 within bootstrap noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)