### PR TITLE
feat(autoconfig): controller v3 planner -- Phase 6 (ExecutionPlan observability)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/cli/_controller_render.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/_controller_render.py
@@ -296,6 +296,9 @@ def render_controller_panel(
     """
     parts: list[RenderableType] = []
     parts.append(_header(profile, history))
+    plan_row = _execution_plan(history)
+    if plan_row is not None:
+        parts.append(plan_row)
     mks = _committed_matchkeys(committed_config)
     if mks is not None:
         parts.append(mks)
@@ -330,6 +333,9 @@ def render_short_status(*, profile: Any, history: Any, committed_config: Any) ->
     if history is not None:
         decisions = [e for e in getattr(history, "entries", []) if e.decision is not None]
         bits.append(f"iterations={len(decisions)}")
+    plan_short = _execution_plan_short(history)
+    if plan_short:
+        bits.append(plan_short)
     if committed_config is not None:
         try:
             matchkeys = committed_config.get_matchkeys()
@@ -343,6 +349,51 @@ def render_short_status(*, profile: Any, history: Any, committed_config: Any) ->
 
 
 # ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _execution_plan(history: Any) -> RenderableType | None:
+    """Render the controller v3 ExecutionPlan as a Rich Text row.
+
+    ``None`` when history is missing or pre-v3 (no execution_plan field).
+    Highlights the rule + backend; tuning knobs follow in dim style so the
+    rule selection is the headline.
+    """
+    if history is None:
+        return None
+    plan = getattr(history, "execution_plan", None)
+    if plan is None:
+        return None
+    rule = getattr(plan, "rule_name", None) or "unknown"
+    backend = getattr(plan, "backend", "polars-direct")
+    extras: list[str] = []
+    chunk = getattr(plan, "chunk_size", None)
+    if chunk is not None:
+        extras.append(f"chunk_size={chunk}")
+    workers = getattr(plan, "max_workers", None)
+    if workers:
+        extras.append(f"max_workers={workers}")
+    spill = getattr(plan, "pair_spill_threshold", None)
+    if spill:
+        extras.append(f"spill={spill}")
+    strategy = getattr(plan, "clustering_strategy", None)
+    if strategy and strategy != "in_memory":
+        extras.append(f"clustering={strategy}")
+    head = f"[bold cyan]Plan:[/] [bold]{rule}[/] -> backend=[bold]{backend}[/]"
+    if extras:
+        head = f"{head} [dim]({', '.join(extras)})[/]"
+    return Text.from_markup(head)
+
+
+def _execution_plan_short(history: Any) -> str:
+    """One-token summary of the execution plan, or empty string when absent."""
+    if history is None:
+        return ""
+    plan = getattr(history, "execution_plan", None)
+    if plan is None:
+        return ""
+    rule = getattr(plan, "rule_name", None) or "unknown"
+    backend = getattr(plan, "backend", "polars-direct")
+    return f"plan={rule}/{backend}"
 
 
 def _truncate(s: str, max_len: int) -> str:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
@@ -261,7 +261,34 @@ class PostflightReport:
         mem_line = _render_memory_line(self.memory_stats)
         if mem_line:
             parts.append(f"  {mem_line}")
+        plan_line = _render_plan_line(self.controller_history)
+        if plan_line:
+            parts.append(f"  {plan_line}")
         return "\n".join(parts)
+
+
+def _render_plan_line(history: Any) -> str:
+    """Render the controller v3 execution plan in one line, or '' when absent.
+
+    Reads ``history.execution_plan`` (an ``ExecutionPlan`` from the v3
+    planner). Surfaces the rule that fired + the resulting backend so users
+    can answer "why did goldenmatch pick chunked?" at a glance. ASCII only.
+    """
+    if history is None:
+        return ""
+    plan = getattr(history, "execution_plan", None)
+    if plan is None:
+        return ""
+    rule = getattr(plan, "rule_name", None) or "unknown"
+    backend = getattr(plan, "backend", "polars-direct")
+    parts = [f"Plan: {rule} -> backend={backend}"]
+    chunk = getattr(plan, "chunk_size", None)
+    if chunk is not None:
+        parts.append(f"chunk_size={chunk}")
+    workers = getattr(plan, "max_workers", None)
+    if workers:
+        parts.append(f"max_workers={workers}")
+    return ", ".join(parts)
 
 
 def _render_memory_line(stats: Any) -> str:

--- a/packages/python/goldenmatch/goldenmatch/web/controller_telemetry.py
+++ b/packages/python/goldenmatch/goldenmatch/web/controller_telemetry.py
@@ -287,6 +287,29 @@ def serialize_telemetry(
         "column_priors": _column_priors(profile),
         "decisions": _decisions(history),
         "errors": _errors(history),
+        "execution_plan": _execution_plan(history),
         "committed_matchkeys": _committed_matchkeys_summary(committed_config),
         "negative_evidence": _negative_evidence(committed_config),
+    }
+
+
+def _execution_plan(history: Any) -> dict[str, Any] | None:
+    """Serialize the controller v3 ExecutionPlan, or None when absent.
+
+    Pulls from ``history.execution_plan`` (populated by
+    ``AutoConfigController.run``). Returns None for legacy histories or
+    hand-written configs that bypass the controller.
+    """
+    if history is None:
+        return None
+    plan = getattr(history, "execution_plan", None)
+    if plan is None:
+        return None
+    return {
+        "rule_name": plan.rule_name,
+        "backend": plan.backend,
+        "chunk_size": plan.chunk_size,
+        "max_workers": plan.max_workers,
+        "pair_spill_threshold": plan.pair_spill_threshold,
+        "clustering_strategy": plan.clustering_strategy,
     }

--- a/packages/python/goldenmatch/tests/test_execution_plan_observability.py
+++ b/packages/python/goldenmatch/tests/test_execution_plan_observability.py
@@ -1,0 +1,170 @@
+"""Phase 6: ExecutionPlan surfaces on every consumer-facing channel.
+
+Spec §Observability: planner decisions must be observable from CLI, MCP,
+web telemetry, and PostflightReport string rendering.
+"""
+from __future__ import annotations
+
+import goldenmatch as gm
+import polars as pl
+from goldenmatch.cli._controller_render import (
+    _execution_plan,
+    _execution_plan_short,
+    render_short_status,
+)
+from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+from goldenmatch.core.autoconfig_history import RunHistory
+from goldenmatch.core.execution_plan import ExecutionPlan
+from goldenmatch.web.controller_telemetry import serialize_telemetry
+
+
+def _df() -> pl.DataFrame:
+    return pl.DataFrame({
+        "name": ["alice", "alyce", "bob", "robert"] * 20,
+        "email": [f"u{i}@x.com" for i in range(80)],
+    })
+
+
+# ── PostflightReport.__str__ ────────────────────────────────────────────────
+
+
+def test_postflight_str_includes_plan_line_after_dedupe():
+    """Running zero-config dedupe should leave a 'Plan: ...' line in the
+    PostflightReport string render (the line CLI shows to users)."""
+    result = gm.dedupe_df(_df())
+    pf = result.postflight_report
+    assert pf is not None, "zero-config dedupe should have PostflightReport"
+    rendered = str(pf)
+    assert "Plan:" in rendered, (
+        f"PostflightReport.__str__ should surface the ExecutionPlan; "
+        f"got:\n{rendered}"
+    )
+    assert "backend=" in rendered
+
+
+def test_postflight_str_omits_plan_line_when_history_absent():
+    """Hand-written-config path: no controller_history -> no Plan line."""
+    from goldenmatch.core.autoconfig_verify import PostflightReport
+
+    pf = PostflightReport()
+    assert "Plan:" not in str(pf)
+
+
+# ── web/controller_telemetry.serialize_telemetry ───────────────────────────
+
+
+def test_serialize_telemetry_includes_execution_plan_key():
+    """Every cross-surface telemetry consumer reads through this serializer
+    (per CLAUDE.md). The execution_plan key must be present."""
+    history = RunHistory()
+    history.execution_plan = ExecutionPlan(
+        backend="chunked",
+        chunk_size=250_000,
+        max_workers=16,
+        pair_spill_threshold="ram",
+        clustering_strategy="in_memory",
+        rule_name="plan_selected_chunked",
+    )
+    blob = serialize_telemetry(
+        profile=None,
+        history=history,
+        committed_config=None,
+        source=None,
+        run_name=None,
+        recorded_at=None,
+    )
+    assert "execution_plan" in blob
+    plan_dict = blob["execution_plan"]
+    assert plan_dict is not None
+    assert plan_dict["rule_name"] == "plan_selected_chunked"
+    assert plan_dict["backend"] == "chunked"
+    assert plan_dict["chunk_size"] == 250_000
+    assert plan_dict["max_workers"] == 16
+    assert plan_dict["pair_spill_threshold"] == "ram"
+    assert plan_dict["clustering_strategy"] == "in_memory"
+
+
+def test_serialize_telemetry_returns_none_for_pre_v3_history():
+    """Histories without execution_plan field still serialize cleanly."""
+    history = RunHistory()  # execution_plan default = None
+    blob = serialize_telemetry(
+        profile=None,
+        history=history,
+        committed_config=None,
+        source=None,
+        run_name=None,
+        recorded_at=None,
+    )
+    assert blob["execution_plan"] is None
+
+
+def test_serialize_telemetry_no_history_returns_none():
+    blob = serialize_telemetry(
+        profile=None,
+        history=None,
+        committed_config=None,
+        source=None,
+        run_name=None,
+        recorded_at=None,
+    )
+    assert blob["execution_plan"] is None
+
+
+# ── CLI _controller_render ────────────────────────────────────────────────
+
+
+def test_cli_execution_plan_renders_rule_and_backend():
+    history = RunHistory()
+    history.execution_plan = ExecutionPlan(
+        backend="duckdb",
+        max_workers=8,
+        pair_spill_threshold="duckdb",
+        clustering_strategy="partitioned_union_find",
+        rule_name="plan_selected_duckdb",
+    )
+    row = _execution_plan(history)
+    assert row is not None
+    # Rich Text -- inspect plain text (markup stripped).
+    plain = row.plain
+    assert "plan_selected_duckdb" in plain
+    assert "duckdb" in plain
+    assert "max_workers=8" in plain
+    # non-default clustering is shown
+    assert "partitioned_union_find" in plain
+
+
+def test_cli_execution_plan_omits_default_clustering():
+    """In-memory clustering is the default; don't clutter the panel with it."""
+    history = RunHistory()
+    history.execution_plan = ExecutionPlan(
+        backend="polars-direct",
+        max_workers=4,
+        rule_name="plan_selected_simple",
+    )
+    row = _execution_plan(history)
+    assert row is not None
+    assert "clustering=" not in row.plain
+
+
+def test_cli_execution_plan_returns_none_when_history_missing():
+    assert _execution_plan(None) is None
+
+
+def test_cli_execution_plan_short_returns_one_token():
+    history = RunHistory()
+    history.execution_plan = ExecutionPlan(
+        backend="ray",
+        rule_name="plan_selected_ray",
+    )
+    assert _execution_plan_short(history) == "plan=plan_selected_ray/ray"
+
+
+def test_cli_render_short_status_includes_plan_token():
+    """End-to-end: render_short_status surfaces the plan alongside health
+    and stop_reason so a CI log line carries the full controller verdict."""
+    gm.dedupe_df(_df())
+    state = _LAST_CONTROLLER_RUN.get()
+    assert state is not None
+    _profile, history = state
+    line = render_short_status(profile=_profile, history=history, committed_config=None)
+    assert "plan=" in line


### PR DESCRIPTION
## Summary

Phase 6 of the controller v3 planner ([plan](docs/superpowers/plans/2026-05-15-controller-v3-planner.md)). Surfaces \`ExecutionPlan\` on every consumer-facing channel so users can answer "which plan did goldenmatch pick?" without diving into \`controller_history.execution_plan\`.

**Stacked on #264** (Phase 5 recovery). Base = \`perf/controller-v3-phase-5-recovery\`.

- \`PostflightReport.__str__\` — new \`Plan: <rule> -> backend=<X>\` line after the Memory line.
- \`web/controller_telemetry.serialize_telemetry\` — new \`execution_plan\` key. Per CLAUDE.md "single serializer surface" rule, this auto-threads into web \`/api/v1/controller/telemetry\`, MCP \`auto_configure\` + agent tools, and TUI Controller tab.
- \`cli/_controller_render\` — \`_execution_plan\` Rich row in \`render_controller_panel\`; \`_execution_plan_short\` adds \`plan=<rule>/<backend>\` to \`render_short_status\` (CI log line).

Default \`clustering_strategy=in_memory\` is omitted from the rendering to keep the panel readable; non-default values (\`partitioned_union_find\`, \`streaming_cc\`) are surfaced.

## Test plan

- [x] 10 new tests covering PostflightReport string, serialize_telemetry dict, CLI Rich row + short status.
- [x] Tests cover the absence path (no history -> no plan).
- [x] Full suite: 2478 passed / 5 skipped.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)