### PR TITLE
feat(autoconfig): controller-budget pathology -- Phase 2 (exception + helper)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -147,6 +147,75 @@ class ConfigValidationError(Exception):
     """Raised when input data is unworkable for ER (empty, all-null, etc.)."""
 
 
+class ControllerNotConfidentError(Exception):
+    """Raised when AutoConfigController committed a RED-health config on
+    a large input (df.height >= REFUSE_AT_N). Carries the failing
+    sub-profile + a DOCS_URL so the caller can recover programmatically.
+
+    Spec: docs/superpowers/specs/2026-05-16-controller-budget-vs-
+    blocking-discovery-design.md §Design / Confidence gate.
+
+    The exception deliberately does NOT carry a "suggested config"
+    because the only material the controller has to suggest from is
+    config_v0 + the priors that produced the RED commit -- handing those
+    back as a suggestion is a footgun (looks authoritative; isn't).
+    """
+
+    DOCS_URL = (
+        "https://github.com/benseverndev-oss/goldenmatch/blob/main/"
+        "docs/explicit-config.md"
+    )
+
+    def __init__(
+        self,
+        *,
+        n_rows: int,
+        failing_sub_profile: str,
+        stop_reason: str,
+    ) -> None:
+        self.n_rows = n_rows
+        self.failing_sub_profile = failing_sub_profile
+        self.stop_reason = stop_reason
+        super().__init__(
+            f"AutoConfigController committed a RED config on a "
+            f"{n_rows}-row input (failing sub-profile: {failing_sub_profile}, "
+            f"stop_reason: {stop_reason}). Running this config would produce "
+            f"degenerate dedupe; passing it back instead of running. "
+            f"Options: pass an explicit GoldenMatchConfig, lower the matchkey "
+            f"threshold, or re-call with confidence_required=False. See "
+            f"{self.DOCS_URL}."
+        )
+
+
+# Priority order for failing-sub-profile diagnostics: root causes
+# upstream first. Spec §Design / Confidence gate.
+_SUBPROFILE_PRIORITY_ORDER = ("data", "blocking", "scoring", "matchkey", "cluster")
+
+
+def _identify_failing_subprofile(profile: ComplexityProfile) -> str:  # pyright: ignore[reportUnusedFunction]
+    """Walk the ComplexityProfile sub-profiles in priority order; return
+    the name of the first one reporting RED. Returns '' when none are
+    RED (defensive -- the confidence gate's RED precondition guarantees
+    at least one will be).
+
+    Priority order [data, blocking, scoring, matchkey, cluster] surfaces
+    upstream causes first: if data is RED, blocking RED is a consequence;
+    if blocking is RED, scoring RED is a consequence; etc.
+    """
+    n_rows = profile.data.n_rows
+    health_calls = {
+        "data": lambda: profile.data.health(),
+        "blocking": lambda: profile.blocking.health(n_rows=n_rows),
+        "scoring": lambda: profile.scoring.health(),
+        "matchkey": lambda: profile.matchkey.health(),
+        "cluster": lambda: profile.cluster.health(n_rows=n_rows),
+    }
+    for name in _SUBPROFILE_PRIORITY_ORDER:
+        if health_calls[name]() == HealthVerdict.RED:
+            return name
+    return ""
+
+
 def _assemble_v0_history_entry(
     sample: pl.DataFrame,
     reference: pl.DataFrame | None,

--- a/packages/python/goldenmatch/tests/test_controller_not_confident_error.py
+++ b/packages/python/goldenmatch/tests/test_controller_not_confident_error.py
@@ -1,0 +1,62 @@
+"""Unit tests for ControllerNotConfidentError.
+
+Spec §Design / Confidence gate -- exception construction, structured
+fields, DOCS_URL class attribute. No suggested_config field (footgun).
+"""
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig_controller import ControllerNotConfidentError
+
+
+def test_exception_carries_structured_fields():
+    exc = ControllerNotConfidentError(
+        n_rows=500_000,
+        failing_sub_profile="scoring",
+        stop_reason="BUDGET_TIME",
+    )
+    assert exc.n_rows == 500_000
+    assert exc.failing_sub_profile == "scoring"
+    assert exc.stop_reason == "BUDGET_TIME"
+
+
+def test_exception_has_docs_url_class_attribute():
+    """DOCS_URL is a class attribute so callers can reference it without
+    catching the exception first."""
+    assert hasattr(ControllerNotConfidentError, "DOCS_URL")
+    assert isinstance(ControllerNotConfidentError.DOCS_URL, str)
+    assert ControllerNotConfidentError.DOCS_URL.startswith("https://")
+
+
+def test_exception_str_rendering_includes_diagnostic_fields():
+    exc = ControllerNotConfidentError(
+        n_rows=500_000,
+        failing_sub_profile="scoring",
+        stop_reason="BUDGET_TIME",
+    )
+    rendered = str(exc)
+    assert "500000" in rendered or "500_000" in rendered
+    assert "scoring" in rendered
+    assert "BUDGET_TIME" in rendered
+    # The error tells the caller how to recover -- this is load-bearing
+    # for users seeing the exception cold without context.
+    assert "confidence_required=False" in rendered
+    assert ControllerNotConfidentError.DOCS_URL in rendered
+
+
+def test_exception_has_no_suggested_config_field():
+    """Spec deliberately omits suggested_config (footgun: 'suggestion'
+    derived from the config that just produced the RED commit). Verify
+    the field is NOT present so a future refactor can't silently
+    re-introduce it without the spec change."""
+    exc = ControllerNotConfidentError(
+        n_rows=500_000,
+        failing_sub_profile="scoring",
+        stop_reason="BUDGET_TIME",
+    )
+    assert not hasattr(exc, "suggested_config")
+
+
+def test_exception_is_exception_subclass():
+    """Plain Exception, not subclass of ValueError / RuntimeError. Caller
+    catches by type, not by hierarchy."""
+    assert issubclass(ControllerNotConfidentError, Exception)

--- a/packages/python/goldenmatch/tests/test_identify_failing_subprofile.py
+++ b/packages/python/goldenmatch/tests/test_identify_failing_subprofile.py
@@ -1,0 +1,106 @@
+"""Unit tests for _identify_failing_subprofile.
+
+Spec §Design / Confidence gate -- priority order [data, blocking,
+scoring, matchkey, cluster] (root causes upstream first).
+"""
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig_controller import _identify_failing_subprofile
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ClusterProfile,
+    ComplexityProfile,
+    DataProfile,
+    MatchkeyProfile,
+    ProfileMeta,
+    ScoringProfile,
+)
+
+
+def _green_profile() -> ComplexityProfile:
+    """Builds a profile where every sub-profile reports GREEN."""
+    return ComplexityProfile(
+        data=DataProfile(n_rows=1000, n_cols=3, column_types={
+            "a": "text", "b": "text", "c": "text",
+        }),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=10, total_comparisons=100,
+            reduction_ratio=0.9, block_sizes_p50=10, block_sizes_p95=15,
+            block_sizes_p99=20, block_sizes_max=25,
+            singleton_block_count=0, oversized_block_count=0,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=100, candidates_compared=100,
+            mass_above_threshold=0.5, mass_in_borderline=0.1,
+            dip_statistic=0.01,
+        ),
+        matchkey=MatchkeyProfile(),
+        cluster=ClusterProfile(),
+        meta=ProfileMeta(
+            iteration=0, is_sample=False, sample_size=1000,
+            n_rows_full=1000, wall_clock_ms=0, seed=0,
+        ),
+    )
+
+
+def test_data_red_returns_data():
+    """Data sub-profile RED (n_rows == 0) -> 'data'."""
+    p = _green_profile()
+    import dataclasses
+    p = dataclasses.replace(p, data=DataProfile(n_rows=0))
+    assert _identify_failing_subprofile(p) == "data"
+
+
+def test_blocking_red_returns_blocking():
+    """Blocking sub-profile RED (n_blocks == 0) -> 'blocking'."""
+    p = _green_profile()
+    import dataclasses
+    bp = BlockingProfile()  # n_blocks=0 default -> RED via health()
+    p = dataclasses.replace(p, blocking=bp)
+    assert _identify_failing_subprofile(p) == "blocking"
+
+
+def test_scoring_red_returns_scoring():
+    """Scoring RED (mass_above_threshold == 0 with candidates compared)."""
+    p = _green_profile()
+    import dataclasses
+    sp = ScoringProfile(
+        n_pairs_scored=100, candidates_compared=100,
+        mass_above_threshold=0.0, mass_in_borderline=0.1,
+    )
+    p = dataclasses.replace(p, scoring=sp)
+    assert _identify_failing_subprofile(p) == "scoring"
+
+
+def test_priority_order_data_beats_blocking():
+    """When multiple sub-profiles RED, data wins (root cause upstream)."""
+    p = _green_profile()
+    import dataclasses
+    p = dataclasses.replace(
+        p,
+        data=DataProfile(n_rows=0),               # RED
+        blocking=BlockingProfile(),               # RED
+    )
+    assert _identify_failing_subprofile(p) == "data"
+
+
+def test_priority_order_blocking_beats_scoring():
+    """Blocking RED + Scoring RED -> 'blocking' (upstream cause)."""
+    p = _green_profile()
+    import dataclasses
+    p = dataclasses.replace(
+        p,
+        blocking=BlockingProfile(),
+        scoring=ScoringProfile(
+            n_pairs_scored=0, candidates_compared=0,
+        ),
+    )
+    assert _identify_failing_subprofile(p) == "blocking"
+
+
+def test_all_green_returns_empty_string():
+    """Defensive: gate's RED-precondition means this shouldn't happen,
+    but the helper must not raise. Returns '' so the error message
+    degrades gracefully."""
+    p = _green_profile()
+    assert _identify_failing_subprofile(p) == ""


### PR DESCRIPTION
## Summary

Phase 2 of the controller-budget-pathology plan. Two pure additions; no wiring. Phase 3 calls them from inside `AutoConfigController.run`.

- `ControllerNotConfidentError` — structured exception. Fields: `n_rows`, `failing_sub_profile`, `stop_reason`. `DOCS_URL` class attr. **Deliberately no `suggested_config`** field (spec footgun rationale).
- `_identify_failing_subprofile(ComplexityProfile) -> str` — priority order `[data, blocking, scoring, matchkey, cluster]` (root causes upstream first). Returns `''` when no sub-profile is RED (defensive).

Spec section: §Design / Confidence gate.

## Test plan

- [x] 11 new tests: 5 exception construction + 6 helper priority order.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
