### PR TITLE
perf(goldenflow): migrate 5 transforms from mode=series to mode=expr (Tier 1 batch 1)

### DIFF
--- a/packages/python/goldenflow/goldenflow/transforms/email.py
+++ b/packages/python/goldenflow/goldenflow/transforms/email.py
@@ -14,17 +14,16 @@ _EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
     input_types=["email", "string"],
     auto_apply=False,
     priority=55,
-    mode="series",
+    mode="expr",
 )
-def email_lowercase(series: pl.Series) -> pl.Series:
-    """Lowercase the entire email address."""
+def email_lowercase(column: str) -> pl.Expr:
+    """Lowercase the entire email address.
 
-    def _lower(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return val.strip().lower()
-
-    return series.map_elements(_lower, return_dtype=pl.Utf8)
+    Native Polars: strip then to_lowercase. Drops the per-row Python UDF
+    (previously map_elements). Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return pl.col(column).str.strip_chars().str.to_lowercase()
 
 
 @register_transform(
@@ -60,19 +59,22 @@ def email_normalize(series: pl.Series) -> pl.Series:
     input_types=["email"],
     auto_apply=False,
     priority=40,
-    mode="series",
+    mode="expr",
 )
-def email_extract_domain(series: pl.Series) -> pl.Series:
-    """Extract the domain from an email address."""
+def email_extract_domain(column: str) -> pl.Expr:
+    """Extract the lowercased domain from an email address.
 
-    def _domain(val: str | None) -> str | None:
-        if val is None:
-            return None
-        if "@" not in val:
-            return None
-        return val.strip().rsplit("@", 1)[1].lower()
-
-    return series.map_elements(_domain, return_dtype=pl.Utf8)
+    Native Polars: strip → regex extract after '@' → lowercase. Inputs
+    without '@' (or None) yield None via Polars's native null propagation.
+    Spec docs/superpowers/specs/2026-05-15-map-elements-attack-design.md
+    Tier 1.
+    """
+    return (
+        pl.col(column)
+        .str.strip_chars()
+        .str.extract(r"@([^@]+)$", 1)
+        .str.to_lowercase()
+    )
 
 
 @register_transform(

--- a/packages/python/goldenflow/goldenflow/transforms/text.py
+++ b/packages/python/goldenflow/goldenflow/transforms/text.py
@@ -93,18 +93,15 @@ def normalize_quotes(column: str) -> pl.Expr:
     input_types=["string"],
     auto_apply=False,
     priority=45,
-    mode="series",
+    mode="expr",
 )
-def remove_html_tags(series: pl.Series) -> pl.Series:
-    """Strip HTML tags from text."""
-    _tag_re = re.compile(r"<[^>]+>")
+def remove_html_tags(column: str) -> pl.Expr:
+    """Strip HTML tags from text.
 
-    def _strip(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return _tag_re.sub("", val)
-
-    return series.map_elements(_strip, return_dtype=pl.Utf8)
+    Native Polars regex replace_all. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return pl.col(column).str.replace_all(r"<[^>]+>", "")
 
 
 @register_transform(
@@ -112,18 +109,15 @@ def remove_html_tags(series: pl.Series) -> pl.Series:
     input_types=["string"],
     auto_apply=False,
     priority=40,
-    mode="series",
+    mode="expr",
 )
-def remove_urls(series: pl.Series) -> pl.Series:
-    """Strip URLs (http/https) from text."""
-    _url_re = re.compile(r"https?://\S+")
+def remove_urls(column: str) -> pl.Expr:
+    """Strip URLs (http/https) from text.
 
-    def _strip(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return _url_re.sub("", val)
-
-    return series.map_elements(_strip, return_dtype=pl.Utf8)
+    Native Polars regex replace_all. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return pl.col(column).str.replace_all(r"https?://\S+", "")
 
 
 @register_transform(
@@ -258,14 +252,12 @@ _NUMBER_RE = re.compile(r"\d+\.?\d*")
     input_types=["string"],
     auto_apply=False,
     priority=30,
-    mode="series",
+    mode="expr",
 )
-def extract_numbers(series: pl.Series) -> pl.Series:
-    """Extract all numbers from text, joined by spaces."""
+def extract_numbers(column: str) -> pl.Expr:
+    """Extract all numbers from text, joined by spaces.
 
-    def _extract(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return " ".join(_NUMBER_RE.findall(val))
-
-    return series.map_elements(_extract, return_dtype=pl.Utf8)
+    Native Polars: extract_all → list.join. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return pl.col(column).str.extract_all(r"\d+\.?\d*").list.join(" ")

--- a/packages/python/goldenflow/tests/transforms/test_email.py
+++ b/packages/python/goldenflow/tests/transforms/test_email.py
@@ -7,9 +7,18 @@ from goldenflow.transforms.email import (
 )
 
 
+def _apply_expr(func, column: str, data: list) -> list:
+    """Helper to apply an expr-mode transform to test data."""
+    df = pl.DataFrame({column: data})
+    expr = func(column)
+    return df.select(expr.alias(column))[column].to_list()
+
+
 def test_email_lowercase():
-    s = pl.Series("e", ["John.DOE@Gmail.Com", "ADMIN@EXAMPLE.COM", None])
-    result = email_lowercase(s)
+    result = _apply_expr(
+        email_lowercase, "e",
+        ["John.DOE@Gmail.Com", "ADMIN@EXAMPLE.COM", None],
+    )
     assert result[0] == "john.doe@gmail.com"
     assert result[1] == "admin@example.com"
     assert result[2] is None
@@ -44,8 +53,10 @@ def test_email_normalize_preserves_none_and_invalid():
 
 
 def test_email_extract_domain():
-    s = pl.Series("e", ["user@example.com", "admin@sub.domain.org", None, "invalid"])
-    result = email_extract_domain(s)
+    result = _apply_expr(
+        email_extract_domain, "e",
+        ["user@example.com", "admin@sub.domain.org", None, "invalid"],
+    )
     assert result[0] == "example.com"
     assert result[1] == "sub.domain.org"
     assert result[2] is None

--- a/packages/python/goldenflow/tests/transforms/test_text.py
+++ b/packages/python/goldenflow/tests/transforms/test_text.py
@@ -82,8 +82,7 @@ def test_normalize_quotes():
 
 
 def test_remove_html_tags():
-    s = pl.Series("a", ["<p>Hello</p>", "<b>bold</b> text", "no tags", None])
-    result = remove_html_tags(s)
+    result = _apply_expr(remove_html_tags, "a", ["<p>Hello</p>", "<b>bold</b> text", "no tags", None])
     assert result[0] == "Hello"
     assert result[1] == "bold text"
     assert result[2] == "no tags"
@@ -91,20 +90,18 @@ def test_remove_html_tags():
 
 
 def test_remove_html_tags_nested():
-    s = pl.Series("a", ["<div><span>nested</span></div>", "<a href='url'>link</a>"])
-    result = remove_html_tags(s)
+    result = _apply_expr(remove_html_tags, "a", ["<div><span>nested</span></div>", "<a href='url'>link</a>"])
     assert result[0] == "nested"
     assert result[1] == "link"
 
 
 def test_remove_urls():
-    s = pl.Series("a", [
+    result = _apply_expr(remove_urls, "a", [
         "visit https://example.com for info",
         "go to http://test.org/path?q=1 now",
         "no url here",
         None,
     ])
-    result = remove_urls(s)
     assert result[0] == "visit  for info"
     assert result[1] == "go to  now"
     assert result[2] == "no url here"
@@ -167,8 +164,7 @@ def test_normalize_line_endings():
 
 
 def test_extract_numbers():
-    s = pl.Series("a", ["Weight: 150 lbs", "Age 25, Height 5.11", "none", None])
-    result = extract_numbers(s)
+    result = _apply_expr(extract_numbers, "a", ["Weight: 150 lbs", "Age 25, Height 5.11", "none", None])
     assert result[0] == "150"
     assert result[1] == "25 5.11"
     assert result[2] == ""


### PR DESCRIPTION
First batch of the map_elements attack's Tier 1 from catalog PR #252. Five transforms moved from `mode="series"` (uses `map_elements`) to `mode="expr"` (native Polars, stays in Rust):

| Transform | Old (Python per row) | New (native Polars) |
|---|---|---|
| `email_lowercase` | `val.strip().lower()` | `str.strip_chars().str.to_lowercase()` |
| `email_extract_domain` | `val.strip().rsplit('@',1)[1].lower()` | `str.extract(r'@([^@]+)$', 1).str.to_lowercase()` |
| `remove_html_tags` | `re.sub(r'<[^>]+>', '', val)` | `str.replace_all(r'<[^>]+>', '')` |
| `remove_urls` | `re.sub(r'https?://\S+', '', val)` | `str.replace_all(r'https?://\S+', '')` |
| `extract_numbers` | `' '.join(_NUMBER_RE.findall(val))` | `str.extract_all(r'\d+\.?\d*').list.join(' ')` |

## Test results

- Affected tests: 11/11 pass.
- Full `goldenflow` suite: 234/234 non-flake pass (one pre-existing GCS-permission failure unrelated).
- All tests updated to use `_apply_expr` helper (added one to `test_email.py`).

## Scope

This is **batch 1** of the Tier 1 migration. The catalog lists 15-20 candidates total. Subsequent batches will cover state lookups (`state_abbreviate`, `state_expand`), numeric strip/cast (`currency_strip`, `percentage_normalize`, `to_integer`), name normalization (`name_proper` needs regex callback handling), etc.

After all Tier 1 lands, expected 100K wall reduction is ~3-5s (15% of the spec's target). Tier 2 (`phone_e164` gate + date extractions) lands next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)