### PR TITLE
bench: prepared-record-store baseline-vs-treatment workflow

### DIFF
--- a/.github/workflows/bench-prepared-store.yml
+++ b/.github/workflows/bench-prepared-store.yml
@@ -1,0 +1,60 @@
+name: bench-prepared-store
+
+# Compare dedupe_df with and without config.prepared_record_store on a
+# synthetic person-shape df. Validates Component 1 of Distributed Plan v1.
+#
+# Trigger: workflow_dispatch (manual). Default rows = 500_000.
+
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "Synthetic df row count"
+        required: false
+        default: "500000"
+      ref:
+        description: "Branch / tag / SHA to bench (default: workflow ref)"
+        required: false
+
+jobs:
+  bench:
+    name: "bench prepared-record-store"
+    runs-on: large-new-64GB
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install goldenmatch
+        working-directory: packages/python/goldenmatch
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Run bench
+        working-directory: packages/python/goldenmatch
+        env:
+          GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+        run: |
+          mkdir -p bench-out
+          python scripts/bench_prepared_store.py \
+            --rows "${{ inputs.rows }}" \
+            --store-dir bench-out/store \
+            --out bench-out/results.json
+          echo '## bench-prepared-store results' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat bench-out/results.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-prepared-store-${{ inputs.rows }}-rows
+          path: packages/python/goldenmatch/bench-out/results.json
+          retention-days: 30

--- a/packages/python/goldenmatch/scripts/bench_prepared_store.py
+++ b/packages/python/goldenmatch/scripts/bench_prepared_store.py
@@ -1,0 +1,153 @@
+"""Benchmark the PreparedRecordStore (Distributed Plan v1 Component 1).
+
+Runs ``dedupe_df`` twice on the same synthetic person-shape df:
+  * Baseline: ``prepared_record_store=False`` (in-memory ``_PREP_CACHE`` only).
+  * Treatment: ``prepared_record_store=True`` (controller-owned disk store).
+
+Captures per-stage wall via ``goldenmatch.core.bench.bench_capture`` and
+peak RSS via ``tracemalloc``. Writes one JSON object per config plus a
+``diff`` block so CI can show whether the disk store pays for itself at
+the requested row count.
+
+Usage::
+
+    python scripts/bench_prepared_store.py --rows 500000 --out bench.json
+
+Memory-safe up to whatever the controller iteration loop can hold; the
+disk-store branch is the point of comparison.
+
+Notes:
+  * Synthetic surnames span 10 soundex buckets so blocking + scoring
+    don't degenerate — see ``feedback_synthetic_surname_fixtures.md``.
+  * Default rows = 500_000 -- big enough that prep wall is measurable,
+    small enough to fit in 64GB without per-block memory tricks.
+  * ``confidence_required=False`` because RED commits at 100K+ would
+    otherwise raise ``ControllerNotConfidentError`` and skip the
+    measurement entirely.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tracemalloc
+from pathlib import Path
+from time import perf_counter
+
+import polars as pl
+
+
+def build_df(n: int) -> pl.DataFrame:
+    """Person-shape synthetic df with surnames across soundex codes."""
+    first_names = [
+        "Alice", "Bob", "Charlie", "Dana", "Eve", "Frank",
+        "Grace", "Henry", "Iris", "Jack",
+    ]
+    # Ten surnames spanning ten distinct soundex codes so blocking
+    # produces realistically-sized buckets rather than one O(N^2) bucket.
+    surnames = [
+        "Smith",     # S530
+        "Johnson",   # J525
+        "Williams",  # W452
+        "Brown",     # B650
+        "Jones",     # J520
+        "Garcia",    # G620
+        "Miller",    # M460
+        "Davis",     # D120
+        "Rodriguez", # R362
+        "Martinez",  # M635
+    ]
+    rows = []
+    for i in range(n):
+        rows.append({
+            "first_name": first_names[i % len(first_names)],
+            "last_name":  surnames[i % len(surnames)],
+            "email":      f"user{i // 3}@example.com",  # ~3 duplicates per email
+            "zip":        f"{10000 + (i % 100):05d}",
+        })
+    return pl.DataFrame(rows)
+
+
+def run_one(label: str, df: pl.DataFrame, *, prepared_record_store: bool) -> dict:
+    """Run dedupe_df once under bench_capture + tracemalloc."""
+    import goldenmatch as gm
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    from goldenmatch.core.bench import bench_capture
+
+    cfg = GoldenMatchConfig(prepared_record_store=prepared_record_store)
+
+    tracemalloc.start()
+    t0 = perf_counter()
+    with bench_capture() as rec:
+        result = gm.dedupe_df(df, config=cfg, confidence_required=False)
+    wall = perf_counter() - t0
+    _current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    bench = rec.to_dict()
+    return {
+        "label": label,
+        "prepared_record_store": prepared_record_store,
+        "rows": df.height,
+        "wall_seconds": round(wall, 3),
+        "peak_rss_mb": round(peak / (1024 * 1024), 2),
+        "clusters": len(result.clusters),
+        "stage_timings_seconds": bench["stage_timings_seconds"],
+        "metrics": bench["metrics"],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, default=500_000)
+    parser.add_argument("--out", type=Path, default=Path("bench_prepared_store.json"))
+    parser.add_argument(
+        "--store-dir", type=Path, default=None,
+        help="Directory for the prepared-record store (defaults to system tmp).",
+    )
+    args = parser.parse_args(argv)
+
+    # Make sure both runs share the same controller-side conditions.
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    if args.store_dir is not None:
+        args.store_dir.mkdir(parents=True, exist_ok=True)
+        os.environ["GOLDENMATCH_PREPARED_RECORD_STORE_DIR"] = str(args.store_dir)
+        os.environ["GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST"] = "1"
+
+    print(f"Building synthetic df ({args.rows:,} rows)...", flush=True)
+    df = build_df(args.rows)
+
+    print("Run 1/2: baseline (prepared_record_store=False)...", flush=True)
+    baseline = run_one("baseline", df, prepared_record_store=False)
+    print(f"  wall = {baseline['wall_seconds']}s; peak = {baseline['peak_rss_mb']} MB", flush=True)
+
+    print("Run 2/2: treatment (prepared_record_store=True)...", flush=True)
+    treatment = run_one("treatment", df, prepared_record_store=True)
+    print(f"  wall = {treatment['wall_seconds']}s; peak = {treatment['peak_rss_mb']} MB", flush=True)
+
+    wall_delta = baseline["wall_seconds"] - treatment["wall_seconds"]
+    rss_delta = baseline["peak_rss_mb"] - treatment["peak_rss_mb"]
+    out = {
+        "rows": args.rows,
+        "baseline": baseline,
+        "treatment": treatment,
+        "diff": {
+            "wall_saved_seconds": round(wall_delta, 3),
+            "wall_pct_change": round(
+                (-wall_delta / baseline["wall_seconds"]) * 100, 2
+            ) if baseline["wall_seconds"] else 0.0,
+            "peak_rss_saved_mb": round(rss_delta, 2),
+            "peak_rss_pct_change": round(
+                (-rss_delta / baseline["peak_rss_mb"]) * 100, 2
+            ) if baseline["peak_rss_mb"] else 0.0,
+        },
+    }
+    args.out.write_text(json.dumps(out, indent=2))
+    print(f"\nWrote {args.out}.", flush=True)
+    print(json.dumps(out["diff"], indent=2), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds the bench infrastructure (script + workflow) to measure whether \`config.prepared_record_store=True\` actually pays for itself on the controller iteration loop. Validates Component 1 of Distributed Plan v1 (PRs #280-#282) before we design Component 2 wiring.

- \`scripts/bench_prepared_store.py\`: builds a synthetic person-shape df (10 soundex buckets per memory \`feedback_synthetic_surname_fixtures\`), runs \`dedupe_df\` twice (False vs True) under \`bench_capture\` + tracemalloc, outputs JSON with per-stage wall, peak RSS, and a diff block. Uses \`confidence_required=False\` so RED commits at 100K+ don't short-circuit the measurement.
- \`.github/workflows/bench-prepared-store.yml\`: workflow_dispatch with \`rows\` input (default 500_000) and \`ref\` input. Runs on \`large-new-64GB\` per \`feedback_bench_default_runner\`. Posts JSON to step summary + uploads as 30-day artifact.

Local smoke test at 200 rows succeeded (numbers not load-bearing at that scale; this is just to validate the wiring). Real numbers come from triggering the workflow against this branch once it merges, OR against this PR's branch via the \`ref\` input.

## Test plan

- [x] Local script runs end-to-end at 200 rows.
- [ ] Workflow triggers cleanly via \`gh workflow run\` once landed.
- [ ] 500K bench produces a measurable diff (wall or RSS, ideally both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)