### PR TITLE
perf(goldenflow): migrate 7 more transforms incl. parameterized pattern (Tier 1 batch 3)

### DIFF
--- a/packages/python/goldenflow/goldenflow/transforms/address.py
+++ b/packages/python/goldenflow/goldenflow/transforms/address.py
@@ -34,61 +34,87 @@ _STATES_LOWER = {k.lower(): v for k, v in _STATES.items()}
 
 
 @register_transform(
-    name="address_standardize", input_types=["address"], auto_apply=False, priority=50, mode="series"
+    name="address_standardize", input_types=["address"], auto_apply=False, priority=50, mode="expr"
 )
-def address_standardize(series: pl.Series) -> pl.Series:
-    def _std(val: str | None) -> str | None:
-        if val is None:
-            return None
-        result = val
-        for full, abbr in _STREET_ABBREV.items():
-            result = re.sub(rf"\b{full}\b", abbr, result, flags=re.IGNORECASE)
-        return result
+def address_standardize(column: str) -> pl.Expr:
+    """Replace full street suffixes (Street, Avenue...) with abbreviations.
 
-    return series.map_elements(_std, return_dtype=pl.Utf8)
+    Native Polars: chain of case-insensitive word-boundary regex replaces.
+    One `str.replace_all` per (full, abbr) pair. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    expr = pl.col(column)
+    for full, abbr in _STREET_ABBREV.items():
+        expr = expr.str.replace_all(rf"(?i)\b{full}\b", abbr)
+    return expr
 
 
 @register_transform(
-    name="address_expand", input_types=["address"], auto_apply=False, priority=50, mode="series"
+    name="address_expand", input_types=["address"], auto_apply=False, priority=50, mode="expr"
 )
-def address_expand(series: pl.Series) -> pl.Series:
-    def _expand(val: str | None) -> str | None:
-        if val is None:
-            return None
-        result = val
-        for abbr, full in _STREET_EXPAND.items():
-            result = re.sub(rf"\b{abbr}\b", full, result, flags=re.IGNORECASE)
-        return result
+def address_expand(column: str) -> pl.Expr:
+    """Replace street abbreviations (St, Ave...) with full forms.
 
-    return series.map_elements(_expand, return_dtype=pl.Utf8)
+    Native Polars: chain of case-insensitive word-boundary regex replaces.
+    Spec docs/superpowers/specs/2026-05-15-map-elements-attack-design.md
+    Tier 1.
+    """
+    expr = pl.col(column)
+    for abbr, full in _STREET_EXPAND.items():
+        expr = expr.str.replace_all(rf"(?i)\b{abbr}\b", full)
+    return expr
 
 
 @register_transform(
-    name="state_abbreviate", input_types=["state", "string"], auto_apply=False, priority=50, mode="series"
+    name="state_abbreviate", input_types=["state", "string"], auto_apply=False, priority=50, mode="expr"
 )
-def state_abbreviate(series: pl.Series) -> pl.Series:
-    def _abbr(val: str | None) -> str | None:
-        if val is None:
-            return None
-        val_stripped = val.strip()
-        if len(val_stripped) == 2 and val_stripped.upper() in _STATES_REVERSE:
-            return val_stripped.upper()
-        matched = _STATES_LOWER.get(val_stripped.lower())
-        return matched if matched else val
+def state_abbreviate(column: str) -> pl.Expr:
+    """Normalize state name to 2-letter abbreviation.
 
-    return series.map_elements(_abbr, return_dtype=pl.Utf8)
+    Three-way fallback:
+      1. 2-letter input that's a valid abbreviation -> uppercase it.
+      2. Full name (case-insensitive) -> look up in _STATES_LOWER.
+      3. Neither matched -> return original column value unchanged.
+
+    Native Polars: `replace_strict` with `default=...` provides the
+    not-matched fallback; combined with `when/then` to handle the
+    2-letter-already-valid case. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    cleaned = pl.col(column).str.strip_chars()
+    upper = cleaned.str.to_uppercase()
+    is_valid_2letter = (cleaned.str.len_chars() == 2) & upper.is_in(
+        list(_STATES_REVERSE.keys())
+    )
+    # Lower-cased lookup; default to a sentinel that means "not in dict".
+    matched_full = cleaned.str.to_lowercase().replace_strict(
+        _STATES_LOWER, default=None, return_dtype=pl.Utf8,
+    )
+    return (
+        pl.when(is_valid_2letter).then(upper)
+        .when(matched_full.is_not_null()).then(matched_full)
+        .otherwise(pl.col(column))
+    )
 
 
 @register_transform(
-    name="state_expand", input_types=["state", "string"], auto_apply=False, priority=50, mode="series"
+    name="state_expand", input_types=["state", "string"], auto_apply=False, priority=50, mode="expr"
 )
-def state_expand(series: pl.Series) -> pl.Series:
-    def _expand(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return _STATES_REVERSE.get(val.strip().upper(), val)
+def state_expand(column: str) -> pl.Expr:
+    """Expand 2-letter state abbreviation to full name.
 
-    return series.map_elements(_expand, return_dtype=pl.Utf8)
+    Native Polars: `replace_strict` with the dict, default=original value
+    for unmatched inputs. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return (
+        pl.col(column)
+        .str.strip_chars()
+        .str.to_uppercase()
+        .replace_strict(
+            _STATES_REVERSE, default=pl.col(column), return_dtype=pl.Utf8,
+        )
+    )
 
 
 @register_transform(

--- a/packages/python/goldenflow/goldenflow/transforms/text.py
+++ b/packages/python/goldenflow/goldenflow/transforms/text.py
@@ -62,10 +62,17 @@ def collapse_whitespace(column: str) -> pl.Expr:
 
 
 @register_transform(
-    name="truncate", input_types=["string"], auto_apply=False, priority=30, mode="series"
+    name="truncate", input_types=["string"], auto_apply=False, priority=30, mode="expr"
 )
-def truncate(series: pl.Series, n: int = 255) -> pl.Series:
-    return series.str.slice(0, n)
+def truncate(column: str, n: int | str = 255) -> pl.Expr:
+    """Truncate string to first n characters.
+
+    Native Polars: str.slice. Accepts str or int for `n` because the engine
+    passes config params as strings; tests + code passing kwargs use int.
+    Spec docs/superpowers/specs/2026-05-15-map-elements-attack-design.md
+    Tier 1 (parameterized).
+    """
+    return pl.col(column).str.slice(0, int(n))
 
 
 @register_transform(
@@ -137,17 +144,15 @@ def remove_digits(column: str) -> pl.Expr:
     input_types=["string"],
     auto_apply=False,
     priority=30,
-    mode="series",
+    mode="expr",
 )
-def pad_left(series: pl.Series, width: int = 10, char: str = "0") -> pl.Series:
-    """Left-pad strings to a fixed width."""
+def pad_left(column: str, width: int | str = 10, char: str = "0") -> pl.Expr:
+    """Left-pad strings to a fixed width.
 
-    def _pad(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return val.rjust(width, char)
-
-    return series.map_elements(_pad, return_dtype=pl.Utf8)
+    Native Polars: str.pad_start. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return pl.col(column).str.pad_start(int(width), char)
 
 
 @register_transform(
@@ -155,17 +160,15 @@ def pad_left(series: pl.Series, width: int = 10, char: str = "0") -> pl.Series:
     input_types=["string"],
     auto_apply=False,
     priority=30,
-    mode="series",
+    mode="expr",
 )
-def pad_right(series: pl.Series, width: int = 10, char: str = " ") -> pl.Series:
-    """Right-pad strings to a fixed width."""
+def pad_right(column: str, width: int | str = 10, char: str = " ") -> pl.Expr:
+    """Right-pad strings to a fixed width.
 
-    def _pad(val: str | None) -> str | None:
-        if val is None:
-            return None
-        return val.ljust(width, char)
-
-    return series.map_elements(_pad, return_dtype=pl.Utf8)
+    Native Polars: str.pad_end. Spec
+    docs/superpowers/specs/2026-05-15-map-elements-attack-design.md Tier 1.
+    """
+    return pl.col(column).str.pad_end(int(width), char)
 
 
 _EMOJI_RE = re.compile(

--- a/packages/python/goldenflow/tests/transforms/test_address.py
+++ b/packages/python/goldenflow/tests/transforms/test_address.py
@@ -11,24 +11,35 @@ from goldenflow.transforms.address import (
 )
 
 
+def _apply_expr(func, column: str, data: list, *params) -> list:
+    """Helper to apply an expr-mode transform to test data."""
+    df = pl.DataFrame({column: data})
+    expr = func(column, *params)
+    return df.select(expr.alias(column))[column].to_list()
+
+
 def test_address_standardize():
-    s = pl.Series("a", ["123 Main Street", "456 Oak Avenue", "789 Elm Drive"])
-    result = address_standardize(s)
+    result = _apply_expr(
+        address_standardize, "a",
+        ["123 Main Street", "456 Oak Avenue", "789 Elm Drive"],
+    )
     assert result[0] == "123 Main St"
     assert result[1] == "456 Oak Ave"
     assert result[2] == "789 Elm Dr"
 
 
 def test_address_expand():
-    s = pl.Series("a", ["123 Main St", "456 Oak Ave"])
-    result = address_expand(s)
+    result = _apply_expr(
+        address_expand, "a", ["123 Main St", "456 Oak Ave"],
+    )
     assert result[0] == "123 Main Street"
     assert result[1] == "456 Oak Avenue"
 
 
 def test_state_abbreviate():
-    s = pl.Series("st", ["Pennsylvania", "California", "new york", "TX"])
-    result = state_abbreviate(s)
+    result = _apply_expr(
+        state_abbreviate, "st", ["Pennsylvania", "California", "new york", "TX"],
+    )
     assert result[0] == "PA"
     assert result[1] == "CA"
     assert result[2] == "NY"
@@ -36,8 +47,9 @@ def test_state_abbreviate():
 
 
 def test_state_expand():
-    s = pl.Series("st", ["PA", "CA", "NY"])
-    result = state_expand(s)
+    result = _apply_expr(
+        state_expand, "st", ["PA", "CA", "NY"],
+    )
     assert result[0] == "Pennsylvania"
     assert result[1] == "California"
     assert result[2] == "New York"

--- a/packages/python/goldenflow/tests/transforms/test_text.py
+++ b/packages/python/goldenflow/tests/transforms/test_text.py
@@ -21,10 +21,14 @@ from goldenflow.transforms.text import (
 )
 
 
-def _apply_expr(func, column: str, data: list[str]) -> list[str]:
-    """Helper to apply an expr-mode transform to test data."""
+def _apply_expr(func, column: str, data: list, *params) -> list:
+    """Helper to apply an expr-mode transform to test data.
+
+    Trailing positional args are forwarded to ``func`` after the column
+    name (engine-equivalent call shape: ``func(column, *params)``).
+    """
     df = pl.DataFrame({column: data})
-    expr = func(column)
+    expr = func(column, *params)
     return df.select(expr.alias(column))[column].to_list()
 
 
@@ -65,9 +69,8 @@ def test_collapse_whitespace():
 
 
 def test_truncate():
-    s = pl.Series("a", ["hello world", "hi", "a very long string"])
-    result = truncate(s, n=5)
-    assert result.to_list() == ["hello", "hi", "a ver"]
+    result = _apply_expr(truncate, "a", ["hello world", "hi", "a very long string"], 5)
+    assert result == ["hello", "hi", "a ver"]
 
 
 def test_normalize_quotes():
@@ -114,8 +117,7 @@ def test_remove_digits():
 
 
 def test_pad_left():
-    s = pl.Series("a", ["42", "7", "123", None])
-    result = pad_left(s, width=5, char="0")
+    result = _apply_expr(pad_left, "a", ["42", "7", "123", None], 5, "0")
     assert result[0] == "00042"
     assert result[1] == "00007"
     assert result[2] == "00123"
@@ -123,8 +125,7 @@ def test_pad_left():
 
 
 def test_pad_right():
-    s = pl.Series("a", ["AB", "X", "ABCDE", None])
-    result = pad_right(s, width=5, char=" ")
+    result = _apply_expr(pad_right, "a", ["AB", "X", "ABCDE", None], 5, " ")
     assert result[0] == "AB   "
     assert result[1] == "X    "
     assert result[2] == "ABCDE"


### PR DESCRIPTION
Third (and effectively final) Tier 1 batch of the map_elements attack. 7 transforms migrated, including the first parameterized ones — **establishes the pattern for parameterized expr transforms.**

## Migrated

**Parameterized** (3) — engine passes config params as strings; functions accept `int | str` and cast internally:

| Transform | Old | New |
|---|---|---|
| `truncate` | `series.str.slice(0, n)` | `pl.col(c).str.slice(0, int(n))` |
| `pad_left` | `val.rjust(width, char)` | `str.pad_start(int(width), char)` |
| `pad_right` | `val.ljust(width, char)` | `str.pad_end(int(width), char)` |

**Dict lookups + chained regex** (4):

| Transform | Strategy |
|---|---|
| `address_standardize` | Chained `str.replace_all(rf"(?i)\b{full}\b", abbr)` for each street type |
| `address_expand` | Same shape, reversed |
| `state_abbreviate` | `when(is_valid_2letter).then(upper).when(matched.is_not_null()).then(matched).otherwise(original)` using `replace_strict` for the lookup branch |
| `state_expand` | `replace_strict(_STATES_REVERSE, default=pl.col(c))` |

`_apply_expr` test helper extended to forward trailing positional args (engine-equivalent shape: `func(column, *params)`); added the helper to `test_address.py`.

## Test results

- 7 affected tests pass
- Full goldenflow suite: 229/229 non-flake pass

## Cumulative Tier 1 progress (post-merge)

| Batch | PR | Transforms |
|---|---|---|
| 1 | #253 | 5 |
| 2 | #254 | 7 |
| 3 | this | 7 |
| **Total** | | **19** |

Effectively Tier 1 complete (catalog target was 15-20).

## Remaining in mode="series" by design

- `name_proper` — callback-style regex (`lambda m: f"Mc{m.group(1).upper()}"`) has no native Polars equivalent. Could split into hardcoded prefix replacements if it shows up hot in profiling.
- `normalize_unicode`, `fix_mojibake` — genuinely Python (unicodedata, latin-1 round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)