### PR TITLE
feat(autoconfig): controller v3 planner -- Phase 4 (rules 3/4/7: fast-box, chunked, user-override)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1344,18 +1344,30 @@ def select_model(row_count: int, has_embedding_columns: bool, threshold: int = 5
 _AUTOCONFIG_BACKEND_DEFAULT_THRESHOLD = 1_000_000
 
 
-def _scale_aware_backend(row_count: int) -> str | None:
-    """Select an execution backend based on row count.
+def _scale_aware_backend(row_count: int) -> str | None:  # pyright: ignore[reportUnusedFunction]
+    """DEPRECATED: frozen PR-#239 shim, kept for one release.
 
-    Returns the value to assign to ``GoldenMatchConfig.backend``:
-      * ``None`` for small data → in-memory polars-direct (fastest).
-      * ``"duckdb"`` at large N → spills pair accumulator off-heap.
+    The controller v3 planner (``apply_planner_rules`` in
+    ``core/autoconfig_planner.py``) is now the source of truth for
+    backend selection during ``auto_configure_df``. This helper is
+    frozen at PR-#239 behavior (single-threshold ``"duckdb"`` if
+    ``row_count >= GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD``) and does
+    NOT reflect the full v3 rule table -- external callers consuming
+    the shim get stable behavior across the deprecation window. Will
+    be removed in v2.0.
 
-    Future tiers (chunked, ray) will extend this ladder once they're
-    wired into the public pipeline. For now the duckdb pair store is
-    the only out-of-core option the main pipeline already routes
-    through (``_get_block_scorer`` in core/pipeline.py).
+    Spec: docs/superpowers/specs/2026-05-15-controller-v3-planner-design.md
+    §Backward compatibility.
     """
+    import warnings
+
+    warnings.warn(
+        "_scale_aware_backend is deprecated; the v3 planner "
+        "(goldenmatch.core.autoconfig_planner.apply_planner_rules) is "
+        "now the source of truth. Will be removed in v2.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     override = os.environ.get("GOLDENMATCH_AUTOCONFIG_BACKEND")
     if override is not None:
         token = override.strip().lower()
@@ -1517,17 +1529,13 @@ def auto_configure_df(
         skip_finalize=_skip_finalize,
     )
 
-    # Scale-aware backend selection. Only set when the controller didn't
-    # already commit a backend choice (preserves explicit user/test
-    # overrides plumbed through v0_kwargs in the future).
-    if getattr(config, "backend", None) is None:
-        selected = _scale_aware_backend(df.height)
-        if selected is not None:
-            config.backend = selected
-            logger.info(
-                "auto-config: selected backend=%s for %d rows (threshold heuristic)",
-                selected, df.height,
-            )
+    # Backend selection is now driven by the controller v3 planner inside
+    # AutoConfigController.run -- it captures RuntimeProfile, extrapolates
+    # the committed BlockingProfile to full-row count, and writes the
+    # selected backend onto config via ExecutionPlan.apply_to. The legacy
+    # _scale_aware_backend env-var path (PR #239) is preserved as a frozen
+    # shim for external callers during the deprecation window but is no
+    # longer consulted from this entry point.
 
     _LAST_CONTROLLER_RUN.set((profile, history))
     return config

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -557,11 +557,18 @@ class AutoConfigController:
         else:
             profile_for_planner = committed_profile
 
+        # Rule 7 (user_override) consumes ``context["user_backend"]``.
+        # auto_configure_df does not yet expose a ``backend`` kwarg, so the
+        # signal is always None here -- Rule 7 stays a no-op in production
+        # until the kwarg lands. Threading the context now means the
+        # infrastructure is in place and rule_user_override is unit-testable
+        # in isolation.
         plan = apply_planner_rules(
             profile=profile_for_planner,
             runtime=runtime,
             n_rows_full=df.height,
             rules=DEFAULT_RULES,
+            context={"user_backend": None},
         )
         plan.apply_to(committed_config)
         history.execution_plan = plan

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner.py
@@ -14,15 +14,41 @@ Phases 3-6 register rules; this module just dispatches.
 from __future__ import annotations
 
 import dataclasses
+import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 from goldenmatch.core.complexity_profile import ComplexityProfile
 from goldenmatch.core.execution_plan import ExecutionPlan
 from goldenmatch.core.runtime_profile import RuntimeProfile
 
+# Variadic so both 3-arg (profile, runtime, n_rows_full) and 4-arg
+# (..., context) callables type-check. The dispatcher introspects each
+# rule's signature and threads context only when accepted.
 Predicate = Callable[..., bool]
 Action = Callable[..., ExecutionPlan]
+
+
+def _accepts_context(fn: Callable[..., Any]) -> bool:
+    """True if ``fn`` declares a ``context`` parameter.
+
+    Cached on the function via ``__planner_accepts_context__`` so the
+    inspect.signature call only runs once per rule.
+    """
+    cached = getattr(fn, "__planner_accepts_context__", None)
+    if cached is not None:
+        return cached
+    try:
+        params = inspect.signature(fn).parameters
+        accepts = "context" in params
+    except (TypeError, ValueError):
+        accepts = False
+    try:
+        fn.__planner_accepts_context__ = accepts  # type: ignore[attr-defined]
+    except (AttributeError, TypeError):
+        pass
+    return accepts
 
 
 @dataclass(frozen=True)
@@ -46,6 +72,7 @@ def apply_planner_rules(
     runtime: RuntimeProfile,
     n_rows_full: int,
     rules: list[PlannerRule],
+    context: dict[str, Any] | None = None,
 ) -> ExecutionPlan:
     """Walk the rule list in order; first match's action returns the plan.
 
@@ -55,7 +82,12 @@ def apply_planner_rules(
             on a sample.
         runtime: ``RuntimeProfile`` captured at controller-start.
         n_rows_full: Total row count of the caller's input DataFrame.
-        rules: The rule registry. Empty -> default plan. Phases 3-6 populate.
+        rules: The rule registry. Empty -> default plan.
+        context: Optional dict of side-channel signals (e.g.
+            ``{"user_backend": "ray"}``). Rules declare a ``context``
+            parameter to receive it; rules without that parameter are
+            called with the legacy 3-arg signature (phase-2 unit tests
+            stay green).
 
     Returns:
         ``ExecutionPlan`` with ``rule_name`` set to either the matched
@@ -66,10 +98,18 @@ def apply_planner_rules(
         return ExecutionPlan(rule_name="no_rules_registered")
 
     for rule in rules:
-        if rule.predicate(profile, runtime, n_rows_full):
+        if _accepts_context(rule.predicate):
+            fired = rule.predicate(profile, runtime, n_rows_full, context=context)
+        else:
+            fired = rule.predicate(profile, runtime, n_rows_full)
+        if not fired:
+            continue
+        if _accepts_context(rule.action):
+            plan = rule.action(profile, runtime, n_rows_full, context=context)
+        else:
             plan = rule.action(profile, runtime, n_rows_full)
-            if plan.rule_name is None:
-                plan = dataclasses.replace(plan, rule_name=rule.name)
-            return plan
+        if plan.rule_name is None:
+            plan = dataclasses.replace(plan, rule_name=rule.name)
+        return plan
 
     return ExecutionPlan(rule_name="no_rule_matched")

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
@@ -90,14 +90,166 @@ rule_simple_plan = PlannerRule(
 )
 
 
+# ── Rule 3: fast-box plan (spec §Rule 3) ────────────────────────────────────
+
+FAST_BOX_MIN_RAM_GB = 32.0
+
+
+def _is_fast_box_eligible(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> bool:
+    """Spec §Rule 3: large row count but sparse pair count on a fat machine.
+
+    Fires when the simple plan's row ceiling is exceeded but pair count
+    still fits in RAM and the machine has >= 32 GB available.
+    """
+    return (
+        n_rows_full >= SIMPLE_PLAN_MAX_ROWS
+        and profile.blocking.estimated_pair_count < SIMPLE_PLAN_MAX_PAIRS
+        and runtime.available_ram_gb >= FAST_BOX_MIN_RAM_GB
+    )
+
+
+def _fast_box_plan(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> ExecutionPlan:
+    return ExecutionPlan(
+        backend="polars-direct",
+        max_workers=min(16, runtime.cpu_count),
+        clustering_strategy="in_memory",
+        rule_name="plan_selected_fast_box",
+    )
+
+
+rule_fast_box = PlannerRule(
+    name="plan_selected_fast_box",
+    predicate=_is_fast_box_eligible,
+    action=_fast_box_plan,
+)
+
+
+# ── Rule 4: chunked plan (spec §Rule 4) ─────────────────────────────────────
+
+CHUNKED_MIN_PAIRS = SIMPLE_PLAN_MAX_PAIRS  # 50M
+CHUNKED_MAX_PAIRS = 5_000_000_000  # 5B
+CHUNKED_MIN_RAM_GB = 16.0
+CHUNKED_TARGET_RAM_USE_FRACTION = 0.6
+_CHUNKED_BYTES_PER_ROW = 1024  # empirical: ~1 KB per row incl. __row_id__ + matchkey
+
+
+def auto_chunk_size(n_rows_full: int, available_ram_gb: float) -> int:
+    """Spec §Rule 4: pick chunk_size targeting ~60% of available RAM.
+
+    Estimated bytes per row is a constant tuning lever; result clamped
+    to ``[10_000, 1_000_000]`` per spec range.
+    """
+    import math
+
+    estimated_gb = (n_rows_full * _CHUNKED_BYTES_PER_ROW) / (1024 ** 3)
+    target_chunks = math.ceil(
+        estimated_gb / max(available_ram_gb * CHUNKED_TARGET_RAM_USE_FRACTION, 0.001)
+    )
+    target_chunks = max(target_chunks, 1)
+    chunk = n_rows_full // target_chunks
+    return max(10_000, min(1_000_000, chunk))
+
+
+def _is_chunked_eligible(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> bool:
+    pairs = profile.blocking.estimated_pair_count
+    return (
+        pairs >= CHUNKED_MIN_PAIRS
+        and pairs < CHUNKED_MAX_PAIRS
+        and runtime.available_ram_gb >= CHUNKED_MIN_RAM_GB
+    )
+
+
+def _chunked_plan(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> ExecutionPlan:
+    return ExecutionPlan(
+        backend="chunked",
+        chunk_size=auto_chunk_size(n_rows_full, runtime.available_ram_gb),
+        max_workers=min(16, runtime.cpu_count),
+        pair_spill_threshold="ram",
+        clustering_strategy="in_memory",
+        rule_name="plan_selected_chunked",
+    )
+
+
+rule_chunked = PlannerRule(
+    name="plan_selected_chunked",
+    predicate=_is_chunked_eligible,
+    action=_chunked_plan,
+)
+
+
+# ── Rule 7: explicit user override (spec §Rule 7) ───────────────────────────
+# Must be FIRST in the registry -- beats every other rule.
+
+
+def _user_set_backend(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+    context: dict | None,
+) -> bool:
+    """Spec §Rule 7: fires when context says user set ``config.backend``
+    explicitly. Empty / None means no preference; user-set ``polars-direct``
+    is technically a no-op vs the default but still counts as an explicit
+    preference (don't second-guess the user)."""
+    if context is None:
+        return False
+    return context.get("user_backend") not in (None, "")
+
+
+def _user_override_plan(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+    context: dict | None,
+) -> ExecutionPlan:
+    user_backend = (context or {}).get("user_backend", "polars-direct")
+    if user_backend == "chunked":
+        chunk = auto_chunk_size(n_rows_full, runtime.available_ram_gb)
+    else:
+        chunk = None
+    return ExecutionPlan(
+        backend=user_backend,
+        chunk_size=chunk,
+        max_workers=min(16, runtime.cpu_count),
+        clustering_strategy="in_memory",
+        rule_name="plan_user_override",
+    )
+
+
+rule_user_override = PlannerRule(
+    name="plan_user_override",
+    predicate=_user_set_backend,
+    action=_user_override_plan,
+)
+
+
 # ── Registry ────────────────────────────────────────────────────────────────
 #
-# Phase 3 ships these two rules. Order matters: pathological must fire
-# before the simple plan, otherwise the simple plan would absorb
-# 1-row inputs. Phases 4-6 append fast-box, chunked, DuckDB, Ray, and
-# the user-override rule (which moves to position [0]).
+# Order matters: rule_user_override MUST be first (beats every other rule);
+# rule_pathological must precede rule_simple_plan so 1-row inputs hit the
+# defensive path. Phases 5-6 append rule_duckdb + rule_ray below
+# rule_chunked.
 
 DEFAULT_RULES: list[PlannerRule] = [
+    rule_user_override,  # MUST be first -- explicit user backend beats all
     rule_pathological,
     rule_simple_plan,
+    rule_fast_box,
+    rule_chunked,
 ]

--- a/packages/python/goldenmatch/tests/test_autoconfig_backend_routing.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_backend_routing.py
@@ -1,48 +1,106 @@
-"""Tests for scale-aware backend selection in auto_configure_df.
+"""Tests for scale-aware backend selection in auto-config.
 
-The routing exists so that zero-config users at large N automatically
-get an out-of-core backend (today: duckdb pair store) instead of OOMing
-the default polars-direct path. See `_scale_aware_backend` in
-`goldenmatch/core/autoconfig.py`.
+Phase 4 of the controller v3 planner promoted ``_scale_aware_backend``'s
+PR-#239 env-var behavior to a first-class planner rule (rule_chunked +
+rule_user_override etc). The original function is now a frozen shim that
+still returns PR-#239's single-threshold answer for external callers
+during the deprecation window; it does NOT delegate to the planner.
+
+Tests split into:
+- ``TestScaleAwareBackendShim`` -- unit tests for the frozen shim. Same
+  spec as PR #239; here to prove the shim still behaves predictably.
+- ``TestPlannerBackendSelection`` -- planner-level tests using
+  ``apply_planner_rules`` directly. These are the authoritative
+  source of truth for "which backend gets picked at scale X".
+- ``TestAutoConfigureDfWiring`` -- end-to-end tests via auto_configure_df.
+  The env-var contract is gone; today these only test that the planner
+  doesn't accidentally set backend on small inputs.
 """
 from __future__ import annotations
 
+import warnings
+
 import polars as pl
+import pytest
 from goldenmatch.core.autoconfig import (
     _AUTOCONFIG_BACKEND_DEFAULT_THRESHOLD,
     _scale_aware_backend,
 )
+from goldenmatch.core.autoconfig_planner import apply_planner_rules
+from goldenmatch.core.autoconfig_planner_rules import DEFAULT_RULES
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ComplexityProfile,
+    DataProfile,
+    ProfileMeta,
+)
+from goldenmatch.core.runtime_profile import RuntimeProfile
 
 
-class TestScaleAwareBackendHelper:
-    """Unit tests for the row-count → backend mapping."""
+def _profile(n_rows: int = 1000, total_comparisons: int = 100) -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(n_rows=n_rows, n_cols=3),
+        blocking=BlockingProfile(
+            keys_used=[["name"]],
+            n_blocks=10,
+            total_comparisons=total_comparisons,
+            reduction_ratio=0.9,
+            block_sizes_p50=10,
+            block_sizes_p95=15,
+            block_sizes_p99=20,
+            block_sizes_max=25,
+            singleton_block_count=0,
+            oversized_block_count=0,
+        ),
+        meta=ProfileMeta(
+            iteration=0,
+            is_sample=False,
+            sample_size=n_rows,
+            n_rows_full=n_rows,
+            wall_clock_ms=0,
+            seed=0,
+        ),
+    )
+
+
+def _runtime(ram_gb: float = 32.0, cpus: int = 8) -> RuntimeProfile:
+    return RuntimeProfile(available_ram_gb=ram_gb, cpu_count=cpus, disk_free_gb=100.0)
+
+
+@pytest.fixture(autouse=True)
+def _silence_deprecation_warnings():
+    """Shim emits DeprecationWarning; tests assert behavior, not the warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        yield
+
+
+class TestScaleAwareBackendShim:
+    """Unit tests for the frozen PR-#239 shim. Same behavior as before
+    Phase 4; the shim is kept exportable for one release as deprecation
+    cushion. The planner is now the source of truth for production paths."""
 
     def test_small_data_returns_none(self):
-        """Below threshold: keep polars-direct (fastest at small N)."""
         assert _scale_aware_backend(0) is None
         assert _scale_aware_backend(100) is None
         assert _scale_aware_backend(_AUTOCONFIG_BACKEND_DEFAULT_THRESHOLD - 1) is None
 
     def test_large_data_returns_duckdb(self):
-        """At/above threshold: spill via duckdb pair store."""
         assert _scale_aware_backend(_AUTOCONFIG_BACKEND_DEFAULT_THRESHOLD) == "duckdb"
         assert _scale_aware_backend(5_000_000) == "duckdb"
         assert _scale_aware_backend(100_000_000) == "duckdb"
 
     def test_threshold_env_override(self, monkeypatch):
-        """Threshold can be lowered/raised via env var."""
         monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD", "10000")
         assert _scale_aware_backend(9_999) is None
         assert _scale_aware_backend(10_000) == "duckdb"
 
-    def test_threshold_env_malformed_falls_back(self, monkeypatch, caplog):
-        """Garbage threshold env var should warn and use the default."""
+    def test_threshold_env_malformed_falls_back(self, monkeypatch):
         monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD", "not-a-number")
         assert _scale_aware_backend(100) is None
         assert _scale_aware_backend(_AUTOCONFIG_BACKEND_DEFAULT_THRESHOLD) == "duckdb"
 
     def test_backend_env_disables(self, monkeypatch):
-        """Explicit opt-out: no auto-selection regardless of N."""
         for token in ("0", "false", "disabled", ""):
             monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_BACKEND", token)
             assert _scale_aware_backend(50_000_000) is None
@@ -52,25 +110,81 @@ class TestScaleAwareBackendHelper:
         assert _scale_aware_backend(50_000_000) is None
 
     def test_backend_env_forces_explicit(self, monkeypatch):
-        """Explicit force: small N also gets the named backend."""
         monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_BACKEND", "duckdb")
         assert _scale_aware_backend(10) == "duckdb"
 
     def test_backend_env_passes_through_unknown(self, monkeypatch):
-        """Unknown backend names pass through; pipeline layer validates."""
         monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_BACKEND", "ray")
         assert _scale_aware_backend(10) == "ray"
 
+    def test_shim_emits_deprecation_warning(self):
+        """The shim is deprecated; new code should use apply_planner_rules."""
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            _scale_aware_backend(100)
+        assert any(
+            issubclass(w.category, DeprecationWarning) for w in recorded
+        ), "shim should emit DeprecationWarning"
+
+
+class TestPlannerBackendSelection:
+    """Authoritative tests for which backend the planner picks at scale X."""
+
+    def test_planner_picks_polars_direct_below_100k(self):
+        plan = apply_planner_rules(
+            profile=_profile(n_rows=100, total_comparisons=10),
+            runtime=_runtime(),
+            n_rows_full=100,
+            rules=DEFAULT_RULES,
+            context={"user_backend": None},
+        )
+        assert plan.backend == "polars-direct"
+        assert plan.rule_name == "plan_selected_simple"
+
+    def test_planner_picks_fast_box_at_500k_with_64gb_and_sparse_pairs(self):
+        plan = apply_planner_rules(
+            profile=_profile(n_rows=500_000, total_comparisons=10_000_000),
+            runtime=_runtime(ram_gb=64.0, cpus=16),
+            n_rows_full=500_000,
+            rules=DEFAULT_RULES,
+            context={"user_backend": None},
+        )
+        assert plan.backend == "polars-direct"
+        assert plan.rule_name == "plan_selected_fast_box"
+
+    def test_planner_picks_chunked_at_2m_with_dense_pairs(self):
+        plan = apply_planner_rules(
+            profile=_profile(n_rows=2_000_000, total_comparisons=200_000_000),
+            runtime=_runtime(ram_gb=32.0, cpus=16),
+            n_rows_full=2_000_000,
+            rules=DEFAULT_RULES,
+            context={"user_backend": None},
+        )
+        assert plan.backend == "chunked"
+        assert plan.rule_name == "plan_selected_chunked"
+        assert plan.chunk_size is not None and plan.chunk_size > 0
+
+    def test_planner_user_override_beats_scale_heuristics(self):
+        """User explicitly picking 'ray' beats every other rule, even at
+        small N where rule_simple_plan would otherwise fire."""
+        plan = apply_planner_rules(
+            profile=_profile(n_rows=100, total_comparisons=10),
+            runtime=_runtime(),
+            n_rows_full=100,
+            rules=DEFAULT_RULES,
+            context={"user_backend": "ray"},
+        )
+        assert plan.backend == "ray"
+        assert plan.rule_name == "plan_user_override"
+
 
 class TestAutoConfigureDfWiring:
-    """auto_configure_df() must apply the selected backend to the returned config."""
+    """auto_configure_df() now drives backend selection through the planner.
+    The env-var contract (GOLDENMATCH_AUTOCONFIG_BACKEND / _THRESHOLD) is
+    deprecated and only honored by the frozen shim, NOT by the planner --
+    so it no longer affects what auto_configure_df returns."""
 
     def _personlike_df(self, n: int) -> pl.DataFrame:
-        """Synthetic person-shape dataframe sized to N rows.
-
-        Cheap to construct at small N; matches what the controller's
-        column-classifier needs to pick weighted/exact matchkeys.
-        """
         names = ["Alice", "Bob", "Charlie", "Dana", "Eve", "Frank"]
         zips = ["10001", "10002", "10003", "10004", "10005"]
         return pl.DataFrame({
@@ -81,11 +195,10 @@ class TestAutoConfigureDfWiring:
         })
 
     def test_small_df_leaves_backend_unset(self, monkeypatch):
-        """Below threshold: backend remains None (no behavior change)."""
-        # Ensure no env override leaks from CI/dev shell.
+        """Below the simple-plan ceiling: planner picks polars-direct,
+        plan.apply_to leaves config.backend at its default (None)."""
         monkeypatch.delenv("GOLDENMATCH_AUTOCONFIG_BACKEND", raising=False)
         monkeypatch.delenv("GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD", raising=False)
-        # Disable cross-run memory so cached configs don't override the test.
         monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
         from goldenmatch.core.autoconfig import auto_configure_df
 
@@ -93,22 +206,27 @@ class TestAutoConfigureDfWiring:
         cfg = auto_configure_df(df)
         assert cfg.backend is None
 
-    def test_large_df_promotes_to_duckdb(self, monkeypatch):
-        """At threshold: backend auto-set to duckdb without touching matchkeys."""
+    def test_threshold_env_no_longer_promotes_to_duckdb(self, monkeypatch):
+        """Phase 4 disconnected the env var from auto_configure_df.
+        Setting threshold=50 on a 60-row input used to promote to duckdb
+        (PR #239 behavior); after Phase 4 the planner ignores the env
+        and picks rule_simple_plan -> polars-direct -> backend stays None."""
         monkeypatch.delenv("GOLDENMATCH_AUTOCONFIG_BACKEND", raising=False)
-        # Use a tiny threshold so we don't have to build a 1M-row fixture.
         monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD", "50")
         monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
         from goldenmatch.core.autoconfig import auto_configure_df
 
         df = self._personlike_df(60)
         cfg = auto_configure_df(df)
-        assert cfg.backend == "duckdb", (
-            f"Expected duckdb at 60 rows with threshold=50, got {cfg.backend!r}"
+        assert cfg.backend is None, (
+            f"Phase 4: planner ignores GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD; "
+            f"60-row input should land on polars-direct, got backend={cfg.backend!r}"
         )
 
-    def test_disable_env_overrides_threshold(self, monkeypatch):
-        """Explicit disable wins over scale heuristic."""
+    def test_disable_env_no_longer_relevant(self, monkeypatch):
+        """The disable env var was a counter to the shim's auto-promotion;
+        with the shim disconnected, neither setting matters for the
+        planner. 100-row inputs land on polars-direct regardless."""
         monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_BACKEND", "0")
         monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD", "10")
         monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")

--- a/packages/python/goldenmatch/tests/test_autoconfig_planner_rules.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_planner_rules.py
@@ -13,8 +13,12 @@ from __future__ import annotations
 
 from goldenmatch.core.autoconfig_planner_rules import (
     DEFAULT_RULES,
+    auto_chunk_size,
+    rule_chunked,
+    rule_fast_box,
     rule_pathological,
     rule_simple_plan,
+    rule_user_override,
 )
 from goldenmatch.core.complexity_profile import (
     BlockingProfile,
@@ -97,8 +101,146 @@ def test_rule_simple_plan_does_not_fire_over_50m_pairs():
     assert rule_simple_plan.predicate(p, _runtime(), 50_000) is False
 
 
-def test_default_rules_phase_3_includes_both():
-    """Phase 3's DEFAULT_RULES has rule_pathological first, then
-    rule_simple_plan. Phases 4-6 append more rules."""
+def test_default_rules_phase_4_order():
+    """Phase 4: user_override MUST be first; pathological precedes simple;
+    fast-box / chunked come after. Phase 5 will append duckdb + ray."""
     rule_names = [r.name for r in DEFAULT_RULES]
-    assert rule_names == ["plan_pathological", "plan_selected_simple"]
+    assert rule_names == [
+        "plan_user_override",
+        "plan_pathological",
+        "plan_selected_simple",
+        "plan_selected_fast_box",
+        "plan_selected_chunked",
+    ]
+
+
+# ── Rule 3: fast-box ────────────────────────────────────────────────────────
+
+
+def test_rule_fast_box_fires_at_500k_with_64gb_and_sparse_pairs():
+    """Spec §Rule 3: n_rows >= 100K AND pair_count < 50M AND ram >= 32GB."""
+    p = _profile(n_rows=500_000, total_comparisons=40_000_000)
+    assert rule_fast_box.predicate(p, _runtime(ram_gb=64.0, cpus=16), 500_000) is True
+    plan = rule_fast_box.action(p, _runtime(ram_gb=64.0, cpus=16), 500_000)
+    assert plan.backend == "polars-direct"
+    assert plan.max_workers == 16
+    assert plan.rule_name == "plan_selected_fast_box"
+
+
+def test_rule_fast_box_does_not_fire_below_32gb_ram():
+    p = _profile(n_rows=500_000, total_comparisons=40_000_000)
+    assert rule_fast_box.predicate(p, _runtime(ram_gb=16.0), 500_000) is False
+
+
+def test_rule_fast_box_does_not_fire_when_pairs_too_high():
+    """50M+ pairs falls through to rule_chunked, not fast-box."""
+    p = _profile(n_rows=500_000, total_comparisons=80_000_000)
+    assert rule_fast_box.predicate(p, _runtime(ram_gb=64.0), 500_000) is False
+
+
+def test_rule_fast_box_max_workers_caps_at_16():
+    p = _profile(n_rows=500_000, total_comparisons=40_000_000)
+    plan = rule_fast_box.action(p, _runtime(ram_gb=64.0, cpus=64), 500_000)
+    assert plan.max_workers == 16
+
+
+# ── Rule 4: chunked ─────────────────────────────────────────────────────────
+
+
+def test_rule_chunked_fires_at_2m_with_32gb():
+    """Spec §Rule 4: 50M <= pair_count < 5B, ram >= 16GB."""
+    p = _profile(n_rows=2_000_000, total_comparisons=200_000_000)
+    assert rule_chunked.predicate(p, _runtime(ram_gb=32.0, cpus=16), 2_000_000) is True
+    plan = rule_chunked.action(p, _runtime(ram_gb=32.0, cpus=16), 2_000_000)
+    assert plan.backend == "chunked"
+    assert plan.chunk_size is not None and plan.chunk_size > 0
+    assert plan.pair_spill_threshold == "ram"
+    assert plan.rule_name == "plan_selected_chunked"
+
+
+def test_rule_chunked_picks_chunk_size_in_spec_range():
+    """auto_chunk_size targets ~60% of available RAM; clamped to [10K, 1M]."""
+    p = _profile(n_rows=2_000_000, total_comparisons=200_000_000)
+    plan = rule_chunked.action(p, _runtime(ram_gb=32.0, cpus=16), 2_000_000)
+    assert plan.chunk_size is not None
+    assert 10_000 <= plan.chunk_size <= 1_000_000
+
+
+def test_rule_chunked_does_not_fire_below_16gb_ram():
+    p = _profile(n_rows=2_000_000, total_comparisons=200_000_000)
+    assert rule_chunked.predicate(p, _runtime(ram_gb=8.0), 2_000_000) is False
+
+
+def test_rule_chunked_does_not_fire_when_pairs_exceed_5b():
+    """5B+ pairs falls through to rule_duckdb (phase 5)."""
+    p = _profile(n_rows=10_000_000, total_comparisons=6_000_000_000)
+    assert rule_chunked.predicate(p, _runtime(ram_gb=32.0), 10_000_000) is False
+
+
+def test_auto_chunk_size_clamps_at_10k_floor():
+    """Tiny RAM (1GB) on 100K rows would push chunks below 10K; clamped."""
+    assert auto_chunk_size(100_000, available_ram_gb=1.0) >= 10_000
+
+
+def test_auto_chunk_size_clamps_at_1m_ceiling():
+    """Huge RAM on small rows would push chunks above 1M; clamped."""
+    assert auto_chunk_size(500_000_000, available_ram_gb=1024.0) <= 1_000_000
+
+
+# ── Rule 7: user override ───────────────────────────────────────────────────
+
+
+def test_rule_user_override_fires_when_context_has_backend():
+    """Spec §Rule 7: explicit user override beats every other rule. Must
+    be FIRST in the registry."""
+    p = _profile()
+    assert (
+        rule_user_override.predicate(
+            p, _runtime(), 1000, context={"user_backend": "ray"}
+        )
+        is True
+    )
+    plan = rule_user_override.action(p, _runtime(), 1000, context={"user_backend": "ray"})
+    assert plan.backend == "ray"
+    assert plan.rule_name == "plan_user_override"
+
+
+def test_rule_user_override_does_not_fire_when_context_is_none():
+    p = _profile()
+    assert rule_user_override.predicate(p, _runtime(), 1000, context=None) is False
+
+
+def test_rule_user_override_does_not_fire_when_user_backend_is_none():
+    p = _profile()
+    assert (
+        rule_user_override.predicate(p, _runtime(), 1000, context={"user_backend": None})
+        is False
+    )
+
+
+def test_rule_user_override_fills_chunk_size_for_chunked_backend():
+    """User says chunked -- planner fills chunk_size + other knobs."""
+    p = _profile(n_rows=2_000_000)
+    plan = rule_user_override.action(
+        p, _runtime(ram_gb=32.0, cpus=16), 2_000_000,
+        context={"user_backend": "chunked"},
+    )
+    assert plan.backend == "chunked"
+    assert plan.chunk_size is not None and plan.chunk_size > 0
+
+
+def test_rule_user_override_fires_first_in_dispatcher():
+    """End-to-end: even when conditions favor rule_simple_plan, the
+    override still wins because it sits at position [0] of DEFAULT_RULES."""
+    from goldenmatch.core.autoconfig_planner import apply_planner_rules
+
+    p = _profile(n_rows=1000, total_comparisons=100)
+    plan = apply_planner_rules(
+        profile=p,
+        runtime=_runtime(),
+        n_rows_full=1000,
+        rules=DEFAULT_RULES,
+        context={"user_backend": "duckdb"},
+    )
+    assert plan.rule_name == "plan_user_override"
+    assert plan.backend == "duckdb"


### PR DESCRIPTION
## Summary

Phase 4 of the controller v3 planner ([plan](docs/superpowers/plans/2026-05-15-controller-v3-planner.md)). **First phase that produces non-default plans.**

- \`rule_fast_box\` (Rule 3) — 100K+ rows, < 50M pairs, >= 32 GB RAM → \`polars-direct\` + \`max_workers=min(16, cpu)\`.
- \`rule_chunked\` (Rule 4) — 50M–5B pairs, >= 16 GB RAM → \`chunked\` backend + \`auto_chunk_size\` (60% RAM target, clamped to [10K, 1M]).
- \`rule_user_override\` (Rule 7) — fires on \`context[\"user_backend\"]\`. **First in \`DEFAULT_RULES\`** so explicit user choice always wins.

Dispatcher widened with optional \`context\` arg. Uses \`inspect.signature\` to call each rule with 3 or 4 positional args depending on its declared signature, so phase-2 unit-test predicates stay green.

\`_scale_aware_backend\` is now a **frozen PR-#239 shim** with \`DeprecationWarning\`. Its call site in \`auto_configure_df\` is removed — the planner is now the sole source of truth for backend selection inside the controller.

\`rule_user_override\` is unit-testable today, but plumbing of a user \`backend\` kwarg through \`auto_configure_df\` is left for a follow-up; controller passes \`context={\"user_backend\": None}\` for now.

## Test plan

- [x] 20 new tests across rules + backend-routing migration.
- [x] Phase-2 dispatcher tests (3-arg predicates) still green via signature introspection.
- [x] Frozen shim preserves all PR-#239 behavior; \`DeprecationWarning\` test added.
- [x] Full suite: 2459 passed / 5 skipped.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)