### PR TITLE
feat(autoconfig): controller-budget pathology -- Phase 1 (ControllerBudget.for_dataset)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -240,6 +240,30 @@ class ControllerBudget:
     converge_epsilon: float = 0.05
     drift_threshold: float = 0.30
 
+    @classmethod
+    def for_dataset(cls, n_rows: int) -> ControllerBudget:
+        """Calibrate budget + sample size to the input row count.
+
+        Spec §Design / ControllerBudget.for_dataset. Sqrt-scaling above
+        100K preserves expected dup-pair density in the sample within an
+        order of magnitude as N grows from 100K -> 1M. Cap at 20K so
+        sample-iteration cost stays bounded above 1M.
+
+        Tiers (n_rows -> max_seconds, sample_size_default):
+          - <5K        -> 15s, 2K (sample_skip_below bypasses sampling)
+          - 5K-100K    -> 30s, 2K (historical defaults; preserves 100K bench)
+          - 100K-1M    -> 60s, int(sqrt(n) * 20) capped at 20K
+          - >=1M       -> 120s, 20K (capped)
+        """
+        if n_rows < 5_000:
+            return cls(max_seconds=15.0)
+        if n_rows < 100_000:
+            return cls()  # historical defaults
+        if n_rows < 1_000_000:
+            sample = min(int((n_rows**0.5) * 20), 20_000)
+            return cls(sample_size_default=sample, max_seconds=60.0)
+        return cls(sample_size_default=20_000, max_seconds=120.0)
+
 
 class AutoConfigController:
     """Drives iterative refit: pathological-input gates, sampling, policy loop, finalize."""

--- a/packages/python/goldenmatch/tests/test_controller_budget_for_dataset.py
+++ b/packages/python/goldenmatch/tests/test_controller_budget_for_dataset.py
@@ -1,0 +1,75 @@
+"""Unit tests for ControllerBudget.for_dataset(n_rows).
+
+Spec §Design / ControllerBudget.for_dataset:
+docs/superpowers/specs/2026-05-16-controller-budget-vs-blocking-discovery-design.md.
+
+Pure function -- no side effects, table-driven, trivially testable.
+"""
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig_controller import ControllerBudget
+
+
+def test_for_dataset_below_5k_returns_tight_budget():
+    """At <5K, sample_skip_below kicks in (full df) -- max_seconds tight."""
+    b = ControllerBudget.for_dataset(100)
+    assert b.max_seconds == 15.0
+    assert b.sample_size_default == 2000  # default; doesn't matter at this N
+
+
+def test_for_dataset_10k_returns_historical_defaults():
+    """5K-100K: today's defaults (30s / 2K). Preserves 100K bench wall."""
+    b = ControllerBudget.for_dataset(10_000)
+    assert b.max_seconds == 30.0
+    assert b.sample_size_default == 2000
+
+
+def test_for_dataset_at_100k_boundary_lands_in_new_tier():
+    """100K exactly hits the >=100K branch. New tier: sqrt-scaled sample,
+    60s budget. Bench gate (Phase 5) is calibrated for this."""
+    b = ControllerBudget.for_dataset(100_000)
+    assert b.max_seconds == 60.0
+    # sqrt(100_000) * 20 = 6324.555..., int() => 6324
+    assert b.sample_size_default == 6324
+
+
+def test_for_dataset_500k_sqrt_scaled():
+    """500K: sqrt-scaled sample preserves expected dup-pair signal density."""
+    b = ControllerBudget.for_dataset(500_000)
+    assert b.max_seconds == 60.0
+    # sqrt(500_000) * 20 = 14142.135..., int() => 14142
+    assert b.sample_size_default == 14142
+
+
+def test_for_dataset_at_1m_boundary_caps_sample_at_20k():
+    """At 1M exactly, hit the cap branch. sample_size capped at 20K to
+    keep sample-iteration cost bounded."""
+    b = ControllerBudget.for_dataset(1_000_000)
+    assert b.max_seconds == 120.0
+    assert b.sample_size_default == 20_000
+
+
+def test_for_dataset_10m_caps_at_20k():
+    """Above 1M, sample stays at the cap (no further growth)."""
+    b = ControllerBudget.for_dataset(10_000_000)
+    assert b.max_seconds == 120.0
+    assert b.sample_size_default == 20_000
+
+
+def test_for_dataset_returns_new_instance_each_call():
+    """Pure function; no shared state across calls."""
+    b1 = ControllerBudget.for_dataset(50_000)
+    b2 = ControllerBudget.for_dataset(50_000)
+    assert b1 is not b2
+    assert b1 == b2  # but equal
+
+
+def test_for_dataset_preserves_other_budget_fields():
+    """Only sample_size_default and max_seconds vary by tier; the rest
+    (max_iterations, sample_skip_below, converge_epsilon, drift_threshold)
+    keep their defaults so the iteration loop's other tuning stays stable."""
+    b = ControllerBudget.for_dataset(500_000)
+    assert b.max_iterations == 3
+    assert b.sample_skip_below == 5000
+    assert b.converge_epsilon == 0.05
+    assert b.drift_threshold == 0.30


### PR DESCRIPTION
## Summary

Phase 1 of the controller-budget-pathology plan ([plan](docs/superpowers/plans/2026-05-16-controller-budget-pathology.md), [spec](docs/superpowers/specs/2026-05-16-controller-budget-vs-blocking-discovery-design.md)). Pure function, no wiring.

`ControllerBudget.for_dataset(n_rows)` classmethod returns a tier-calibrated budget:

| `n_rows` | `max_seconds` | `sample_size_default` |
|---|---|---|
| <5K | 15s | (sampling bypassed) |
| 5K-100K | 30s | 2K (today's defaults) |
| 100K-1M | 60s | sqrt(n)*20 capped at 20K |
| >=1M | 120s | 20K |

Sqrt-scaling preserves expected dup-pair density within an order of magnitude over 100K -> 1M (~158 -> ~500 expected pairs at 0.5% dup rate).

Phase 4 will thread this into `auto_configure_df` via `ControllerBudget.for_dataset(df.height)`.

## Test plan

- [x] 8 new unit tests cover every tier boundary + immutability + preserved-fields invariant. All 8 passed locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
