### PR TITLE
perf(goldenflow): migrate 7 more transforms from mode=series to mode=expr (Tier 1 batch 2)

### DIFF
--- a/packages/python/goldenflow/goldenflow/transforms/names.py
+++ b/packages/python/goldenflow/goldenflow/transforms/names.py
@@ -69,27 +69,41 @@ def split_name_reverse(df: pl.DataFrame, column: str) -> pl.DataFrame:
 
 
 @register_transform(
-    name="strip_titles", input_types=["name"], auto_apply=True, priority=70, mode="series"
+    name="strip_titles", input_types=["name"], auto_apply=True, priority=70, mode="expr"
 )
-def strip_titles(series: pl.Series) -> pl.Series:
-    def _strip(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return _TITLES.sub("", val).strip()
+def strip_titles(column: str) -> pl.Expr:
+    """Strip leading personal titles (Mr/Mrs/Ms/Dr/Prof/etc.) from names.
 
-    return series.map_elements(_strip, return_dtype=pl.Utf8)
+    Native Polars: case-insensitive regex replace then strip. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return (
+        pl.col(column)
+        .str.replace(
+            r"(?i)^(Mr\.?|Mrs\.?|Ms\.?|Miss\.?|Dr\.?|Prof\.?|Rev\.?|Sr\.?|Sra\.?)\s+",
+            "",
+        )
+        .str.strip_chars()
+    )
 
 
 @register_transform(
-    name="strip_suffixes", input_types=["name"], auto_apply=False, priority=60, mode="series"
+    name="strip_suffixes", input_types=["name"], auto_apply=False, priority=60, mode="expr"
 )
-def strip_suffixes(series: pl.Series) -> pl.Series:
-    def _strip(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return _SUFFIXES.sub("", val).strip()
+def strip_suffixes(column: str) -> pl.Expr:
+    """Strip trailing professional suffixes (Jr/Sr/II/MD/PhD/etc.) from names.
 
-    return series.map_elements(_strip, return_dtype=pl.Utf8)
+    Native Polars: case-insensitive regex replace then strip. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return (
+        pl.col(column)
+        .str.replace(
+            r"(?i)\s+(Jr\.?|Sr\.?|II|III|IV|MD|PhD|PharmD|DDS|DVM|Esq\.?|CPA|RN|DO)$",
+            "",
+        )
+        .str.strip_chars()
+    )
 
 
 @register_transform(

--- a/packages/python/goldenflow/goldenflow/transforms/numeric.py
+++ b/packages/python/goldenflow/goldenflow/transforms/numeric.py
@@ -8,19 +8,22 @@ from goldenflow.transforms import register_transform
 
 
 @register_transform(
-    name="currency_strip", input_types=["string", "numeric"], auto_apply=False, priority=50, mode="series"
+    name="currency_strip", input_types=["string", "numeric"], auto_apply=False, priority=50, mode="expr"
 )
-def currency_strip(series: pl.Series) -> pl.Series:
-    def _strip(val: str | None) -> float | None:
-        if val is None:
-            return None
-        cleaned = re.sub(r"[^\d.\-]", "", str(val))
-        try:
-            return float(cleaned)
-        except ValueError:
-            return None
+def currency_strip(column: str) -> pl.Expr:
+    """Strip currency symbols and thousand separators, return numeric.
 
-    return series.map_elements(_strip, return_dtype=pl.Float64)
+    Native Polars: cast to Utf8, regex-strip non-numeric chars, cast to
+    Float64 (strict=False yields null on failure, matching the old
+    try/except). Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return (
+        pl.col(column)
+        .cast(pl.Utf8, strict=False)
+        .str.replace_all(r"[^\d.\-]", "")
+        .cast(pl.Float64, strict=False)
+    )
 
 
 @register_transform(
@@ -28,19 +31,23 @@ def currency_strip(series: pl.Series) -> pl.Series:
     input_types=["string", "numeric"],
     auto_apply=False,
     priority=50,
-    mode="series",
+    mode="expr",
 )
-def percentage_normalize(series: pl.Series) -> pl.Series:
-    def _norm(val: str | None) -> float | None:
-        if val is None:
-            return None
-        v = str(val).strip().rstrip("%")
-        try:
-            return float(v) / 100.0
-        except ValueError:
-            return None
+def percentage_normalize(column: str) -> pl.Expr:
+    """Strip trailing %, parse to float, divide by 100.
 
-    return series.map_elements(_norm, return_dtype=pl.Float64)
+    Native Polars: cast to Utf8, strip whitespace + trailing %, cast to
+    Float64 (null on failure), then divide. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return (
+        pl.col(column)
+        .cast(pl.Utf8, strict=False)
+        .str.strip_chars()
+        .str.replace(r"%+$", "")
+        .cast(pl.Float64, strict=False)
+        / 100.0
+    )
 
 
 @register_transform(
@@ -62,20 +69,21 @@ def clamp(series: pl.Series, min_val: float = 0.0, max_val: float = 1.0) -> pl.S
     input_types=["string", "numeric"],
     auto_apply=False,
     priority=45,
-    mode="series",
+    mode="expr",
 )
-def to_integer(series: pl.Series) -> pl.Series:
-    """Parse string to integer, truncating any decimal part."""
+def to_integer(column: str) -> pl.Expr:
+    """Parse string to integer, truncating any decimal part.
 
-    def _to_int(val: str | None) -> int | None:
-        if val is None:
-            return None
-        try:
-            return int(float(val))
-        except (ValueError, OverflowError):
-            return None
-
-    return series.map_elements(_to_int, return_dtype=pl.Int64)
+    Native Polars: cast via Float64 (truncation matches the old int(float(val))
+    semantics) then Int64. strict=False yields null on parse failure, matching
+    the old try/except. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return (
+        pl.col(column)
+        .cast(pl.Float64, strict=False)
+        .cast(pl.Int64, strict=False)
+    )
 
 
 @register_transform(

--- a/packages/python/goldenflow/goldenflow/transforms/numeric.py
+++ b/packages/python/goldenflow/goldenflow/transforms/numeric.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import re
-
 import polars as pl
 
 from goldenflow.transforms import register_transform

--- a/packages/python/goldenflow/goldenflow/transforms/text.py
+++ b/packages/python/goldenflow/goldenflow/transforms/text.py
@@ -193,22 +193,38 @@ _EMOJI_RE = re.compile(
 )
 
 
+_EMOJI_PATTERN = (
+    "["
+    "\U0001f600-\U0001f64f"
+    "\U0001f300-\U0001f5ff"
+    "\U0001f680-\U0001f6ff"
+    "\U0001f1e0-\U0001f1ff"
+    "\U00002702-\U000027b0"
+    "\U000024c2-\U0001f251"
+    "\U0001f900-\U0001f9ff"
+    "\U0001fa00-\U0001fa6f"
+    "\U0001fa70-\U0001faff"
+    "\U00002600-\U000026ff"
+    "\U0000200d"
+    "\U0000fe0f"
+    "]+"
+)
+
+
 @register_transform(
     name="remove_emojis",
     input_types=["string"],
     auto_apply=False,
     priority=38,
-    mode="series",
+    mode="expr",
 )
-def remove_emojis(series: pl.Series) -> pl.Series:
-    """Remove emoji characters from text."""
+def remove_emojis(column: str) -> pl.Expr:
+    """Remove emoji characters from text.
 
-    def _strip(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return _EMOJI_RE.sub("", val)
-
-    return series.map_elements(_strip, return_dtype=pl.Utf8)
+    Native Polars regex replace_all. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return pl.col(column).str.replace_all(_EMOJI_PATTERN, "")
 
 
 @register_transform(
@@ -237,17 +253,20 @@ def fix_mojibake(series: pl.Series) -> pl.Series:
     input_types=["string"],
     auto_apply=False,
     priority=82,
-    mode="series",
+    mode="expr",
 )
-def normalize_line_endings(series: pl.Series) -> pl.Series:
-    """Normalize \\r\\n and \\r to \\n."""
+def normalize_line_endings(column: str) -> pl.Expr:
+    """Normalize \\r\\n and \\r to \\n.
 
-    def _norm(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return val.replace("\r\n", "\n").replace("\r", "\n")
-
-    return series.map_elements(_norm, return_dtype=pl.Utf8)
+    Native Polars: chained literal replace_all. Order matters — replace
+    \\r\\n first (longer match wins), then any remaining \\r. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return (
+        pl.col(column)
+        .str.replace_all("\r\n", "\n", literal=True)
+        .str.replace_all("\r", "\n", literal=True)
+    )
 
 
 _NUMBER_RE = re.compile(r"\d+\.?\d*")

--- a/packages/python/goldenflow/tests/transforms/test_names.py
+++ b/packages/python/goldenflow/tests/transforms/test_names.py
@@ -11,6 +11,13 @@ from goldenflow.transforms.names import (
 )
 
 
+def _apply_expr(func, column: str, data: list) -> list:
+    """Helper to apply an expr-mode transform to test data."""
+    df = pl.DataFrame({column: data})
+    expr = func(column)
+    return df.select(expr.alias(column))[column].to_list()
+
+
 def test_split_name():
     df = pl.DataFrame({"name": ["John Smith", "Jane Marie Doe", "Madonna"]})
     result = split_name(df, "name")
@@ -26,16 +33,20 @@ def test_split_name_reverse():
 
 
 def test_strip_titles():
-    s = pl.Series("n", ["Dr. James Wilson", "Mrs. Jane Smith", "Mr. Bob Jones Jr."])
-    result = strip_titles(s)
+    result = _apply_expr(
+        strip_titles, "n",
+        ["Dr. James Wilson", "Mrs. Jane Smith", "Mr. Bob Jones Jr."],
+    )
     assert result[0] == "James Wilson"
     assert result[1] == "Jane Smith"
     assert result[2] == "Bob Jones Jr."
 
 
 def test_strip_suffixes():
-    s = pl.Series("n", ["James Wilson MD", "Jane Smith PhD", "Bob Jones Esq"])
-    result = strip_suffixes(s)
+    result = _apply_expr(
+        strip_suffixes, "n",
+        ["James Wilson MD", "Jane Smith PhD", "Bob Jones Esq"],
+    )
     assert result[0] == "James Wilson"
     assert result[1] == "Jane Smith"
     assert result[2] == "Bob Jones"

--- a/packages/python/goldenflow/tests/transforms/test_numeric.py
+++ b/packages/python/goldenflow/tests/transforms/test_numeric.py
@@ -12,9 +12,17 @@ from goldenflow.transforms.numeric import (
 )
 
 
+def _apply_expr(func, column: str, data: list) -> list:
+    """Helper to apply an expr-mode transform to test data."""
+    df = pl.DataFrame({column: data})
+    expr = func(column)
+    return df.select(expr.alias(column))[column].to_list()
+
+
 def test_currency_strip():
-    s = pl.Series("p", ["$1,234.56", "$99.99", "$0.50", "free"])
-    result = currency_strip(s)
+    result = _apply_expr(
+        currency_strip, "p", ["$1,234.56", "$99.99", "$0.50", "free"],
+    )
     assert result[0] == 1234.56
     assert result[1] == 99.99
     assert result[2] == 0.50
@@ -22,8 +30,9 @@ def test_currency_strip():
 
 
 def test_percentage_normalize():
-    s = pl.Series("p", ["85%", "100%", "0.5%", "50"])
-    result = percentage_normalize(s)
+    result = _apply_expr(
+        percentage_normalize, "p", ["85%", "100%", "0.5%", "50"],
+    )
     assert result[0] == 0.85
     assert result[1] == 1.0
     assert result[2] == 0.005
@@ -42,8 +51,9 @@ def test_clamp():
 
 
 def test_to_integer():
-    s = pl.Series("v", ["42", "3.7", "100", "abc", None])
-    result = to_integer(s)
+    result = _apply_expr(
+        to_integer, "v", ["42", "3.7", "100", "abc", None],
+    )
     assert result[0] == 42
     assert result[1] == 3  # truncates decimal
     assert result[2] == 100

--- a/packages/python/goldenflow/tests/transforms/test_text.py
+++ b/packages/python/goldenflow/tests/transforms/test_text.py
@@ -135,8 +135,9 @@ def test_pad_right():
 
 
 def test_remove_emojis():
-    s = pl.Series("a", ["Hello \U0001f600 World", "No emojis", "\U0001f44d Great \U0001f44d", None])
-    result = remove_emojis(s)
+    result = _apply_expr(remove_emojis, "a", [
+        "Hello \U0001f600 World", "No emojis", "\U0001f44d Great \U0001f44d", None,
+    ])
     assert result[0] == "Hello  World"
     assert result[1] == "No emojis"
     assert result[2] == " Great "
@@ -158,8 +159,9 @@ def test_fix_mojibake():
 
 
 def test_normalize_line_endings():
-    s = pl.Series("a", ["hello\r\nworld", "foo\rbar", "no change\n", None])
-    result = normalize_line_endings(s)
+    result = _apply_expr(normalize_line_endings, "a", [
+        "hello\r\nworld", "foo\rbar", "no change\n", None,
+    ])
     assert result[0] == "hello\nworld"
     assert result[1] == "foo\nbar"
     assert result[2] == "no change\n"


### PR DESCRIPTION
Tier 1 batch 2 of the map_elements attack. 7 transforms moved from `mode="series"` to `mode="expr"` (native Polars, stays in Rust):

| File | Transform | Notes |
|---|---|---|
| names.py | `strip_titles` | regex replace + strip (case-insensitive via `(?i)` flag) |
| names.py | `strip_suffixes` | same shape, trailing-position regex |
| text.py | `remove_emojis` | regex char-class moved to module constant |
| text.py | `normalize_line_endings` | chained `str.replace_all` with `literal=True`; longer match first |
| numeric.py | `currency_strip` | strict=False on `cast(Float64)` matches old try/except null behavior |
| numeric.py | `percentage_normalize` | strip whitespace + trailing %, parse, divide by 100 |
| numeric.py | `to_integer` | double cast Float64 → Int64 truncates toward zero same as `int(float(x))` |

## Test results

- 7 affected tests updated to use `_apply_expr` helper
- All 7 pass
- Full goldenflow suite: 229/229 non-flake pass (excluded pre-existing GCS-perm flake)

## Cumulative Tier 1 progress (post-merge)

- Batch 1 (PR #253): 5 transforms
- Batch 2 (this): 7 transforms
- **Total: 12 of catalog's 15-20 candidates done**

## Remaining Tier 1 (future batches)

- `name_proper` — has Mc/O' regex callback (`lambda m: f"Mc{m.group(1).upper()}"`); needs splitting into multiple replace passes
- `pad_left`, `pad_right`, `truncate` — parameterized; need to establish a pattern for params in mode="expr"
- `address.*` lookups (different file) — dict-based; use `replace_strict` or `when().then()` chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)