### PR TITLE
ci: combine goldenmatch pytest + coverage into one suite pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,26 +211,27 @@ jobs:
           # trace (vs the whole job timing out at 6h with zero diagnostics).
           # PR #66 hit a goldencheck pytest hang on Linux that didn't
           # reproduce locally — this converts that into actionable signal.
-          uv run pytest packages/python/${{ matrix.pkg }} -n auto --timeout=120 --timeout-method=thread $IGNORE
+          #
+          # For goldenmatch only: also produce coverage.xml in this same
+          # pytest run so the floor check (next step) has the artifact
+          # without re-executing the suite. Coverage instrumentation adds
+          # ~30% wall vs ~4x for a second serial pytest pass (pre-2026-05-16
+          # this lane was 105s plain + 406s with cov; combining drops total
+          # to ~140s for the goldenmatch matrix entry).
+          COV_ARGS=""
+          if [ "${{ matrix.pkg }}" = "goldenmatch" ]; then
+            COV_ARGS="--cov=goldenmatch --cov-report=xml:packages/python/goldenmatch/coverage.xml --cov-report=term"
+          fi
+          uv run pytest packages/python/${{ matrix.pkg }} -n auto --timeout=120 --timeout-method=thread $COV_ARGS $IGNORE
       # Per-module coverage gate (goldenmatch only — other packages don't yet
-      # have floors defined). Fails CI if any tracked module regresses below
-      # its floor in scripts/check_coverage_floors.py. Ratchet floors upward
-      # over time; never silently drop a module from the dict.
+      # have floors defined). Reads the coverage.xml produced by the pytest
+      # step above. Fails CI if any tracked module regresses below its floor
+      # in scripts/check_coverage_floors.py. Ratchet floors upward over
+      # time; never silently drop a module from the dict.
       - name: Coverage floors (goldenmatch only)
         if: matrix.pkg == 'goldenmatch'
         shell: bash
         run: |
-          uv run pytest packages/python/goldenmatch --cov=goldenmatch \
-            --cov-report=xml:packages/python/goldenmatch/coverage.xml \
-            --cov-report=term \
-            --timeout=120 --timeout-method=thread \
-            --ignore=packages/python/goldenmatch/tests/test_db.py \
-            --ignore=packages/python/goldenmatch/tests/test_reconcile.py \
-            --ignore=packages/python/goldenmatch/tests/test_mcp_and_watch.py \
-            --ignore=packages/python/goldenmatch/tests/test_embedder.py \
-            --ignore=packages/python/goldenmatch/tests/test_llm_boost.py \
-            --ignore=packages/python/goldenmatch/tests/test_autoconfig_benchmarks.py \
-            -q -x || true
           uv run python scripts/check_coverage_floors.py packages/python/goldenmatch/coverage.xml
 
   # Visibility lanes for tests that the main `python` job currently --ignores.


### PR DESCRIPTION
## Summary

The \`python (goldenmatch)\` matrix entry was running the entire pytest suite **twice**: once parallel for pass/fail (~105s), then once serial with \`--cov\` to produce the floor-check \`coverage.xml\` artifact (~406s). Total ~8:30, making it the long pole of every CI run on every PR.

This change collapses the two into one parallel \`pytest -n auto --cov\` pass in the goldenmatch matrix entry. The floor-check step then just reads the \`coverage.xml\` that pass produced.

### Projected impact

- **Coverage step**: 406s → eliminated (it's now just \`check_coverage_floors.py\` against an existing xml — milliseconds).
- **pytest step**: 105s → ~140s (coverage instrumentation adds ~30% wall).
- **Total lane**: 8:30 → ~2:30.

### Diagnosis context

Last 50 successful main CI runs:

| | avg | max |
|---|---|---|
| pre-2026-05-09 | 1 min | 2 min |
| 2026-05-09 to now | 4 min | 17 min |

Slowdown is concentrated in the goldenmatch lane; test count grew from ~2000 to ~2440 over two weeks (controller v3 + budget pathology + identity graph) which compounds the cost of running the suite twice.

### Behavior change worth flagging

The old coverage step had \`-q -x || true\` — failures didn't block CI (cov step was best-effort). The combined step doesn't suppress; if pytest fails, the lane fails immediately. This is the right behavior — we want to know about failures — but if anyone had been relying on the cov step to absorb known flakes, those will now surface.

Other matrix packages (goldencheck, goldenflow, goldenpipe, infermap, goldencheck-types) are unaffected — they didn't have the coverage step in the first place.

## Test plan

- [ ] CI green on this PR.
- [ ] Lane time on this PR's run lands in the projected 2-3 min window.
- [ ] Coverage floors still enforced (intentionally regress a module to verify the step still fails the build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)