### PR TITLE
fix(autoconfig): extend confidence gate to all-iterations-errored fallback

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -555,6 +555,19 @@ class AutoConfigController:
                 history.stop_reason.name if history.stop_reason else "unset",
             )
             _LAST_CONTROLLER_RUN.set(history)
+            # Confidence gate (followup to Phase 3 of controller-budget spec):
+            # the all-iterations-errored path is the same user-facing
+            # pathology as a RED committed entry -- caller would run the
+            # full pipeline on the _RED_PROFILE sentinel and produce
+            # degenerate output. Refuse loudly at scale.
+            if confidence_required and df.height >= REFUSE_AT_N:
+                raise ControllerNotConfidentError(
+                    n_rows=df.height,
+                    failing_sub_profile="data",  # n_errored=all means data path itself failed
+                    stop_reason=(
+                        history.stop_reason.name if history.stop_reason else "unset"
+                    ),
+                )
             return config_v0, _RED_PROFILE, history
 
         # Confidence gate (Phase 3 of controller-budget pathology spec).

--- a/packages/python/goldenmatch/tests/test_controller_adaptive_e2e.py
+++ b/packages/python/goldenmatch/tests/test_controller_adaptive_e2e.py
@@ -45,23 +45,17 @@ def _adversarial_df_at_threshold() -> pl.DataFrame:
     })
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Adversarial fixture causes every iteration to ERROR (DuplicateError "
-        "on auto-fix column derivation), which hits the controller's separate "
-        "'every iteration errored' fallback path that returns config_v0 + "
-        "_RED_PROFILE WITHOUT going through pick_committed -- so the gate "
-        "doesn't fire. Followup: either find a fixture that REDs without "
-        "erroring, or extend the gate to fire on the all-errored fallback "
-        "path too (Phase 3 contract change). The Phase 3 monkey-patched "
-        "gate tests still cover the gate's branching."
-    ),
-    strict=True,
-)
 def test_gate_fires_via_real_iteration_loop():
     """End-to-end: build a 100K-row adversarial fixture, let
     AutoConfigController iterate normally (no monkey-patch). When it
-    commits RED, the gate must fire."""
+    commits RED OR every iteration errors, the gate must fire.
+
+    Note: the adversarial fixture (all surnames in one soundex bucket)
+    actually triggers the *all-iterations-errored* fallback path rather
+    than a clean RED commit (DuplicateError on auto-fix column
+    derivation). The followup-#62 extension of the gate to that
+    fallback path is what makes this test pass via the real iteration
+    loop instead of monkey-patched pick_committed."""
     df = _adversarial_df_at_threshold()
     with pytest.raises(ControllerNotConfidentError) as exc_info:
         gm.dedupe_df(df)


### PR DESCRIPTION
## Summary

Closes followup #62 from the controller-budget-pathology work.

Phase 3's confidence gate fires after `pick_committed` returns a RED entry. But when **every** iteration errors, the controller short-circuits via a separate fallback (`autoconfig_controller.py` ~line 549) that returns `config_v0 + _RED_PROFILE` WITHOUT going through `pick_committed` — the gate is bypassed.

Same user-facing pathology either way: caller runs the full pipeline on the `_RED_PROFILE` sentinel and produces degenerate output. The spec's "loud not slow" intent applies equally.

**Fix:** add the same gate check inside the all-errored fallback branch. At `df.height >= REFUSE_AT_N` with `confidence_required=True`, raise `ControllerNotConfidentError(failing_sub_profile="data")` — "data" is the upstream-most cause since iterations errored before producing a sub-profile to diagnose from.

**Bonus:** flips Phase 5's e2e test (`test_gate_fires_via_real_iteration_loop`) from `xfail(strict=True)` to a real passing test — the adversarial fixture that previously bypassed the gate now hits the extended fallback and raises as expected.

## Test plan

- [x] Ruff clean.
- [ ] CI green — including Phase 5's previously-xfail e2e test, now passing for the right reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
