### PR TITLE
feat(distributed): Component 1 / Phase 1 -- PreparedRecordStore primitive

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/distributed/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/__init__.py
@@ -1,0 +1,8 @@
+"""Distributed execution primitives for 50M+ row deduplication.
+
+Spec: docs/superpowers/specs/2026-05-15-distributed-plan-v1-design.md.
+
+Component 1 (prepared-record store) is the first piece. Components 2–6
+(partitioned execution, distributed scoring, streaming pair store,
+distributed clustering, planner integration) ship as their own sub-projects.
+"""

--- a/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
@@ -1,0 +1,152 @@
+"""DuckDB-backed prepared-record store.
+
+Spec: docs/superpowers/specs/2026-05-15-distributed-plan-v1-design.md
+§Component 1.
+
+The controller's iteration loop (and downstream distributed workers) need
+to read the post-transform / post-auto-fix DataFrame multiple times. The
+in-memory ``_PREP_CACHE`` in ``core/pipeline.py`` covers small-N within
+one process; this store covers large-N (doesn't fit in RAM) and the
+distributed case (workers in separate processes / machines need shared
+access).
+
+Lifecycle:
+- ``PreparedRecordStore()`` (no args) -> ephemeral tempfile, cleaned on close.
+- ``PreparedRecordStore(base_dir=...)`` -> tempfile inside that dir.
+- ``PreparedRecordStore(path=...)`` -> open an existing store; useful for
+  cross-call persistence.
+- ``cleanup=False`` keeps the file after close (for persistence).
+
+The store is keyed by ``signature`` (typically the
+``_prep_cache_signature(config)`` produced by ``core/pipeline.py``).
+Multiple distinct signatures coexist in the same store; lookups are
+exact-match.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import polars as pl
+
+_TABLE_PREFIX = "prepared_"
+
+
+def _sanitize_signature(signature: str) -> str:
+    """Map any signature string to a valid DuckDB table-name suffix.
+
+    DuckDB table names must be ``[A-Za-z_][A-Za-z0-9_]*``. We hash the
+    signature so the table-name length is bounded and the input character
+    set doesn't matter.
+    """
+    import hashlib
+
+    h = hashlib.sha256(signature.encode("utf-8")).hexdigest()
+    return h[:16]
+
+
+class PreparedRecordStore:
+    """Owns one DuckDB connection backing a partitioned record store.
+
+    Usage:
+
+    .. code-block:: python
+
+        with PreparedRecordStore() as store:
+            materialize_prepared_records(store, df, signature="sig-v1")
+            loaded = load_prepared_records(store, signature="sig-v1")
+    """
+
+    def __init__(
+        self,
+        *,
+        base_dir: Path | str | None = None,
+        path: Path | str | None = None,
+        cleanup: bool = True,
+    ) -> None:
+        if path is not None:
+            self.path = Path(path)
+            self._owns_file = False  # caller manages lifecycle
+        else:
+            base = Path(base_dir) if base_dir is not None else None
+            fd, p = tempfile.mkstemp(
+                suffix=".duckdb", prefix="goldenmatch_prepared_", dir=base,
+            )
+            os.close(fd)
+            # DuckDB rejects a pre-existing empty file (it's not a valid
+            # DuckDB database). Remove the placeholder so duckdb.connect()
+            # creates a fresh database at that path.
+            os.unlink(p)
+            self.path = Path(p)
+            self._owns_file = True
+        self._cleanup = cleanup
+        self._con: duckdb.DuckDBPyConnection | None = duckdb.connect(str(self.path))
+        self._closed = False
+
+    @property
+    def connection(self) -> duckdb.DuckDBPyConnection:
+        if self._con is None:
+            raise RuntimeError("PreparedRecordStore is closed")
+        return self._con
+
+    def close(self) -> None:
+        """Idempotent close. Removes the file when cleanup=True and the
+        store owns it."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._con is not None:
+            self._con.close()
+            self._con = None
+        if self._cleanup and self._owns_file and self.path.exists():
+            self.path.unlink(missing_ok=True)
+
+    def __enter__(self) -> PreparedRecordStore:
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.close()
+
+
+def materialize_prepared_records(
+    store: PreparedRecordStore,
+    df: pl.DataFrame,
+    *,
+    signature: str,
+) -> None:
+    """Write ``df`` into the store under ``signature``.
+
+    Polars -> Arrow -> DuckDB via ``arrow_table`` view registration. Same
+    pattern as ``backends/score_duckdb.py`` (PR #235). Existing entries
+    at the same signature are replaced.
+    """
+    table = _TABLE_PREFIX + _sanitize_signature(signature)
+    con = store.connection
+    arrow_table = df.to_arrow()  # noqa: F841  -- DuckDB resolves by local name
+    con.execute(f'DROP TABLE IF EXISTS "{table}"')
+    con.execute(f'CREATE TABLE "{table}" AS SELECT * FROM arrow_table')
+
+
+def load_prepared_records(
+    store: PreparedRecordStore,
+    *,
+    signature: str,
+) -> pl.DataFrame | None:
+    """Read ``signature``'s entry back as a Polars DataFrame.
+
+    Returns None when the signature isn't present in the store (cache
+    miss; caller prepares + materializes).
+    """
+    table = _TABLE_PREFIX + _sanitize_signature(signature)
+    con = store.connection
+    exists = con.execute(
+        "SELECT 1 FROM duckdb_tables() WHERE table_name = ?",
+        [table],
+    ).fetchone()
+    if exists is None:
+        return None
+    arrow_table = con.execute(f'SELECT * FROM "{table}"').arrow()
+    return pl.from_arrow(arrow_table)

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "diptest>=0.5.2",
     "psutil>=5.9",
     "duckdb>=0.9",
+    "pyarrow>=10",
 ]
 
 [project.urls]

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "textual>=1.0",
     "diptest>=0.5.2",
     "psutil>=5.9",
+    "duckdb>=0.9",
 ]
 
 [project.urls]

--- a/packages/python/goldenmatch/tests/test_prepared_record_store.py
+++ b/packages/python/goldenmatch/tests/test_prepared_record_store.py
@@ -1,0 +1,124 @@
+"""Unit tests for PreparedRecordStore (Component 1 of Distributed Plan v1).
+
+Spec: docs/superpowers/specs/2026-05-15-distributed-plan-v1-design.md
+§Component 1.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+from goldenmatch.distributed.record_store import (
+    PreparedRecordStore,
+    load_prepared_records,
+    materialize_prepared_records,
+)
+
+
+def _sample_df() -> pl.DataFrame:
+    return pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "name": ["alice", "bob", "charlie", "dana"],
+        "email": ["a@x.com", "b@x.com", "c@x.com", "d@x.com"],
+        "__mk_email_lower__": ["a@x.com", "b@x.com", "c@x.com", "d@x.com"],
+    })
+
+
+def test_store_init_creates_tempdir(tmp_path: Path):
+    store = PreparedRecordStore(base_dir=tmp_path)
+    assert store.path.exists()
+    assert store.path.parent == tmp_path
+    store.close()
+
+
+def test_store_init_creates_tempfile_when_no_base_dir():
+    """No base_dir -> mkstemp into system temp. Cleaned up on close()."""
+    store = PreparedRecordStore()
+    p = store.path
+    assert p.exists()
+    store.close()
+    assert not p.exists()
+
+
+def test_materialize_and_load_roundtrips_dataframe(tmp_path: Path):
+    """Polars -> DuckDB -> Polars roundtrip preserves data + dtypes."""
+    store = PreparedRecordStore(base_dir=tmp_path)
+    try:
+        df = _sample_df()
+        signature = "sig-v1"
+        materialize_prepared_records(store, df, signature=signature)
+        loaded = load_prepared_records(store, signature=signature)
+        # Order may differ post-DuckDB; compare as sets of row tuples.
+        assert set(loaded.iter_rows()) == set(df.iter_rows())
+        assert set(loaded.columns) == set(df.columns)
+    finally:
+        store.close()
+
+
+def test_load_missing_signature_returns_none(tmp_path: Path):
+    """Cache miss is signaled by None; callers prep + materialize."""
+    store = PreparedRecordStore(base_dir=tmp_path)
+    try:
+        assert load_prepared_records(store, signature="missing") is None
+    finally:
+        store.close()
+
+
+def test_signature_isolates_entries(tmp_path: Path):
+    """Two different signatures address two different cached frames."""
+    store = PreparedRecordStore(base_dir=tmp_path)
+    try:
+        df1 = _sample_df()
+        df2 = pl.DataFrame({"__row_id__": [10], "x": ["other"]})
+        materialize_prepared_records(store, df1, signature="sig-a")
+        materialize_prepared_records(store, df2, signature="sig-b")
+        loaded_a = load_prepared_records(store, signature="sig-a")
+        loaded_b = load_prepared_records(store, signature="sig-b")
+        assert loaded_a is not None
+        assert loaded_b is not None
+        assert set(loaded_a.columns) == {"__row_id__", "name", "email", "__mk_email_lower__"}
+        assert set(loaded_b.columns) == {"__row_id__", "x"}
+    finally:
+        store.close()
+
+
+def test_close_is_idempotent(tmp_path: Path):
+    """Multiple close() calls don't raise — important for finally blocks
+    in the controller's exception paths."""
+    store = PreparedRecordStore(base_dir=tmp_path)
+    store.close()
+    store.close()  # no-op
+
+
+def test_close_cleans_up_file(tmp_path: Path):
+    """close() removes the underlying DuckDB file when cleanup=True."""
+    store = PreparedRecordStore(base_dir=tmp_path)
+    p = store.path
+    assert p.exists()
+    store.close()
+    assert not p.exists()
+
+
+def test_close_preserves_file_when_cleanup_false(tmp_path: Path):
+    """cleanup=False keeps the file (useful for cross-call persistence)."""
+    store = PreparedRecordStore(base_dir=tmp_path, cleanup=False)
+    p = store.path
+    materialize_prepared_records(store, _sample_df(), signature="sig-v1")
+    store.close()
+    assert p.exists()
+    # Re-open and read back.
+    store2 = PreparedRecordStore(path=p, cleanup=False)
+    try:
+        loaded = load_prepared_records(store2, signature="sig-v1")
+        assert loaded is not None
+        assert loaded.height == 4
+    finally:
+        store2.close()
+
+
+def test_context_manager_closes_on_exit(tmp_path: Path):
+    """PreparedRecordStore is a context manager."""
+    with PreparedRecordStore(base_dir=tmp_path) as store:
+        p = store.path
+        assert p.exists()
+    assert not p.exists()


### PR DESCRIPTION
## Summary

Phase 1 of Distributed Plan v1 Component 1 (plan: PR #279). Pure primitive — no pipeline wiring (Phase 2) or controller wiring (Phase 3) yet.

- `goldenmatch/distributed/__init__.py` (NEW): package marker.
- `goldenmatch/distributed/record_store.py` (NEW): `PreparedRecordStore` class + `materialize_prepared_records` / `load_prepared_records` helpers. DuckDB-backed disk store keyed by signature (SHA-256 → 16-hex table suffix); Polars↔DuckDB via Arrow bulk handoff (mirrors `score_duckdb.py` from PR #235). Lifecycle: ephemeral tempfile by default; `cleanup=False` for cross-call persistence; idempotent `close()`; context manager.
- `pyproject.toml`: promote `duckdb>=0.9` from `[optional-dependencies].duckdb` to a hard dep. Optional-dep block stays as a no-op alias for backward compat.

### Deviation from plan (one)

`tempfile.mkstemp` reserves an empty placeholder file; DuckDB 1.5.1 raises `IOException: not a valid DuckDB database file` when opening a pre-existing empty file. Fixed with `os.unlink(p)` between `os.close(fd)` and `duckdb.connect(...)` — `mkstemp` still reserves the unique name; DuckDB then creates a fresh database at that path.

## Test plan

- [x] 9 new unit tests pass (`tests/test_prepared_record_store.py`): roundtrip, signature isolation, missing-signature → None, idempotent close, file cleanup, `cleanup=False` persistence, context manager.
- [x] Existing prep-cache tests stay green (`test_prep_cache.py`, 7 tests).
- [x] ruff clean (5 auto-fixed, 0 remaining).
- [ ] CI green on Linux + Windows + macOS matrix.

Spec: `docs/superpowers/specs/2026-05-15-distributed-plan-v1-design.md` §Component 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)