### PR TITLE
feat(autoconfig): controller-budget pathology -- Phase 3 (confidence gate in run())

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -147,6 +147,75 @@ class ConfigValidationError(Exception):
     """Raised when input data is unworkable for ER (empty, all-null, etc.)."""
 
 
+class ControllerNotConfidentError(Exception):
+    """Raised when AutoConfigController committed a RED-health config on
+    a large input (df.height >= REFUSE_AT_N). Carries the failing
+    sub-profile + a DOCS_URL so the caller can recover programmatically.
+
+    Spec: docs/superpowers/specs/2026-05-16-controller-budget-vs-
+    blocking-discovery-design.md §Design / Confidence gate.
+
+    The exception deliberately does NOT carry a "suggested config"
+    because the only material the controller has to suggest from is
+    config_v0 + the priors that produced the RED commit -- handing those
+    back as a suggestion is a footgun (looks authoritative; isn't).
+    """
+
+    DOCS_URL = (
+        "https://github.com/benseverndev-oss/goldenmatch/blob/main/"
+        "docs/explicit-config.md"
+    )
+
+    def __init__(
+        self,
+        *,
+        n_rows: int,
+        failing_sub_profile: str,
+        stop_reason: str,
+    ) -> None:
+        self.n_rows = n_rows
+        self.failing_sub_profile = failing_sub_profile
+        self.stop_reason = stop_reason
+        super().__init__(
+            f"AutoConfigController committed a RED config on a "
+            f"{n_rows}-row input (failing sub-profile: {failing_sub_profile}, "
+            f"stop_reason: {stop_reason}). Running this config would produce "
+            f"degenerate dedupe; passing it back instead of running. "
+            f"Options: pass an explicit GoldenMatchConfig, lower the matchkey "
+            f"threshold, or re-call with confidence_required=False. See "
+            f"{self.DOCS_URL}."
+        )
+
+
+# Priority order for failing-sub-profile diagnostics: root causes
+# upstream first. Spec §Design / Confidence gate.
+_SUBPROFILE_PRIORITY_ORDER = ("data", "blocking", "scoring", "matchkey", "cluster")
+
+
+def _identify_failing_subprofile(profile: ComplexityProfile) -> str:  # pyright: ignore[reportUnusedFunction]
+    """Walk the ComplexityProfile sub-profiles in priority order; return
+    the name of the first one reporting RED. Returns '' when none are
+    RED (defensive -- the confidence gate's RED precondition guarantees
+    at least one will be).
+
+    Priority order [data, blocking, scoring, matchkey, cluster] surfaces
+    upstream causes first: if data is RED, blocking RED is a consequence;
+    if blocking is RED, scoring RED is a consequence; etc.
+    """
+    n_rows = profile.data.n_rows
+    health_calls = {
+        "data": lambda: profile.data.health(),
+        "blocking": lambda: profile.blocking.health(n_rows=n_rows),
+        "scoring": lambda: profile.scoring.health(),
+        "matchkey": lambda: profile.matchkey.health(),
+        "cluster": lambda: profile.cluster.health(n_rows=n_rows),
+    }
+    for name in _SUBPROFILE_PRIORITY_ORDER:
+        if health_calls[name]() == HealthVerdict.RED:
+            return name
+    return ""
+
+
 def _assemble_v0_history_entry(
     sample: pl.DataFrame,
     reference: pl.DataFrame | None,

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -38,6 +38,13 @@ logger = logging.getLogger(__name__)
 # Sentinel: forces RED via DataProfile.health() when n_rows == 0.
 _RED_PROFILE: ComplexityProfile = ComplexityProfile(data=DataProfile(n_rows=0))
 
+# Confidence gate threshold (Phase 3 of controller-budget-pathology spec).
+# Back-projected from the 500K -> ~26 min measured wall on synthetic
+# surname fixtures: committing a RED config on a large input produces
+# degenerate full-data dedupe. 100K is the safe upper bound below which
+# the pipeline still completes in a tolerable wall-clock window.
+REFUSE_AT_N: int = 100_000
+
 # ContextVar populated at every exit path of AutoConfigController.run()
 # (including KeyboardInterrupt) so callers can inspect RunHistory after
 # either normal return or exception.  Stores RunHistory directly
@@ -331,6 +338,7 @@ class AutoConfigController:
         reference: pl.DataFrame | None = None,
         v0_kwargs: dict | None = None,
         skip_finalize: bool = False,
+        confidence_required: bool = True,
     ) -> tuple[GoldenMatchConfig, ComplexityProfile, RunHistory]:
         """Run iterative auto-config.
 
@@ -524,6 +532,32 @@ class AutoConfigController:
             )
             _LAST_CONTROLLER_RUN.set(history)
             return config_v0, _RED_PROFILE, history
+
+        # Confidence gate (Phase 3 of controller-budget pathology spec).
+        # When the controller committed a RED entry on a large input,
+        # running the full pipeline would produce ~26-min degenerate
+        # dedupe. Refuse loudly instead. Spec §Design / Confidence gate.
+        if (
+            confidence_required
+            and df.height >= REFUSE_AT_N
+            and best_entry.profile.health() == HealthVerdict.RED
+        ):
+            failing = _identify_failing_subprofile(best_entry.profile)
+            # ``_LAST_CONTROLLER_RUN`` here is the CONTROLLER-LOCAL ContextVar
+            # defined at the top of this file (line ~45), NOT the
+            # ``(profile, history)`` tuple ContextVar in ``autoconfig.py``.
+            # Mirror the existing pattern (line 456, line 549) that sets it
+            # right before each return.
+            _LAST_CONTROLLER_RUN.set(history)  # surface history before raise
+            raise ControllerNotConfidentError(
+                n_rows=df.height,
+                failing_sub_profile=failing,
+                stop_reason=(
+                    history.stop_reason.name
+                    if history.stop_reason
+                    else "unset"
+                ),
+            )
 
         # Task 6.1: stamp committed profile with eager column_priors + indicators.
         import dataclasses

--- a/packages/python/goldenmatch/tests/test_controller_confidence_gate.py
+++ b/packages/python/goldenmatch/tests/test_controller_confidence_gate.py
@@ -1,0 +1,152 @@
+"""Unit tests for the confidence gate inside AutoConfigController.run.
+
+Spec §Design / Confidence gate. Gate fires when:
+    confidence_required=True
+    AND df.height >= REFUSE_AT_N
+    AND best_entry.profile.health() == RED.
+
+These tests use a monkey-patched pick_committed to force RED entries
+without needing a real 100K fixture. Phase 5 adds an end-to-end test
+that exercises the real iteration loop.
+"""
+from __future__ import annotations
+
+import goldenmatch as gm
+import polars as pl
+import pytest
+from goldenmatch.core.autoconfig_controller import (
+    REFUSE_AT_N,
+    ControllerNotConfidentError,
+)
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ComplexityProfile,
+    DataProfile,
+    ProfileMeta,
+    ScoringProfile,
+)
+
+
+@pytest.fixture(autouse=True)
+def _disable_autoconfig_memory(monkeypatch):
+    """Match the integration-test convention: prevent cross-run cache
+    short-circuits from affecting these gate tests."""
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+
+
+def _force_red_history_entry(monkeypatch, n_rows_in_df: int):
+    """Replace RunHistory.pick_committed with a callable returning a
+    forced-RED HistoryEntry."""
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    from goldenmatch.core.autoconfig_history import HistoryEntry, RunHistory
+    from goldenmatch.core.complexity_profile import HealthVerdict
+
+    red_profile = ComplexityProfile(
+        data=DataProfile(n_rows=0),  # n_rows==0 forces data.health() == RED
+        blocking=BlockingProfile(),
+        scoring=ScoringProfile(),
+        meta=ProfileMeta(
+            iteration=0, is_sample=False, sample_size=n_rows_in_df,
+            n_rows_full=n_rows_in_df, wall_clock_ms=0, seed=0,
+        ),
+    )
+    assert red_profile.health() == HealthVerdict.RED  # sanity
+
+    # A minimal config is required so the code paths after the confidence
+    # gate (Task 6.1 stamp, LLM decorator, planner) can access
+    # best_entry.config.blocking without AttributeError when the gate
+    # doesn't fire (below-threshold or non-RED cases).
+    _minimal_config = GoldenMatchConfig()
+
+    def _picker(self, *args, **kwargs):
+        return HistoryEntry(
+            iteration=0,
+            config=_minimal_config,
+            profile=red_profile,
+            decision=None,
+            error=None,
+            wall_clock_ms=0,
+        )
+
+    monkeypatch.setattr(RunHistory, "pick_committed", _picker)
+
+
+def _df(n_rows: int) -> pl.DataFrame:
+    """Minimum-shape df where only df.height matters for the gate."""
+    return pl.DataFrame({
+        "name": ["alice"] * n_rows,
+        "email": [f"u{i}@x.com" for i in range(n_rows)],
+    })
+
+
+def test_refuse_at_n_constant_is_100k():
+    assert REFUSE_AT_N == 100_000
+
+
+def test_gate_fires_on_red_at_or_above_threshold(monkeypatch):
+    """df.height = REFUSE_AT_N exactly + RED -> raise."""
+    _force_red_history_entry(monkeypatch, n_rows_in_df=REFUSE_AT_N)
+    df = _df(REFUSE_AT_N)
+    with pytest.raises(ControllerNotConfidentError) as exc_info:
+        gm.dedupe_df(df)
+    assert exc_info.value.n_rows == REFUSE_AT_N
+    assert exc_info.value.failing_sub_profile == "data"
+
+
+def test_gate_does_not_fire_below_threshold(monkeypatch):
+    """df.height < REFUSE_AT_N + RED -> warn-and-run (current behavior)."""
+    n = REFUSE_AT_N - 1
+    _force_red_history_entry(monkeypatch, n_rows_in_df=n)
+    df = _df(n)
+    result = gm.dedupe_df(df)
+    assert result is not None
+
+
+def test_gate_does_not_fire_on_yellow_or_green(monkeypatch):
+    """Only RED triggers the gate. YELLOW/GREEN at large N: proceed."""
+    from goldenmatch.core.autoconfig_history import HistoryEntry, RunHistory
+
+    green_profile = ComplexityProfile(
+        data=DataProfile(n_rows=REFUSE_AT_N, n_cols=3, column_types={
+            "a": "text", "b": "text", "c": "text",
+        }),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=10, total_comparisons=100,
+            reduction_ratio=0.9, block_sizes_p50=10, block_sizes_p95=15,
+            block_sizes_p99=20, block_sizes_max=25,
+            singleton_block_count=0, oversized_block_count=0,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=100, candidates_compared=100,
+            mass_above_threshold=0.5, mass_in_borderline=0.1,
+            dip_statistic=0.05,  # avoid RED: health() returns RED when dip<0.005
+        ),
+        meta=ProfileMeta(
+            iteration=0, is_sample=False, sample_size=REFUSE_AT_N,
+            n_rows_full=REFUSE_AT_N, wall_clock_ms=0, seed=0,
+        ),
+    )
+
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    _minimal_config = GoldenMatchConfig()
+
+    def _picker(self, *args, **kwargs):
+        return HistoryEntry(
+            iteration=0, config=_minimal_config, profile=green_profile,
+            decision=None, error=None, wall_clock_ms=0,
+        )
+
+    monkeypatch.setattr(RunHistory, "pick_committed", _picker)
+    df = _df(REFUSE_AT_N)
+    result = gm.dedupe_df(df)  # should NOT raise
+    assert result is not None
+
+
+@pytest.mark.skip(reason="confidence_required kwarg lands in Phase 4")
+def test_gate_short_circuits_with_confidence_required_false(monkeypatch):
+    """Spec §Backward compatibility: kwarg opt-out preserves today's
+    warn-and-run behavior. Un-skipped in Phase 4."""
+    _force_red_history_entry(monkeypatch, n_rows_in_df=REFUSE_AT_N)
+    df = _df(REFUSE_AT_N)
+    result = gm.dedupe_df(df, confidence_required=False)
+    assert result is not None

--- a/packages/python/goldenmatch/tests/test_controller_not_confident_error.py
+++ b/packages/python/goldenmatch/tests/test_controller_not_confident_error.py
@@ -1,0 +1,62 @@
+"""Unit tests for ControllerNotConfidentError.
+
+Spec §Design / Confidence gate -- exception construction, structured
+fields, DOCS_URL class attribute. No suggested_config field (footgun).
+"""
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig_controller import ControllerNotConfidentError
+
+
+def test_exception_carries_structured_fields():
+    exc = ControllerNotConfidentError(
+        n_rows=500_000,
+        failing_sub_profile="scoring",
+        stop_reason="BUDGET_TIME",
+    )
+    assert exc.n_rows == 500_000
+    assert exc.failing_sub_profile == "scoring"
+    assert exc.stop_reason == "BUDGET_TIME"
+
+
+def test_exception_has_docs_url_class_attribute():
+    """DOCS_URL is a class attribute so callers can reference it without
+    catching the exception first."""
+    assert hasattr(ControllerNotConfidentError, "DOCS_URL")
+    assert isinstance(ControllerNotConfidentError.DOCS_URL, str)
+    assert ControllerNotConfidentError.DOCS_URL.startswith("https://")
+
+
+def test_exception_str_rendering_includes_diagnostic_fields():
+    exc = ControllerNotConfidentError(
+        n_rows=500_000,
+        failing_sub_profile="scoring",
+        stop_reason="BUDGET_TIME",
+    )
+    rendered = str(exc)
+    assert "500000" in rendered or "500_000" in rendered
+    assert "scoring" in rendered
+    assert "BUDGET_TIME" in rendered
+    # The error tells the caller how to recover -- this is load-bearing
+    # for users seeing the exception cold without context.
+    assert "confidence_required=False" in rendered
+    assert ControllerNotConfidentError.DOCS_URL in rendered
+
+
+def test_exception_has_no_suggested_config_field():
+    """Spec deliberately omits suggested_config (footgun: 'suggestion'
+    derived from the config that just produced the RED commit). Verify
+    the field is NOT present so a future refactor can't silently
+    re-introduce it without the spec change."""
+    exc = ControllerNotConfidentError(
+        n_rows=500_000,
+        failing_sub_profile="scoring",
+        stop_reason="BUDGET_TIME",
+    )
+    assert not hasattr(exc, "suggested_config")
+
+
+def test_exception_is_exception_subclass():
+    """Plain Exception, not subclass of ValueError / RuntimeError. Caller
+    catches by type, not by hierarchy."""
+    assert issubclass(ControllerNotConfidentError, Exception)

--- a/packages/python/goldenmatch/tests/test_identify_failing_subprofile.py
+++ b/packages/python/goldenmatch/tests/test_identify_failing_subprofile.py
@@ -1,0 +1,106 @@
+"""Unit tests for _identify_failing_subprofile.
+
+Spec §Design / Confidence gate -- priority order [data, blocking,
+scoring, matchkey, cluster] (root causes upstream first).
+"""
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig_controller import _identify_failing_subprofile
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ClusterProfile,
+    ComplexityProfile,
+    DataProfile,
+    MatchkeyProfile,
+    ProfileMeta,
+    ScoringProfile,
+)
+
+
+def _green_profile() -> ComplexityProfile:
+    """Builds a profile where every sub-profile reports GREEN."""
+    return ComplexityProfile(
+        data=DataProfile(n_rows=1000, n_cols=3, column_types={
+            "a": "text", "b": "text", "c": "text",
+        }),
+        blocking=BlockingProfile(
+            keys_used=[["a"]], n_blocks=10, total_comparisons=100,
+            reduction_ratio=0.9, block_sizes_p50=10, block_sizes_p95=15,
+            block_sizes_p99=20, block_sizes_max=25,
+            singleton_block_count=0, oversized_block_count=0,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=100, candidates_compared=100,
+            mass_above_threshold=0.5, mass_in_borderline=0.1,
+            dip_statistic=0.01,
+        ),
+        matchkey=MatchkeyProfile(),
+        cluster=ClusterProfile(),
+        meta=ProfileMeta(
+            iteration=0, is_sample=False, sample_size=1000,
+            n_rows_full=1000, wall_clock_ms=0, seed=0,
+        ),
+    )
+
+
+def test_data_red_returns_data():
+    """Data sub-profile RED (n_rows == 0) -> 'data'."""
+    p = _green_profile()
+    import dataclasses
+    p = dataclasses.replace(p, data=DataProfile(n_rows=0))
+    assert _identify_failing_subprofile(p) == "data"
+
+
+def test_blocking_red_returns_blocking():
+    """Blocking sub-profile RED (n_blocks == 0) -> 'blocking'."""
+    p = _green_profile()
+    import dataclasses
+    bp = BlockingProfile()  # n_blocks=0 default -> RED via health()
+    p = dataclasses.replace(p, blocking=bp)
+    assert _identify_failing_subprofile(p) == "blocking"
+
+
+def test_scoring_red_returns_scoring():
+    """Scoring RED (mass_above_threshold == 0 with candidates compared)."""
+    p = _green_profile()
+    import dataclasses
+    sp = ScoringProfile(
+        n_pairs_scored=100, candidates_compared=100,
+        mass_above_threshold=0.0, mass_in_borderline=0.1,
+    )
+    p = dataclasses.replace(p, scoring=sp)
+    assert _identify_failing_subprofile(p) == "scoring"
+
+
+def test_priority_order_data_beats_blocking():
+    """When multiple sub-profiles RED, data wins (root cause upstream)."""
+    p = _green_profile()
+    import dataclasses
+    p = dataclasses.replace(
+        p,
+        data=DataProfile(n_rows=0),               # RED
+        blocking=BlockingProfile(),               # RED
+    )
+    assert _identify_failing_subprofile(p) == "data"
+
+
+def test_priority_order_blocking_beats_scoring():
+    """Blocking RED + Scoring RED -> 'blocking' (upstream cause)."""
+    p = _green_profile()
+    import dataclasses
+    p = dataclasses.replace(
+        p,
+        blocking=BlockingProfile(),
+        scoring=ScoringProfile(
+            n_pairs_scored=0, candidates_compared=0,
+        ),
+    )
+    assert _identify_failing_subprofile(p) == "blocking"
+
+
+def test_all_green_returns_empty_string():
+    """Defensive: gate's RED-precondition means this shouldn't happen,
+    but the helper must not raise. Returns '' so the error message
+    degrades gracefully."""
+    p = _green_profile()
+    assert _identify_failing_subprofile(p) == ""


### PR DESCRIPTION
## Summary

Phase 3 of the controller-budget-pathology plan. Adds the gate that refuses to commit a RED config at >=100K rows.

**Stacked locally on PRs #271 + #272** (Phase 1 + Phase 2). The diff against `main` includes Phase 2's exception + helper for symbol availability; once #272 merges, the diff narrows to just Phase 3's additions.

- `REFUSE_AT_N = 100_000` module constant (back-projection from 500K -> ~26 min measured wall).
- `AutoConfigController.run()` gains keyword-only `confidence_required: bool = True`.
- After `pick_committed`, if `confidence_required AND df.height >= REFUSE_AT_N AND best_entry.profile.health() == RED`: raise `ControllerNotConfidentError`. `_LAST_CONTROLLER_RUN.set(history)` runs BEFORE the raise so callers can introspect history on exception.

**No public API change yet** — Phase 4 surfaces `confidence_required` on `dedupe_df` / `match_df`.

Spec: §Design / Confidence gate.

## Test plan

- [x] 4 new tests + 1 skipped (the kwarg-opt-out test, unskipped in Phase 4). 4 passed, 1 skipped locally.
- [x] Ruff clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
