### PR TITLE
feat(autoconfig): controller v3 planner -- Phase 3 (rules 1+2: pathological + simple)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -541,6 +541,7 @@ class AutoConfigController:
         # committed profile + runtime introspection. Phase 2 lands with an
         # empty rule list (no behavior change); phases 3-6 register rules.
         from goldenmatch.core.autoconfig_planner import apply_planner_rules
+        from goldenmatch.core.autoconfig_planner_rules import DEFAULT_RULES
         from goldenmatch.core.runtime_profile import capture_runtime_profile
 
         runtime = capture_runtime_profile()
@@ -560,7 +561,7 @@ class AutoConfigController:
             profile=profile_for_planner,
             runtime=runtime,
             n_rows_full=df.height,
-            rules=[],  # phases 3-6 register rules
+            rules=DEFAULT_RULES,
         )
         plan.apply_to(committed_config)
         history.execution_plan = plan

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
@@ -1,0 +1,104 @@
+"""Concrete planner rules for controller v3.
+
+Spec §Decision rules; one section per rule:
+docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md.
+
+This module owns the **planner's** rule table (deciding the execution
+plan -- backend, chunk_size, max_workers, etc.). It is distinct from
+``autoconfig_rules`` which owns the v1.10/v1.11 HeuristicRefitPolicy
+rules that mutate the GoldenMatchConfig during controller iteration.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig_planner import PlannerRule
+from goldenmatch.core.complexity_profile import ComplexityProfile
+from goldenmatch.core.execution_plan import ExecutionPlan
+from goldenmatch.core.runtime_profile import RuntimeProfile
+
+
+# ── Rule 1: pathological inputs (spec §Rule 1) ──────────────────────────────
+
+
+def _is_pathological(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> bool:
+    """Spec §Rule 1: n_rows <= 1. The controller's earlier paths raise
+    ConfigValidationError for n_rows == 0 / single column / all-null;
+    this rule catches the trivial n_rows == 1 case so the planner's
+    decision table reads completely (defensive)."""
+    return n_rows_full <= 1
+
+
+def _pathological_plan(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> ExecutionPlan:
+    return ExecutionPlan(
+        backend="polars-direct",
+        max_workers=1,
+        rule_name="plan_pathological",
+    )
+
+
+rule_pathological = PlannerRule(
+    name="plan_pathological",
+    predicate=_is_pathological,
+    action=_pathological_plan,
+)
+
+
+# ── Rule 2: simple plan (spec §Rule 2) ──────────────────────────────────────
+
+# Spec thresholds pinned as named constants so calibration is one-liner.
+SIMPLE_PLAN_MAX_ROWS = 100_000
+SIMPLE_PLAN_MAX_PAIRS = 50_000_000
+
+
+def _is_simple_eligible(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> bool:
+    """Spec §Rule 2: ``n_rows < 100_000 AND estimated_pair_count < 50_000_000``."""
+    return (
+        n_rows_full < SIMPLE_PLAN_MAX_ROWS
+        and profile.blocking.estimated_pair_count < SIMPLE_PLAN_MAX_PAIRS
+    )
+
+
+def _simple_plan(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> ExecutionPlan:
+    return ExecutionPlan(
+        backend="polars-direct",
+        chunk_size=None,
+        max_workers=min(4, runtime.cpu_count),
+        pair_spill_threshold=None,
+        clustering_strategy="in_memory",
+        rule_name="plan_selected_simple",
+    )
+
+
+rule_simple_plan = PlannerRule(
+    name="plan_selected_simple",
+    predicate=_is_simple_eligible,
+    action=_simple_plan,
+)
+
+
+# ── Registry ────────────────────────────────────────────────────────────────
+#
+# Phase 3 ships these two rules. Order matters: pathological must fire
+# before the simple plan, otherwise the simple plan would absorb
+# 1-row inputs. Phases 4-6 append fast-box, chunked, DuckDB, Ray, and
+# the user-override rule (which moves to position [0]).
+
+DEFAULT_RULES: list[PlannerRule] = [
+    rule_pathological,
+    rule_simple_plan,
+]

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
@@ -15,7 +15,6 @@ from goldenmatch.core.complexity_profile import ComplexityProfile
 from goldenmatch.core.execution_plan import ExecutionPlan
 from goldenmatch.core.runtime_profile import RuntimeProfile
 
-
 # ── Rule 1: pathological inputs (spec §Rule 1) ──────────────────────────────
 
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_planner_protocol.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_planner_protocol.py
@@ -149,9 +149,9 @@ def test_controller_run_attaches_execution_plan_to_history():
     _profile, history = ctrl_state
     plan = getattr(history, "execution_plan", None)
     assert plan is not None, "history should have execution_plan attached"
-    assert plan.rule_name in ("no_rules_registered", "no_rule_matched"), (
-        f"phase 2 has no rules registered; got {plan.rule_name}"
-    )
-    assert plan.backend == "polars-direct", (
-        f"phase 2 default plan should preserve polars-direct; got {plan.backend}"
-    )
+    # rule_name is one of the registered DEFAULT_RULES, or a sentinel if
+    # no rule matched. Specific rule selection is covered by
+    # test_autoconfig_planner_rules.py + per-phase integration tests.
+    assert plan.rule_name is not None
+    # 80-row fixture hits the simple plan (rule 2), preserving polars-direct.
+    assert plan.backend == "polars-direct"

--- a/packages/python/goldenmatch/tests/test_autoconfig_planner_rules.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_planner_rules.py
@@ -1,0 +1,104 @@
+"""Unit tests for individual planner rules.
+
+Spec §Decision rules: each rule is a (predicate, action) pair. Tests
+construct synthetic profiles + runtimes that should trigger each rule
+and assert the resulting ExecutionPlan's backend + rule_name.
+
+NB: This module covers ``autoconfig_planner_rules`` (the controller v3
+planner's rule table). The legacy ``autoconfig_rules`` module +
+``test_autoconfig_rules`` cover the v1.10/v1.11 HeuristicRefitPolicy
+rules -- a different layer.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig_planner_rules import (
+    DEFAULT_RULES,
+    rule_pathological,
+    rule_simple_plan,
+)
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ComplexityProfile,
+    DataProfile,
+    ProfileMeta,
+)
+from goldenmatch.core.runtime_profile import RuntimeProfile
+
+
+def _profile(n_rows: int = 1000, total_comparisons: int = 100) -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(n_rows=n_rows, n_cols=3),
+        blocking=BlockingProfile(
+            keys_used=[["name"]],
+            n_blocks=10,
+            total_comparisons=total_comparisons,
+            reduction_ratio=0.9,
+            block_sizes_p50=10,
+            block_sizes_p95=15,
+            block_sizes_p99=20,
+            block_sizes_max=25,
+            singleton_block_count=0,
+            oversized_block_count=0,
+        ),
+        meta=ProfileMeta(
+            iteration=0,
+            is_sample=False,
+            sample_size=n_rows,
+            n_rows_full=n_rows,
+            wall_clock_ms=0,
+            seed=0,
+        ),
+    )
+
+
+def _runtime(ram_gb: float = 16.0, cpus: int = 4) -> RuntimeProfile:
+    return RuntimeProfile(available_ram_gb=ram_gb, cpu_count=cpus, disk_free_gb=100.0)
+
+
+def test_rule_pathological_fires_at_one_row():
+    """Single-row inputs trigger the pathological rule. Defensive -- the
+    controller already short-circuits these earlier; the rule exists so
+    the planner's decision table reads completely."""
+    p = _profile(n_rows=1)
+    assert rule_pathological.predicate(p, _runtime(), 1) is True
+    plan = rule_pathological.action(p, _runtime(), 1)
+    assert plan.backend == "polars-direct"
+    assert plan.rule_name == "plan_pathological"
+
+
+def test_rule_pathological_does_not_fire_on_normal_inputs():
+    p = _profile(n_rows=1000)
+    assert rule_pathological.predicate(p, _runtime(), 1000) is False
+
+
+def test_rule_simple_plan_fires_under_100k_rows():
+    p = _profile(n_rows=50_000, total_comparisons=1_000_000)
+    assert rule_simple_plan.predicate(p, _runtime(), 50_000) is True
+    plan = rule_simple_plan.action(p, _runtime(), 50_000)
+    assert plan.backend == "polars-direct"
+    assert plan.max_workers == 4
+    assert plan.clustering_strategy == "in_memory"
+    assert plan.rule_name == "plan_selected_simple"
+
+
+def test_rule_simple_plan_fires_under_50m_pairs_at_99k_rows():
+    """Even near the upper-bound row count, low pair count keeps simple plan eligible."""
+    p = _profile(n_rows=99_000, total_comparisons=49_000_000)
+    assert rule_simple_plan.predicate(p, _runtime(), 99_000) is True
+
+
+def test_rule_simple_plan_does_not_fire_over_100k_rows():
+    p = _profile(n_rows=200_000, total_comparisons=1_000)
+    assert rule_simple_plan.predicate(p, _runtime(), 200_000) is False
+
+
+def test_rule_simple_plan_does_not_fire_over_50m_pairs():
+    p = _profile(n_rows=50_000, total_comparisons=51_000_000)
+    assert rule_simple_plan.predicate(p, _runtime(), 50_000) is False
+
+
+def test_default_rules_phase_3_includes_both():
+    """Phase 3's DEFAULT_RULES has rule_pathological first, then
+    rule_simple_plan. Phases 4-6 append more rules."""
+    rule_names = [r.name for r in DEFAULT_RULES]
+    assert rule_names == ["plan_pathological", "plan_selected_simple"]


### PR DESCRIPTION
## Summary

Phase 3 of the controller v3 planner ([plan](docs/superpowers/plans/2026-05-15-controller-v3-planner.md)). First two concrete rules registered, no behavior change (both rules currently produce `polars-direct`).

**Stacked on #260** (Phase 2). Base = \`perf/controller-v3-phase-2\`.

**Naming note:** new module is \`autoconfig_planner_rules.py\` (not \`autoconfig_rules.py\` per the original plan) — the latter is already taken by the v1.10/v1.11 \`HeuristicRefitPolicy\` rules (a different layer). The planner rules pick an \`ExecutionPlan\` at the end of the controller; the legacy refit rules mutate \`GoldenMatchConfig\` during iteration.

- \`core/autoconfig_planner_rules.py\` (NEW):
  - \`rule_pathological\` — \`n_rows <= 1\` → \`polars-direct\` + \`max_workers=1\`.
  - \`rule_simple_plan\` — \`n_rows < 100_000 AND estimated_pair_count < 50_000_000\` → \`polars-direct\` + \`in_memory\` clustering.
  - Thresholds as named constants (\`SIMPLE_PLAN_MAX_ROWS\`, \`SIMPLE_PLAN_MAX_PAIRS\`).
  - \`DEFAULT_RULES = [rule_pathological, rule_simple_plan]\`. Order matters: pathological must precede simple.
- \`core/autoconfig_controller.py\` — \`rules=[]\` → \`rules=DEFAULT_RULES\`.
- Phase-2 integration test relaxed: now asserts plan attachment + \`polars-direct\` backend rather than pinning the empty-registry sentinel \`rule_name\`.

## Test plan

- [x] 7 new unit tests covering predicate boundaries (1 row, 99K rows, 49M / 51M pairs, 200K rows) + plan shape + registry order.
- [x] Targeted regression (\`test_autoconfig*\`, \`test_pipeline\`, \`test_prep_cache\`, legacy \`test_autoconfig_rules\`): 228 passed.
- [x] Full suite: 2439 passed / 5 skipped.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)