### PR TITLE
docs(perf): three-spec roadmap post-#239 (map_elements + controller v3 + distributed v1)

### DIFF
--- a/docs/superpowers/plans/2026-05-15-post-controller-full-df-perf.md
+++ b/docs/superpowers/plans/2026-05-15-post-controller-full-df-perf.md
@@ -1,0 +1,1110 @@
+# Post-controller full-df perf — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut `gm.dedupe_df(df)` zero-config wall by ≥40% at 500K on the default polars-direct backend by killing the two cross-stage Python hotspots the bench identified (462K `LazyFrame.collect` calls and 55M `builtins.max` calls in the cluster split path).
+
+**Architecture:** Two sequential PRs. **Attack A** rewrites `BlockResult` to carry positional indices instead of a per-block `LazyFrame`, eliminating the `lazy() → collect()` round-trip in `apply_learned_blocks` and the per-block collect in `_score_one_block`. **Attack B** vectorizes `_build_mst` and `compute_cluster_confidence` in NumPy to remove the 55M Python `max()`/`min()` calls. Each PR has its own measurement gate. Net target: 500K median 488s → ≤150s (target re-baselined in Phase 0.2 against post-#239 main).
+
+**Tech Stack:** Python 3.12, Polars, NumPy, dataclasses, Hypothesis (property tests). Measurement runs on GitHub Actions (`.github/workflows/bench-zero-config.yml`) via `ubuntu-latest-large` — local Polars OOMs cannot be measured reliably on this laptop without a restart, so cloud runs are the canonical bench surface.
+
+**Spec:** `docs/superpowers/specs/2026-05-15-post-controller-full-df-perf-design.md` — read this first; the plan refers to it by section.
+
+## Material context changes since the spec was written (read before Phase 0)
+
+1. **PR #239 landed on main** (`615d760`): "perf(zero-config): 6x at 100K — routing, bench, DuckDB+Arrow, golden vectorize." Touched `core/pipeline.py` (+218/-91), `core/blocker.py` (+61), `core/scorer.py` (+7), `backends/score_duckdb.py` (+133), `core/autoconfig.py` (+71), added `core/bench.py` (NEW), `refdata/scorer.py` (+72). **Did NOT touch `core/learned_blocking.py` or `core/cluster.py`** — Attack A and B's target files. The spec's hypotheses remain valid; the magnitudes need re-baselining.
+2. **`goldenmatch.core.bench` module added by #239** supersedes this plan's prior Phase 4.1 monkey-patch fix. The bench script now uses `bench_capture()` directly. Pipeline already wraps major stages internally.
+3. **`autoconfig.py` auto-selects `backend="duckdb"` at ≥1M rows.** Attack A/B target the polars-direct path. Workflow pins `GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD=10000000` to keep 500K/1M on polars-direct.
+4. **Local measurement is blocked.** Polars OOMs leave the laptop python state hung and require a system restart to recover. All bench runs in this plan happen via the `bench-zero-config` GHA workflow.
+5. **The pre-#239 baseline (`.profile_tmp/bench_500k_zero_config.json`, median 487.7s, 462K LazyFrame.collect, 55M builtins.max) was measured against site-packages**, not the worktree (CWD-based import resolution mistake). Treat it as directional, not load-bearing. Phase 0.2 captures the real post-#239 baseline.
+
+---
+
+## Pre-flight checklist
+
+Before starting any task:
+
+- [ ] Working on `perf/post-controller-full-df` off `main` (created in the brainstorm session). `git status -sb` confirms.
+- [ ] Local imports MUST run from the package dir to hit the worktree: `cd packages/python/goldenmatch && python -c "import goldenmatch; print(goldenmatch.__file__)"` shows the worktree path. Running from repo root falls back to site-packages — known gotcha; the CI workflow handles this explicitly via `pip install -e`.
+- [ ] Baseline test suite green from package dir: `cd packages/python/goldenmatch && C:/Users/bsevern/AppData/Local/Programs/Python/Python312/python.exe -m pytest -q --timeout=120 --ignore=tests/test_db.py --ignore=tests/test_reconcile.py --ignore=tests/test_mcp_and_watch.py --ignore=tests/test_embedder.py --ignore=tests/test_llm_boost.py --ignore=tests/benchmarks` returns the documented 1572+ passing (post-#239 may have a different count; record actual).
+- [ ] Workflow file `.github/workflows/bench-zero-config.yml` present (committed in the brainstorm session).
+- [ ] `scripts/bench_1m_zero_config.py` uses `bench_capture()` (post-revision), not the monkey-patch approach.
+
+---
+
+## Phase 0 — Verify spec's multi-pass single-parent-df assumption
+
+Per spec §Attack A "Risk and mitigation" bullet 3 and reviewer advisory #1: confirm that all `build_blocks` callers operate against a single materialized parent DataFrame before committing to the `BlockResult.member_positions` contract. If multi-pass blocking builds blocks against differently-transformed frames, the positional contract needs refinement.
+
+### Task 0.1: Audit `build_blocks` call sites
+
+**Files:**
+- Read-only: `packages/python/goldenmatch/goldenmatch/core/pipeline.py`, `goldenmatch/tui/engine.py`, `goldenmatch/core/chunked.py`, `goldenmatch/core/blocker.py`, `goldenmatch/core/learned_blocking.py`
+
+- [ ] **Step 1: Grep all `build_blocks(` / `_build_learned_blocks(` / `_build_canopy_blocks(` / `_build_ann_pair_blocks(` call sites.**
+
+```bash
+grep -rn "build_blocks\|_build_learned_blocks\|_build_canopy_blocks\|_build_ann_pair_blocks" packages/python/goldenmatch/goldenmatch/ --include="*.py"
+```
+
+- [ ] **Step 2: For each call site, confirm:** (a) the LazyFrame passed in derives from the same materialized DataFrame that flows into `score_blocks_parallel` afterward, and (b) the `__row_id__` column is stable across both (no row drops or reorders between block-build and scoring).
+
+- [ ] **Step 3: Record findings inline in this plan** by adding a short note under Phase 0 below this task. Two acceptable outcomes:
+   - **All call sites OK:** "Single parent df confirmed for static / adaptive / learned / canopy / ann blocking — positional contract is safe." Proceed to Phase 1.
+   - **Mismatch found:** "Path X passes a transformed frame; needs Y change." STOP and add a Phase 0.2 task to surface to the user.
+
+- [ ] **Step 4: No commit** — this is read-only verification.
+
+**Findings (fill in during execution):**
+> _Implementer: write findings here, one paragraph._
+
+### Task 0.2: Capture post-#239 baseline via GHA
+
+The pre-#239 local baseline is stale (site-packages, not worktree). Re-baseline against current main on `ubuntu-latest-large` before any code changes.
+
+**Files:**
+- Run: `.github/workflows/bench-zero-config.yml` (workflow_dispatch)
+- Output (artifact): `bench_post-pr239-baseline.json` + `.prof`
+
+- [ ] **Step 1: Trigger the workflow.**
+
+GitHub UI → Actions → "bench-zero-config" → Run workflow. Inputs:
+- `n_records`: `500000`
+- `runs`: `5`
+- `dupe_rate`: `0.15`
+- `backend`: leave blank
+- `label`: `post-pr239-baseline`
+- Branch: `perf/post-controller-full-df`
+
+Or CLI: `gh workflow run bench-zero-config.yml --ref perf/post-controller-full-df -f n_records=500000 -f runs=5 -f dupe_rate=0.15 -f label=post-pr239-baseline`.
+
+ETA ~30 min. Watch with `gh run watch <run-id> --exit-status`.
+
+- [ ] **Step 2: Download artifact.**
+
+```
+gh run download <run-id> -n bench-zero-config-post-pr239-baseline -D .profile_tmp/
+```
+
+- [ ] **Step 3: Read the headline from the workflow summary** (or the JSON). Record three numbers below:
+
+**Post-#239 baseline:**
+> - 500K median wall: ____s
+> - LazyFrame.collect ncalls: ____ (from cprofile_top)
+> - builtins.max ncalls: ____ (from cprofile_top)
+> - Top 3 bench_capture stages (name, seconds): ____
+
+- [ ] **Step 4: Update Attack A and Attack B gates in this plan to be deltas off the post-#239 baseline.**
+
+Spec gates say "≤ 250s post-A" and "≤ 150s post-A+B" against the 488s pre-#239 baseline. If post-#239 is materially different (e.g. already 200s because golden vectorize helped here too), rescale gates: keep the *percentage* reduction targets (≥ 49% off baseline for A, ≥ another 40% off post-A median for B).
+
+- [ ] **Step 5: Commit baseline JSON to `.profile_tmp/`** (gitignored, so use `-f`):
+
+```
+git add -f .profile_tmp/bench_post-pr239-baseline.json
+git commit -m "bench(perf): post-#239 baseline at 500K"
+```
+
+---
+
+## Phase 1 — Attack A: BlockResult positional contract
+
+Per spec §Attack A. Replace `BlockResult.df: LazyFrame` with a positional contract that stores row indices and materializes on demand at the single scoring consumer.
+
+### Task 1.1: Add `BlockResult.member_positions` + `materialize()` helper
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/blocker.py:87-96` (the `BlockResult` dataclass)
+- Test: `packages/python/goldenmatch/tests/test_blocking.py` (new test function appended)
+
+- [ ] **Step 1: Write the failing test.**
+
+Append to `packages/python/goldenmatch/tests/test_blocking.py`:
+
+```python
+def test_block_result_materialize_uses_positions():
+    """BlockResult with member_positions materializes via positional slice,
+    not via LazyFrame.collect — the load-bearing invariant for Attack A
+    (spec docs/superpowers/specs/2026-05-15-post-controller-full-df-perf-design.md)."""
+    import polars as pl
+    from goldenmatch.core.blocker import BlockResult
+
+    df = pl.DataFrame({
+        "__row_id__": [10, 20, 30, 40],
+        "name":       ["a", "b", "c", "d"],
+    })
+    br = BlockResult(
+        block_key="t",
+        df=None,                       # NEW: optional when positions present
+        member_positions=[1, 3],       # NEW field
+    )
+    out = br.materialize(df)
+    assert out.height == 2
+    assert out["__row_id__"].to_list() == [20, 40]
+    assert out["name"].to_list() == ["b", "d"]
+
+
+def test_block_result_materialize_falls_back_to_lazyframe():
+    """Back-compat: when positions are absent, materialize() must collect df."""
+    import polars as pl
+    from goldenmatch.core.blocker import BlockResult
+
+    inner = pl.DataFrame({"__row_id__": [1, 2], "name": ["x", "y"]}).lazy()
+    br = BlockResult(block_key="t", df=inner)   # no member_positions
+    out = br.materialize(parent_df=None)        # parent unused in fallback
+    assert out.height == 2
+    assert out["__row_id__"].to_list() == [1, 2]
+```
+
+- [ ] **Step 2: Run tests to verify they fail.**
+
+```
+cd packages/python/goldenmatch
+C:/Users/bsevern/AppData/Local/Programs/Python/Python312/python.exe -m pytest tests/test_blocking.py::test_block_result_materialize_uses_positions tests/test_blocking.py::test_block_result_materialize_falls_back_to_lazyframe -v
+```
+
+Expected: FAIL with `TypeError: __init__() got an unexpected keyword argument 'member_positions'` (first) and `AttributeError: 'BlockResult' object has no attribute 'materialize'` (second).
+
+- [ ] **Step 3: Implement minimal change in `blocker.py`.**
+
+Replace the `BlockResult` dataclass at `blocker.py:87-96` with:
+
+```python
+@dataclass
+class BlockResult:
+    """Result of blocking: a block key and its members.
+
+    Two construction modes:
+    - **Positional (preferred):** pass ``member_positions`` (positions into a
+      parent ``pl.DataFrame`` that the caller holds). ``materialize(parent_df)``
+      returns ``parent_df[positions]`` directly — no LazyFrame round-trip.
+    - **LazyFrame (back-compat):** pass ``df`` only. ``materialize()`` falls
+      back to ``df.collect()``.
+
+    The positional contract is load-bearing for the Attack A perf fix; the
+    LazyFrame mode stays for one release to give external consumers time to
+    migrate. See spec
+    ``docs/superpowers/specs/2026-05-15-post-controller-full-df-perf-design.md``.
+    """
+
+    block_key: str
+    df: pl.LazyFrame | None = None
+    strategy: str = "static"
+    depth: int = 0
+    parent_key: str | None = None
+    pre_scored_pairs: list[tuple[int, int, float]] | None = None
+    member_positions: list[int] | None = None
+
+    def materialize(self, parent_df: pl.DataFrame | None) -> pl.DataFrame:
+        """Return the block as an eager DataFrame.
+
+        Positional path: ``parent_df[self.member_positions]`` (no .lazy() wrap).
+        LazyFrame fallback: ``self.df.collect()`` when positions are absent.
+        """
+        if self.member_positions is not None:
+            if parent_df is None:
+                raise ValueError(
+                    "BlockResult.materialize requires parent_df when "
+                    "member_positions is set"
+                )
+            return parent_df[self.member_positions]
+        if self.df is None:
+            raise ValueError(
+                "BlockResult.materialize requires either member_positions "
+                "(with parent_df) or df (LazyFrame)"
+            )
+        return self.df.collect()
+```
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+```
+C:/Users/bsevern/AppData/Local/Programs/Python/Python312/python.exe -m pytest tests/test_blocking.py::test_block_result_materialize_uses_positions tests/test_blocking.py::test_block_result_materialize_falls_back_to_lazyframe -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Run the full `tests/test_blocking.py` to confirm no regression.**
+
+```
+C:/Users/bsevern/AppData/Local/Programs/Python/Python312/python.exe -m pytest tests/test_blocking.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit.**
+
+```
+git add packages/python/goldenmatch/goldenmatch/core/blocker.py packages/python/goldenmatch/tests/test_blocking.py
+git commit -m "feat(blocker): BlockResult.member_positions + materialize() helper
+
+Adds optional positional contract to BlockResult. Spec
+docs/superpowers/specs/2026-05-15-post-controller-full-df-perf-design.md
+Attack A step 1. Back-compat preserved: LazyFrame mode still works via
+materialize() fallback. No call-site changes yet — those follow in the
+next commit."
+```
+
+### Task 1.2: Wire `apply_learned_blocks` to emit positional `BlockResult`
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/learned_blocking.py:278-329` (the `apply_learned_blocks` function)
+- Test: `packages/python/goldenmatch/tests/test_learned_blocking.py` (new test function appended)
+
+- [ ] **Step 1: Write the failing test.**
+
+Append to `packages/python/goldenmatch/tests/test_learned_blocking.py`:
+
+```python
+def test_apply_learned_blocks_emits_positions_not_lazyframe():
+    """apply_learned_blocks must produce positional BlockResults — no per-block
+    LazyFrame wrap. Spec Attack A step 2: kills the 462K LazyFrame.collect
+    explosion. Failure mode if regressed: cProfile shows LazyFrame.collect
+    ncalls back at ~1× n_rows."""
+    import polars as pl
+    from goldenmatch.core.learned_blocking import (
+        BlockingRule, BlockingPredicate, apply_learned_blocks,
+    )
+
+    df = pl.DataFrame({
+        "__row_id__": [1, 2, 3, 4, 5, 6],
+        "name":       ["alice", "alice", "bob", "bob", "carol", "dave"],
+    })
+    rule = BlockingRule(predicates=[
+        BlockingPredicate(field="name", transform="lower"),
+    ])
+    blocks = apply_learned_blocks(df.lazy(), [rule], max_block_size=100)
+
+    assert len(blocks) >= 1
+    for br in blocks:
+        # Positional contract is mandatory in the new implementation.
+        assert br.member_positions is not None, (
+            "apply_learned_blocks must emit member_positions; "
+            "regressed to LazyFrame mode"
+        )
+        # df may still be present for back-compat, but positions take priority.
+        # Verify materialize uses positional path.
+        materialized = br.materialize(df)
+        assert materialized.height == len(br.member_positions)
+
+
+def test_apply_learned_blocks_dedupe_uses_positions_not_collect():
+    """The dedupe-by-member-set pass must compare position tuples, not collect
+    each block to read __row_id__. Spec Attack A: 'Dedupe blocks by
+    tuple(sorted(member_positions)) before constructing BlockResult.'"""
+    import polars as pl
+    from goldenmatch.core.learned_blocking import (
+        BlockingRule, BlockingPredicate, apply_learned_blocks,
+    )
+
+    df = pl.DataFrame({
+        "__row_id__": [1, 2, 3, 4],
+        # Two rules that produce identical blocks — must be deduped.
+        "a": ["x", "x", "y", "y"],
+        "b": ["x", "x", "y", "y"],
+    })
+    rules = [
+        BlockingRule(predicates=[BlockingPredicate(field="a", transform="lower")]),
+        BlockingRule(predicates=[BlockingPredicate(field="b", transform="lower")]),
+    ]
+    blocks = apply_learned_blocks(df.lazy(), rules, max_block_size=100)
+
+    # Dedup by frozenset of positions
+    seen: set[frozenset[int]] = set()
+    for br in blocks:
+        positions_frozen = frozenset(br.member_positions or [])
+        assert positions_frozen not in seen, (
+            f"Duplicate block survived dedupe: {positions_frozen}"
+        )
+        seen.add(positions_frozen)
+```
+
+- [ ] **Step 2: Run tests to verify they fail.**
+
+```
+C:/Users/bsevern/AppData/Local/Programs/Python/Python312/python.exe -m pytest tests/test_learned_blocking.py::test_apply_learned_blocks_emits_positions_not_lazyframe tests/test_learned_blocking.py::test_apply_learned_blocks_dedupe_uses_positions_not_collect -v
+```
+
+Expected: FAIL — current implementation produces `BlockResult` with `df=block_lf` and `member_positions=None`.
+
+- [ ] **Step 3: Rewrite `apply_learned_blocks` body.**
+
+Replace `learned_blocking.py:278-329` with:
+
+```python
+def apply_learned_blocks(
+    lf: pl.LazyFrame,
+    rules: list[BlockingRule],
+    max_block_size: int = 5000,
+) -> list:
+    """Apply learned blocking rules to produce positional BlockResult list.
+
+    Per spec Attack A: emits BlockResult.member_positions (not a per-block
+    LazyFrame wrap). Dedup by position-tuple before construction — eliminates
+    the second collect pass that previously read __row_id__ per block.
+    """
+    from goldenmatch.core.blocker import BlockResult
+
+    df = lf.collect()
+    seen: set[tuple[int, ...]] = set()
+    deduped: list = []
+
+    for rule in rules[:3]:  # limit to top 3 rules
+        rows = df.select(
+            ["__row_id__"] + list({p.field for p in rule.predicates})
+        ).to_dicts()
+
+        # Build (block_key -> positions) via positional indexing into df.
+        blocks: dict[str, list[int]] = {}
+        for pos, row in enumerate(rows):
+            key = _compute_block_key(row, rule.predicates)
+            if key:
+                blocks.setdefault(key, []).append(pos)
+
+        for block_key, member_positions in blocks.items():
+            if len(member_positions) < 2:
+                continue
+            if len(member_positions) > max_block_size:
+                continue
+            sorted_positions = sorted(member_positions)
+            position_tuple = tuple(sorted_positions)
+            if position_tuple in seen:
+                continue
+            seen.add(position_tuple)
+            deduped.append(BlockResult(
+                block_key=f"learned:{rule.key()}:{block_key}",
+                df=None,                         # positional mode
+                member_positions=sorted_positions,
+                strategy="learned",
+            ))
+
+    logger.info(
+        "Learned blocking produced %d blocks from %d rules",
+        len(deduped), min(len(rules), 3),
+    )
+    return deduped
+```
+
+- [ ] **Step 4: Run the two new tests.**
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Run the full `tests/test_learned_blocking.py`.**
+
+```
+C:/Users/bsevern/AppData/Local/Programs/Python/Python312/python.exe -m pytest tests/test_learned_blocking.py -v
+```
+
+Expected: all pass. If any pre-existing test reads `br.df.collect()` directly and fails, fix the test to use `br.materialize(parent_df)` — that's an intentional API migration, not a regression.
+
+- [ ] **Step 6: Commit.**
+
+```
+git add packages/python/goldenmatch/goldenmatch/core/learned_blocking.py packages/python/goldenmatch/tests/test_learned_blocking.py
+git commit -m "feat(learned_blocking): emit positional BlockResult, dedup by positions
+
+Spec Attack A step 2. Replaces per-block lazy()/collect round-trip in
+apply_learned_blocks; eliminates the second collect pass that materialized
+each block to dedup by __row_id__ frozenset. Block content invariant
+asserted in the new tests."
+```
+
+### Task 1.3: Wire `_score_one_block` / `score_blocks_parallel` to use `materialize(parent_df)`
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/scorer.py:760-887` (`_score_one_block`, `score_blocks_parallel`)
+- Modify: call sites in `packages/python/goldenmatch/goldenmatch/core/pipeline.py`, `goldenmatch/tui/engine.py`, `goldenmatch/core/chunked.py`
+- Test: `packages/python/goldenmatch/tests/test_scorer.py` (new test)
+
+- [ ] **Step 1: Identify call sites.**
+
+```
+grep -rn "score_blocks_parallel\|_score_one_block" packages/python/goldenmatch/goldenmatch/ --include="*.py"
+```
+
+Expected: callers in `pipeline.py` (dedupe + match paths), `engine.py` (TUI), `chunked.py`. Note each call site's current signature so the parent-df addition is mechanical.
+
+- [ ] **Step 2: Write the failing test.**
+
+Append to `packages/python/goldenmatch/tests/test_scorer.py`:
+
+```python
+def test_score_blocks_parallel_accepts_parent_df_and_positional_blocks():
+    """score_blocks_parallel must accept a parent_df and materialize positional
+    blocks via parent_df[positions], not via per-block LazyFrame.collect."""
+    import polars as pl
+    from goldenmatch.core.blocker import BlockResult
+    from goldenmatch.core.scorer import score_blocks_parallel
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    parent_df = pl.DataFrame({
+        "__row_id__":   [1, 2, 3, 4],
+        "__source__":   ["s", "s", "s", "s"],
+        "name":         ["alice", "alyce", "bob", "robert"],
+        "__mk_name__":  ["alice", "alyce", "bob", "robert"],
+    })
+    mk = MatchkeyConfig(
+        name="name_fuzzy",
+        type="weighted",
+        threshold=0.5,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+    )
+    blocks = [
+        BlockResult(
+            block_key="b1", df=None, member_positions=[0, 1], strategy="learned",
+        ),
+        BlockResult(
+            block_key="b2", df=None, member_positions=[2, 3], strategy="learned",
+        ),
+    ]
+    pairs = score_blocks_parallel(
+        blocks, mk, matched_pairs=set(), max_workers=2,
+        parent_df=parent_df,
+    )
+    # alice~alyce should clear 0.5; bob~robert may or may not — invariant is
+    # that scoring runs without LazyFrame.collect on positional blocks.
+    assert isinstance(pairs, list)
+```
+
+- [ ] **Step 3: Run the test to verify it fails.**
+
+Expected: `TypeError: score_blocks_parallel() got an unexpected keyword argument 'parent_df'`.
+
+- [ ] **Step 4: Update `_score_one_block` and `score_blocks_parallel` signatures.**
+
+In `scorer.py:760-787` (`_score_one_block`):
+
+```python
+def _score_one_block(
+    block: Any,
+    mk: MatchkeyConfig,
+    exclude_pairs: set[tuple[int, int]] | frozenset[tuple[int, int]],
+    across_files_only: bool = False,
+    source_lookup: dict[int, str] | None = None,
+    parent_df: pl.DataFrame | None = None,
+) -> list[tuple[int, int, float]]:
+    """Score a single block — safe to call from a thread."""
+    block_df = block.materialize(parent_df)
+    # ... rest unchanged ...
+```
+
+In `scorer.py:790-887` (`score_blocks_parallel`):
+
+- Add `parent_df: pl.DataFrame | None = None` kwarg.
+- Replace the two `block.df.collect()` occurrences (line 825 small-blocks fast path and line 856 candidates-counting loop) with `block.materialize(parent_df)`.
+- Pass `parent_df` to `_score_one_block` in both the small-blocks path and the `ThreadPoolExecutor.submit` call.
+
+- [ ] **Step 5: Update `score_blocks_ray` for parity** (parallel function in `backends/ray_backend.py`).
+
+Add the same `parent_df` kwarg and use `block.materialize(parent_df)` instead of `block.df.collect()`. If the function doesn't currently collect lazily, this is a no-op signature add.
+
+- [ ] **Step 6: Update call sites in `pipeline.py`, `engine.py`, `chunked.py`.**
+
+In each call site, locate the `precompute_matchkey_transforms(...).lazy()` line — the result of `precompute_matchkey_transforms` is already an eager `pl.DataFrame` per the spec assumption (verified in Phase 0). Pass that eager frame as `parent_df=`.
+
+Example, in `pipeline.py` around line 660:
+
+```python
+collected_df = precompute_matchkey_transforms(combined_lf.collect(), matchkeys)
+# ... later:
+pairs = block_scorer(
+    blocks, mk, matched_pairs,
+    parent_df=collected_df,        # NEW
+    across_files_only=across_files_only,
+    source_lookup=source_lookup,
+)
+```
+
+If the local variable name is different (e.g. `engine.py` may use `materialized` or similar), keep the variable; just pipe it as `parent_df=`.
+
+- [ ] **Step 7: Run the new scorer test.**
+
+Expected: pass.
+
+- [ ] **Step 8: Run the full scorer + chunked + pipeline tests.**
+
+```
+C:/Users/bsevern/AppData/Local/Programs/Python/Python312/python.exe -m pytest tests/test_scorer.py tests/test_chunked.py tests/test_pipeline.py -v
+```
+
+Expected: all pass. If chunked's `BlockResult` construction still wraps `LazyFrame`s, that's fine — `materialize()` falls back to `df.collect()` automatically.
+
+- [ ] **Step 9: Commit.**
+
+```
+git add packages/python/goldenmatch/goldenmatch/core/scorer.py packages/python/goldenmatch/goldenmatch/backends/ray_backend.py packages/python/goldenmatch/goldenmatch/core/pipeline.py packages/python/goldenmatch/goldenmatch/tui/engine.py packages/python/goldenmatch/goldenmatch/core/chunked.py packages/python/goldenmatch/tests/test_scorer.py
+git commit -m "feat(scorer): score_blocks_parallel accepts parent_df, uses BlockResult.materialize
+
+Spec Attack A step 3. Replaces per-block LazyFrame.collect in
+_score_one_block and the candidates-counting loop in score_blocks_parallel
+with BlockResult.materialize(parent_df). Call sites in pipeline.py,
+engine.py, chunked.py now pass the materialized parent df forward."
+```
+
+### Task 1.4: Static / adaptive `build_blocks` also emit positional BlockResults
+
+Static + adaptive blocking (the non-learned strategies) also construct `BlockResult` with `df=lf`. Fold those into the positional contract while the change is small.
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/blocker.py` — `build_blocks` and helpers that construct `BlockResult`
+
+- [ ] **Step 1: Find every `BlockResult(` constructor in `blocker.py`.**
+
+```
+grep -n "BlockResult(" packages/python/goldenmatch/goldenmatch/core/blocker.py
+```
+
+- [ ] **Step 2: For each constructor whose `df=` argument is a `lf.filter(...)` or similar lazy slice over a materialized parent**, convert to positional.
+
+The pattern is the same as Task 1.2: materialize the parent once, build `dict[block_key, list[positions]]`, construct `BlockResult(member_positions=sorted_positions, df=None)`.
+
+If a constructor produces a fresh LazyFrame that does **not** derive from a positional slice of the parent (e.g. a join, an aggregation), leave it on the `df=` path. `materialize()` falls back automatically.
+
+- [ ] **Step 3: Run blocking + scoring tests + the broader pipeline tests.**
+
+```
+C:/Users/bsevern/AppData/Local/Programs/Python/Python312/python.exe -m pytest tests/test_blocking.py tests/test_scorer.py tests/test_pipeline.py tests/test_autoconfig_regressions.py -v --timeout=120
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit.**
+
+```
+git add packages/python/goldenmatch/goldenmatch/core/blocker.py
+git commit -m "feat(blocker): static + adaptive build_blocks emit positional BlockResults
+
+Spec Attack A step 4. Same positional contract as apply_learned_blocks;
+keeps the BlockResult interface consistent across strategies."
+```
+
+### Task 1.5: Re-bench at 500K via GHA — Attack A exit gate
+
+Per spec §Attack A "Acceptance": median wall hitting the rescaled gate from Phase 0.2 AND `LazyFrame.collect` ncalls < 50,000 AND F1 within 0.005 of baseline.
+
+**Files:**
+- Trigger: `.github/workflows/bench-zero-config.yml`
+- Artifact: `bench-zero-config-post-attack-a`
+
+- [ ] **Step 1: Push the branch.**
+
+```
+git push -u origin perf/post-controller-full-df
+```
+
+- [ ] **Step 2: Trigger the bench workflow.**
+
+```
+gh workflow run bench-zero-config.yml --ref perf/post-controller-full-df \
+  -f n_records=500000 -f runs=5 -f dupe_rate=0.15 -f label=post-attack-a
+```
+
+ETA ~30 min on `ubuntu-latest-large` ($0.07).
+
+- [ ] **Step 3: Watch the workflow.**
+
+```
+gh run watch <run-id> --exit-status
+```
+
+- [ ] **Step 4: Read the workflow summary for the headline numbers.** Compare against Phase 0.2 baseline:
+
+- `wall_seconds_median` ≤ the rescaled gate from Phase 0.2 Step 4. **GATE.**
+- In `cprofile_top`, the row for `<method 'collect' of 'builtins.PyLazyFrame' objects>` has ncalls < 50,000. **GATE.**
+
+- [ ] **Step 5: Confirm F1 invariant via the existing scale-audit workflow.**
+
+```
+gh workflow run scale-audit-5m.yml --ref perf/post-controller-full-df \
+  -f n_records=500000 -f dupe_rate=0.15
+```
+
+The audit workflow reports F1 in its run summary. Tolerance: ±0.005 of the pre-Attack-A audit F1 (re-run the audit on the post-#239 baseline branch if no prior 500K F1 exists).
+
+- [ ] **Step 6: Download and commit the bench artifact.**
+
+```
+gh run download <bench-run-id> -n bench-zero-config-post-attack-a -D .profile_tmp/
+git add -f .profile_tmp/bench_post-attack-a.json
+git commit -m "bench(perf): post-Attack-A 500K results
+
+Median wall: {actual}s (post-#239 baseline {prev}s, gate ≤{gate}s).
+LazyFrame.collect ncalls: {actual} (gate <50,000).
+F1 delta vs baseline: {actual} (gate ±0.005)."
+```
+
+- [ ] **Step 7: If gates fail, STOP.**
+
+Download the .prof artifact and open in snakeviz locally: `python -m snakeviz .profile_tmp/bench_post-attack-a.prof`. Identify which call site is still emitting LazyFrames. Adjust and re-bench. Do not proceed to Attack B until A's gates clear.
+
+### Task 1.6: Open the PR for Attack A
+
+- [ ] **Step 1: Push branch.**
+
+```
+git push -u origin perf/post-controller-full-df
+```
+
+- [ ] **Step 2: Open PR titled "perf: BlockResult positional contract (Attack A, 500K 488s -> {actual}s)".**
+
+PR body must include:
+- Link to spec.
+- Before/after table for the three Attack A gates.
+- Link to the committed bench JSON.
+- "Attack B follow-up: see plan task Phase 2."
+
+---
+
+## Phase 2 — Attack B: `split_oversized_cluster` NumPy vectorization
+
+Per spec §Attack B. Vectorize `_build_mst` and `compute_cluster_confidence` to remove the 55M Python `max()`/`min()` calls.
+
+### Task 2.1: Add the NumPy MST helper
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/cluster.py:105-156` (`_build_mst`, `split_oversized_cluster`, `compute_cluster_confidence` — last is in same file or imported)
+- Test: `packages/python/goldenmatch/tests/test_cluster.py` (new test)
+
+- [ ] **Step 1: Write the failing property test.**
+
+Append to `packages/python/goldenmatch/tests/test_cluster.py`:
+
+```python
+import pytest
+
+try:
+    from hypothesis import given, strategies as st, settings
+    _HAS_HYPOTHESIS = True
+except ImportError:
+    _HAS_HYPOTHESIS = False
+
+
+@pytest.mark.skipif(not _HAS_HYPOTHESIS, reason="hypothesis not installed")
+@given(
+    n=st.integers(min_value=3, max_value=20),
+    seed=st.integers(min_value=0, max_value=10_000),
+)
+@settings(max_examples=200, deadline=None)
+def test_split_oversized_cluster_python_equals_numpy(n: int, seed: int):
+    """The vectorized split must produce the same partition as the Python
+    implementation. Spec Attack B testing tier 3."""
+    import random
+    from goldenmatch.core.cluster import (
+        split_oversized_cluster,
+        _split_oversized_cluster_python,    # private kept for parity
+    )
+    rng = random.Random(seed)
+    members = list(range(n))
+    # Dense graph with random weights.
+    pair_scores: dict[tuple[int, int], float] = {}
+    for i in range(n):
+        for j in range(i + 1, n):
+            pair_scores[(i, j)] = round(rng.random(), 6)
+
+    py = _split_oversized_cluster_python(members, pair_scores)
+    nv = split_oversized_cluster(members, pair_scores)
+
+    def normalize(parts):
+        return sorted(frozenset(sc["members"]) for sc in parts)
+
+    assert normalize(py) == normalize(nv), (
+        f"Vectorized split differs from Python on n={n}, seed={seed}:\n"
+        f"  python: {normalize(py)}\n"
+        f"  numpy:  {normalize(nv)}"
+    )
+```
+
+- [ ] **Step 2: Run the test to verify it fails.**
+
+Expected: `ImportError: cannot import name '_split_oversized_cluster_python'` — the private parity function doesn't exist yet.
+
+- [ ] **Step 3: Refactor + implement.**
+
+In `packages/python/goldenmatch/goldenmatch/core/cluster.py`:
+
+- Rename the current `split_oversized_cluster` to `_split_oversized_cluster_python` (preserve verbatim — this is the parity oracle).
+- Rename `_build_mst` to `_build_mst_python` similarly.
+- Add `_build_mst_numpy` and a new `split_oversized_cluster` that uses NumPy:
+
+```python
+def _build_mst_numpy(
+    members: list[int], pair_scores: dict[tuple[int, int], float],
+) -> list[tuple[int, int, float]]:
+    """Max-weight spanning tree via NumPy-packed Kruskal.
+
+    Eliminates the per-edge tuple unpacking that drives 55M Python max/min
+    calls at 500K scale (spec Attack B).
+    """
+    import numpy as np
+    if not pair_scores:
+        return []
+    n = len(pair_scores)
+    edges_uv = np.empty((n, 2), dtype=np.int64)
+    weights = np.empty(n, dtype=np.float64)
+    for k, ((a, b), w) in enumerate(pair_scores.items()):
+        edges_uv[k, 0] = a
+        edges_uv[k, 1] = b
+        weights[k] = w
+    order = np.argsort(-weights, kind="stable")
+    edges_uv = edges_uv[order]
+    weights = weights[order]
+
+    uf = UnionFind()
+    uf.add_many(members)
+    mst: list[tuple[int, int, float]] = []
+    target_edges = len(members) - 1
+    for idx in range(n):
+        a = int(edges_uv[idx, 0])
+        b = int(edges_uv[idx, 1])
+        if uf.find(a) != uf.find(b):
+            uf.union(a, b)
+            mst.append((a, b, float(weights[idx])))
+            if len(mst) == target_edges:
+                break
+    return mst
+
+
+def split_oversized_cluster(
+    members: list[int], pair_scores: dict[tuple[int, int], float],
+) -> list[dict]:
+    """Split a cluster by removing the weakest MST edge — NumPy-vectorized.
+
+    Spec Attack B. Algorithmically identical to the prior Python version;
+    parity asserted via tests/test_cluster.py::
+    test_split_oversized_cluster_python_equals_numpy.
+    """
+    import numpy as np
+    if len(members) <= 1 or not pair_scores:
+        return [{"members": sorted(members), "size": len(members),
+                 "oversized": False, "pair_scores": pair_scores}]
+
+    mst = _build_mst_numpy(members, pair_scores)
+    if not mst:
+        return [{"members": sorted(members), "size": len(members),
+                 "oversized": False, "pair_scores": pair_scores}]
+
+    # Weakest edge by argmin (no Python min(...,key=)).
+    mst_weights = np.fromiter((s for _, _, s in mst), dtype=np.float64, count=len(mst))
+    weakest_idx = int(mst_weights.argmin())
+    weakest = mst[weakest_idx]
+    remaining = mst[:weakest_idx] + mst[weakest_idx + 1:]
+
+    uf = UnionFind()
+    uf.add_many(members)
+    for a, b, _s in remaining:
+        uf.union(a, b)
+
+    result = []
+    for sc_members in uf.get_clusters():
+        sc_list = sorted(sc_members)
+        sc_pairs = {(a, b): s for (a, b), s in pair_scores.items()
+                    if a in sc_members and b in sc_members}
+        size = len(sc_list)
+        conf = compute_cluster_confidence(sc_pairs, size)
+        result.append({
+            "members": sc_list, "size": size, "oversized": False,
+            "pair_scores": sc_pairs, "confidence": conf["confidence"],
+            "bottleneck_pair": conf["bottleneck_pair"],
+        })
+    return result
+```
+
+- [ ] **Step 4: Run the property test.**
+
+```
+C:/Users/bsevern/AppData/Local/Programs/Python/Python312/python.exe -m pytest tests/test_cluster.py::test_split_oversized_cluster_python_equals_numpy -v --timeout=60
+```
+
+Expected: 200 examples pass.
+
+- [ ] **Step 5: Run the full cluster tests.**
+
+```
+C:/Users/bsevern/AppData/Local/Programs/Python/Python312/python.exe -m pytest tests/test_cluster.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit.**
+
+```
+git add packages/python/goldenmatch/goldenmatch/core/cluster.py packages/python/goldenmatch/tests/test_cluster.py
+git commit -m "perf(cluster): NumPy-vectorize MST + split_oversized_cluster
+
+Spec Attack B. Eliminates 55M Python max/min calls in the cluster split
+path by packing pair_scores into NumPy arrays, sorting once with argsort,
+and using argmin for the weakest-edge pick. Parity with the prior Python
+implementation asserted via Hypothesis property test (200 examples)."
+```
+
+### Task 2.2: Vectorize `compute_cluster_confidence`
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/cluster.py` — `compute_cluster_confidence` (grep for the def)
+
+- [ ] **Step 1: Locate the function.**
+
+```
+grep -n "def compute_cluster_confidence" packages/python/goldenmatch/goldenmatch/core/cluster.py
+```
+
+- [ ] **Step 2: Read the current Python implementation.**
+
+Look for `min(scores)`, `sum(scores)/len(scores)`, and the bottleneck-pair pick. These are the 55M-call surface.
+
+- [ ] **Step 3: Write the failing test.**
+
+Append to `tests/test_cluster.py`:
+
+```python
+def test_compute_cluster_confidence_uses_numpy_aggregations():
+    """compute_cluster_confidence should use NumPy reductions for min/mean
+    instead of Python loops. We assert behavior not implementation, but the
+    perf gate is enforced in the bench."""
+    from goldenmatch.core.cluster import compute_cluster_confidence
+    pair_scores = {(0, 1): 0.9, (0, 2): 0.8, (1, 2): 0.7}
+    conf = compute_cluster_confidence(pair_scores, size=3)
+    assert conf["confidence"] > 0.0
+    assert conf["bottleneck_pair"] in ((1, 2), (2, 1))
+```
+
+- [ ] **Step 4: Run — should pass already.**
+
+This test is mostly a guard for the rewrite, not a true failing-first TDD case. Run it green first to baseline, then rewrite, then run green again.
+
+- [ ] **Step 5: Rewrite `compute_cluster_confidence` to use NumPy.**
+
+```python
+def compute_cluster_confidence(
+    pair_scores: dict[tuple[int, int], float], size: int,
+) -> dict:
+    """Cluster confidence + bottleneck pair, NumPy-vectorized.
+
+    Spec Attack B: replaces the Python min/avg loop that drove ~55M
+    max/min calls at 500K scale.
+    """
+    import numpy as np
+    if not pair_scores or size <= 1:
+        return {"confidence": 1.0 if size <= 1 else 0.0, "bottleneck_pair": None}
+    keys = list(pair_scores.keys())
+    weights = np.fromiter(pair_scores.values(), dtype=np.float64, count=len(pair_scores))
+    min_idx = int(weights.argmin())
+    min_edge = float(weights[min_idx])
+    avg_edge = float(weights.mean())
+    # Connectivity: actual edges / max possible edges in a clique of `size`.
+    max_edges = size * (size - 1) // 2
+    connectivity = len(weights) / max_edges if max_edges else 0.0
+    confidence = 0.4 * min_edge + 0.3 * avg_edge + 0.3 * connectivity
+    return {
+        "confidence": confidence,
+        "bottleneck_pair": keys[min_idx],
+    }
+```
+
+- [ ] **Step 6: Run cluster tests.**
+
+```
+C:/Users/bsevern/AppData/Local/Programs/Python/Python312/python.exe -m pytest tests/test_cluster.py -v
+```
+
+Expected: all pass, including the property test from Task 2.1 (the change to `compute_cluster_confidence` is inside `split_oversized_cluster`'s sub-cluster confidence computation; parity must hold).
+
+- [ ] **Step 7: Commit.**
+
+```
+git add packages/python/goldenmatch/goldenmatch/core/cluster.py packages/python/goldenmatch/tests/test_cluster.py
+git commit -m "perf(cluster): NumPy-vectorize compute_cluster_confidence
+
+Spec Attack B finalization. Same algorithmic shape, NumPy reductions
+instead of Python min/mean loops over the pair_scores dict."
+```
+
+### Task 2.3: Re-bench at 500K via GHA — Attack B exit gate
+
+Per spec §Attack B "Acceptance": median wall hitting the rescaled gate AND `builtins.max` cumtime < 30s AND F1 within 0.005.
+
+- [ ] **Step 1: Push and trigger.**
+
+```
+git push
+gh workflow run bench-zero-config.yml --ref perf/post-controller-full-df \
+  -f n_records=500000 -f runs=5 -f dupe_rate=0.15 -f label=post-attack-b
+```
+
+- [ ] **Step 2: Watch + read summary.**
+
+```
+gh run watch <run-id> --exit-status
+```
+
+Gates against post-A baseline (from Task 1.5):
+- `wall_seconds_median` ≤ post-A median minus ≥60s OR rescaled per Phase 0.2. **GATE.**
+- In `cprofile_top`, no `builtins.max` entry above 30s cumtime. **GATE.**
+
+- [ ] **Step 3: F1 invariant via scale-audit workflow** (same shape as Task 1.5 Step 5). F1 within 0.005 of post-A audit. **GATE.**
+
+- [ ] **Step 4: Download + commit bench artifact.**
+
+```
+gh run download <bench-run-id> -n bench-zero-config-post-attack-b -D .profile_tmp/
+git add -f .profile_tmp/bench_post-attack-b.json
+git commit -m "bench(perf): post-Attack-B 500K results
+
+Median wall: {actual}s (post-A {prev}s, gate ≤{gate}s).
+builtins.max cumtime: {actual}s (gate <30s).
+F1 delta vs post-A: {actual} (gate ±0.005)."
+```
+
+### Task 2.4: Open the PR for Attack B
+
+- [ ] **Step 1: Push (existing branch or new — author's call; spec says two PRs).**
+
+If continuing on `perf/post-controller-full-df`, push and open the second PR off the same branch only after Attack A's PR is merged. Otherwise: `git switch -c perf/post-controller-full-df-attack-b` and push.
+
+- [ ] **Step 2: Open PR titled "perf: NumPy-vectorize cluster split (Attack B, 500K {prev}s -> {actual}s)".**
+
+Body: spec link, gate table, bench JSON link.
+
+---
+
+## Phase 3 — 1M headline measurement + docs
+
+### Task 3.1: 1M re-bench via GHA (the spec's actual exit criterion)
+
+Per spec §Acceptance criteria step 3. Single workflow run, captured for the CHANGELOG.
+
+- [ ] **Step 1: Trigger the bench workflow at 1M.**
+
+```
+gh workflow run bench-zero-config.yml --ref perf/post-controller-full-df \
+  -f n_records=1000000 -f runs=5 -f dupe_rate=0.15 -f label=post-attack-ab-1m
+```
+
+The workflow pins `GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD=10000000` so 1M still runs on polars-direct (not auto-promoted to DuckDB). Expected total wall: ~60-90 min depending on actual post-A+B speedup.
+
+- [ ] **Step 2: Watch.**
+
+```
+gh run watch <run-id> --exit-status
+```
+
+- [ ] **Step 3: Confirm headline gate.**
+
+`wall_seconds_median` ≤ 480 (8 min, per spec). If above, examine the cProfile artifact for the new top hotspot. Surface as a follow-up — **do not** retro-fit the spec.
+
+- [ ] **Step 4: Download + commit the JSON.**
+
+```
+gh run download <run-id> -n bench-zero-config-post-attack-ab-1m -D .profile_tmp/
+git add -f .profile_tmp/bench_post-attack-ab-1m.json
+git commit -m "bench(perf): post-A+B 1M headline result
+
+Median wall: {actual}s on ubuntu-latest-large (post-#239 baseline at 1M
+TBD via Phase 0.2 follow-up if a 1M baseline run is wanted; the spec's
+acceptance target is absolute (8 min) so the comparison is to the gate,
+not a prior 1M measurement)."
+```
+
+### Task 3.2: CHANGELOG + README callout
+
+**Files:**
+- Modify: `packages/python/goldenmatch/CHANGELOG.md`
+- Modify (conditional): `README.md` "what's new" section if delta > 50%
+
+- [ ] **Step 1: Append CHANGELOG entry under the next unreleased section.**
+
+```markdown
+### Performance
+
+- Default-backend `gm.dedupe_df(df)` zero-config is ~{X}× faster at 500K.
+  Two cross-stage Python hotspots eliminated: (A) the per-block
+  `LazyFrame.collect` round-trip in `apply_learned_blocks` (was 462K
+  collects at 500K) is replaced with a positional `BlockResult` contract
+  that materializes via `parent_df[positions]` once at the single scoring
+  consumer; (B) `split_oversized_cluster` + `compute_cluster_confidence`
+  are NumPy-vectorized (eliminates ~55M Python `max()`/`min()` calls).
+  500K median wall: 488s -> {actual}s. 1M median: {actual_1m}s. See
+  `docs/superpowers/specs/2026-05-15-post-controller-full-df-perf-design.md`.
+```
+
+- [ ] **Step 2: If 1M median dropped > 50%, add a one-line callout to README.md** under the existing "what's new" or performance section. Match the formatting of prior callouts.
+
+- [ ] **Step 3: Commit.**
+
+```
+git add packages/python/goldenmatch/CHANGELOG.md README.md
+git commit -m "docs(changelog): record post-controller full-df perf wins (Attacks A + B)"
+```
+
+### Task 3.3: Memory entry — capture the cross-stage-primitive lesson
+
+Per spec §Implementation order step 6 and reviewer advisory #3.
+
+**Files:**
+- Create: `C:\Users\bsevern\.claude\projects\D--show-case-goldenmatch\memory\project_post_controller_full_df_perf.md`
+- Modify: `C:\Users\bsevern\.claude\projects\D--show-case-goldenmatch\memory\MEMORY.md`
+
+- [ ] **Step 1: Create the memory file.**
+
+```markdown
+---
+name: project-post-controller-full-df-perf
+description: Post-controller full-df perf attack (May 2026) — cross-stage primitives owned 40% of wall, not single stages. Lesson for future perf audits.
+metadata:
+  type: project
+---
+
+The 500K bench of `gm.dedupe_df(df)` showed no single pipeline stage cleared
+30% of wall — blocking, scoring, and clustering each owned ~22-24%. The real
+bottlenecks were two **cross-stage Python primitives**: 462K `LazyFrame.collect`
+calls (27% wall) and 55M `builtins.max` calls (13% wall). Both fixed in
+PRs (Attack A + Attack B, see `docs/superpowers/specs/2026-05-15-post-controller-full-df-perf-design.md`).
+
+**Why:** Earlier audits ranked by per-stage cumtime and missed cross-stage costs.
+The spec's CLAUDE.md performance-audit lesson ("rank by measured wall, not
+static structure") captured the rule; this audit was the first to actually
+apply it at scale.
+
+**How to apply:** When profiling a multi-stage pipeline, always group cProfile
+top by *primitive* (tottime over function name, ignoring caller chain) in
+addition to grouping by stage subtree. If a primitive appears across multiple
+stages, that's a cross-cutting hotspot that no single stage owns.
+
+Related: [[reference-bench-1m-zero-config-script]] if I write that memory later.
+```
+
+- [ ] **Step 2: Add the index line to `MEMORY.md`.**
+
+```
+- [Post-controller full-df perf lessons](project_post_controller_full_df_perf.md) — cross-stage primitives owned 40% wall; rank cProfile by primitive too
+```
+
+- [ ] **Step 3: No git commit (memory is outside the repo).**
+
+---
+
+## Phase 4 — Cleanup + follow-ups (out of scope but tracked)
+
+### Task 4.1: ~~Fix the bench script's stage-monkey-patch~~ — OBSOLETE
+
+PR #239 added `goldenmatch.core.bench` with `bench_capture()` + in-pipeline stage wrapping. The bench script was already migrated to use it during the brainstorm session. This task is dropped.
+
+### Task 4.2: Filed-as-followups (do NOT do as part of this plan)
+
+These were flagged in the spec but are out of scope. File them as GitHub issues with `perf` label after Phase 3 lands:
+
+- GoldenCheck quality scan firing 3× per `dedupe_df` call (~5-6% wall).
+- Controller committing RED on the synthetic 500K fixture (`failing_subprofile=scoring`).
+- `score_blocks_parallel` ThreadPoolExecutor scheduling causing 22% wall variance — investigate pinning `max_workers`.
+- chunked / DuckDB backend parity: apply analogous positional + NumPy-vectorize patterns if 5M profiling shows the same primitives dominate.
+
+---
+
+## Acceptance checklist (matches spec §Acceptance criteria)
+
+- [ ] Attack A PR merged. 500K bench median ≤ 250s, `LazyFrame.collect` ncalls < 50,000, F1 within 0.005.
+- [ ] Attack B PR merged. 500K bench median ≤ 150s, `builtins.max` cumtime < 30s, F1 within 0.005.
+- [ ] 1M bench re-run committed to `.profile_tmp/bench_1m_zero_config_after.json`, median ≤ 8 min.
+- [ ] CHANGELOG entry merged with measured before/after deltas. README callout if delta > 50%.
+- [ ] Memory entry `project_post_controller_full_df_perf.md` written.
+- [ ] Existing test suite (1572+ passing per CLAUDE.md baseline) green.

--- a/docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md
+++ b/docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md
@@ -1,0 +1,237 @@
+# Controller v3 — the auto-config controller becomes the execution planner
+
+**Status:** Design (drafted 2026-05-15)
+**Author:** Claude + bsevern, brainstorm from the 50M readiness conversation
+**Scope:** `packages/python/goldenmatch/goldenmatch/core/autoconfig.py`, `core/autoconfig_controller.py`, `core/autoconfig_policy.py`. Extension to the existing introspective controller's decision space.
+**Related:**
+- Existing controller spec: [`2026-05-06-autoconfig-introspective-controller-design.md`](2026-05-06-autoconfig-introspective-controller-design.md) — v1 picks blocking key, matchkey weights, threshold. This spec extends to also pick backend + chunk_size + workers + spill thresholds.
+- Distributed Plan v1: [`2026-05-15-distributed-plan-v1-design.md`](2026-05-15-distributed-plan-v1-design.md) — the 50M architecture. Controller v3 is the planner that selects which execution plan to run.
+- PR #239: introduced the prototype `autoconfig.py` scale-aware backend selection (`GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD` env var). This spec promotes that env-var hack to first-class controller state.
+
+## Problem
+
+GoldenMatch's zero-config promise is "user calls `gm.dedupe_df(df)` and we figure out everything else." Today, "everything else" means: blocking keys, matchkey weights, threshold, scorers — but **not** backend, chunk size, worker count, or memory budget. Those are left as kwargs the user has to pick.
+
+The result: real callers either accept the default polars-direct backend (which OOMs at 5M on a 16GB box) or read CLAUDE.md and learn the spell "use `backend='chunked'` + `config_mode='explicit-personlike'`". That spell defeats zero-config.
+
+PR #239's `autoconfig.py` already prototypes the right idea:
+
+```python
+# at n_rows >= 1M, force backend="duckdb"
+if n_rows >= int(os.environ.get("GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD", "1_000_000")):
+    config.backend = "duckdb"
+```
+
+That's planning. It's just hard-coded, single-signal, and env-var-gated. **Controller v3 makes execution planning a first-class concern of the auto-config loop.**
+
+## Goals
+
+1. **Auto-select execution plan** without user input: backend, chunk_size, max_workers, pair_spill_threshold, and clustering strategy (in-memory union-find vs spill-and-merge).
+2. **Signal-driven, not row-count-thresholded.** Use the controller's existing `ComplexityProfile` (block size distribution, estimated pair count) + runtime introspection (available RAM via psutil) to decide.
+3. **Backward compat.** Users who pass `backend="..."` or `config.backend=...` explicitly still get their choice; the planner only fills gaps.
+4. **Observable.** The planner's decision + reasoning lands on `PostflightReport.controller_history` next to the existing matchkey/blocking decisions.
+
+## Non-goals (v1)
+
+- Implementing the chunked or distributed backends themselves. v3 is the planner; the backends it selects from must exist or be tagged as "planned" placeholders.
+- LLM-driven planning. The `LLMRefitPolicy` hook from the v1 controller spec is the future home; not implemented here.
+- Cross-machine cluster orchestration. The planner decides "use Ray with N workers"; Ray initialization stays in the existing `backends/ray_backend.py`.
+
+## Decision space (what the planner picks)
+
+Six knobs the user currently has to set manually (or accepts defaults that don't scale):
+
+| Knob | Current default | Range | Picked when |
+|---|---|---|---|
+| `backend` | `"polars-direct"` | `polars-direct` / `chunked` / `duckdb` / `ray` | Always (default not size-aware) |
+| `chunk_size` (chunked backend) | `100_000` | 10K–1M | Backend = `chunked` |
+| `max_workers` (Ray + ThreadPoolExecutor) | 4 | 1 to `os.cpu_count()` | Always |
+| `pair_spill_threshold` (when to write pairs to disk vs RAM) | None — all pairs in RAM | None / 1M / 10M / 100M | Backend ∈ {`chunked`, `duckdb`, `ray`} |
+| `clustering_strategy` | In-memory union-find on all pairs | `in_memory` / `partitioned_union_find` / `streaming_cc` | Backend / spill threshold combination |
+| `auto_fix_quality_scan_mode` | enabled, runs 3x via controller iteration | `enabled` / `cached` / `disabled` | Always — caching is the v3 add |
+
+## Signals (what the planner reads)
+
+Existing on `ComplexityProfile` (no new collection needed):
+
+- `DataProfile.n_rows`, `DataProfile.column_types`, `DataProfile.cardinality_ratio`
+- `BlockingProfile.n_blocks`, `BlockingProfile.block_sizes_p50/p95/p99/max`, `BlockingProfile.total_comparisons`
+- `MatchkeyProfile.per_field.*`
+
+New signals to add:
+
+- `RuntimeProfile.available_ram_gb`: `psutil.virtual_memory().available / (1024**3)` at controller-start.
+- `RuntimeProfile.cpu_count`: `os.cpu_count()`.
+- `RuntimeProfile.disk_free_gb` (for spill threshold sanity).
+- `EstimatedPairCount`: `sum(max(0, n) * max(0, n-1) // 2 for n in block_sizes)`. Computed from `BlockingProfile`. Already implicitly available; surface as a named field.
+
+## Decision rules (the planner's policy table)
+
+Each rule is a `(predicate, action)` pair. Rules evaluate in order; first match wins. The point is to make the policy table readable and overridable, not a hairy if-tree.
+
+### Rule 1 — pathological inputs (mirror existing controller §Error handling 6)
+
+| Predicate | Action |
+|---|---|
+| `n_rows == 0` | `ConfigValidationError` |
+| `n_rows == 1` | Skip controller; return v0 |
+| All columns null | `ConfigValidationError` |
+| Single non-empty column | v0 + `health=yellow` |
+
+### Rule 2 — small enough for the simple plan
+
+| Predicate | Action |
+|---|---|
+| `n_rows < 100_000` AND `estimated_pair_count < 50_000_000` | `backend=polars-direct`, `chunk_size=None`, `max_workers=min(4, cpu_count)`, `clustering=in_memory`, `pair_spill=None` |
+
+This is the "laptop demo" plan. Fits comfortably in 8 GB.
+
+### Rule 3 — large rows, sparse pairs
+
+| Predicate | Action |
+|---|---|
+| `n_rows >= 100_000` AND `estimated_pair_count < 50_000_000` AND `available_ram_gb >= 32` | `backend=polars-direct`, `max_workers=min(cpu_count, 16)`, `clustering=in_memory` |
+
+The mid-tier "fast box" plan. Examples: 5M rows with very selective blocking keeping pair count under 50M.
+
+### Rule 4 — large rows, lots of pairs, fits in memory with chunking
+
+| Predicate | Action |
+|---|---|
+| `estimated_pair_count >= 50_000_000` AND `estimated_pair_count < 5_000_000_000` AND `available_ram_gb >= 16` | `backend=chunked`, `chunk_size=auto_chunk_size(n_rows, available_ram_gb)`, `pair_spill=ram`, `clustering=in_memory`, `max_workers=min(cpu_count, 16)` |
+
+Where `auto_chunk_size = n_rows // ceil(estimated_memory_gb / available_ram_gb_target_use_fraction)`. Concretely: target using 60% of available RAM, divide rows accordingly.
+
+### Rule 5 — DuckDB out-of-core regime
+
+| Predicate | Action |
+|---|---|
+| `estimated_pair_count >= 5_000_000_000` OR `available_ram_gb < 16` | `backend=duckdb`, `pair_spill=duckdb`, `clustering=partitioned_union_find`, `max_workers=min(cpu_count, 8)` |
+
+The "single-box scale" plan. Uses DuckDB as the data plane (spill to disk natively, parallel query exec). Clustering shifts to partitioned union-find because the full pair set won't fit in Python memory.
+
+### Rule 6 — Ray escape hatch
+
+| Predicate | Action |
+|---|---|
+| `n_rows >= 50_000_000` AND `ray_available` (`ray` import succeeds, cluster initializable) | `backend=ray`, `max_workers=cpu_count_total_cluster`, `pair_spill=disk_per_worker`, `clustering=streaming_cc` |
+
+The 50M+ plan. Requires Distributed Plan v1's clustering strategy. Falls back to Rule 5 if Ray isn't available.
+
+### Rule 7 — explicit override always wins
+
+If the user passes `config.backend` or `gm.dedupe_df(..., backend=...)` explicitly, **all of the above rules are skipped for the backend slot**. The planner still fills `chunk_size`, `max_workers`, etc. for whichever backend the user picked.
+
+## Auto-cache the auto-fix + quality scan
+
+Per the post-#239 100K cProfile, `transform.run_transform` and the GoldenCheck quality scan each fire **5 times** per `dedupe_df()` call because the controller iterates 5 times (sample iterations + finalize). The transform output is deterministic for a given input; cache it.
+
+Implementation:
+
+- `ControllerCache` keyed on `(content_hash(df), config_version_hash)`.
+- First iteration computes + caches; subsequent iterations read from cache.
+- Cache lives on the controller instance, dies with the dedupe call (no cross-call persistence in v1).
+
+Expected savings: ~10s per 100K dedupe (12.91s cumtime for `run_transform` reduced to ~3s for one application + ~0.1s × 4 for cache hits).
+
+Out of scope: cross-call caching (would persist across `dedupe_df` invocations; risk of stale entries; needs the existing AutoConfigMemory mechanism). v1 caches within a single call only.
+
+## Observability
+
+Planner decisions land on `RunHistory.decisions` alongside the existing matchkey/blocking decisions. New `PolicyDecision.rule_name` values:
+
+- `plan_selected_simple` (Rule 2)
+- `plan_selected_fast_box` (Rule 3)
+- `plan_selected_chunked` (Rule 4)
+- `plan_selected_duckdb` (Rule 5)
+- `plan_selected_ray` (Rule 6)
+- `plan_user_override` (Rule 7)
+
+Each carries `config_diff` with the actual `backend`, `chunk_size`, `max_workers`, etc. selected.
+
+`PostflightReport` gets one new field surfaced via the existing controller-history hook: `execution_plan`, a frozen dataclass capturing all six knobs. CLI / MCP / web tab rendering updated to show this.
+
+## Pipeline integration
+
+The planner runs **as the last step of `AutoConfigController.run`**, after the existing matchkey/blocking/threshold loop converges. It reads the final `ComplexityProfile` (which has the block size distribution from the last iteration) plus `RuntimeProfile`, applies the rule table, and writes the plan onto `GoldenMatchConfig` before returning.
+
+Order matters: the existing controller iterates on a 2K-row sample to pick blocking/matchkey/threshold. The plan that runs the final full-data dedupe is selected **based on the full-data row count + the sampled block size distribution + the actual runtime**. Sampling doesn't tell us the runtime is — that's a runtime introspection.
+
+```
+AutoConfigController.run(df):
+    profile_v0 = profile(sample(df))
+    config_v0 = initial_config(profile_v0)
+    config_n, profile_n, history = iterate(sample(df), config_v0)
+                                   # picks matchkey/blocking/threshold
+    runtime = capture_runtime_profile()     # NEW: psutil snapshot
+    plan = apply_planner_rules(profile_n.extrapolate(n_rows_full),
+                               runtime, config_n)        # NEW
+    config_n.apply_plan(plan)               # NEW
+    history.append(PolicyDecision(rule_name="plan_selected_*", ...))
+    return config_n, profile_n, history
+```
+
+`profile_n.extrapolate(n_rows_full)` projects the sample's block-size distribution to the full data. The simplest projection: `n_blocks_full = n_blocks_sample * (n_rows_full / n_rows_sample)`, `block_sizes_*_full = block_sizes_*_sample * (n_rows_full / n_rows_sample)`. Crude but defensible — pair count estimate is the load-bearing signal, and that scales linearly with the projection.
+
+## Backward compatibility
+
+- Users on `gm.dedupe_df(df)` zero-config: plan auto-selected. Behavior changes for callers near the rule boundaries (e.g. previously OOM'd at 5M, now switches to chunked transparently). This is the headline improvement.
+- Users on `gm.dedupe_df(df, backend="...")`: explicit override wins per Rule 7. No behavior change.
+- Users on `config.backend="..."` via YAML: same as above. The plan fills only the unset knobs.
+- The `GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD` env var from PR #239 is retained as a Rule 5 threshold override for one release, with a `DeprecationWarning` when set. Drop in v2.
+
+## Testing
+
+### Tier 1 — unit tests on the rule table
+
+Each rule gets its own test: construct a synthetic `ComplexityProfile` + `RuntimeProfile` that should hit the rule, call the planner, assert the right `config_diff`. ~10 tests.
+
+Boundary tests for each rule's edge of applicability (n_rows just below / just above threshold). ~6 tests.
+
+User-override test: user passes `backend="ray"` on a 1K dataset. Assert Rule 7 fires and the plan has `backend="ray"` regardless of size. ~2 tests.
+
+### Tier 2 — integration tests
+
+For each plan tier, run `gm.dedupe_df` end-to-end on a fixture sized to trigger that tier:
+
+- Simple plan: Febrl3 (5K). Assert plan rule + clean run.
+- Fast-box plan: synthetic 100K. Assert plan rule + clean run.
+- Chunked plan: synthetic 500K with available RAM mocked to 8 GB. Assert chunk_size auto-picked + clean run.
+- DuckDB plan: synthetic 500K with available RAM mocked to 4 GB. Assert DuckDB selected + clean run.
+- Ray plan: synthetic 1M with `ray` available + sample of pair count ≥ 50M. Assert Ray selected (skipped if `ray` not installed).
+
+### Tier 3 — bench gate
+
+Re-run `bench-zero-config` at 100K (post-attack baseline) and confirm:
+- Plan selected: `simple` (Rule 2).
+- 100K wall ≤ 24s (carries over from map_elements attack).
+- Cached transform: `run_transform` cumtime in cProfile < 4s (was 12.91s).
+
+Re-run at 500K:
+- Plan selected: probably `fast-box` on the 64 GB runner (Rule 3); on a 16 GB lane it should select `chunked` (Rule 4).
+- Wall ≤ 110s (extrapolated from 100K × 5x linear).
+
+### Tier 4 — scale audit
+
+The existing scale-audit-5m workflow at 5M:
+- Pre-v3: requires explicit `backend="chunked"` + `config_mode="explicit-personlike"` per CLAUDE.md (~50 min, 11.9 GB peak).
+- Post-v3: `gm.dedupe_df(df)` zero-config should produce the same plan automatically. Same wall + RSS targets ±10%.
+
+This is the load-bearing test for the spec. If 5M zero-config doesn't auto-select `chunked` with sensible chunk size on `ubuntu-latest-large`, the planner is wrong.
+
+## Open questions
+
+1. **Pair-count extrapolation accuracy.** The simple linear projection from sample to full-data block size distribution will be wrong for skewed data. Worst case: sample shows tight blocks (P99=200), full data has one giant block (P99=50K). The planner picks the wrong tier. Mitigation: bias toward larger plans when the sample's `block_sizes_p99 / block_sizes_p50 > 5` (likely-skewed signal).
+2. **Runtime introspection on Ray.** `psutil.virtual_memory()` reports the head node's memory, not the worker pool's. The Ray rule needs cluster introspection (`ray.cluster_resources()`). Out of scope for v1; document the caveat.
+3. **Cache invalidation correctness.** The within-call transform cache is keyed on `content_hash(df)` — needs to hash the polars Series content stably. Use Polars's built-in hash for the column subset that transforms touch; document the key derivation.
+4. **Threshold values.** All concrete thresholds (50M pair count, 16 GB RAM, 100K row breakpoint) are starting points. Each will need calibration once we have measurements at each tier.
+
+## Acceptance criteria
+
+- v1 ships when:
+  1. All six knobs in the decision space have a default rule that fires sensibly on test fixtures.
+  2. `ExecutionPlan` lands on `PostflightReport` and is visible in CLI / MCP output.
+  3. 100K bench shows the cached transform (cumtime < 4s) without regression.
+  4. The 5M zero-config audit produces the same wall + F1 as the documented explicit-personlike + chunked combo, ±10%.
+  5. All existing tests continue to pass.
+  6. Spec [`2026-05-15-map-elements-attack-design.md`](2026-05-15-map-elements-attack-design.md) is merged before this; the planner cache assumes per-call transform is the expensive bit.

--- a/docs/superpowers/specs/2026-05-15-distributed-plan-v1-design.md
+++ b/docs/superpowers/specs/2026-05-15-distributed-plan-v1-design.md
@@ -1,0 +1,214 @@
+# GoldenMatch Distributed Plan v1 — architecture for 50M+ records
+
+**Status:** Design (drafted 2026-05-15)
+**Author:** Claude + bsevern, brainstorm from the 50M readiness conversation
+**Scope:** A new execution plan, selected by the [controller v3 planner](2026-05-15-controller-v3-planner-design.md) at scale, that replaces single-process Polars-direct with a partitioned, spillable, distributed pipeline. Architectural; implementation is a multi-PR arc, not a single change.
+**Related:**
+- [`2026-05-15-controller-v3-planner-design.md`](2026-05-15-controller-v3-planner-design.md) — the planner that selects this plan vs the simpler ones.
+- [`2026-05-15-map-elements-attack-design.md`](2026-05-15-map-elements-attack-design.md) — single-process optimizations that take us to 10M.
+- PRs #233/#234/#235: chunked backend foundations + block-keyed cross-chunk index + score_blocks_duckdb out-of-core pair store. **These are partial implementations of the components here.**
+- `packages/python/goldenmatch/goldenmatch/backends/ray_backend.py`: prior-art distributed scoring backend. v1 builds on it.
+- 5M audit (CLAUDE.md): the chunked + explicit-personlike combo took 50 min for 5M on ubuntu-latest (4c/16GB). 50M on the same hardware shape would be 100x compute + bigger memory pressure than chunking can paper over. **Architectural change required.**
+
+## Problem
+
+GoldenMatch's current scale ceiling is 5-10M with the chunked backend + explicit blocking. The single-process pipeline has these hard limits:
+
+1. **Pair generation.** O(sum(block_size²)) per blocking pass. At 50M with even tight blocking, candidate pairs grow into the billions.
+2. **Pair storage.** All pairs currently land in a Python list/set in memory before clustering. PR #235 added `score_blocks_duckdb` as an out-of-core pair store, but the in-memory polars-direct path is unchanged.
+3. **Clustering.** `core/cluster.py::build_clusters` uses a Python `UnionFind` over the **full** pair set in one process. At 50M with 100M+ pairs, this single-driver step OOMs before it starts.
+4. **No partitioning.** All workers in `score_blocks_parallel` operate on the same parent DataFrame. There's no "this worker owns these blocks; this other worker owns those" boundary.
+5. **No retry / no failure isolation.** A single block's scoring error fails the whole pipeline.
+
+The intuition from PR #239's improvements: "make Python faster" pays off cleanly up to 10M, then the asymptote bends. **50M is a distributed graph processing problem wearing a fuzzy-matching jacket.**
+
+## Goals
+
+1. **`gm.dedupe_df(big_df)` zero-config at 50M+** without manual backend selection. Planner picks Distributed Plan automatically per [controller v3 Rule 6](2026-05-15-controller-v3-planner-design.md).
+2. **No correctness regression vs single-process.** Same clusters (modulo ordering), same F1, same lineage.
+3. **Bounded peak memory per worker.** Distributed plan must run on commodity hardware (a few dozen GB per worker), not require fat instances.
+4. **Observability.** Per-partition stage timings, pair counts, spill volumes, and clustering merge boundary stats land on `PostflightReport`.
+5. **Quality gate.** Every released scale tier (10M, 25M, 50M, ...) verified via `eval-er-evaluation` pairwise + B-cubed + cluster F1 within bootstrap noise of the 100K baseline.
+
+## Non-goals (v1)
+
+- Cross-data-center sharding. Single-cluster only.
+- Replicated scoring (running each block on multiple workers for fault tolerance). Workers retry on failure; replication is v2.
+- GPU scoring. The rapidfuzz CPU path is well-served by parallelism alone at the rec/s rates we need.
+- Spark backend. Documented as a future enterprise/Databricks lane; not the zero-config default. Different code path, different team.
+- Streaming live ingestion. The plan operates on a bounded input frame, not a Kafka topic.
+
+## The six architectural components
+
+This is the load-bearing list. Five are well-trodden; component #5 is the hard one and the one most likely to determine v1's success.
+
+### Component 1 — Prepared-record store
+
+Where: new module `goldenmatch/distributed/record_store.py` (or extension of `backends/score_duckdb.py`).
+
+**Function:** materialize the post-`compute_matchkeys` + post-`precompute_matchkey_transforms` DataFrame once to a partitioned Arrow/Parquet store on disk. All downstream stages read from this store; the raw input frame is forgotten.
+
+**Why it matters:** the controller iterates 5x. Today each iteration re-transforms the (sampled) data. At 50M scale, even one transform pass is the bottleneck if it touches every row. Persisting prepared records eliminates the re-do.
+
+**Choice point:** Arrow IPC files vs Parquet vs DuckDB tables.
+- **Arrow IPC:** zero-copy load via mmap. Fast for repeated full-frame access. Polars + DuckDB both consume natively.
+- **Parquet:** more compact (compressed), but read costs decompression on every access.
+- **DuckDB tables:** the data plane handles spill/parallelism natively; SQL-queryable; pairs naturally with component #2.
+
+**Recommendation:** DuckDB tables for the prepared-record store. Already validated in PR #235's `score_blocks_duckdb`. The data plane becomes "DuckDB owns records and pairs; Python owns scoring UDFs and clustering logic." Mirrors Splink.
+
+### Component 2 — Block-key partitioned execution
+
+Where: extension to `core/blocker.py` + new `goldenmatch/distributed/partitioner.py`.
+
+**Function:** instead of treating blocks as units of work passed to a thread pool over a shared parent DataFrame, *partition* the prepared-record store by block key. Each partition becomes the unit of work for one worker. Workers operate on their own slice; no shared global frame.
+
+**Implementation:** `df.partition_by("__block_key__", ...)` in Polars, or `PARTITION BY` in DuckDB. The chunked backend (#233) already has the partitioning primitive; v1 promotes it to first-class.
+
+**Why it matters:** removes the shared-state coordination overhead in `score_blocks_parallel`. Workers can be on different machines. Boundary edges (pairs whose two records are in different block-key partitions) require handling — that's component #5.
+
+### Component 3 — Distributed scoring
+
+Where: extension of `backends/ray_backend.py`, possibly renamed `goldenmatch/distributed/scorer.py`.
+
+**Function:** each worker scores its assigned partition's blocks. rapidfuzz is Python/Rust native, releases the GIL, parallelizes well via Ray remote tasks. The existing Ray backend already does block-level distribution; v1 extends it to operate on the prepared-record store from component #1 rather than the in-memory parent frame.
+
+**Existing prior art:** `score_blocks_ray` in `backends/ray_backend.py`. Tested on small block counts; falls back to the threaded scorer below ~4 blocks per CLAUDE.md.
+
+**Why it matters:** parallelism by worker count rather than by thread pool size. Scales with cluster.
+
+### Component 4 — Streaming pair store
+
+Where: extension of PR #235's DuckDB pair store, or new `goldenmatch/distributed/pair_store.py`.
+
+**Function:** scored pairs land in a partitioned on-disk store (DuckDB table or Parquet, partitioned by `__block_key__` of one of the records). The store accepts streaming writes from workers and supports range/key reads for the clustering step.
+
+**Why it matters:** at 50M+ the pair count blows past Python-process memory. Pairs must spill. DuckDB's INSERT + Arrow bulk import (proven in PR #235) is the right tool.
+
+**Schema:**
+```sql
+CREATE TABLE pairs (
+    record_a_id BIGINT,
+    record_b_id BIGINT,
+    block_key TEXT,    -- partition column
+    score DOUBLE,
+    matchkey_name TEXT
+);
+CREATE INDEX pairs_a ON pairs (record_a_id);
+CREATE INDEX pairs_b ON pairs (record_b_id);
+```
+
+### Component 5 — Distributed clustering (the hard one)
+
+**This is THE architectural decision.** Everything else is solved patterns; clustering at distributed scale is where v1 lives or dies.
+
+Three viable approaches:
+
+#### Approach A — Boundary-aware per-partition union-find (recommended for v1)
+
+1. Each worker runs `UnionFind` over the pairs in its partition. Produces local clusters keyed by partition.
+2. Boundary edges (pairs where the two records' canonical partition assignments differ) get written to a dedicated `boundary_pairs` table.
+3. A single coordination pass (driver-side, but operating only on boundary pairs — orders of magnitude smaller) merges clusters that share boundary records.
+
+**Pros:**
+- 95% of clustering work is partition-local and parallel.
+- Driver pass handles only boundary edges; size is bounded by blocking coverage, not total pair count.
+- No iterative messaging framework needed.
+
+**Cons:**
+- Correctness depends on **the boundary-edge tracking layer being complete** — every cross-partition pair must be captured. A bug there silently splits clusters.
+- Worst case: very coarse blocking produces many boundary pairs; degrades toward Approach B.
+
+**Pre-existing foundation:** PR #234's block-keyed cross-chunk index lookup is already a primitive form of this for the chunked backend. v1 generalizes the pattern.
+
+#### Approach B — GraphX / Pregel-style iterative messaging
+
+Workers exchange messages until cluster IDs converge. Standard Spark/GraphX pattern. Heavy. Requires actual cluster orchestration (Ray is borderline; Spark is natural).
+
+**Verdict for v1:** rejected. Drags in Spark or hand-rolled iterative coordination on Ray. Doesn't pay back at our scale tier.
+
+#### Approach C — DuckDB recursive CTE for connected components
+
+DuckDB 0.10+ supports recursive CTEs. A single SQL query could compute CC over the pair table.
+
+**Pros:** simple to write, data plane handles everything.
+**Cons:** untested at 100M+ rows. DuckDB's CTE optimizer may not handle the join volume gracefully. Worth a 1M+ smoke test, but not the v1 default.
+
+**Decision:** Approach A (boundary-aware per-partition union-find) is the v1 plan. Approach C is a parallel experiment worth tracking as a possibly-simpler v2 alternative.
+
+### Component 6 — Planner integration
+
+Where: [`controller v3`](2026-05-15-controller-v3-planner-design.md) Rule 6.
+
+**Function:** the planner selects Distributed Plan when `n_rows >= 50_000_000` AND `ray_available`. Falls back to the DuckDB single-box plan (Rule 5) if Ray isn't installed or fails to initialize.
+
+**Knobs the plan exposes to the planner:**
+- `n_partitions` (= number of unique block keys, capped at `cluster_total_cores * 4`)
+- `pair_spill_path` (where the DuckDB pair store lives)
+- `max_workers` (Ray actor count)
+- `clustering_strategy = "partitioned_union_find"`
+
+The plan is invisible to the user. `gm.dedupe_df(big_df)` is the only API surface.
+
+## Failure modes and recovery
+
+| Failure | Detection | Recovery |
+|---|---|---|
+| Worker dies mid-scoring | Ray task heartbeat timeout | Retry the partition on another worker. Idempotent because each partition writes to its own pair-store key range. |
+| DuckDB pair store full | INSERT raises | Surface `OutOfStorageError` immediately. Disk overflow is a hardware problem, not a software one — fail loudly with the spill path and disk free for the user to act on. |
+| Boundary-edge merge produces giant cluster | Driver-side check: post-merge, any cluster with `size > 0.1 * n_rows` is suspect | Run the existing `split_oversized_cluster` MST-cut routine per oversized cluster. Logged + surfaced on `PostflightReport`. |
+| One partition has pathological skew (one block has 90% of rows) | Pre-scoring: `block_sizes_p99 / block_sizes_p50 > 50` per partition | Apply `_auto_split_block` (PR #239) before scoring. Auto-splits the hot block into sub-blocks via a secondary blocking key. |
+| Network partition splits the Ray cluster | Ray scheduler raises | Fail the run. v1 doesn't do partial-cluster degradation. |
+
+## Quality gate
+
+Every scale-tier milestone (10M, 25M, 50M, 100M) must pass:
+
+1. **er-evaluation pairwise F1** within bootstrap noise of the 100K Febrl3 baseline (currently 0.9097 ± 0.002).
+2. **er-evaluation B-cubed F1** within bootstrap noise (currently 0.9935 ± 0.0001).
+3. **er-evaluation cluster F1** within bootstrap noise (currently 0.9647 ± 0.001).
+4. **Internal scale-audit F1** within ±0.005 of the comparable tier on chunked + explicit-personlike (the current 5M audit shape).
+5. **Wall time** recorded. Not gated for the first milestone hit. Target curves added in subsequent revisions.
+6. **Peak RSS per worker** recorded. Distributed plan's whole point is to keep this bounded.
+
+No "passes" without all five quality numbers.
+
+## Implementation arc
+
+Spec → multiple PRs over multiple sessions. Sequencing:
+
+1. **Component 1** (prepared-record store, DuckDB-backed). 1-2 PRs. Lands the persistence layer. **Gate:** existing 5M chunked audit reads from prepared store instead of re-transforming. Wall ≤ existing 50 min.
+2. **Component 4** (streaming pair store). 1 PR. Extends PR #235 with the partition-by-block-key column + indexes. **Gate:** 5M audit with on-disk pair store. RSS reduction visible.
+3. **Component 2** (block-key partitioning). 1-2 PRs. Threads partition-by through blocker + scorer. **Gate:** 5M with parallel partitions on the threaded backend (no Ray yet). Wall ≤ existing.
+4. **Component 5A** (boundary-aware per-partition union-find). The hard one. 2-3 PRs. **Gate:** 5M end-to-end same F1 as chunked baseline. **This is the load-bearing milestone for the architecture.**
+5. **Component 3** (distributed scoring on Ray). 1-2 PRs. Migrates the partition-aware scorer to Ray remote tasks. **Gate:** 10M zero-config on a 2-node Ray cluster.
+6. **Component 6** (planner integration). 1 PR. Controller v3 Rule 6 activates. **Gate:** `gm.dedupe_df(df)` zero-config at 10M auto-selects Distributed Plan, same F1 as chunked-explicit at the same N.
+7. **Milestone runs.** 25M, 50M, 100M with the quality gate. Each is its own run + spec amendment with the numbers.
+
+Estimated effort: components 1-4 are 2-3 weeks of focused work each; component 5 is the open-ended one (could be 4-8 weeks depending on what boundary-edge tracking turns into).
+
+## Open architectural questions
+
+1. **Worker pool sizing.** Auto-scale or fixed? v1 picks a fixed count based on the planner's signal; v2 could auto-scale based on per-partition wall time observed mid-run.
+2. **Pair store sharing across runs.** If the user calls `dedupe_df` on overlapping fixtures, can the pair store cache hits? Probably yes for v2; out of scope for v1 (every call starts with an empty store).
+3. **Backpressure on the scoring stage.** If workers produce pairs faster than the pair store can ingest, RAM grows. v1 uses bounded queues; v2 could use credit-based flow control.
+4. **Ray vs Dask vs raw `concurrent.futures.ProcessPoolExecutor`.** Ray is the v1 pick (CLAUDE.md cites the existing `backends/ray_backend.py` as 50M-targeted). Dask is a serious alternative if the team finds Ray ops-heavy. Raw multiprocessing fails on the cross-worker memory sharing required for the boundary-edge step.
+5. **DuckDB version pinning.** Recursive CTE behavior changes across DuckDB versions. The chosen pair-store + cluster approach must pin a tested DuckDB version range.
+
+## Acceptance criteria
+
+- v1 ships when:
+  1. Components 1-6 implemented and individually tested.
+  2. `gm.dedupe_df(df)` zero-config at 10M produces the same F1 as the explicit chunked baseline (within ±0.005 internal F1; within bootstrap noise on er-evaluation).
+  3. 50M zero-config run completes on a Ray cluster of size ≥ 4 workers × 16 cores. Quality gate (er-evaluation Tier 1) passes. Wall + RSS + spill volume recorded.
+  4. `PostflightReport.execution_plan` reflects the auto-selected Distributed Plan.
+  5. Documentation in `packages/python/goldenmatch/docs/scale-100m-ray-vs-spark.md` (already present, drafted in PR #239) updated with the realized numbers.
+
+## What this spec is NOT promising
+
+- That 50M will be cheap. It will not. Distributed plans cost cluster time.
+- That the chunked backend goes away. It's the right choice up to ~10M on a single big box and stays the planner's choice in that range.
+- That this lands by any specific date. It's a multi-month arc; the milestone is 10M zero-config first, then everything else.
+- That Spark won't matter eventually. It will for Databricks customers. Not the v1 default; documented as a future lane.
+
+The whole point of this spec is: **stop trying to make 50M happen via Polars optimization, design the new path explicitly, then ship it.**

--- a/docs/superpowers/specs/2026-05-15-map-elements-attack-design.md
+++ b/docs/superpowers/specs/2026-05-15-map-elements-attack-design.md
@@ -1,0 +1,158 @@
+# map_elements attack — eliminate per-row Python on the Polars boundary
+
+**Status:** Design (drafted 2026-05-15)
+**Author:** post-#239 cProfile finding, Claude + bsevern
+**Scope:** `packages/python/goldenmatch/goldenmatch/core/transform.py`, `core/standardize.py`, `core/matchkey.py`, and any other call site where `polars.Series.map_elements` (or its DataFrame equivalents) fires inside the dedupe hot path.
+**Supersedes:** [`2026-05-15-post-controller-full-df-perf-design.md`](2026-05-15-post-controller-full-df-perf-design.md) — Attacks A & B were eliminated by PR #239.
+**Related:**
+- Post-#239 baseline JSON: `.profile_tmp/bench_post-pr239-100k.json` (run 25944251741, captured 2026-05-15)
+- PR #239 (`perf(zero-config): 6x at 100K`): the hotspot-shifting commit
+- Controller v3 / planner spec (sibling): [`2026-05-15-controller-v3-planner-design.md`](2026-05-15-controller-v3-planner-design.md) — the auto-config controller that picks backend + chunk_size + spill thresholds; this spec is one of the per-stage optimizations that feeds its inputs.
+
+## Problem
+
+Post-#239, the dominant Python-side hotspot in `gm.dedupe_df()` is `polars.Series.map_elements`. cProfile at 100K (synthetic person, 15% dupe, one full dedupe under cProfile):
+
+| Function | ncalls | tottime | cumtime | % of one-run wall |
+|---|---|---|---|---|
+| `PySeries.map_elements` | 542 | 1.59s | **15.80s** | **~28% of 56.6s cProfile wall** |
+| `transform.py:run_transform` | 5 | 0.0003s | 12.91s | (controller iterates 5x) |
+| `transform.py:_apply_auto_transforms` | 5 | 0.0001s | 12.91s | same |
+
+Five `run_transform` calls and ~108 `map_elements` per call (542 / 5) suggests the auto-transform chain in GoldenFlow is applying a per-row Python UDF on each transformed column, once per controller iteration.
+
+Polars's `map_elements` is documented as the slow path. The library publishes the rule: anything `map_elements` can do, a native expression chain can do faster — usually 10-100x — because native expressions stay inside the Rust kernel and don't cross the FFI boundary per row.
+
+**Headline number to beat:** 100K post-#239 median wall is **28.4s**. If `map_elements` accounts for ~5s of that (its share inside one un-cProfile'd run, scaling 28% of 56.6 → ~5s of 28.4), eliminating it puts 100K at **~23s**. The same fraction at 500K (extrapolated) is ~25s out of ~140s. Bigger wins likely at scale because per-row Python tax compounds with `map_elements`-heavy transforms over larger frames.
+
+## Goals
+
+1. **Cut 100K median wall by ≥15%** (28.4s → ≤24s) on the post-#239 baseline.
+2. **Eliminate `map_elements` from the top 5 cumtime** in the post-attack cProfile.
+3. **Preserve correctness** — auto-transform output must be bitwise identical for the same input on the same matchkey config.
+4. **No public-API change.** Internal-only rewrite of transform expression chains.
+
+## Non-goals (v1)
+
+- Other hotspots (controller iteration cost at 1M+, `phone_e164`, `score_blocks_parallel` orchestration). Each merits its own spec.
+- Backend selection / chunk_size tuning. Owned by [controller v3](2026-05-15-controller-v3-planner-design.md).
+- The 500K and 1M baseline. The 100K post-attack number is the gate; scaling extrapolation is informative, not gated.
+
+## Diagnosis
+
+`map_elements` is invoked inside Polars expression chains. To attack it we need to know the exact call sites. Three categories worth checking, in priority order by suspected wall share:
+
+### 1. GoldenFlow auto-transform chain (`packages/python/goldenflow/.../transformer.py`)
+
+Hot path entry from cProfile:
+
+```
+transform.py:run_transform              cumtime 12.91s
+  → __init__.py:64:transform_df          cumtime 12.91s
+    → transformer.py:65:transform_df     cumtime 12.91s
+      → transformer.py:156:_apply_auto_transforms
+```
+
+GoldenFlow's `_apply_auto_transforms` iterates over a list of transforms (e.g. `trim_whitespace`, `lower`, `phone_e164`, address normalization) and applies them per column. If any transform implementation uses `df.with_columns(pl.col(c).map_elements(fn, return_dtype=...))`, that's the culprit.
+
+**Action:** Audit every `_apply_auto_transforms` branch and every transform under `packages/python/goldenflow/goldenflow/transforms/` for `map_elements` usage. Replace with native Polars expressions:
+
+- `trim_whitespace`: `pl.col(c).str.strip_chars()` (already native, likely OK)
+- `lower`: `pl.col(c).str.to_lowercase()` (native)
+- `phone_e164`: **likely the worst offender** — `phonenumbers.parse(x).e164` is a Python call per row. Possible mitigations: (a) gate it by column-type detection (only fire on actual phone columns), (b) use `lib.phonenumbers` Rust port, (c) vectorize via regex + bulk validate.
+- Address normalize: similar shape; check the implementation.
+
+CLAUDE.md explicitly names this in PR #239's "next targets surfaced by the harness":
+> GoldenFlow `phone_e164` at large N (Python `phonenumbers.parse` per row) — likely the new top contender for biggest single chunk in the post-fix audit.
+
+### 2. Matchkey transform chains (`core/matchkey.py`)
+
+The codebase has `_try_native_chain` which fast-paths simple transform chains to native Polars expressions. Anything that falls off this path goes through `map_elements`. Per CLAUDE.md:
+
+> Matchkey transforms have native Polars fast path (`_try_native_chain` in matchkey.py)
+
+**Action:** Run a 100K dedupe with logging instrumentation that emits a WARN every time `_try_native_chain` returns "no native path" for a transform. Count the falloffs per transform name. Each falloff is a `map_elements` invocation. Top 3 by call count become rewrite targets.
+
+### 3. Standardize chains (`core/standardize.py`)
+
+Same shape as matchkey: `_NATIVE_STANDARDIZERS` is the fast-path table. Standardizers not in the table fall through to Python.
+
+**Action:** Same as #2 — instrument the falloff path, find top offenders.
+
+## Attacks (in priority order)
+
+### Attack A: `phone_e164` vectorization
+
+Per CLAUDE.md and the GoldenFlow source, `phone_e164` calls `phonenumbers.parse(x).e164` per row. At 100K with one phone column and 5 controller iterations, that's 500K Python calls into a C extension. Each call ~30μs = ~15s. Matches the cumtime budget.
+
+**Three escalating options:**
+
+1. **Gate by column-type detection.** GoldenFlow already calls this — if the column-type profile says `phone`, it fires; otherwise it doesn't. Verify the gate is tight. Synthetic person fixture has no phone column; if `phone_e164` is firing anyway, the gate is the bug.
+
+2. **Bulk normalize via regex.** `re.sub(r'[^\d+]', '', x)` extracts digits + leading +, then a single `phonenumbers.format_number` per unique extracted-key (cache via `lru_cache`). Cuts Python work by the cardinality ratio of unique phone strings vs total rows. Typical real data has cardinality 0.7-0.9, so this saves 10-30% only.
+
+3. **Drop the Python `phonenumbers` dep on the hot path.** Use a pre-compiled set of regex patterns for the common formats (US, UK, EU, intl); fall back to `phonenumbers` only for ambiguous cases. Native Polars regex + `pl.when(...).then(...).otherwise(...)` chain.
+
+Option 1 is the highest-leverage fix if the gate is broken. Option 2 is mechanical. Option 3 is the v2 if 1+2 aren't enough.
+
+### Attack B: catalog and rewrite remaining `map_elements` call sites
+
+Grep + audit, then rewrite each in the `_NATIVE_STANDARDIZERS` / `_try_native_chain` pattern:
+
+```bash
+grep -rn "map_elements" packages/python/goldenmatch/goldenmatch/core/ packages/python/goldenflow/goldenflow/ --include="*.py"
+```
+
+For each hit:
+- Note the operation
+- Find or construct the native Polars equivalent
+- Add a test asserting bitwise equality with the `map_elements` version
+- Replace; remove the `map_elements` branch
+
+### Attack C: cache the controller's transform output
+
+The controller runs `_run_dedupe_pipeline` ~5x (sample iterations + finalize). Each iteration re-applies the auto-transform chain to the sample. If the transform output is deterministic for a given config + frame, cache it keyed on `(frame_id, config_hash)`. Skips 4 of 5 transform applications per dedupe call.
+
+This is more invasive (touches controller iteration loop) but pays back ~10s on the cProfile budget at 100K. Land it after A + B confirm the per-call cost is what we think it is.
+
+## Testing
+
+### Tier 1 — correctness invariants
+
+Per call site, before/after diff:
+- Hash the column after the existing `map_elements` path
+- Hash the column after the rewrite
+- Assert bitwise equal across N hand-crafted edge cases (empty strings, unicode, leading/trailing whitespace, NULLs)
+
+For `phone_e164` specifically: a fixture of 1000 real-shape phone strings with their expected E.164 form. Pass through old + new, compare.
+
+### Tier 2 — bench gate
+
+Re-run `bench-zero-config` workflow at 100K. Acceptance:
+- Median wall ≤ 24s (was 28.4s, target ≥15% reduction).
+- `map_elements` ncalls in cProfile top: < 50 (was 542).
+- F1 against ground truth (run via `eval-er-evaluation`) within bootstrap noise of the post-#239 baseline (pairwise F1 was 0.9097 ± 0.002 at 100K synthetic).
+
+### Tier 3 — scaling check
+
+500K wall-only (no cProfile) after the fix. Acceptance:
+- Median wall ≤ 110s (extrapolated from 100K × 5x linear; the post-#239 baseline at 500K we couldn't measure cleanly).
+- No regression in `eval-er-evaluation` pairwise + B-cubed + cluster F1 vs the er-evaluation 100K numbers (Febrl3 + DBLP-ACM also rerun as cross-check).
+
+## Implementation order
+
+1. Audit grep for `map_elements` across goldenmatch + goldenflow. Catalog every call site (~30 min).
+2. Add instrumentation: log every `_try_native_chain` fallback + every `map_elements` call. Bench 100K to count which fire most (~1 hr).
+3. Attack the top-3 offenders by call count. Each is its own small PR (correctness test + rewrite). The `phone_e164` gate fix is the likely top-1.
+4. Re-bench 100K. Confirm gate hit (≥15% wall reduction, `map_elements` < 50 ncalls).
+5. Re-bench 500K wall-only to verify scaling.
+6. CHANGELOG entry + memory entry noting the per-row-Python-on-Polars-boundary lesson.
+
+## Acceptance criteria
+
+- v1 ships when:
+  1. 100K bench median wall ≤ 24s (≥15% reduction from 28.4s baseline).
+  2. `map_elements` ncalls in cProfile top: < 50.
+  3. er-evaluation pairwise/B-cubed/cluster F1 each within bootstrap noise of post-#239 baseline.
+  4. `tests/benchmarks/run_leipzig.py` (internal scorer) F1 unchanged within ±0.005.
+  5. Full test suite (1572+ passing per CLAUDE.md) continues to pass.

--- a/docs/superpowers/specs/2026-05-15-post-controller-full-df-perf-design.md
+++ b/docs/superpowers/specs/2026-05-15-post-controller-full-df-perf-design.md
@@ -1,0 +1,263 @@
+# Post-controller full-df perf — Attacks A & B
+
+> **⚠ SUPERSEDED 2026-05-15.** Empirically obsolete. Post-#239 cProfile at 100K shows neither hotspot (`LazyFrame.collect` 462K calls; `builtins.max` 55M calls) appears in the top 30 cumtime. PR #239 (`perf(zero-config): 6x at 100K`) eliminated both via golden vectorize + adaptive blocking. **Do not implement Attacks A or B.** The pre-#239 487s baseline this spec was framed against was measuring stale site-packages code, not the worktree.
+>
+> Successor: [`2026-05-15-map-elements-attack-design.md`](2026-05-15-map-elements-attack-design.md) targets the new dominant hotspot (`PySeries.map_elements`, 15.8s cumtime per dedupe, 542 calls at 100K).
+>
+> The methodology in this spec is preserved as historical record. "Rank by measured wall, not static structure" was the right rule — applied to fresh data, it would have steered us at `map_elements` from the start. This spec's value is the cross-cutting-primitives lesson, not the specific attacks.
+
+**Status:** Superseded 2026-05-15 (originally: Design, approved by user)
+**Author:** brainstorm session, Claude + bsevern
+**Scope:** `packages/python/goldenmatch/goldenmatch/core/learned_blocking.py`, `packages/python/goldenmatch/goldenmatch/core/cluster.py`, plus minimal call-site updates in `core/blocker.py` and `core/scorer.py` to consume the new `BlockResult` shape.
+**Related:**
+- Auto-config controller spec: `docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-design.md` — the controller itself is not modified; this spec attacks the full-df pipeline that runs *after* the controller commits.
+- 5M scale-audit spec: `docs/superpowers/specs/2026-05-13-scale-audit-5m.md` — the chunked/DuckDB lane has separate optimizations (#231-#235); this spec targets the default polars-direct backend that `gm.dedupe_df(big_df)` invokes when the caller passes no `backend` override.
+
+## Problem
+
+`gm.dedupe_df(df)` zero-config on a 500K synthetic person dataset takes a median **487.7s** wall (5 runs: 441-548s, 22% spread). The dominant cost is *not* a single pipeline stage but two cross-cutting Python hotspots that span blocking, scoring, and clustering.
+
+The CLAUDE.md performance-audit lesson is explicit on this: rank by measured wall, not static structure. Earlier hypotheses (`precompute_matchkey_transforms`, `phone_e164`, `build_learned_blocks` *as a unit*) turned out to be partial — `build_learned_blocks` is hot, but the cost is concentrated in one sub-call (`apply_learned_blocks`) whose dominant primitive (`LazyFrame.collect`) also fires from scoring.
+
+### Measurement (500K, polars-direct backend, this laptop)
+
+5-run median wall **487.7s**, single cProfile run wall **1213.6s** (cProfile overhead ~2.5×). Numbers below are cProfile cumtime % of the cProfile run.
+
+#### By stage (cumtime)
+
+| Stage | cumtime | % wall |
+|---|---|---|
+| `_build_learned_blocks` (→ `apply_learned_blocks` 230.9s) | 295.5s | **24.4%** |
+| `score_blocks_parallel` (→ `_score_one_block`) | 279.1s | **23.0%** |
+| `build_clusters` (→ `split_oversized_cluster`) | 269.4s | **22.2%** |
+| `run_transform` (GoldenFlow) | 69.1s | 5.7% |
+
+No single stage clears 30%. Diffuse: blocking ≈ scoring ≈ clustering.
+
+#### By cross-stage primitive (tottime)
+
+| Primitive | ncalls | tottime | % wall |
+|---|---|---|---|
+| `LazyFrame.collect` | 462,061 | 326.8s | **27%** |
+| `builtins.max` (in `split_oversized_cluster` / `compute_cluster_confidence`) | 55,312,521 | 155.9s | **13%** |
+
+**~40% of wall sits in these two primitives.** They cross stage boundaries because both are caused by per-block / per-edge Python loops that materialize LazyFrames or call `max()`/`min()` on dict values.
+
+### Source artifacts
+
+- `.profile_tmp/bench_500k_zero_config.json` — full bench output (medians, stages, cProfile top 30).
+- `.profile_tmp/bench_500k_zero_config.prof` — cProfile dump (snakeviz / pstats friendly).
+- `scripts/bench_1m_zero_config.py` — the bench harness (5-run median wall + per-stage timing + cProfile pass).
+- `scripts/scale_audit_5m.py` — patched 2026-05-15 to use `_skip_finalize=True` and avoid the controller-finalize-plus-caller double-run that was inflating the prior cloud measurement (1237s) by ~2×.
+
+### Caveats from the bench
+
+1. **Stage monkey-patching mostly missed.** `setattr(matchkey, "compute_matchkeys", ...)` only rebinds the source module; `pipeline.py` does `from X import Y` and keeps the original reference. cProfile cumtime carried the day. Bench-harness fix is filed under §Out of scope.
+2. **Controller commits RED on this fixture.** Every run hit `iter=v0, stop_reason=POLICY_SATISFIED, failing_subprofile=scoring`. The synthetic dataset has a scoring pathology the controller can't refit. The bench still measures the production caller path correctly, but the config under test is the heuristic v0, not a refit config. Real customer data may exercise different downstream paths.
+3. **GoldenCheck fires 3× per `dedupe_df`.** Twice during auto-config (sample iteration + one extra), once during the caller pass. Quality scan dominates ~5-6% of wall. Quality is disabled-able via `config.quality.mode="disabled"` and is *not* in scope for this spec.
+4. **Wall variance 22%.** Likely `ThreadPoolExecutor` scheduling in `score_blocks_parallel` + GC pressure from the 462K LazyFrames. Attack A should narrow this naturally by killing the LazyFrame churn.
+5. **The recent chunked / DuckDB optimization wave (#231-#235) does not help here.** Those PRs target `backend="chunked"` and `backend="duckdb"`. The default polars-direct path that real `gm.dedupe_df(df)` callers use was untouched.
+
+## Goals
+
+1. **Cut polars-direct full-df wall by ≥40% at 500K** without changing config shape, output, or quality.
+2. **Land the wins in two small PRs**, each independently measurable. Attack A primary; Attack B follow-up.
+3. **Preserve correctness invariants** — same blocking output, same cluster partitioning, same F1 against ground truth (within 0.005 tolerance for non-determinism in scoring).
+4. **Re-measure honestly** — the headline number for this spec is the **post-A+B 1M median wall** on the same laptop, captured in `.profile_tmp/bench_1m_zero_config_after.json`.
+
+## Non-goals (v1)
+
+- Stages other than blocking + clustering. Scoring's `score_blocks_parallel` is hot but the cost is mostly inside `rapidfuzz.cdist` (GIL-releasing C code), not the Python orchestration we can touch here. Separate audit.
+- Chunked / DuckDB backends — already optimized in #231-#235 and have separate measurement lanes.
+- 5M cloud re-measurement — that's the 5M scale-audit spec's problem; this spec lands wins for the default backend that the 1M lane consumes.
+- Bench-harness improvements (stage-patch fix, controller-RED-on-synthetic investigation) — folded into a small follow-up.
+- Controller refit policy improvements (the synthetic fixture's RED is a real signal; out of scope for the perf attack).
+
+## Attack A — `LazyFrame.collect` explosion in `apply_learned_blocks`
+
+### Diagnosis
+
+In `core/learned_blocking.py`, the current implementation produces a `BlockResult` per learned block by wrapping a slice of the materialized DataFrame back into a `LazyFrame`, then collects each block once more during the dedup-by-member-set pass:
+
+```python
+# learned_blocking.py:312
+block_lf = df[sorted(member_positions)].lazy()             # per-block lazy wrap (1 of 2)
+all_blocks.append(BlockResult(df=block_lf, ...))
+
+# learned_blocking.py:323
+for block in all_blocks:
+    block_df = block.df.collect()                          # per-block collect to dedupe
+    members = frozenset(block_df["__row_id__"].to_list())
+```
+
+For each block produced, the lazy() wrap + downstream `.collect()` round-trip costs Polars' lazy-engine setup twice. `score_blocks_parallel` then calls `block.df.collect()` *again* inside `_score_one_block` to materialize the slice for rapidfuzz. That's three Polars round-trips per block, on already-in-memory positional data.
+
+At 500K rows the bench shows **462,061 `LazyFrame.collect` calls** — roughly one per row, which matches "~60-100K blocks × 3-4 collects each."
+
+### Fix
+
+Replace `BlockResult.df: LazyFrame` with a positional contract: store `member_positions: list[int]` (or `np.ndarray[int64]`) and materialize the slice on demand at the single consumer (`_score_one_block`) using `df[positions]` — already an in-memory operation, no lazy round-trip.
+
+Concretely:
+
+1. **`BlockResult`** in `core/blocker.py`:
+   - Add `member_positions: list[int] | None = None`.
+   - Keep `df` field for backward compat (deprecation path; downstream code that reads `.df` continues to work for one release).
+   - Add a `materialize(parent_df: pl.DataFrame) -> pl.DataFrame` helper that does `parent_df[self.member_positions]` if positions are present, else falls back to `self.df.collect()`.
+
+2. **`apply_learned_blocks`** in `core/learned_blocking.py`:
+   - Build `BlockResult(member_positions=sorted(member_positions), df=None, ...)` instead of wrapping in `LazyFrame`.
+   - Dedupe blocks by `tuple(sorted(member_positions))` *before* constructing `BlockResult`. Eliminates the second collect pass entirely.
+   - Pass the parent `df` reference downstream (one shared `pl.DataFrame`, not per-block).
+
+3. **`score_blocks_parallel` / `_score_one_block`** in `core/scorer.py`:
+   - Accept the parent `df` as an argument.
+   - Replace `block.df.collect()` with `block.materialize(parent_df)`.
+
+4. **`build_blocks`** in `core/blocker.py`:
+   - Static / multi-pass blocking paths also wrap slices in `LazyFrame`. Apply the same positional pattern. Smaller share of the 462K collects, but folding it in keeps the contract consistent.
+
+### Expected reduction
+
+- 462,061 collects → 1 per block (single materialize during scoring) × ~60-100K blocks = ~70-100K collects, of which scoring's are already needed for rapidfuzz.
+- Net: ~250-280s off wall at 500K (~51-57% of `apply_learned_blocks` cumtime).
+- Wall variance should narrow: fewer LazyFrame objects means less GC pressure and less Polars-internal threadpool interference.
+
+### Risk and mitigation
+
+- **`BlockResult.df` is a public-ish interface.** Any external consumer reading `.df` keeps working via the fallback path during the deprecation window. Single release later, drop the fallback.
+- **Position-vs-`__row_id__` confusion.** `apply_learned_blocks` already uses positions (see comment at `learned_blocking.py:297-300` from the prior optimization). Positions track df ordering — same invariant the function already relies on.
+- **Multi-pass blocking writes blocks from multiple `build_blocks` calls into one list.** All passes share the same parent `df` because the pipeline materializes once at `precompute_matchkey_transforms`. Spec assumes this; verify in implementation.
+- **`score_blocks_parallel` worker function signature changes.** It's an internal helper — call sites are `pipeline.py`, `engine.py`, `chunked.py`. All three updated atomically.
+
+### Acceptance for Attack A
+
+- Re-run `scripts/bench_1m_zero_config.py` at 500K. Median wall ≤ 250s (was 488s; target ≥ 49% reduction, ≥ 200s absolute).
+- `LazyFrame.collect` ncalls in cProfile drops to < 50,000.
+- F1 against the synthetic ground truth within 0.005 of pre-A baseline.
+- All existing tests in `tests/test_blocking.py`, `tests/test_scorer.py`, `tests/test_chunked.py` pass without modification.
+
+## Attack B — `split_oversized_cluster` vectorization
+
+### Diagnosis
+
+`core/cluster.py::_build_mst` runs Kruskal's algorithm in pure Python over `pair_scores` items, picking the weakest MST edge via `min(mst, key=lambda e: e[2])`. `compute_cluster_confidence` iterates the same dict per sub-cluster to compute min/avg edges and bottleneck pair. With 38,315 split iterations on the bench fixture, the inner Python work multiplies out.
+
+The bench measures **55,312,521 `builtins.max` calls** (we also see the symmetric `min` cost — pstats groups them differently but the algorithmic shape is the same). At 13% of wall this is the second-largest cross-stage primitive after the LazyFrame churn.
+
+### Fix
+
+Vectorize the inner loop with NumPy:
+
+1. **Pack pair_scores once per split:**
+   ```python
+   edges_uv = np.fromiter(((a, b) for (a, b) in pair_scores), dtype=np.int64, count=len(pair_scores) * 2).reshape(-1, 2)
+   weights = np.fromiter(pair_scores.values(), dtype=np.float64, count=len(pair_scores))
+   ```
+
+2. **Sort by weight descending once:**
+   ```python
+   order = np.argsort(-weights, kind="stable")
+   edges_uv = edges_uv[order]
+   weights = weights[order]
+   ```
+
+3. **Run Kruskal with the existing `UnionFind` but iterate over the sorted NumPy arrays directly** — eliminates the per-edge tuple unpacking that drives most of the Python-side overhead.
+
+4. **Weakest MST edge** becomes `mst_weights.argmin()` → `weakest_idx`; no Python `min(..., key=...)`.
+
+5. **`compute_cluster_confidence`:** take the cluster's edge subset as a NumPy view (`weights[mask]`), compute `min()`, `mean()`, `len()` natively. Bottleneck pair: `edges_uv[mask][weights[mask].argmin()]`.
+
+The UnionFind itself stays Python — it's hot but tiny (≤ cluster_size operations per edge). If profiling shows it remaining as the bottleneck after the vectorization, swap to a NumPy-backed UF in a follow-up.
+
+### Expected reduction
+
+- ~13% wall → ≤ 2% wall (NumPy ops vs 55M Python ops).
+- Net: ~80-100s off wall at 500K.
+- Combined with Attack A, target post-A+B 500K median ≈ 150s.
+
+### Risk and mitigation
+
+- **Algorithmic correctness must match exactly.** Existing `tests/test_cluster.py` covers split correctness on hand-crafted oversized clusters. Plus: add a Hypothesis property test asserting `split_oversized_cluster_vectorized(members, pair_scores) == split_oversized_cluster_python(members, pair_scores)` for random graphs ≤ 50 nodes.
+- **`pair_scores` key canonicalization.** The codebase invariant is `(min(a,b), max(a,b))` (per `packages/python/goldenmatch/CLAUDE.md`). NumPy pack code must preserve that — pack via `(min, max)` regardless of dict key order.
+- **Float precision.** NumPy float64 matches Python float in IEEE 754; sort stability via `kind="stable"` preserves deterministic ordering on equal weights.
+
+### Acceptance for Attack B
+
+- Re-run bench. Median wall ≤ 150s (target ≥ 60s additional absolute reduction beyond A).
+- `builtins.max` cumtime in cProfile drops below 30s (was 156s, expecting an order of magnitude).
+- All `tests/test_cluster.py` tests pass without modification.
+- Hypothesis property test (new) passes for ≥1000 random inputs.
+
+## Combined target table
+
+| Lane | Today | Post-A | Post-A+B |
+|---|---|---|---|
+| 500K median wall (this laptop) | 487.7s | ≤ 250s | ≤ 150s |
+| 1M median wall (linear extrapolation, ceiling) | ~16 min | ~8 min | ~5 min |
+| `LazyFrame.collect` ncalls | 462,061 | < 50,000 | < 50,000 |
+| `builtins.max` ncalls (cluster path) | 55,312,521 | unchanged | < 5,000,000 |
+
+The 1M numbers are linear projections from 500K. Clustering can be super-linear in pathological cases; final exit gate is the measured 1M run after both attacks land, **not** the projection.
+
+## Testing
+
+### Tier 1 — Existing unit tests (no modification)
+
+`tests/test_blocking.py`, `tests/test_learned_blocking.py`, `tests/test_scorer.py`, `tests/test_chunked.py`, `tests/test_cluster.py` all pass unchanged. Any test that needs to access `BlockResult.df` exercises the deprecation-fallback path.
+
+### Tier 2 — Correctness invariants (new)
+
+- **Block content equality:** `apply_learned_blocks(df, rules)` produces the same `__row_id__` member sets before and after Attack A. Compare by hashing each block's frozenset of row_ids; assert equal multisets.
+- **Cluster partition equality:** `split_oversized_cluster_vectorized` returns the same partition as the Python implementation on hand-crafted fixtures. Drop the old implementation only after at least one full release cycle.
+- **F1 invariance:** running the synthetic 500K fixture end-to-end before and after each attack produces F1 within 0.005. Tolerance accounts for `ThreadPoolExecutor` non-determinism in pair ordering, which can rarely swap pair_scores ties.
+
+### Tier 3 — Property tests (new, Hypothesis)
+
+- `split_oversized_cluster` python ≡ numpy on random graphs (≤ 50 nodes, edge density 0.3-0.9, random weights).
+- `BlockResult.materialize(parent_df)` returns a DataFrame whose `__row_id__` column matches `member_positions` translated through `parent_df`.
+
+### Tier 4 — Performance bench (gating)
+
+`scripts/bench_1m_zero_config.py` re-run after each attack. Exit gates per attack:
+- Attack A: 500K median ≤ 250s AND `LazyFrame.collect` ncalls < 50,000.
+- Attack B: 500K median ≤ 150s AND `builtins.max` cumtime < 30s.
+- Combined (after both land): 1M median ≤ 8 min on this laptop, captured in `.profile_tmp/bench_1m_zero_config_after.json`.
+
+### Tier 5 — CI scale-audit (sanity)
+
+The existing scale-audit workflow (`.github/workflows/scale-audit-5m.yml` and the 1M cloud runs) re-runs on `ubuntu-latest-large`. Numbers won't be directly comparable to laptop (different hardware) but the qualitative shape — 500K and 1M both fitting in memory, F1 unchanged — should hold.
+
+## Implementation order
+
+1. Land Attack A as a single PR. Include the `BlockResult.member_positions` field, `apply_learned_blocks` rewrite, `_score_one_block` consumer update, and the block-content correctness test.
+2. Re-measure at 500K. Confirm Attack A gate. Land before starting B.
+3. Land Attack B as a separate PR. Include the NumPy vectorization, Hypothesis property test, cluster partition correctness test.
+4. Re-measure at 500K. Confirm Attack B gate.
+5. Run the 1M bench. Capture `.profile_tmp/bench_1m_zero_config_after.json`. Update CHANGELOG with the measured delta.
+6. Memory entry under `project_post_controller_full_df_perf.md` — capture what surprised us (e.g. "stages were diffuse, but two cross-stage primitives owned 40%; LazyFrame churn was the bigger fish; future audits should grep cProfile by primitive, not just stage").
+
+## Out of scope (v1) / Future work
+
+- **Bench-harness stage-patch fix.** Patch at `pipeline.py` call sites or use `unittest.mock.patch.object` with `wraps=`. Folded into the implementation plan's tooling task, not a blocker.
+- **GoldenCheck triple-fire.** Quality scan runs three times per `dedupe_df` call. Probably a controller-internal duplicate. Separate audit; ~5-6% wall at 500K.
+- **`score_blocks_parallel` Python orchestration.** Rapidfuzz `cdist` is C-level GIL-releasing — the residual Python cost is in pair-emission and threadpool dispatch. Smaller surface; revisit after A+B land.
+- **Controller RED commit on synthetic fixture.** The synthetic person dataset has a scoring pathology the v1 heuristic policy can't refit out of. Could be a synthetic-generator issue, could be a real policy gap. Out of scope here; flagged for the controller v1.13 cycle.
+- **`backend="chunked"` and `backend="duckdb"` parity.** Both have their own optimization arc (#231-#235). Apply analogous lazy-collapse + cluster-vectorization patterns if profiling shows the same hotspots at 5M+; out of scope for v1 of this spec.
+
+## Open questions / things to validate during implementation
+
+1. **Will the deprecation shim on `BlockResult.df` slow Attack A?** If keeping the fallback adds branching cost inside the hot scorer loop, drop it and update consumers atomically. Decide during implementation; measure both ways.
+2. **Multi-pass `build_blocks` (static + soundex) call shape.** Spec assumes a single parent `df` reference flows through. If passes are constructed against different transformed frames, the contract needs refinement.
+3. **NumPy vs Polars for the cluster vectorization.** NumPy is the safe choice (no Polars lazy-engine setup). If Polars expressions on the pair_scores frame turn out cleaner, swap during implementation — same algorithmic shape, smaller diff.
+4. **Wall variance.** 22% spread at 500K is uncomfortable. If Attack A doesn't narrow it materially, dig into ThreadPoolExecutor worker count (pin to `os.cpu_count() // 2`?) before declaring victory.
+
+## Acceptance criteria
+
+- v1 ships when:
+  1. Attack A PR merged, 500K bench median ≤ 250s, `LazyFrame.collect` ncalls < 50,000, F1 within 0.005.
+  2. Attack B PR merged, 500K bench median ≤ 150s, `builtins.max` cumtime < 30s, F1 within 0.005.
+  3. 1M bench re-run, median ≤ 8 min on this laptop. Result committed to `.profile_tmp/bench_1m_zero_config_after.json`.
+  4. CHANGELOG entry with the measured before/after deltas. README "what's new" callout if delta > 50%.
+  5. Memory entry under `project_post_controller_full_df_perf.md` capturing the cross-stage-primitive lesson.
+  6. Existing test suite (1572 passing per CLAUDE.md baseline) continues to pass.


### PR DESCRIPTION
## Summary

Strategic spec set reframing the perf direction after the post-#239 100K bench showed Attacks A & B from the original 2026-05-15 spec are empirically obsolete.

| Spec | Status | Scope |
|---|---|---|
| `2026-05-15-post-controller-full-df-perf-design.md` | **Superseded** | Old Attacks A/B targets (LazyFrame.collect, builtins.max) eliminated by PR #239 |
| `2026-05-15-map-elements-attack-design.md` | NEW | Attacks the new dominant hotspot. Target: 100K wall 28.4s → 24s. Path to 10M. |
| `2026-05-15-controller-v3-planner-design.md` | NEW | Promotes PR #239's env-var to first-class controller decision. Auto-selects backend/chunk_size/workers/spill at runtime. |
| `2026-05-15-distributed-plan-v1-design.md` | NEW | The 50M+ architecture. Six components, with **boundary-aware per-partition union-find** as the load-bearing clustering choice. |

## Why three specs not one

These map to three different problem classes:

- **map_elements** = ordinary optimization. Pays off through 10M.
- **Controller v3** = planning. Makes zero-config scale-aware. Required before distributed makes sense (the planner decides when to use it).
- **Distributed v1** = architecture. 50M isn't "Polars faster"; it's distributed graph processing with a fuzzy-matching jacket.

They sequence: map_elements lands → controller v3 lands → distributed v1 PRs land in 6 stages over months.

## What's in scope here

Specs only. No code in this PR. Implementation arcs are sketched in each doc; each will get its own implementation-plan companion in subsequent sessions.

## What's NOT in scope

- A Spark backend (future enterprise lane, not zero-config)
- Implementing any of the three (this PR is design, not build)
- Killing the chunked backend — it stays as the right choice for 5-10M tiers under the planner

🤖 Generated with [Claude Code](https://claude.com/claude-code)