### PR TITLE
feat(autoconfig): controller v3 planner -- Phase 5 (rules 5+6: DuckDB + Ray)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
@@ -239,12 +239,113 @@ rule_user_override = PlannerRule(
 )
 
 
+# ── Rule 6: Ray escape hatch (spec §Rule 6) ─────────────────────────────────
+# Slotted BEFORE rule_duckdb so ray gets first crack at 50M+; falls through
+# to rule_duckdb when ``import ray`` fails (closed-fail behavior per spec).
+
+RAY_MIN_ROWS = 50_000_000
+
+
+def _has_ray() -> bool:
+    """Probe whether ``ray`` is importable. Cheap and side-effect free.
+
+    Uses ``importlib.util.find_spec`` so pyright doesn't complain about
+    the optional ``ray`` dep being unresolvable; ``find_spec`` returns
+    None when the package isn't installed, without raising.
+    """
+    import importlib.util
+
+    return importlib.util.find_spec("ray") is not None
+
+
+def _is_ray_eligible(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> bool:
+    """Spec §Rule 6: 50M+ rows AND ray import succeeds.
+
+    Failing closed: when ray isn't installed, predicate returns False and
+    the planner falls through to rule_duckdb (Rule 5).
+    """
+    return n_rows_full >= RAY_MIN_ROWS and _has_ray()
+
+
+def _ray_plan(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> ExecutionPlan:
+    return ExecutionPlan(
+        backend="ray",
+        max_workers=runtime.cpu_count,
+        pair_spill_threshold="disk_per_worker",
+        clustering_strategy="streaming_cc",
+        rule_name="plan_selected_ray",
+    )
+
+
+rule_ray = PlannerRule(
+    name="plan_selected_ray",
+    predicate=_is_ray_eligible,
+    action=_ray_plan,
+)
+
+
+# ── Rule 5: DuckDB out-of-core regime (spec §Rule 5) ────────────────────────
+
+DUCKDB_MIN_PAIRS = 5_000_000_000  # 5B
+DUCKDB_MAX_RAM_GB = 16.0  # below this, force DuckDB regardless of pair count
+DUCKDB_MAX_WORKERS = 8
+
+
+def _is_duckdb_eligible(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> bool:
+    """Spec §Rule 5: pair_count >= 5B OR available_ram_gb < 16.
+
+    Single-box at-scale plan. Uses DuckDB for the pair store + partitioned
+    union-find for clustering (full pair set won't fit in Python memory).
+    """
+    pairs = profile.blocking.estimated_pair_count
+    return (
+        pairs >= DUCKDB_MIN_PAIRS
+        or runtime.available_ram_gb < DUCKDB_MAX_RAM_GB
+    )
+
+
+def _duckdb_plan(
+    profile: ComplexityProfile,
+    runtime: RuntimeProfile,
+    n_rows_full: int,
+) -> ExecutionPlan:
+    return ExecutionPlan(
+        backend="duckdb",
+        max_workers=min(DUCKDB_MAX_WORKERS, runtime.cpu_count),
+        pair_spill_threshold="duckdb",
+        clustering_strategy="partitioned_union_find",
+        rule_name="plan_selected_duckdb",
+    )
+
+
+rule_duckdb = PlannerRule(
+    name="plan_selected_duckdb",
+    predicate=_is_duckdb_eligible,
+    action=_duckdb_plan,
+)
+
+
 # ── Registry ────────────────────────────────────────────────────────────────
 #
-# Order matters: rule_user_override MUST be first (beats every other rule);
-# rule_pathological must precede rule_simple_plan so 1-row inputs hit the
-# defensive path. Phases 5-6 append rule_duckdb + rule_ray below
-# rule_chunked.
+# Order matters:
+#   - rule_user_override MUST be first (beats every other rule).
+#   - rule_pathological must precede rule_simple_plan so 1-row inputs hit
+#     the defensive path.
+#   - rule_ray sits BEFORE rule_duckdb so 50M+ inputs hit ray when it's
+#     installed; when ``import ray`` fails, predicate returns False and
+#     the planner falls through to rule_duckdb.
 
 DEFAULT_RULES: list[PlannerRule] = [
     rule_user_override,  # MUST be first -- explicit user backend beats all
@@ -252,4 +353,6 @@ DEFAULT_RULES: list[PlannerRule] = [
     rule_simple_plan,
     rule_fast_box,
     rule_chunked,
+    rule_ray,            # try first at 50M+; falls through if ray unavailable
+    rule_duckdb,         # catch-all for very dense pair counts or low RAM
 ]

--- a/packages/python/goldenmatch/tests/test_autoconfig_planner_rules.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_planner_rules.py
@@ -11,12 +11,16 @@ rules -- a different layer.
 """
 from __future__ import annotations
 
+import pytest
 from goldenmatch.core.autoconfig_planner_rules import (
     DEFAULT_RULES,
+    _has_ray,
     auto_chunk_size,
     rule_chunked,
+    rule_duckdb,
     rule_fast_box,
     rule_pathological,
+    rule_ray,
     rule_simple_plan,
     rule_user_override,
 )
@@ -27,6 +31,8 @@ from goldenmatch.core.complexity_profile import (
     ProfileMeta,
 )
 from goldenmatch.core.runtime_profile import RuntimeProfile
+
+HAS_RAY = _has_ray()
 
 
 def _profile(n_rows: int = 1000, total_comparisons: int = 100) -> ComplexityProfile:
@@ -101,9 +107,10 @@ def test_rule_simple_plan_does_not_fire_over_50m_pairs():
     assert rule_simple_plan.predicate(p, _runtime(), 50_000) is False
 
 
-def test_default_rules_phase_4_order():
-    """Phase 4: user_override MUST be first; pathological precedes simple;
-    fast-box / chunked come after. Phase 5 will append duckdb + ray."""
+def test_default_rules_phase_5_order():
+    """Phase 5: user_override first; pathological precedes simple; fast-box,
+    chunked, then ray BEFORE duckdb so 50M+ tries ray first and falls
+    through to duckdb when ray isn't installed."""
     rule_names = [r.name for r in DEFAULT_RULES]
     assert rule_names == [
         "plan_user_override",
@@ -111,6 +118,8 @@ def test_default_rules_phase_4_order():
         "plan_selected_simple",
         "plan_selected_fast_box",
         "plan_selected_chunked",
+        "plan_selected_ray",
+        "plan_selected_duckdb",
     ]
 
 
@@ -244,3 +253,91 @@ def test_rule_user_override_fires_first_in_dispatcher():
     )
     assert plan.rule_name == "plan_user_override"
     assert plan.backend == "duckdb"
+
+
+# ── Rule 5: DuckDB ──────────────────────────────────────────────────────────
+
+
+def test_rule_duckdb_fires_when_pairs_exceed_5b():
+    """Spec §Rule 5: pair_count >= 5B (regardless of RAM)."""
+    p = _profile(n_rows=10_000_000, total_comparisons=6_000_000_000)
+    assert rule_duckdb.predicate(p, _runtime(ram_gb=64.0, cpus=16), 10_000_000) is True
+    plan = rule_duckdb.action(p, _runtime(ram_gb=64.0, cpus=16), 10_000_000)
+    assert plan.backend == "duckdb"
+    assert plan.pair_spill_threshold == "duckdb"
+    assert plan.clustering_strategy == "partitioned_union_find"
+    assert plan.max_workers == 8
+    assert plan.rule_name == "plan_selected_duckdb"
+
+
+def test_rule_duckdb_fires_on_low_ram_even_with_few_pairs():
+    """Spec §Rule 5: OR condition -- RAM < 16GB forces DuckDB regardless."""
+    p = _profile(n_rows=200_000, total_comparisons=1_000_000)
+    assert rule_duckdb.predicate(p, _runtime(ram_gb=8.0), 200_000) is True
+
+
+def test_rule_duckdb_does_not_fire_at_ram_threshold_with_modest_pairs():
+    """16GB RAM (exactly the floor) + < 5B pairs: should not fire."""
+    p = _profile(n_rows=1_000_000, total_comparisons=100_000_000)
+    assert rule_duckdb.predicate(p, _runtime(ram_gb=16.0), 1_000_000) is False
+
+
+def test_rule_duckdb_max_workers_caps_at_8():
+    """Spec: max_workers = min(cpu_count, 8). Even 64-core box gets 8."""
+    p = _profile(n_rows=10_000_000, total_comparisons=6_000_000_000)
+    plan = rule_duckdb.action(p, _runtime(ram_gb=64.0, cpus=64), 10_000_000)
+    assert plan.max_workers == 8
+
+
+# ── Rule 6: Ray ─────────────────────────────────────────────────────────────
+
+
+def test_rule_ray_does_not_fire_below_50m_rows():
+    p = _profile(n_rows=10_000_000)
+    assert rule_ray.predicate(p, _runtime(), 10_000_000) is False
+
+
+@pytest.mark.skipif(not HAS_RAY, reason="ray optional dep not installed")
+def test_rule_ray_fires_at_50m_when_ray_is_available():
+    """Spec §Rule 6: n_rows >= 50M AND ray import succeeds."""
+    p = _profile(n_rows=50_000_000)
+    assert rule_ray.predicate(p, _runtime(cpus=32), 50_000_000) is True
+    plan = rule_ray.action(p, _runtime(cpus=32), 50_000_000)
+    assert plan.backend == "ray"
+    assert plan.pair_spill_threshold == "disk_per_worker"
+    assert plan.clustering_strategy == "streaming_cc"
+    assert plan.max_workers == 32  # full cluster cpu count, no cap
+    assert plan.rule_name == "plan_selected_ray"
+
+
+def test_rule_ray_falls_through_to_duckdb_when_ray_unavailable(monkeypatch):
+    """Spec §Rule 6 fail-closed: when ``import ray`` raises, predicate
+    returns False; dispatcher falls through to rule_duckdb at 50M+."""
+    from goldenmatch.core import autoconfig_planner_rules as rules_mod
+    from goldenmatch.core.autoconfig_planner import apply_planner_rules
+
+    monkeypatch.setattr(rules_mod, "_has_ray", lambda: False)
+
+    p = _profile(n_rows=50_000_000, total_comparisons=10_000_000_000)
+    plan = apply_planner_rules(
+        profile=p,
+        runtime=_runtime(ram_gb=32.0, cpus=16),
+        n_rows_full=50_000_000,
+        rules=DEFAULT_RULES,
+        context={"user_backend": None},
+    )
+    # Falls through past rule_ray; rule_duckdb fires because pairs >= 5B.
+    assert plan.rule_name == "plan_selected_duckdb"
+    assert plan.backend == "duckdb"
+
+
+def test_rule_ray_picks_up_full_cluster_cpu_count():
+    """Spec: max_workers=cpu_count_total_cluster (no min(...) cap)."""
+    p = _profile(n_rows=50_000_000)
+    plan = rule_ray.action(p, _runtime(cpus=128), 50_000_000)
+    assert plan.max_workers == 128
+
+
+def test_has_ray_helper_returns_bool():
+    """``_has_ray`` returns True or False, never raises."""
+    assert isinstance(_has_ray(), bool)


### PR DESCRIPTION
## Summary

Phase 5 of the controller v3 planner ([plan](docs/superpowers/plans/2026-05-15-controller-v3-planner.md)). **Completes the rule table.** Phase 6 surfaces \`ExecutionPlan\` to consumer surfaces.

**Stacked on #262** (Phase 4). Base = \`perf/controller-v3-phase-4\`.

- \`rule_duckdb\` (Rule 5) — \`pairs >= 5B OR ram < 16GB\` → \`backend=duckdb\`, \`pair_spill=duckdb\`, \`clustering=partitioned_union_find\`, \`max_workers=min(cpu, 8)\`.
- \`rule_ray\` (Rule 6) — \`n_rows >= 50M AND ray_available\` → \`backend=ray\`, \`max_workers=cpu_count\` (no cap), \`pair_spill=disk_per_worker\`, \`clustering=streaming_cc\`. **Fails closed** when ray isn't installed; dispatcher falls through to rule_duckdb.

Registry order: \`rule_ray\` slotted BEFORE \`rule_duckdb\` so 50M+ inputs try ray first, then cleanly fall through. \`_has_ray\` uses \`importlib.util.find_spec\` to avoid pyright \`reportMissingImports\` on the optional dep.

## Test plan

- [x] 9 new tests (4 duckdb + 5 ray, including the fall-through monkeypatch test).
- [x] Ray-installed test marked \`pytest.mark.skipif(not HAS_RAY)\`.
- [x] Full suite 2468 passed / 5 skipped locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)