### PR TITLE
fix(ci): drop redundant pip install psutil from scale-audit-5m

### DIFF
--- a/.github/workflows/scale-audit-5m.yml
+++ b/.github/workflows/scale-audit-5m.yml
@@ -45,13 +45,11 @@ jobs:
         run: pip install uv
 
       - name: Sync workspace
+        # psutil (used by scripts/scale_audit_5m.py for peak-RSS polling) is
+        # a declared goldenmatch dep as of Phase 1 of controller v3 -- the
+        # separate ".venv/bin/python -m pip install psutil" step that used
+        # to live here was both redundant AND broken on uv venvs (no pip).
         run: uv sync --all-packages
-
-      - name: Install audit-only deps
-        # psutil is used by scripts/scale_audit_5m.py for peak-RSS polling.
-        # Not a declared workspace dep; installed here so the audit script
-        # doesn't have to be patched into pyproject.toml just for one runner.
-        run: .venv/bin/python -m pip install psutil
 
       - name: Generate ${{ inputs.n_records }}-row fixture
         run: |


### PR DESCRIPTION
## Summary

The scale-audit-5m workflow had a leftover `Install audit-only deps` step that ran `.venv/bin/python -m pip install psutil` after `uv sync`. Two problems:

1. **Broken on uv venvs** — uv venvs don't ship pip, so the step errors with `No module named pip` (run [#25965561311](https://github.com/benseverndev-oss/goldenmatch/actions/runs/25965561311)).
2. **Redundant** — psutil is a declared `goldenmatch` dep as of Phase 1 of controller v3 (`pyproject.toml: psutil>=5.9`, PR #259), so `uv sync --all-packages` already installs it.

This drops the broken step and lets `uv sync` cover psutil.

## Test plan

- [x] Sanity: the audit script just imports `psutil` at top-level; if uv sync doesn't install it the very next step fails fast.
- [ ] Validate by re-dispatching `scale-audit-5m` once this lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
