### PR TITLE
feat(autoconfig): controller v3 planner -- Phase 1 (RuntimeProfile + ExecutionPlan + estimated_pair_count)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -179,7 +179,7 @@ class BlockingProfile:
         """
         return self.total_comparisons
 
-    def extrapolate_to(self, n_rows_sample: int, n_rows_full: int) -> "BlockingProfile":
+    def extrapolate_to(self, n_rows_sample: int, n_rows_full: int) -> BlockingProfile:
         """Project sample's pair-count signal to a full-data row count.
 
         Spec §Pipeline integration: pair count scales linearly with the

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -169,6 +169,37 @@ class BlockingProfile:
     singleton_block_count: int = 0
     oversized_block_count: int = 0
 
+    @property
+    def estimated_pair_count(self) -> int:
+        """Spec §Signals: total candidate pairs at this blocking layout.
+
+        Identical to ``total_comparisons``; surfaced under the
+        planner-friendly name so callers don't need to know the underlying
+        field name.
+        """
+        return self.total_comparisons
+
+    def extrapolate_to(self, n_rows_sample: int, n_rows_full: int) -> "BlockingProfile":
+        """Project sample's pair-count signal to a full-data row count.
+
+        Spec §Pipeline integration: pair count scales linearly with the
+        row-count ratio. Over-estimation just pushes toward a heavier
+        plan, which is safer than under-estimating. Block-size percentiles
+        are not scaled -- distribution shape is roughly invariant to N
+        when blocking is well-behaved (spec §Open questions #1).
+        """
+        import dataclasses
+
+        if n_rows_sample <= 0 or n_rows_full <= 0:
+            return self
+        ratio = n_rows_full / n_rows_sample
+        return dataclasses.replace(
+            self,
+            n_blocks=int(self.n_blocks * ratio),
+            total_comparisons=int(self.total_comparisons * ratio),
+            singleton_block_count=int(self.singleton_block_count * ratio),
+        )
+
     def health(self, n_rows: int) -> HealthVerdict:
         if self.n_blocks == 0:
             return HealthVerdict.RED

--- a/packages/python/goldenmatch/goldenmatch/core/execution_plan.py
+++ b/packages/python/goldenmatch/goldenmatch/core/execution_plan.py
@@ -1,0 +1,40 @@
+"""ExecutionPlan dataclass -- the six knobs the controller-v3 planner picks.
+
+Spec §Decision space:
+docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+BackendName = Literal["polars-direct", "chunked", "duckdb", "ray"]
+ClusteringStrategy = Literal["in_memory", "partitioned_union_find", "streaming_cc"]
+SpillThreshold = Optional[Literal["ram", "duckdb", "disk_per_worker"]]
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    """The planner's output: backend selection + tuning knobs.
+
+    Defaults match today's polars-direct path so an unset plan preserves
+    current behavior. Frozen -- replace, don't mutate.
+    """
+
+    backend: BackendName = "polars-direct"
+    chunk_size: int | None = None
+    max_workers: int = 4
+    pair_spill_threshold: SpillThreshold = None
+    clustering_strategy: ClusteringStrategy = "in_memory"
+    rule_name: str | None = None
+
+    def apply_to(self, config) -> None:
+        """Write plan onto a GoldenMatchConfig in place.
+
+        Only ``backend`` lives on the existing config schema today; the
+        remaining knobs (chunk_size, max_workers, pair_spill_threshold,
+        clustering_strategy) get added in phase 2 once GoldenMatchConfig
+        is extended. For phase 1, just wires backend.
+        """
+        if self.backend != "polars-direct":
+            config.backend = self.backend

--- a/packages/python/goldenmatch/goldenmatch/core/execution_plan.py
+++ b/packages/python/goldenmatch/goldenmatch/core/execution_plan.py
@@ -6,11 +6,14 @@ docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from goldenmatch.config.schemas import GoldenMatchConfig
 
 BackendName = Literal["polars-direct", "chunked", "duckdb", "ray"]
 ClusteringStrategy = Literal["in_memory", "partitioned_union_find", "streaming_cc"]
-SpillThreshold = Optional[Literal["ram", "duckdb", "disk_per_worker"]]
+SpillThreshold = Literal["ram", "duckdb", "disk_per_worker"] | None
 
 
 @dataclass(frozen=True)
@@ -28,7 +31,7 @@ class ExecutionPlan:
     clustering_strategy: ClusteringStrategy = "in_memory"
     rule_name: str | None = None
 
-    def apply_to(self, config) -> None:
+    def apply_to(self, config: GoldenMatchConfig) -> None:
         """Write plan onto a GoldenMatchConfig in place.
 
         Only ``backend`` lives on the existing config schema today; the

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -579,8 +579,12 @@ _PREP_CACHE_LRU: list[tuple] = []
 _PREP_CACHE_MAX = 4
 
 
-def _prep_cache_clear() -> None:
-    """Reset the cache. Called by tests to isolate state."""
+def _prep_cache_clear() -> None:  # pyright: ignore[reportUnusedFunction]
+    """Reset the cache. Called by tests to isolate state.
+
+    Pyright flags this as unused because its only callers live in
+    ``tests/test_prep_cache.py`` which the pyright config excludes.
+    """
     _PREP_CACHE.clear()
     _PREP_CACHE_LRU.clear()
 

--- a/packages/python/goldenmatch/goldenmatch/core/runtime_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/runtime_profile.py
@@ -1,0 +1,47 @@
+"""Runtime-introspection signals consumed by the controller-v3 planner.
+
+Captured once at controller-start; not mutated. Spec §Signals:
+docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RuntimeProfile:
+    """Machine-level signals available at controller-start.
+
+    Attributes:
+        available_ram_gb: ``psutil.virtual_memory().available`` in gigabytes.
+        cpu_count: ``os.cpu_count()``; fall back to 1 if None.
+        disk_free_gb: ``shutil.disk_usage(cwd).free`` in gigabytes; used
+            for spill-threshold sanity checks.
+    """
+
+    available_ram_gb: float
+    cpu_count: int
+    disk_free_gb: float
+
+
+def capture_runtime_profile() -> RuntimeProfile:
+    """Snapshot the current process's runtime context.
+
+    Called at the end of ``AutoConfigController.run`` before the planner
+    rules fire. Cheap (psutil + shutil.disk_usage); no caching needed.
+    """
+    import shutil
+
+    import psutil
+
+    vm = psutil.virtual_memory()
+    available_ram_gb = vm.available / (1024 ** 3)
+    cpu_count = os.cpu_count() or 1
+    du = shutil.disk_usage(os.getcwd())
+    disk_free_gb = du.free / (1024 ** 3)
+    return RuntimeProfile(
+        available_ram_gb=available_ram_gb,
+        cpu_count=cpu_count,
+        disk_free_gb=disk_free_gb,
+    )

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "openpyxl>=3.1",
     "textual>=1.0",
     "diptest>=0.5.2",
+    "psutil>=5.9",
 ]
 
 [project.urls]

--- a/packages/python/goldenmatch/tests/test_complexity_profile_pair_count.py
+++ b/packages/python/goldenmatch/tests/test_complexity_profile_pair_count.py
@@ -1,0 +1,45 @@
+"""Verify BlockingProfile exposes estimated_pair_count + an extrapolate()
+helper that scales sample -> full-data row count linearly.
+
+Spec §Signals + §Pipeline integration:
+docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.complexity_profile import BlockingProfile
+
+
+def _make_profile() -> BlockingProfile:
+    return BlockingProfile(
+        keys_used=[["name"]],
+        n_blocks=10,
+        total_comparisons=5_000,
+        reduction_ratio=0.95,
+        block_sizes_p50=20,
+        block_sizes_p95=50,
+        block_sizes_p99=100,
+        block_sizes_max=200,
+        singleton_block_count=2,
+        oversized_block_count=0,
+    )
+
+
+def test_blocking_profile_estimated_pair_count_uses_total_comparisons():
+    """estimated_pair_count is just total_comparisons exposed under the
+    planner-friendly name. Same number, named for the planner."""
+    p = _make_profile()
+    assert p.estimated_pair_count == 5_000
+
+
+def test_blocking_profile_extrapolate_scales_pair_count_linearly():
+    """Sample -> full extrapolation: pair count scales by the
+    (n_rows_full / n_rows_sample) ratio."""
+    p = _make_profile()
+    extrapolated = p.extrapolate_to(n_rows_sample=2_000, n_rows_full=200_000)
+    assert extrapolated.estimated_pair_count == 500_000
+
+
+def test_blocking_profile_extrapolate_identity_when_full_equals_sample():
+    p = _make_profile()
+    extrapolated = p.extrapolate_to(n_rows_sample=2_000, n_rows_full=2_000)
+    assert extrapolated.estimated_pair_count == 5_000

--- a/packages/python/goldenmatch/tests/test_execution_plan.py
+++ b/packages/python/goldenmatch/tests/test_execution_plan.py
@@ -1,0 +1,65 @@
+"""Unit tests for ExecutionPlan.
+
+Spec §Decision space -- the six knobs the planner picks. Frozen
+dataclass; defaults match today's polars-direct path so an empty plan
+preserves current behavior.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.execution_plan import ExecutionPlan
+
+
+def test_execution_plan_defaults_match_current_behavior():
+    p = ExecutionPlan()
+    assert p.backend == "polars-direct"
+    assert p.chunk_size is None
+    assert p.max_workers == 4
+    assert p.pair_spill_threshold is None
+    assert p.clustering_strategy == "in_memory"
+    assert p.rule_name is None
+
+
+def test_execution_plan_is_frozen():
+    import dataclasses
+    p = ExecutionPlan()
+    try:
+        p.backend = "duckdb"  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        return
+    raise AssertionError("ExecutionPlan should be frozen")
+
+
+def test_execution_plan_construction_with_overrides():
+    p = ExecutionPlan(
+        backend="chunked",
+        chunk_size=250_000,
+        max_workers=16,
+        pair_spill_threshold="ram",
+        clustering_strategy="in_memory",
+        rule_name="plan_selected_chunked",
+    )
+    assert p.backend == "chunked"
+    assert p.chunk_size == 250_000
+
+
+def test_execution_plan_apply_to_config_round_trips():
+    """ExecutionPlan.apply_to(config) writes the chosen backend onto
+    config.backend; unset knobs leave existing config fields alone."""
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+    mk = MatchkeyConfig(
+        name="m",
+        type="weighted",
+        threshold=0.5,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+    )
+    block = BlockingConfig(keys=[BlockingKeyConfig(fields=["name"])], max_block_size=1000)
+    cfg = GoldenMatchConfig(matchkeys=[mk], blocking=block)
+    plan = ExecutionPlan(backend="chunked", chunk_size=250_000)
+    plan.apply_to(cfg)
+    assert cfg.backend == "chunked"

--- a/packages/python/goldenmatch/tests/test_runtime_profile.py
+++ b/packages/python/goldenmatch/tests/test_runtime_profile.py
@@ -1,0 +1,35 @@
+"""Unit tests for RuntimeProfile.
+
+Spec §Signals -- captures machine-level signals the planner consumes:
+available RAM, CPU count, disk free. Read once at controller-start; not
+mutated.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.runtime_profile import RuntimeProfile, capture_runtime_profile
+
+
+def test_runtime_profile_is_frozen_dataclass():
+    p = RuntimeProfile(available_ram_gb=16.0, cpu_count=4, disk_free_gb=100.0)
+    import dataclasses
+    assert dataclasses.is_dataclass(p)
+    try:
+        p.available_ram_gb = 32.0  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        return
+    raise AssertionError("RuntimeProfile should be frozen")
+
+
+def test_capture_runtime_profile_returns_positive_values():
+    p = capture_runtime_profile()
+    assert p.available_ram_gb > 0
+    assert p.cpu_count >= 1
+    assert p.disk_free_gb > 0
+
+
+def test_capture_runtime_profile_ram_below_total():
+    """available_ram_gb should be <= total system RAM (sanity check)."""
+    import psutil
+    p = capture_runtime_profile()
+    total_gb = psutil.virtual_memory().total / (1024 ** 3)
+    assert p.available_ram_gb <= total_gb + 0.1  # +0.1 GB slop


### PR DESCRIPTION
## Summary

Phase 1 of the controller v3 planner ([spec](docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md), [plan](docs/superpowers/plans/2026-05-15-controller-v3-planner.md)). Pure data types, no wiring — phase 2 lands the empty-rules dispatcher that consumes them.

- ` core/runtime_profile.py` — frozen `RuntimeProfile` (`available_ram_gb`, `cpu_count`, `disk_free_gb`) + `capture_runtime_profile()` via psutil + shutil.disk_usage.
- `core/execution_plan.py` — frozen `ExecutionPlan` with the six knobs (`backend`, `chunk_size`, `max_workers`, `pair_spill_threshold`, `clustering_strategy`, `rule_name`). Defaults match today's `polars-direct` path. `apply_to(config)` writes `backend` only for phase 1; remaining knobs land on `GoldenMatchConfig` in phase 2.
- `core/complexity_profile.py` — `BlockingProfile.estimated_pair_count` property (alias for `total_comparisons`) and `extrapolate_to(n_rows_sample, n_rows_full)` helper that linearly scales the sample pair count by row-count ratio. Skew bias is the deferred Open question #1.
- `pyproject.toml` — explicit `psutil>=5.9` pin (was transitive).

## Test plan

- [x] 10 new unit tests across 3 files: `test_runtime_profile.py`, `test_execution_plan.py`, `test_complexity_profile_pair_count.py`.
- [x] Full Phase-1 verification suite: 2427 passed / 5 skipped via `pytest tests/ -q --timeout=120 --ignore=tests/test_db.py --ignore=tests/test_reconcile.py --ignore=tests/test_mcp_and_watch.py --ignore=tests/test_embedder.py --ignore=tests/test_llm_boost.py --ignore=tests/benchmarks`.
- [x] Existing `test_complexity_profile.py` (28 tests) still green — no behavior change on the BlockingProfile dataclass shape.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)