### PR TITLE
feat(distributed): Component 2 / Phase 1 -- block-partitioned record store

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -155,3 +156,101 @@ def load_prepared_records(
         return None
     arrow_table = con.execute(f'SELECT * FROM "{table}"').arrow()
     return pl.from_arrow(arrow_table)
+
+
+_BLOCK_PREFIX = "block_"
+
+
+def _block_table_name(signature: str, block_key: str) -> str:
+    sig_h = _sanitize_signature(signature)
+    blk_h = _sanitize_signature(block_key)
+    return f"{_BLOCK_PREFIX}{sig_h}_{blk_h}"
+
+
+def materialize_blocks(
+    store: PreparedRecordStore,
+    df: pl.DataFrame,
+    *,
+    block_assignments: dict[int, str],
+    signature: str,
+) -> None:
+    """Partition ``df`` by ``block_assignments`` ({__row_id__ -> block_key}) and
+    write each block as its own DuckDB table.
+
+    Also writes a `block_index_<sig_hash16>` table mapping block_key -> table_name
+    so list_blocks / iter_blocks can enumerate without scanning ``duckdb_tables()``
+    (which would be O(all_blocks_in_store) across all signatures).
+    """
+    con = store.connection
+    sig_h = _sanitize_signature(signature)
+    index_table = f"block_index_{sig_h}"
+
+    # Build a tiny lookup df once.
+    rid_to_block = pl.DataFrame({
+        "__row_id__": list(block_assignments.keys()),
+        "__block_key__": list(block_assignments.values()),
+    })
+    joined = df.join(rid_to_block, on="__row_id__", how="inner")
+    # Partition by block_key. Order is deterministic for test stability.
+    block_keys: list[str] = sorted(set(block_assignments.values()))
+
+    # Reset prior index for this signature (overwrite semantics).
+    con.execute(f'DROP TABLE IF EXISTS "{index_table}"')
+    con.execute(f'CREATE TABLE "{index_table}" (block_key TEXT, table_name TEXT)')
+
+    for bk in block_keys:
+        block_df = joined.filter(pl.col("__block_key__") == bk).drop("__block_key__")
+        table = _block_table_name(signature, bk)
+        arrow_table = block_df.to_arrow()  # noqa: F841 -- DuckDB resolves by local name
+        con.execute(f'DROP TABLE IF EXISTS "{table}"')
+        con.execute(f'CREATE TABLE "{table}" AS SELECT * FROM arrow_table')
+        con.execute(
+            f'INSERT INTO "{index_table}" VALUES (?, ?)',
+            [bk, table],
+        )
+
+
+def load_block(
+    store: PreparedRecordStore,
+    *,
+    signature: str,
+    block_key: str,
+) -> pl.DataFrame | None:
+    """Read one block's records as a Polars DataFrame. None on miss."""
+    table = _block_table_name(signature, block_key)
+    con = store.connection
+    exists = con.execute(
+        "SELECT 1 FROM duckdb_tables() WHERE table_name = ?",
+        [table],
+    ).fetchone()
+    if exists is None:
+        return None
+    arrow_table = con.execute(f'SELECT * FROM "{table}"').arrow()
+    return pl.from_arrow(arrow_table)
+
+
+def list_blocks(store: PreparedRecordStore, *, signature: str) -> list[str]:
+    """Return all block_keys known for ``signature``. Empty list on unknown sig."""
+    sig_h = _sanitize_signature(signature)
+    index_table = f"block_index_{sig_h}"
+    con = store.connection
+    exists = con.execute(
+        "SELECT 1 FROM duckdb_tables() WHERE table_name = ?",
+        [index_table],
+    ).fetchone()
+    if exists is None:
+        return []
+    rows = con.execute(f'SELECT block_key FROM "{index_table}"').fetchall()
+    return [r[0] for r in rows]
+
+
+def iter_blocks(
+    store: PreparedRecordStore,
+    *,
+    signature: str,
+) -> Iterator[tuple[str, pl.DataFrame]]:
+    """Yield ``(block_key, block_df)`` pairs in sorted block_key order."""
+    for bk in sorted(list_blocks(store, signature=signature)):
+        df = load_block(store, signature=signature, block_key=bk)
+        if df is not None:
+            yield bk, df

--- a/packages/python/goldenmatch/tests/test_block_partitioned_store.py
+++ b/packages/python/goldenmatch/tests/test_block_partitioned_store.py
@@ -1,0 +1,99 @@
+"""Unit tests for block-partitioned helpers in PreparedRecordStore.
+
+Component 2 of Distributed Plan v1. The Component 1 primitive
+(PR #280) handled one-prepared-df-per-signature. Component 2 adds
+per-block partitions so per-block scoring can stream from disk.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+from goldenmatch.distributed.record_store import (
+    PreparedRecordStore,
+    iter_blocks,
+    list_blocks,
+    load_block,
+    materialize_blocks,
+)
+
+
+def _sample_df() -> pl.DataFrame:
+    # 6 rows, 3 blocks of 2 each.
+    return pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3, 4, 5],
+        "name": ["alice", "alyce", "bob", "robert", "carol", "caryl"],
+        "email": [f"u{i}@x.com" for i in range(6)],
+    })
+
+
+def _block_assignments() -> dict[int, str]:
+    # __row_id__ -> block_key
+    return {0: "A1", 1: "A1", 2: "B2", 3: "B2", 4: "C3", 5: "C3"}
+
+
+def test_materialize_blocks_writes_one_table_per_block(tmp_path: Path):
+    with PreparedRecordStore(base_dir=tmp_path) as store:
+        df = _sample_df()
+        materialize_blocks(store, df, block_assignments=_block_assignments(), signature="sig-v1")
+        keys = list_blocks(store, signature="sig-v1")
+        assert sorted(keys) == ["A1", "B2", "C3"]
+
+
+def test_load_block_roundtrips_only_member_rows(tmp_path: Path):
+    with PreparedRecordStore(base_dir=tmp_path) as store:
+        df = _sample_df()
+        materialize_blocks(store, df, block_assignments=_block_assignments(), signature="sig-v1")
+        a1 = load_block(store, signature="sig-v1", block_key="A1")
+        assert a1 is not None
+        assert sorted(a1["__row_id__"].to_list()) == [0, 1]
+        assert set(a1.columns) == set(df.columns)
+
+
+def test_load_missing_block_returns_none(tmp_path: Path):
+    with PreparedRecordStore(base_dir=tmp_path) as store:
+        materialize_blocks(store, _sample_df(), block_assignments=_block_assignments(), signature="sig-v1")
+        assert load_block(store, signature="sig-v1", block_key="ZZ") is None
+        assert load_block(store, signature="missing-sig", block_key="A1") is None
+
+
+def test_signature_isolates_block_namespaces(tmp_path: Path):
+    """Two signatures with overlapping block keys must not collide."""
+    with PreparedRecordStore(base_dir=tmp_path) as store:
+        df1 = _sample_df()
+        df2 = pl.DataFrame({"__row_id__": [10, 11], "name": ["x", "y"], "email": ["x@", "y@"]})
+        materialize_blocks(store, df1, block_assignments=_block_assignments(), signature="sig-a")
+        materialize_blocks(store, df2, block_assignments={10: "A1", 11: "A1"}, signature="sig-b")
+        a_a1 = load_block(store, signature="sig-a", block_key="A1")
+        b_a1 = load_block(store, signature="sig-b", block_key="A1")
+        assert a_a1 is not None and b_a1 is not None
+        assert sorted(a_a1["__row_id__"].to_list()) == [0, 1]
+        assert sorted(b_a1["__row_id__"].to_list()) == [10, 11]
+
+
+def test_iter_blocks_yields_all_partitions(tmp_path: Path):
+    with PreparedRecordStore(base_dir=tmp_path) as store:
+        materialize_blocks(store, _sample_df(), block_assignments=_block_assignments(), signature="sig-v1")
+        yielded = list(iter_blocks(store, signature="sig-v1"))
+        keys = sorted(k for k, _ in yielded)
+        assert keys == ["A1", "B2", "C3"]
+        assert all(df.height == 2 for _, df in yielded)
+
+
+def test_iter_blocks_empty_signature_yields_nothing(tmp_path: Path):
+    with PreparedRecordStore(base_dir=tmp_path) as store:
+        assert list(iter_blocks(store, signature="never-materialized")) == []
+
+
+def test_unsafe_block_keys_handled(tmp_path: Path):
+    """Block keys with special chars / unicode must not break DuckDB table naming."""
+    with PreparedRecordStore(base_dir=tmp_path) as store:
+        df = pl.DataFrame({"__row_id__": [0, 1], "name": ["a", "b"], "email": ["a@", "b@"]})
+        # Keys with quotes / unicode / spaces.
+        assignments = {0: "block with spaces", 1: "block'\"unicode-Ω"}
+        materialize_blocks(store, df, block_assignments=assignments, signature="sig-v1")
+        keys = list_blocks(store, signature="sig-v1")
+        assert sorted(keys) == sorted(["block with spaces", "block'\"unicode-Ω"])
+        loaded = load_block(store, signature="sig-v1", block_key="block with spaces")
+        assert loaded is not None
+        assert loaded["__row_id__"].to_list() == [0]


### PR DESCRIPTION
## Summary

Component 2 Phase 1 of Distributed Plan v1. Extends the Component 1 \`PreparedRecordStore\` (PRs #280-#282) with block-keyed primitives so per-block scoring can stream records from disk. Memory becomes bounded by the largest block, not the whole prepared dataset — the precondition for 50M+ scoring and the future distributed-scoring component.

**Four new helpers in \`goldenmatch/distributed/record_store.py\`:**

- \`materialize_blocks(store, df, *, block_assignments, signature)\`: partition \`df\` by per-row block_key assignments; one DuckDB table per distinct block_key, plus a \`block_index_<sig>\` lookup table for O(blocks-in-sig) enumeration.
- \`load_block(store, *, signature, block_key) -> pl.DataFrame | None\`
- \`list_blocks(store, *, signature) -> list[str]\`
- \`iter_blocks(store, *, signature) -> Iterator[tuple[str, pl.DataFrame]]\` (sorted block_key order for determinism)

Both \`signature\` and \`block_key\` are independently hashed via the existing \`_sanitize_signature\` (SHA-256 → 16hex), so unsafe block-key strings (unicode, spaces, quotes) can't break DuckDB table naming.

**Pipeline + scoring-loop wiring is a follow-up PR.** This ships the primitive only.

## Test plan

- [x] 7 new tests in \`test_block_partitioned_store.py\` pass (materialize, roundtrip, missing-block None, signature isolation, iter ordering, empty-signature, unsafe-keys).
- [x] 9 Component 1 tests stay green (\`test_prepared_record_store.py\`).
- [x] No regression on Component 1 pipeline + controller tests.
- [x] ruff clean.
- [ ] CI green on the full matrix.

Plan (gitignored, local-only): \`docs/superpowers/plans/2026-05-16-distributed-plan-component-2-block-partitioned-store.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)