### PR TITLE
bench: fix prepared-store bench to exercise auto-config path

### DIFF
--- a/.github/workflows/bench-prepared-store.yml
+++ b/.github/workflows/bench-prepared-store.yml
@@ -20,7 +20,7 @@ jobs:
   bench:
     name: "bench prepared-record-store"
     runs-on: large-new-64GB
-    timeout-minutes: 60
+    timeout-minutes: 180
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/python/goldenmatch/scripts/bench_prepared_store.py
+++ b/packages/python/goldenmatch/scripts/bench_prepared_store.py
@@ -70,17 +70,29 @@ def build_df(n: int) -> pl.DataFrame:
 
 
 def run_one(label: str, df: pl.DataFrame, *, prepared_record_store: bool) -> dict:
-    """Run dedupe_df once under bench_capture + tracemalloc."""
-    import goldenmatch as gm
-    from goldenmatch.config.schemas import GoldenMatchConfig
-    from goldenmatch.core.bench import bench_capture
+    """Run dedupe_df once under bench_capture + tracemalloc.
 
-    cfg = GoldenMatchConfig(prepared_record_store=prepared_record_store)
+    Must go through the auto-config path so the controller's 5-iteration
+    loop actually runs -- that's the loop Component 1's disk store
+    benefits. An empty GoldenMatchConfig short-circuits the controller
+    and produces zero pairs (PR #284's first run had cluster_count=N,
+    multi_member_count=0 because of this exact mistake).
+    """
+    import goldenmatch as gm
+    from goldenmatch.core.autoconfig import auto_configure_df
+    from goldenmatch.core.bench import bench_capture, stage
 
     tracemalloc.start()
     t0 = perf_counter()
     with bench_capture() as rec:
-        result = gm.dedupe_df(df, config=cfg, confidence_required=False)
+        # Stage the auto-config call separately from the final dedupe so
+        # the diff between controller-iteration cost and final-run cost
+        # is visible in the JSON output.
+        with stage("auto_configure_outer"):
+            cfg = auto_configure_df(df, confidence_required=False)
+        cfg.prepared_record_store = prepared_record_store
+        with stage("dedupe_final"):
+            result = gm.dedupe_df(df, config=cfg, confidence_required=False)
     wall = perf_counter() - t0
     _current, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()


### PR DESCRIPTION
## Summary

The first bench run on PR #284's workflow produced a null result (wall delta = -0.045s, RSS delta = -0.38 MB) because it constructed an empty \`GoldenMatchConfig\` with no matchkeys. The pipeline short-circuited to "every row is its own cluster" — \`exact_pair_count = 0\`, \`multi_member_cluster_count = 0\`, controller never iterated.

Fix: call \`auto_configure_df\` explicitly, set \`prepared_record_store\` on the resulting config, then call \`dedupe_df\`. This is the path Component 1 (PRs #280-#282) actually benefits.

Also bumps workflow timeout 60 → 180 minutes (5K rows in the auto-config path took 58s locally; 500K projects to ~90 min, which the old cap couldn't hold).

### Local smoke (5K rows)

| | wall | peak RSS |
|---|---|---|
| baseline | 58.25s | 171.13 MB |
| treatment | 51.80s | 164.20 MB |
| **delta** | **-11.08%** | **-4.05%** |

So the savings are real but bounded by **sample size**, not dataset size — iterations 2-5 of the controller hit prep on ~\`min(n, sample_size_default)\` rows, not the full df. At 500K this should hold; at 50M+ it scales with the controller's sample cap, not with N.

## Test plan

- [x] Local script runs end-to-end at 5K.
- [ ] CI green.
- [ ] Trigger workflow against \`main\` after merge; pull the JSON artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)