### PR TITLE
feat(autoconfig): controller v3 planner -- Phase 2 (dispatcher, empty rules)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -10,6 +10,7 @@ import logging
 import time
 import traceback
 from contextvars import ContextVar
+import dataclasses
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
@@ -536,6 +537,34 @@ class AutoConfigController:
         committed_config = self._maybe_decorate_with_llm_scorer(
             best_entry.config, best_entry.profile,
         )
+
+        # ── Controller v3 planner (phase 2): pick execution plan based on the
+        # committed profile + runtime introspection. Phase 2 lands with an
+        # empty rule list (no behavior change); phases 3-6 register rules.
+        from goldenmatch.core.autoconfig_planner import apply_planner_rules
+        from goldenmatch.core.runtime_profile import capture_runtime_profile
+
+        runtime = capture_runtime_profile()
+        # Extrapolate the committed (sample) blocking profile to full-row count
+        # so the planner rules in later phases see signals at full scale.
+        committed_profile = best_entry.profile
+        if committed_profile.meta.is_sample and committed_profile.meta.sample_size > 0:
+            blocking_full = committed_profile.blocking.extrapolate_to(
+                n_rows_sample=committed_profile.meta.sample_size,
+                n_rows_full=df.height,
+            )
+            profile_for_planner = dataclasses.replace(committed_profile, blocking=blocking_full)
+        else:
+            profile_for_planner = committed_profile
+
+        plan = apply_planner_rules(
+            profile=profile_for_planner,
+            runtime=runtime,
+            n_rows_full=df.height,
+            rules=[],  # phases 3-6 register rules
+        )
+        plan.apply_to(committed_config)
+        history.execution_plan = plan
 
         # Fix 4: When skip_finalize=True (called from _api zero-config path),
         # skip the full-data _finalize run. The caller will execute the real

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -10,7 +10,6 @@ import logging
 import time
 import traceback
 from contextvars import ContextVar
-import dataclasses
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from typing import Any
 
 from goldenmatch.core.complexity_profile import ComplexityProfile, HealthVerdict, StopReason
+from goldenmatch.core.execution_plan import ExecutionPlan
 
 
 @dataclass
@@ -67,6 +68,7 @@ class RunHistory:
     elapsed: timedelta = field(default_factory=lambda: timedelta(0))
     prior_runs: list[Any] = field(default_factory=list)  # v2 hook for Learning Memory
     stop_reason: StopReason | None = None
+    execution_plan: ExecutionPlan | None = None
 
     @property
     def iteration(self) -> int:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner.py
@@ -14,8 +14,8 @@ Phases 3-6 register rules; this module just dispatches.
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 from goldenmatch.core.complexity_profile import ComplexityProfile
 from goldenmatch.core.execution_plan import ExecutionPlan

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner.py
@@ -1,0 +1,75 @@
+"""Planner-rule dispatcher for controller v3.
+
+Spec §Decision rules:
+docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md.
+
+Rules are (name, predicate, action) tuples. ``apply_planner_rules``
+evaluates them in registry order; the first predicate to return True
+fires, its action returns an ``ExecutionPlan``. Default plan returned
+when no rule matches (polars-direct; rule_name='no_rules_registered'
+for empty registry, 'no_rule_matched' otherwise).
+
+Phases 3-6 register rules; this module just dispatches.
+"""
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Callable
+
+from goldenmatch.core.complexity_profile import ComplexityProfile
+from goldenmatch.core.execution_plan import ExecutionPlan
+from goldenmatch.core.runtime_profile import RuntimeProfile
+
+Predicate = Callable[..., bool]
+Action = Callable[..., ExecutionPlan]
+
+
+@dataclass(frozen=True)
+class PlannerRule:
+    """One entry in the planner's rule table.
+
+    Attributes:
+        name: Stable identifier surfaced in ``RunHistory.decisions``.
+        predicate: Returns True when this rule applies. Spec §Rule N
+            tables document each rule's predicate.
+        action: Builds the ``ExecutionPlan`` when ``predicate`` is True.
+    """
+
+    name: str
+    predicate: Predicate
+    action: Action
+
+
+def apply_planner_rules(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+    rules: list[PlannerRule],
+) -> ExecutionPlan:
+    """Walk the rule list in order; first match's action returns the plan.
+
+    Args:
+        profile: ``ComplexityProfile`` from the last controller iteration,
+            extrapolated to ``n_rows_full`` if the controller iterated
+            on a sample.
+        runtime: ``RuntimeProfile`` captured at controller-start.
+        n_rows_full: Total row count of the caller's input DataFrame.
+        rules: The rule registry. Empty -> default plan. Phases 3-6 populate.
+
+    Returns:
+        ``ExecutionPlan`` with ``rule_name`` set to either the matched
+        rule's name or a sentinel (``no_rules_registered``,
+        ``no_rule_matched``).
+    """
+    if not rules:
+        return ExecutionPlan(rule_name="no_rules_registered")
+
+    for rule in rules:
+        if rule.predicate(profile, runtime, n_rows_full):
+            plan = rule.action(profile, runtime, n_rows_full)
+            if plan.rule_name is None:
+                plan = dataclasses.replace(plan, rule_name=rule.name)
+            return plan
+
+    return ExecutionPlan(rule_name="no_rule_matched")

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -179,7 +179,7 @@ class BlockingProfile:
         """
         return self.total_comparisons
 
-    def extrapolate_to(self, n_rows_sample: int, n_rows_full: int) -> "BlockingProfile":
+    def extrapolate_to(self, n_rows_sample: int, n_rows_full: int) -> BlockingProfile:
         """Project sample's pair-count signal to a full-data row count.
 
         Spec §Pipeline integration: pair count scales linearly with the

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -169,6 +169,37 @@ class BlockingProfile:
     singleton_block_count: int = 0
     oversized_block_count: int = 0
 
+    @property
+    def estimated_pair_count(self) -> int:
+        """Spec §Signals: total candidate pairs at this blocking layout.
+
+        Identical to ``total_comparisons``; surfaced under the
+        planner-friendly name so callers don't need to know the underlying
+        field name.
+        """
+        return self.total_comparisons
+
+    def extrapolate_to(self, n_rows_sample: int, n_rows_full: int) -> "BlockingProfile":
+        """Project sample's pair-count signal to a full-data row count.
+
+        Spec §Pipeline integration: pair count scales linearly with the
+        row-count ratio. Over-estimation just pushes toward a heavier
+        plan, which is safer than under-estimating. Block-size percentiles
+        are not scaled -- distribution shape is roughly invariant to N
+        when blocking is well-behaved (spec §Open questions #1).
+        """
+        import dataclasses
+
+        if n_rows_sample <= 0 or n_rows_full <= 0:
+            return self
+        ratio = n_rows_full / n_rows_sample
+        return dataclasses.replace(
+            self,
+            n_blocks=int(self.n_blocks * ratio),
+            total_comparisons=int(self.total_comparisons * ratio),
+            singleton_block_count=int(self.singleton_block_count * ratio),
+        )
+
     def health(self, n_rows: int) -> HealthVerdict:
         if self.n_blocks == 0:
             return HealthVerdict.RED

--- a/packages/python/goldenmatch/goldenmatch/core/execution_plan.py
+++ b/packages/python/goldenmatch/goldenmatch/core/execution_plan.py
@@ -1,0 +1,40 @@
+"""ExecutionPlan dataclass -- the six knobs the controller-v3 planner picks.
+
+Spec §Decision space:
+docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+BackendName = Literal["polars-direct", "chunked", "duckdb", "ray"]
+ClusteringStrategy = Literal["in_memory", "partitioned_union_find", "streaming_cc"]
+SpillThreshold = Optional[Literal["ram", "duckdb", "disk_per_worker"]]
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    """The planner's output: backend selection + tuning knobs.
+
+    Defaults match today's polars-direct path so an unset plan preserves
+    current behavior. Frozen -- replace, don't mutate.
+    """
+
+    backend: BackendName = "polars-direct"
+    chunk_size: int | None = None
+    max_workers: int = 4
+    pair_spill_threshold: SpillThreshold = None
+    clustering_strategy: ClusteringStrategy = "in_memory"
+    rule_name: str | None = None
+
+    def apply_to(self, config) -> None:
+        """Write plan onto a GoldenMatchConfig in place.
+
+        Only ``backend`` lives on the existing config schema today; the
+        remaining knobs (chunk_size, max_workers, pair_spill_threshold,
+        clustering_strategy) get added in phase 2 once GoldenMatchConfig
+        is extended. For phase 1, just wires backend.
+        """
+        if self.backend != "polars-direct":
+            config.backend = self.backend

--- a/packages/python/goldenmatch/goldenmatch/core/execution_plan.py
+++ b/packages/python/goldenmatch/goldenmatch/core/execution_plan.py
@@ -6,11 +6,14 @@ docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from goldenmatch.config.schemas import GoldenMatchConfig
 
 BackendName = Literal["polars-direct", "chunked", "duckdb", "ray"]
 ClusteringStrategy = Literal["in_memory", "partitioned_union_find", "streaming_cc"]
-SpillThreshold = Optional[Literal["ram", "duckdb", "disk_per_worker"]]
+SpillThreshold = Literal["ram", "duckdb", "disk_per_worker"] | None
 
 
 @dataclass(frozen=True)
@@ -28,7 +31,7 @@ class ExecutionPlan:
     clustering_strategy: ClusteringStrategy = "in_memory"
     rule_name: str | None = None
 
-    def apply_to(self, config) -> None:
+    def apply_to(self, config: GoldenMatchConfig) -> None:
         """Write plan onto a GoldenMatchConfig in place.
 
         Only ``backend`` lives on the existing config schema today; the

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -579,8 +579,12 @@ _PREP_CACHE_LRU: list[tuple] = []
 _PREP_CACHE_MAX = 4
 
 
-def _prep_cache_clear() -> None:
-    """Reset the cache. Called by tests to isolate state."""
+def _prep_cache_clear() -> None:  # pyright: ignore[reportUnusedFunction]
+    """Reset the cache. Called by tests to isolate state.
+
+    Pyright flags this as unused because its only callers live in
+    ``tests/test_prep_cache.py`` which the pyright config excludes.
+    """
     _PREP_CACHE.clear()
     _PREP_CACHE_LRU.clear()
 

--- a/packages/python/goldenmatch/goldenmatch/core/runtime_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/runtime_profile.py
@@ -1,0 +1,47 @@
+"""Runtime-introspection signals consumed by the controller-v3 planner.
+
+Captured once at controller-start; not mutated. Spec §Signals:
+docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RuntimeProfile:
+    """Machine-level signals available at controller-start.
+
+    Attributes:
+        available_ram_gb: ``psutil.virtual_memory().available`` in gigabytes.
+        cpu_count: ``os.cpu_count()``; fall back to 1 if None.
+        disk_free_gb: ``shutil.disk_usage(cwd).free`` in gigabytes; used
+            for spill-threshold sanity checks.
+    """
+
+    available_ram_gb: float
+    cpu_count: int
+    disk_free_gb: float
+
+
+def capture_runtime_profile() -> RuntimeProfile:
+    """Snapshot the current process's runtime context.
+
+    Called at the end of ``AutoConfigController.run`` before the planner
+    rules fire. Cheap (psutil + shutil.disk_usage); no caching needed.
+    """
+    import shutil
+
+    import psutil
+
+    vm = psutil.virtual_memory()
+    available_ram_gb = vm.available / (1024 ** 3)
+    cpu_count = os.cpu_count() or 1
+    du = shutil.disk_usage(os.getcwd())
+    disk_free_gb = du.free / (1024 ** 3)
+    return RuntimeProfile(
+        available_ram_gb=available_ram_gb,
+        cpu_count=cpu_count,
+        disk_free_gb=disk_free_gb,
+    )

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "openpyxl>=3.1",
     "textual>=1.0",
     "diptest>=0.5.2",
+    "psutil>=5.9",
 ]
 
 [project.urls]

--- a/packages/python/goldenmatch/tests/test_autoconfig_planner_protocol.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_planner_protocol.py
@@ -1,0 +1,157 @@
+"""Tests for the planner-rule dispatcher (no rules registered yet).
+
+Spec §Decision rules: rules are (predicate, action) pairs evaluated in
+order; first match wins. The registry is the source of truth for which
+rules exist; phases 3-6 add concrete rules to it.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig_planner import (
+    PlannerRule,
+    apply_planner_rules,
+)
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ComplexityProfile,
+    DataProfile,
+    ProfileMeta,
+)
+from goldenmatch.core.execution_plan import ExecutionPlan
+from goldenmatch.core.runtime_profile import RuntimeProfile
+
+
+def _minimal_profile(n_rows: int = 1000) -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(n_rows=n_rows, n_cols=3),
+        blocking=BlockingProfile(
+            keys_used=[["name"]],
+            n_blocks=10,
+            total_comparisons=100,
+            reduction_ratio=0.9,
+            block_sizes_p50=10,
+            block_sizes_p95=15,
+            block_sizes_p99=20,
+            block_sizes_max=25,
+            singleton_block_count=0,
+            oversized_block_count=0,
+        ),
+        meta=ProfileMeta(
+            iteration=0,
+            is_sample=False,
+            sample_size=n_rows,
+            n_rows_full=n_rows,
+            wall_clock_ms=0,
+            seed=0,
+        ),
+    )
+
+
+def _minimal_runtime() -> RuntimeProfile:
+    return RuntimeProfile(available_ram_gb=16.0, cpu_count=4, disk_free_gb=100.0)
+
+
+def test_apply_planner_rules_with_no_rules_returns_default_plan():
+    """Empty rule list -> default plan (polars-direct). This is the
+    behavior phase 2 lands; phases 3-6 add rules."""
+    plan = apply_planner_rules(
+        profile=_minimal_profile(),
+        runtime=_minimal_runtime(),
+        n_rows_full=1000,
+        rules=[],
+    )
+    assert plan.backend == "polars-direct"
+    assert plan.rule_name == "no_rules_registered"
+
+
+def test_apply_planner_rules_first_match_wins():
+    """When multiple rules match, the FIRST one in the registry wins."""
+    def predicate_true(profile, runtime, n_rows_full):
+        return True
+
+    def action_a(profile, runtime, n_rows_full):
+        return ExecutionPlan(backend="duckdb", rule_name="rule_a")
+
+    def action_b(profile, runtime, n_rows_full):
+        return ExecutionPlan(backend="ray", rule_name="rule_b")
+
+    plan = apply_planner_rules(
+        profile=_minimal_profile(),
+        runtime=_minimal_runtime(),
+        n_rows_full=1000,
+        rules=[
+            PlannerRule(name="rule_a", predicate=predicate_true, action=action_a),
+            PlannerRule(name="rule_b", predicate=predicate_true, action=action_b),
+        ],
+    )
+    assert plan.backend == "duckdb"
+    assert plan.rule_name == "rule_a"
+
+
+def test_apply_planner_rules_skips_non_matching():
+    def matches_n_rows_gte(threshold):
+        def predicate(profile, runtime, n_rows_full):
+            return n_rows_full >= threshold
+        return predicate
+
+    def action_b(profile, runtime, n_rows_full):
+        return ExecutionPlan(backend="duckdb", rule_name="b_fires")
+
+    def action_a(profile, runtime, n_rows_full):
+        return ExecutionPlan(backend="ray", rule_name="a_fires")
+
+    plan = apply_planner_rules(
+        profile=_minimal_profile(),
+        runtime=_minimal_runtime(),
+        n_rows_full=5_000,
+        rules=[
+            PlannerRule(name="a", predicate=matches_n_rows_gte(1_000_000), action=action_a),
+            PlannerRule(name="b", predicate=matches_n_rows_gte(1_000),    action=action_b),
+        ],
+    )
+    assert plan.rule_name == "b_fires"
+
+
+def test_apply_planner_rules_fills_rule_name_from_registry_when_action_omits():
+    """If an action returns ExecutionPlan without rule_name, the dispatcher
+    fills it in from the registry entry's name. This keeps rule authors
+    from having to thread their own name through."""
+    def always(profile, runtime, n_rows_full):
+        return True
+
+    def action_no_name(profile, runtime, n_rows_full):
+        return ExecutionPlan(backend="chunked")  # rule_name omitted
+
+    plan = apply_planner_rules(
+        profile=_minimal_profile(),
+        runtime=_minimal_runtime(),
+        n_rows_full=1000,
+        rules=[PlannerRule(name="rule_chunked", predicate=always, action=action_no_name)],
+    )
+    assert plan.rule_name == "rule_chunked"
+
+
+def test_controller_run_attaches_execution_plan_to_history():
+    """After phase 2, every successful run leaves an ExecutionPlan on
+    RunHistory.execution_plan. With no rules registered, rule_name is one
+    of the sentinels."""
+    import polars as pl
+    import goldenmatch as gm
+    from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+
+    df = pl.DataFrame({
+        "name": ["alice", "alyce", "bob", "robert"] * 20,
+        "email": [f"u{i}@x.com" for i in range(80)],
+    })
+    # No fuzzy/exact kwargs -> zero-config path -> auto_configure_df fires.
+    _ = gm.dedupe_df(df)
+    ctrl_state = _LAST_CONTROLLER_RUN.get()
+    assert ctrl_state is not None, "controller should have run"
+    _profile, history = ctrl_state
+    plan = getattr(history, "execution_plan", None)
+    assert plan is not None, "history should have execution_plan attached"
+    assert plan.rule_name in ("no_rules_registered", "no_rule_matched"), (
+        f"phase 2 has no rules registered; got {plan.rule_name}"
+    )
+    assert plan.backend == "polars-direct", (
+        f"phase 2 default plan should preserve polars-direct; got {plan.backend}"
+    )

--- a/packages/python/goldenmatch/tests/test_autoconfig_planner_protocol.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_planner_protocol.py
@@ -134,8 +134,8 @@ def test_controller_run_attaches_execution_plan_to_history():
     """After phase 2, every successful run leaves an ExecutionPlan on
     RunHistory.execution_plan. With no rules registered, rule_name is one
     of the sentinels."""
-    import polars as pl
     import goldenmatch as gm
+    import polars as pl
     from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
 
     df = pl.DataFrame({

--- a/packages/python/goldenmatch/tests/test_complexity_profile_pair_count.py
+++ b/packages/python/goldenmatch/tests/test_complexity_profile_pair_count.py
@@ -1,0 +1,45 @@
+"""Verify BlockingProfile exposes estimated_pair_count + an extrapolate()
+helper that scales sample -> full-data row count linearly.
+
+Spec §Signals + §Pipeline integration:
+docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.complexity_profile import BlockingProfile
+
+
+def _make_profile() -> BlockingProfile:
+    return BlockingProfile(
+        keys_used=[["name"]],
+        n_blocks=10,
+        total_comparisons=5_000,
+        reduction_ratio=0.95,
+        block_sizes_p50=20,
+        block_sizes_p95=50,
+        block_sizes_p99=100,
+        block_sizes_max=200,
+        singleton_block_count=2,
+        oversized_block_count=0,
+    )
+
+
+def test_blocking_profile_estimated_pair_count_uses_total_comparisons():
+    """estimated_pair_count is just total_comparisons exposed under the
+    planner-friendly name. Same number, named for the planner."""
+    p = _make_profile()
+    assert p.estimated_pair_count == 5_000
+
+
+def test_blocking_profile_extrapolate_scales_pair_count_linearly():
+    """Sample -> full extrapolation: pair count scales by the
+    (n_rows_full / n_rows_sample) ratio."""
+    p = _make_profile()
+    extrapolated = p.extrapolate_to(n_rows_sample=2_000, n_rows_full=200_000)
+    assert extrapolated.estimated_pair_count == 500_000
+
+
+def test_blocking_profile_extrapolate_identity_when_full_equals_sample():
+    p = _make_profile()
+    extrapolated = p.extrapolate_to(n_rows_sample=2_000, n_rows_full=2_000)
+    assert extrapolated.estimated_pair_count == 5_000

--- a/packages/python/goldenmatch/tests/test_execution_plan.py
+++ b/packages/python/goldenmatch/tests/test_execution_plan.py
@@ -1,0 +1,65 @@
+"""Unit tests for ExecutionPlan.
+
+Spec §Decision space -- the six knobs the planner picks. Frozen
+dataclass; defaults match today's polars-direct path so an empty plan
+preserves current behavior.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.execution_plan import ExecutionPlan
+
+
+def test_execution_plan_defaults_match_current_behavior():
+    p = ExecutionPlan()
+    assert p.backend == "polars-direct"
+    assert p.chunk_size is None
+    assert p.max_workers == 4
+    assert p.pair_spill_threshold is None
+    assert p.clustering_strategy == "in_memory"
+    assert p.rule_name is None
+
+
+def test_execution_plan_is_frozen():
+    import dataclasses
+    p = ExecutionPlan()
+    try:
+        p.backend = "duckdb"  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        return
+    raise AssertionError("ExecutionPlan should be frozen")
+
+
+def test_execution_plan_construction_with_overrides():
+    p = ExecutionPlan(
+        backend="chunked",
+        chunk_size=250_000,
+        max_workers=16,
+        pair_spill_threshold="ram",
+        clustering_strategy="in_memory",
+        rule_name="plan_selected_chunked",
+    )
+    assert p.backend == "chunked"
+    assert p.chunk_size == 250_000
+
+
+def test_execution_plan_apply_to_config_round_trips():
+    """ExecutionPlan.apply_to(config) writes the chosen backend onto
+    config.backend; unset knobs leave existing config fields alone."""
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+    mk = MatchkeyConfig(
+        name="m",
+        type="weighted",
+        threshold=0.5,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+    )
+    block = BlockingConfig(keys=[BlockingKeyConfig(fields=["name"])], max_block_size=1000)
+    cfg = GoldenMatchConfig(matchkeys=[mk], blocking=block)
+    plan = ExecutionPlan(backend="chunked", chunk_size=250_000)
+    plan.apply_to(cfg)
+    assert cfg.backend == "chunked"

--- a/packages/python/goldenmatch/tests/test_runtime_profile.py
+++ b/packages/python/goldenmatch/tests/test_runtime_profile.py
@@ -1,0 +1,35 @@
+"""Unit tests for RuntimeProfile.
+
+Spec §Signals -- captures machine-level signals the planner consumes:
+available RAM, CPU count, disk free. Read once at controller-start; not
+mutated.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.runtime_profile import RuntimeProfile, capture_runtime_profile
+
+
+def test_runtime_profile_is_frozen_dataclass():
+    p = RuntimeProfile(available_ram_gb=16.0, cpu_count=4, disk_free_gb=100.0)
+    import dataclasses
+    assert dataclasses.is_dataclass(p)
+    try:
+        p.available_ram_gb = 32.0  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        return
+    raise AssertionError("RuntimeProfile should be frozen")
+
+
+def test_capture_runtime_profile_returns_positive_values():
+    p = capture_runtime_profile()
+    assert p.available_ram_gb > 0
+    assert p.cpu_count >= 1
+    assert p.disk_free_gb > 0
+
+
+def test_capture_runtime_profile_ram_below_total():
+    """available_ram_gb should be <= total system RAM (sanity check)."""
+    import psutil
+    p = capture_runtime_profile()
+    total_gb = psutil.virtual_memory().total / (1024 ** 3)
+    assert p.available_ram_gb <= total_gb + 0.1  # +0.1 GB slop


### PR DESCRIPTION
## Summary

Phase 2 of the controller v3 planner ([plan](docs/superpowers/plans/2026-05-15-controller-v3-planner.md)). Wires the planner-rule dispatcher into `AutoConfigController.run` with an empty rule list — no behavior change.

**Stacked on #259** (Phase 1). Base = \`perf/controller-v3-phase-1\`.

- \`core/autoconfig_planner.py\` (NEW) — \`PlannerRule\` dataclass + \`apply_planner_rules\` walk-in-order dispatcher. Empty rules → \`rule_name='no_rules_registered'\`. Action that omits \`rule_name\` gets the registry entry's name filled in. Predicate/Action are variadic (\`Callable[..., ...]\`) so phase 4 can widen with a \`context\` kwarg without breaking phase-2 tests.
- \`core/autoconfig_controller.py\` — \`run()\` captures \`RuntimeProfile\`, extrapolates the committed sample's \`BlockingProfile\` to full-row count, calls \`apply_planner_rules\` with \`rules=[]\`, applies plan to \`committed_config\` (no-op for default \`polars-direct\`), stashes on \`history.execution_plan\`.
- \`core/autoconfig_history.py\` — \`RunHistory.execution_plan: ExecutionPlan | None\` field.

## Test plan

- [x] 5 new unit tests: 4 dispatcher behaviors + 1 end-to-end controller integration.
- [x] Targeted regression sweep: \`tests/test_autoconfig.py test_autoconfig_controller.py test_pipeline.py test_autoconfig_backend_routing.py test_prep_cache.py test_autoconfig_planner_protocol.py\` → 193 passed.
- [x] Full Phase-2 suite (excluding db / mcp / embedder / llm_boost / benchmarks): 2432 passed / 5 skipped.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)