### PR TITLE
fix(bench-zero-config): use large-new-64GB runner + uv pip install

### DIFF
--- a/.github/workflows/bench-zero-config.yml
+++ b/.github/workflows/bench-zero-config.yml
@@ -47,7 +47,11 @@ permissions:
 
 jobs:
   bench:
-    runs-on: gm-bench-64c  # org-level GitHub-hosted larger runner: 64c/256GB/2040GB
+    # Per memory feedback_bench_default_runner.md: benchmark workflows use
+    # the org's large-new-64GB runner (16c/64GB Ubuntu 24.04). The earlier
+    # 64-core variant (gm-bench-64c) provisions but jobs never receive a VM,
+    # suspected quota cap on the very large size for newly-created orgs.
+    runs-on: large-new-64GB
     timeout-minutes: 180  # 3 hours; 500K typical ~30 min, 1M ~90 min
     env:
       GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
@@ -72,7 +76,8 @@ jobs:
         # uv sync should already install the workspace member editable, but
         # CLAUDE.md's "shadows worktree code" gotcha cost me an audit cycle —
         # belt and braces. Verify the import path in the bench output too.
-        run: .venv/bin/python -m pip install -e packages/python/goldenmatch
+        # NOTE: uv-created venvs don't ship pip; use `uv pip` not `.venv/bin/pip`.
+        run: uv pip install -e packages/python/goldenmatch
 
       - name: Verify worktree install
         run: |


### PR DESCRIPTION
Two fixes that should have landed via PR #244 but were stripped by the squash-merge. Last bench dispatch ([run 25944106807](https://github.com/benseverndev-oss/goldenmatch/actions/runs/25944106807)) failed at the editable-install step in 16s.

1. `runs-on: gm-bench-64c` → `large-new-64GB`. 64c runner provisions but jobs never get a VM (suspected quota cap on the very large size for newly-created orgs). 16c `large-new-64GB` reliably picks up jobs - proven across many eval-er-evaluation + eval-benchmarks runs.

2. `.venv/bin/python -m pip install -e` → `uv pip install -e`. uv venvs ship without pip; the old command dies with 'No module named pip'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)