### PR TITLE
perf(goldenflow + pipeline): Tier 2 audit + zip_normalize + Attack C prep cache

### DIFF
--- a/docs/superpowers/specs/2026-05-15-tier2-audit-findings.md
+++ b/docs/superpowers/specs/2026-05-15-tier2-audit-findings.md
@@ -1,0 +1,198 @@
+# Tier 2 audit findings — phone gate + date format coverage
+
+**Status:** Audit memo (drafted 2026-05-15)
+**Author:** Claude + bsevern
+**Context:** Tier 2 of the map_elements attack per
+[`2026-05-15-map-elements-attack-design.md`](2026-05-15-map-elements-attack-design.md)
+and [`2026-05-15-map-elements-catalog.md`](2026-05-15-map-elements-catalog.md).
+
+This memo records two diagnostic findings from the Tier 2 audit work,
+and what landed vs what was deferred.
+
+## Finding 1 — phone_e164 gate is correct, not broken
+
+The map_elements spec's "Attack A" hypothesis was: `phone_e164` may be
+firing on non-phone columns because of a broken gate, and the synthetic
+person fixture used in the bench has no phone column.
+
+**Both halves of that hypothesis are wrong.**
+
+Reading `packages/python/goldenmatch/tests/generate_synthetic.py:109`:
+
+```python
+record = {
+    "id": i + 1,
+    "first_name": first,
+    "last_name": last,
+    "email": email,
+    "phone": random_phone(),       # <-- phone column IS present
+    "address": random_address(),
+    "city": ...,
+    ...
+}
+```
+
+And the gate in `packages/python/goldenflow/goldenflow/engine/selector.py`:
+
+```python
+for t in all_transforms:
+    if not t.auto_apply:
+        continue
+    if profile.inferred_type in t.input_types:    # phone_e164 has ["phone"]
+        selected.append(t)
+    elif "string" in t.input_types and profile.inferred_type in (
+        "string", "email", "phone", "name", "address", "date",
+    ):
+        selected.append(t)
+```
+
+`phone_e164` has `input_types=["phone"]` (not `["string"]`), so the second
+branch never fires — it only matches when the column profile says
+`inferred_type == "phone"`. That's correct.
+
+The fixture has a phone column → phone gets profiled as `inferred_type="phone"`
+→ phone_e164 fires → produces 1 `map_elements` call per controller iteration
+(× 5 iterations = 5 of the 542 calls). **Not a meaningful share of the
+hot path.**
+
+## Finding 2 — the real residual hot paths
+
+With phone_e164 mostly innocent, what does account for the 542 `map_elements`
+calls at 100K post-#239? Working backwards from the auto_apply transforms
+that still use `mode="series"` after Tier 1 batches 1-3:
+
+| Transform | `auto_apply` | Fires on | Tier 1 status |
+|---|---|---|---|
+| `normalize_unicode` | True | every string-like column | **Stays mode="series"** — needs Python `unicodedata` |
+| `fix_mojibake` | False | n/a (opt-in) | Stays mode="series" |
+| `phone_e164` | True | phone columns only | Stays mode="series" — needs `phonenumbers` |
+| `date_iso8601` | True | date columns | Stays mode="series" — see Finding 3 |
+| `zip_normalize` | True | zip columns | **Migrated this batch** to mode="expr" |
+
+For the synthetic person fixture (10 columns, 8 string-like, 1 phone, 1 zip):
+
+- `normalize_unicode` on ~8 string columns × 5 iterations ≈ 40 calls
+- `phone_e164` on 1 phone column × 5 iterations = 5 calls
+- `zip_normalize` on 1 zip column × 5 iterations = 5 calls (now eliminated)
+- Plus per-call ramp-up overhead and any non-auto transforms.
+
+After Tier 1 batch 1-3 + zip_normalize → estimated remaining `map_elements`
+calls in the hot path drop to ~50 from the original 542 (a ~90% reduction).
+The dominant remainder is `normalize_unicode` firing across all string-like
+columns. That one **cannot move to `mode="expr"`** — Polars has no native
+NFKD-normalize-and-strip-combining-marks operation; it must stay in
+`mode="series"`. Tier 3 by design.
+
+## Finding 3 — date_iso8601 cannot move to mode="expr" without behavior regression
+
+Tried converting `date_iso8601` to native Polars and discovered a real
+behavior gap:
+
+```python
+>>> import polars as pl
+>>> pl.DataFrame({"d": ["03/15/2024", "Jan 5, 2023", "2024-01-20", "invalid"]})
+...   .select(pl.col("d").str.to_date(strict=False))
+[{'d': None}, {'d': None}, {'d': date(2024, 1, 20)}, {'d': None}]
+```
+
+Polars's `str.to_date(strict=False)` without an explicit format **only
+parses ISO-format dates** (`YYYY-MM-DD`). It does not handle:
+
+- US-style slash dates (`03/15/2024`)
+- English month names (`Jan 5, 2023`)
+- EU-style slash dates (`15/03/2024`)
+- Any other common human-written format
+
+The current `mode="series"` implementation uses `dateutil.parser.parse`,
+which handles all of these. Migrating to `mode="expr"` would silently
+drop format coverage that callers may depend on.
+
+This applies to **every transform that goes through `_parse_date(val)`**:
+
+- `date_iso8601` (auto_apply=True)
+- `date_us`, `date_eu`, `date_parse`
+- `age_from_dob`
+- `datetime_iso8601`
+- `extract_year`, `extract_month`, `extract_day`, `extract_quarter`, `extract_day_of_week`
+- `date_shift`
+- `date_validate`
+
+Twelve transforms. All stay `mode="series"` until one of these design
+decisions is made (see §Options for follow-up).
+
+### Why this matters for the bench
+
+`date_iso8601` is `auto_apply=True` — would fire on every date column.
+The synthetic person fixture has no date column (`generate_synthetic.py`
+defines no DOB / created_at / etc.), so `date_iso8601` doesn't fire on
+the bench at all. **No regression for our bench numbers from leaving
+date transforms in `mode="series"`.**
+
+For real customer data with date columns, the choice between
+"native, fast, ISO-only" and "Python, slow, dateutil-flexible" is a
+product decision. Not blocking Tier 1 perf wins.
+
+## What landed in this batch
+
+| Transform | Change |
+|---|---|
+| `address.zip_normalize` | `mode="series"` → `mode="expr"`. Native: `str.strip_chars().str.split("-").list.first()` then `when(matches r"^\d+$").then(zfill(5)).otherwise(base)`. Auto_apply=True; fires on every zip column. |
+
+That's it — just one transform in this batch, because the date transforms
+need spec-level decisions before migrating.
+
+## Cumulative Tier 1 + Tier 2 progress
+
+| Batch | PR | Transforms |
+|---|---|---|
+| 1 | #253 ✅ | 5 (email, html tags, urls, extract_numbers) |
+| 2 | #254 | 7 (strip_titles, strip_suffixes, remove_emojis, normalize_line_endings, currency_strip, percentage_normalize, to_integer) |
+| 3 | #255 | 7 (truncate, pad_left, pad_right, address_standardize, address_expand, state_abbreviate, state_expand) |
+| 4 (this) | new | 1 (zip_normalize) + audit findings |
+| **Total** | | **20 transforms migrated** |
+
+Tier 1 catalog estimated 15-20 → effectively complete. Catalogued Tier 2
+date transforms remain in `mode="series"` pending a design decision.
+
+## Options for follow-up (date transforms)
+
+1. **Cascade fallback approach.** Try Polars `str.to_date(format=...)` with
+   common formats (`%Y-%m-%d`, `%m/%d/%Y`, `%d/%m/%Y`, `%Y/%m/%d`) in order,
+   using `pl.coalesce` to pick the first successful parse. Doesn't handle
+   English month names — those would silently fall through to null. Net
+   coverage: ~80% of real-world formats, 100% speedup on the covered formats.
+
+2. **Hybrid mode.** Run the Polars-native parse first. For rows where it
+   returns null but `_DATEUTIL_LOOKS_PARSEABLE_RE.match(val)` is True,
+   fall back to a `map_elements` call. Cuts the Python cost proportional
+   to ISO-format coverage in the column. More complex.
+
+3. **Leave as-is.** date columns aren't on the bench's hot path; pursue
+   wins elsewhere.
+
+4. **Specify a "native_dates_only" option** in `GoldenFlowConfig` so
+   advanced users can opt into Polars-native parsing knowing they lose
+   format coverage. Defaults to current behavior.
+
+My recommendation: **option 3 for now.** The bench doesn't show date
+transforms in the top 10, and the format-coverage trade-off needs more
+thought than this audit warrants.
+
+## Connection back to the spec
+
+These findings update what the [map_elements attack spec](2026-05-15-map-elements-attack-design.md)
+should claim:
+
+- **Attack A (phone_e164 gate):** spec hypothesis wrong; no gate fix needed.
+  Phone column genuinely exists on the fixture. Replace this attack section
+  with: "phone_e164 stays mode='series' as Tier 3 (genuinely Python via
+  phonenumbers); 5 calls per dedupe is acceptable."
+- **Attack B (Tier 1 catalog):** complete (20 transforms across 4 PRs).
+- **Attack C (controller transform cache):** still TBD — cache redundant
+  invocations of the auto-transform chain across the controller's 5
+  sample iterations. This is now the biggest remaining single win at
+  spec level.
+
+Spec acceptance criterion #1 ("100K median wall ≤ 24s") will need
+re-measurement on the bench after all batch PRs merge to confirm gates
+are hit.

--- a/packages/python/goldenflow/goldenflow/transforms/address.py
+++ b/packages/python/goldenflow/goldenflow/transforms/address.py
@@ -92,19 +92,22 @@ def state_expand(series: pl.Series) -> pl.Series:
 
 
 @register_transform(
-    name="zip_normalize", input_types=["zip"], auto_apply=True, priority=55, mode="series"
+    name="zip_normalize", input_types=["zip"], auto_apply=True, priority=55, mode="expr"
 )
-def zip_normalize(series: pl.Series) -> pl.Series:
-    def _norm(val: str | None) -> str | None:
-        if val is None:
-            return None
-        val = val.strip()
-        val = val.split("-")[0]  # strip +4
-        if val.isdigit():
-            return val.zfill(5)
-        return val  # preserve invalid
+def zip_normalize(column: str) -> pl.Expr:
+    """Normalize US ZIP to 5-digit form. Strip +4, zero-pad if all-digits,
+    preserve invalid inputs unchanged.
 
-    return series.map_elements(_norm, return_dtype=pl.Utf8)
+    Native Polars: strip + take first segment before '-' + check all-digits
+    via regex contains, then conditionally zfill. Spec Tier 2 (auto_apply=True
+    transform; was firing per-row Python on every dedupe iteration).
+    """
+    base = pl.col(column).str.strip_chars().str.split("-").list.first()
+    return (
+        pl.when(base.str.contains(r"^\d+$"))
+        .then(base.str.zfill(5))
+        .otherwise(base)
+    )
 
 
 @register_transform(

--- a/packages/python/goldenflow/tests/transforms/test_address.py
+++ b/packages/python/goldenflow/tests/transforms/test_address.py
@@ -11,6 +11,13 @@ from goldenflow.transforms.address import (
 )
 
 
+def _apply_expr(func, column: str, data: list, *params) -> list:
+    """Helper to apply an expr-mode transform to test data."""
+    df = pl.DataFrame({column: data})
+    expr = func(column, *params)
+    return df.select(expr.alias(column))[column].to_list()
+
+
 def test_address_standardize():
     s = pl.Series("a", ["123 Main Street", "456 Oak Avenue", "789 Elm Drive"])
     result = address_standardize(s)
@@ -44,8 +51,9 @@ def test_state_expand():
 
 
 def test_zip_normalize():
-    s = pl.Series("z", ["19103", "9001", "10001-1234", "abcde"])
-    result = zip_normalize(s)
+    result = _apply_expr(
+        zip_normalize, "z", ["19103", "9001", "10001-1234", "abcde"],
+    )
     assert result[0] == "19103"
     assert result[1] == "09001"  # zero-padded
     assert result[2] == "10001"  # strip +4

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -613,10 +613,19 @@ def _run_dedupe_pipeline(
     # config.validation). The auto-config controller calls dedupe_df ~5x on
     # the same sample per `auto_configure_df` call; iteration only mutates
     # matchkeys/blocking/threshold, so these prep steps produce identical
-    # output every time. Cache by id(combined_lf) + prep-config signature.
-    # Other callers (production dedupe_df) miss the cache on first call and
-    # populate; if they ever re-call with the same id+config they hit.
-    prep_cache_key = (id(combined_lf), _prep_cache_signature(config))
+    # output every time.
+    #
+    # Cache key: (id(combined_lf), tuple(columns), prep_config_signature).
+    # The columns tuple is a cheap fingerprint that defends against Python
+    # reusing `id()` slots after GC — without it, a NEW LazyFrame that happens
+    # to land at the same memory address as a previously-cached one would
+    # silently get the stale entry. Column names + the id slot together are
+    # collision-proof in practice.
+    prep_cache_key = (
+        id(combined_lf),
+        tuple(combined_lf.collect_schema().names()),
+        _prep_cache_signature(config),
+    )
     cached_prep = _PREP_CACHE.get(prep_cache_key)
     if cached_prep is not None:
         combined_lf = cached_prep.lazy()

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -550,6 +550,41 @@ def run_dedupe(
     )
 
 
+def _prep_cache_signature(config: GoldenMatchConfig) -> str:
+    """Stable string signature of the prep-step config slots.
+
+    Covers GoldenCheck quality scan, GoldenFlow transform, and auto-fix.
+    Used as part of the cache key in ``_run_dedupe_pipeline`` (Attack C
+    of the map_elements perf spec). Other config slots (matchkeys,
+    blocking, threshold) are NOT part of the signature — they don't
+    influence prep output.
+    """
+    import json
+    q = config.quality.model_dump() if config.quality is not None else None
+    t = config.transform.model_dump() if config.transform is not None else None
+    af = bool(config.validation and config.validation.auto_fix)
+    return json.dumps(
+        {"quality": q, "transform": t, "auto_fix": af},
+        sort_keys=True,
+        default=str,
+    )
+
+
+# Process-level LRU cache for the prep steps (quality + transform + auto-fix).
+# Holds at most ``_PREP_CACHE_MAX`` entries; eviction is FIFO on insertion
+# order. Single-threaded design; the controller's iteration loop drives the
+# only realistic cache-hit scenario (5 dedupe_df calls on the same sample).
+_PREP_CACHE: dict[tuple, pl.DataFrame] = {}
+_PREP_CACHE_LRU: list[tuple] = []
+_PREP_CACHE_MAX = 4
+
+
+def _prep_cache_clear() -> None:
+    """Reset the cache. Called by tests to isolate state."""
+    _PREP_CACHE.clear()
+    _PREP_CACHE_LRU.clear()
+
+
 def _run_dedupe_pipeline(
     combined_lf: pl.LazyFrame,
     config: GoldenMatchConfig,
@@ -572,32 +607,57 @@ def _run_dedupe_pipeline(
     output. Both run_dedupe() and run_dedupe_df() delegate to this function.
     """
     memory_store = _open_memory_store(config)
-    # ── Step 1.4: GOLDENCHECK QUALITY SCAN (if available) ──
-    if config.quality is None or config.quality.mode != "disabled":
-        from goldenmatch.core.quality import run_quality_check
-        combined_df_tmp = combined_lf.collect()
-        combined_df_tmp, gc_fixes = run_quality_check(combined_df_tmp, config.quality)
-        if gc_fixes:
-            logger.info("GoldenCheck: %d fixes applied", len(gc_fixes))
-        combined_lf = combined_df_tmp.lazy()
 
-    # ── Step 1.4b: GOLDENFLOW TRANSFORM (if available) ──
-    # Runs after GoldenCheck (validates) and before autofix (remaining cleanup).
-    # Not in _run_match_pipeline -- add there if match pipeline gains a quality step.
-    if config.transform is None or config.transform.mode != "disabled":
-        from goldenmatch.core.transform import run_transform
-        combined_df_tmp = combined_lf.collect()
-        combined_df_tmp, gf_fixes = run_transform(combined_df_tmp, config.transform)
-        if gf_fixes:
-            logger.info("GoldenFlow: %d transforms applied", len(gf_fixes))
-        combined_lf = combined_df_tmp.lazy()
+    # ── Attack C cache lookup (map_elements spec Tier 2): quality + transform
+    # + auto-fix are deterministic in (input_lf, config.quality, config.transform,
+    # config.validation). The auto-config controller calls dedupe_df ~5x on
+    # the same sample per `auto_configure_df` call; iteration only mutates
+    # matchkeys/blocking/threshold, so these prep steps produce identical
+    # output every time. Cache by id(combined_lf) + prep-config signature.
+    # Other callers (production dedupe_df) miss the cache on first call and
+    # populate; if they ever re-call with the same id+config they hit.
+    prep_cache_key = (id(combined_lf), _prep_cache_signature(config))
+    cached_prep = _PREP_CACHE.get(prep_cache_key)
+    if cached_prep is not None:
+        combined_lf = cached_prep.lazy()
+        logger.debug("prep cache HIT (id=%s)", prep_cache_key[0])
+    else:
+        # ── Step 1.4: GOLDENCHECK QUALITY SCAN (if available) ──
+        if config.quality is None or config.quality.mode != "disabled":
+            from goldenmatch.core.quality import run_quality_check
+            combined_df_tmp = combined_lf.collect()
+            combined_df_tmp, gc_fixes = run_quality_check(combined_df_tmp, config.quality)
+            if gc_fixes:
+                logger.info("GoldenCheck: %d fixes applied", len(gc_fixes))
+            combined_lf = combined_df_tmp.lazy()
 
-    # ── Step 1.5a: AUTO-FIX + VALIDATION ──
-    if config.validation and config.validation.auto_fix:
-        combined_df_tmp = combined_lf.collect()
-        combined_df_tmp, fix_log = auto_fix_dataframe(combined_df_tmp)
-        logger.info("Auto-fix applied: %d fix type(s)", len(fix_log))
-        combined_lf = combined_df_tmp.lazy()
+        # ── Step 1.4b: GOLDENFLOW TRANSFORM (if available) ──
+        # Runs after GoldenCheck (validates) and before autofix (remaining cleanup).
+        # Not in _run_match_pipeline -- add there if match pipeline gains a quality step.
+        if config.transform is None or config.transform.mode != "disabled":
+            from goldenmatch.core.transform import run_transform
+            combined_df_tmp = combined_lf.collect()
+            combined_df_tmp, gf_fixes = run_transform(combined_df_tmp, config.transform)
+            if gf_fixes:
+                logger.info("GoldenFlow: %d transforms applied", len(gf_fixes))
+            combined_lf = combined_df_tmp.lazy()
+
+        # ── Step 1.5a: AUTO-FIX + VALIDATION ──
+        if config.validation and config.validation.auto_fix:
+            combined_df_tmp = combined_lf.collect()
+            combined_df_tmp, fix_log = auto_fix_dataframe(combined_df_tmp)
+            logger.info("Auto-fix applied: %d fix type(s)", len(fix_log))
+            combined_lf = combined_df_tmp.lazy()
+
+        # Populate cache (LRU eviction). We materialize as an eager DataFrame
+        # so subsequent hits don't re-evaluate a long lazy plan.
+        prepped_df = combined_lf.collect()
+        if len(_PREP_CACHE_LRU) >= _PREP_CACHE_MAX:
+            evicted = _PREP_CACHE_LRU.pop(0)
+            _PREP_CACHE.pop(evicted, None)
+        _PREP_CACHE[prep_cache_key] = prepped_df
+        _PREP_CACHE_LRU.append(prep_cache_key)
+        combined_lf = prepped_df.lazy()
 
     # ── Step 1.5b: AUTO-CONFIG ON CLEANED DATA (if zero-config) ──
     if auto_config:

--- a/packages/python/goldenmatch/tests/test_prep_cache.py
+++ b/packages/python/goldenmatch/tests/test_prep_cache.py
@@ -1,0 +1,134 @@
+"""Unit tests for the prep-step cache in core/pipeline.py.
+
+Attack C of the map_elements perf spec
+(docs/superpowers/specs/2026-05-15-map-elements-attack-design.md).
+
+The cache memoizes GoldenCheck quality scan + GoldenFlow transform +
+auto-fix output for the duration of a process. The auto-config controller
+calls ``dedupe_df(sample, config)`` ~5x with the same sample object per
+``auto_configure_df`` invocation; caching here means iterations 2-5 skip
+the deterministic prep work entirely.
+"""
+from __future__ import annotations
+
+import polars as pl
+
+import goldenmatch as gm
+from goldenmatch.core.pipeline import (
+    _PREP_CACHE,
+    _PREP_CACHE_LRU,
+    _PREP_CACHE_MAX,
+    _prep_cache_clear,
+    _prep_cache_signature,
+)
+
+
+def _make_df() -> pl.DataFrame:
+    return pl.DataFrame({
+        "name":  ["Alice  ", "Alice", "Bob ", "Bobby"],
+        "email": ["A@x.com", "a@x.com", "B@y.com", "B@y.com"],
+    })
+
+
+def test_prep_cache_starts_empty():
+    _prep_cache_clear()
+    assert _PREP_CACHE == {}
+    assert _PREP_CACHE_LRU == []
+
+
+def test_dedupe_populates_cache():
+    """First gm.dedupe_df() call should leave one entry in the cache."""
+    _prep_cache_clear()
+    df = _make_df()
+    gm.dedupe_df(df, fuzzy={"name": 0.7})
+    # Controller iterates the pipeline several times; the eventual final
+    # full-data call also hits the pipeline. Either way, the cache should
+    # have at least one entry by now.
+    assert len(_PREP_CACHE) >= 1
+
+
+def test_repeated_dedupe_same_df_uses_cache():
+    """Calling dedupe_df twice with the same df object should hit the cache.
+
+    Hits aren't directly observable (cache is internal), but cache size
+    must not grow beyond what the controller normally produces. Critical
+    invariant: results are identical across calls.
+    """
+    _prep_cache_clear()
+    df = _make_df()
+    result_a = gm.dedupe_df(df, fuzzy={"name": 0.7})
+    after_first = dict(_PREP_CACHE)
+    result_b = gm.dedupe_df(df, fuzzy={"name": 0.7})
+    # Same input → same cluster output.
+    a_clusters = {tuple(sorted(c["members"])) for c in result_a.clusters.values()}
+    b_clusters = {tuple(sorted(c["members"])) for c in result_b.clusters.values()}
+    assert a_clusters == b_clusters
+    # Cache must not have grown unboundedly. Because controller iterates
+    # internally on the SAMPLE (different id than `df`), the second call
+    # creates its own sample with a fresh id. So cache may grow by a few
+    # entries on the second call but stays bounded by _PREP_CACHE_MAX.
+    assert len(_PREP_CACHE) <= _PREP_CACHE_MAX
+
+
+def test_lru_eviction():
+    """When more than _PREP_CACHE_MAX distinct (id, sig) pairs land in
+    the cache, the oldest entries get evicted FIFO."""
+    _prep_cache_clear()
+    # Dedupe N distinct dataframes (distinct id() each) and confirm the
+    # cache stays bounded.
+    for i in range(_PREP_CACHE_MAX + 3):
+        df = pl.DataFrame({
+            "name": [f"row_{i}_a", f"row_{i}_a", f"row_{i}_b"],
+            "email": [f"a{i}@x.com", f"a{i}@x.com", f"b{i}@x.com"],
+        })
+        gm.dedupe_df(df, fuzzy={"name": 0.7})
+    assert len(_PREP_CACHE) <= _PREP_CACHE_MAX, (
+        f"cache exceeded max: {len(_PREP_CACHE)} > {_PREP_CACHE_MAX}"
+    )
+
+
+def test_prep_cache_signature_quality_change_misses():
+    """Different quality.mode → different signature → cache miss."""
+    from goldenmatch.config.schemas import (
+        GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+        BlockingConfig, BlockingKeyConfig, QualityConfig,
+    )
+    mk = MatchkeyConfig(
+        name="m", type="weighted", threshold=0.5,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+    )
+    block = BlockingConfig(
+        keys=[BlockingKeyConfig(fields=["name"])], max_block_size=1000,
+    )
+    cfg_enabled = GoldenMatchConfig(
+        matchkeys=[mk], blocking=block, quality=QualityConfig(mode="enabled"),
+    )
+    cfg_disabled = GoldenMatchConfig(
+        matchkeys=[mk], blocking=block, quality=QualityConfig(mode="disabled"),
+    )
+    assert _prep_cache_signature(cfg_enabled) != _prep_cache_signature(cfg_disabled)
+
+
+def test_prep_cache_signature_matchkey_change_does_not_miss():
+    """Matchkey changes do NOT change the prep-cache signature — the prep
+    steps don't depend on matchkey config. This is the load-bearing
+    invariant that makes the controller-iteration cache hits possible:
+    iterating matchkey/blocking/threshold doesn't bust the cache."""
+    from goldenmatch.config.schemas import (
+        GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+        BlockingConfig, BlockingKeyConfig,
+    )
+    mk_v1 = MatchkeyConfig(
+        name="m", type="weighted", threshold=0.5,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+    )
+    mk_v2 = MatchkeyConfig(
+        name="m", type="weighted", threshold=0.7,   # different threshold
+        fields=[MatchkeyField(field="name", scorer="token_sort", weight=2.0)],  # different scorer + weight
+    )
+    block = BlockingConfig(
+        keys=[BlockingKeyConfig(fields=["name"])], max_block_size=1000,
+    )
+    cfg_v1 = GoldenMatchConfig(matchkeys=[mk_v1], blocking=block)
+    cfg_v2 = GoldenMatchConfig(matchkeys=[mk_v2], blocking=block)
+    assert _prep_cache_signature(cfg_v1) == _prep_cache_signature(cfg_v2)

--- a/packages/python/goldenmatch/tests/test_prep_cache.py
+++ b/packages/python/goldenmatch/tests/test_prep_cache.py
@@ -11,9 +11,8 @@ the deterministic prep work entirely.
 """
 from __future__ import annotations
 
-import polars as pl
-
 import goldenmatch as gm
+import polars as pl
 from goldenmatch.core.pipeline import (
     _PREP_CACHE,
     _PREP_CACHE_LRU,
@@ -57,7 +56,6 @@ def test_repeated_dedupe_same_df_uses_cache():
     _prep_cache_clear()
     df = _make_df()
     result_a = gm.dedupe_df(df, fuzzy={"name": 0.7})
-    after_first = dict(_PREP_CACHE)
     result_b = gm.dedupe_df(df, fuzzy={"name": 0.7})
     # Same input → same cluster output.
     a_clusters = {tuple(sorted(c["members"])) for c in result_a.clusters.values()}
@@ -90,8 +88,12 @@ def test_lru_eviction():
 def test_prep_cache_signature_quality_change_misses():
     """Different quality.mode → different signature → cache miss."""
     from goldenmatch.config.schemas import (
-        GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
-        BlockingConfig, BlockingKeyConfig, QualityConfig,
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+        QualityConfig,
     )
     mk = MatchkeyConfig(
         name="m", type="weighted", threshold=0.5,
@@ -115,8 +117,11 @@ def test_prep_cache_signature_matchkey_change_does_not_miss():
     invariant that makes the controller-iteration cache hits possible:
     iterating matchkey/blocking/threshold doesn't bust the cache."""
     from goldenmatch.config.schemas import (
-        GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
-        BlockingConfig, BlockingKeyConfig,
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
     )
     mk_v1 = MatchkeyConfig(
         name="m", type="weighted", threshold=0.5,


### PR DESCRIPTION
Tier 2 of the map_elements attack — three deliverables in one PR:

## 1. Audit findings (memo)

`docs/superpowers/specs/2026-05-15-tier2-audit-findings.md` documents three findings:

- **phone_e164 gate is correct, not broken** — spec hypothesis was wrong; fixture HAS a phone column. Stays mode="series" as Tier 3.
- **normalize_unicode is the real residual hot path** after Tier 1. ~40 of remaining map_elements calls per dedupe. Can't move to expr (no Polars equivalent for NFKD + combining-marks-strip).
- **Date transforms can't migrate without behavior regression.** Polars `str.to_date(strict=False)` parses only ISO; dateutil handles slash US/EU and English month names. 12 date transforms stay mode="series" pending design decision (4 options in memo).

## 2. zip_normalize → mode="expr"

The one transform that survived the audit. `auto_apply=True`, fires on every zip column.

## 3. Attack C — process-level prep-step cache

`core/pipeline.py` gets an LRU cache for the deterministic prep steps:
- Step 1.4 GoldenCheck quality scan
- Step 1.4b GoldenFlow transform
- Step 1.5a Auto-fix + validation

Cache key: `(id(combined_lf), prep_config_signature)`. Sig covers quality + transform + auto_fix only; matchkey/blocking/threshold changes don't bust the cache.

**Load-bearing invariant** (`test_prep_cache_signature_matchkey_change_does_not_miss`): the controller's iteration loop varies matchkey/blocking/threshold per iter but keeps prep config stable, so iterations 2-5 hit the cache.

Expected impact at 100K bench: ~10s wall savings per dedupe (12.91s `run_transform` cumtime in pre-cache cProfile reduced to one prep call + 4 cache hits at ~0.1s each).

Tests: 6 focused unit tests in `tests/test_prep_cache.py` + 185/185 pipeline + autoconfig tests pass.

## Cumulative

| Batch | Transforms |
|---|---|
| Batch 1 (#253 ✅) | 5 |
| Batch 2 (#254) | 7 |
| Batch 3 (#255 ✅) | 7 |
| Batch 4 (this) | 1 + audit + Attack C |
| **Total** | **20 + cache** |

Tier 1 effectively complete (catalog target 15-20). Attack C is the biggest remaining single win at spec level after Tier 1 work lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)