### PR TITLE
feat(distributed): Component 3 / Phase 1 -- PreparedRecordStore read_only kwarg

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
@@ -67,6 +67,7 @@ class PreparedRecordStore:
         base_dir: Path | str | None = None,
         path: Path | str | None = None,
         cleanup: bool = True,
+        read_only: bool = False,
     ) -> None:
         if path is not None:
             self.path = Path(path)
@@ -84,7 +85,9 @@ class PreparedRecordStore:
             self.path = Path(p)
             self._owns_file = True
         self._cleanup = cleanup
-        self._con: duckdb.DuckDBPyConnection | None = duckdb.connect(str(self.path))
+        self._con: duckdb.DuckDBPyConnection | None = duckdb.connect(
+            str(self.path), read_only=read_only,
+        )
         self._closed = False
 
     @property

--- a/packages/python/goldenmatch/tests/test_prepared_record_store.py
+++ b/packages/python/goldenmatch/tests/test_prepared_record_store.py
@@ -122,3 +122,54 @@ def test_context_manager_closes_on_exit(tmp_path: Path):
         p = store.path
         assert p.exists()
     assert not p.exists()
+
+
+# ---------------------------------------------------------------------------
+# Component 3 prereq: read_only kwarg (Phase 1 of distributed-scoring plan)
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_false_allows_write(tmp_path: Path):
+    """Default read_only=False permits materialize_prepared_records."""
+    store = PreparedRecordStore(base_dir=tmp_path, read_only=False)
+    try:
+        materialize_prepared_records(store, _sample_df(), signature="sig-ro")
+        loaded = load_prepared_records(store, signature="sig-ro")
+        assert loaded is not None
+        assert loaded.height == 4
+    finally:
+        store.close()
+
+
+def test_read_only_true_raises_on_write(tmp_path: Path):
+    """read_only=True opens the store in DuckDB read-only mode; writes raise."""
+    # First create a valid DuckDB file with a known-path store.
+    p = tmp_path / "ro_test.duckdb"
+    writer = PreparedRecordStore(path=p, cleanup=False)
+    materialize_prepared_records(writer, _sample_df(), signature="sig-ro")
+    writer.close()
+
+    # Re-open in read-only mode; any write must raise.
+    store = PreparedRecordStore(path=p, cleanup=False, read_only=True)
+    try:
+        import pytest
+        with pytest.raises(Exception):
+            materialize_prepared_records(store, _sample_df(), signature="sig-ro-new")
+    finally:
+        store.close()
+
+
+def test_read_only_true_allows_read(tmp_path: Path):
+    """read_only=True can read tables that were written before opening."""
+    p = tmp_path / "ro_read_test.duckdb"
+    writer = PreparedRecordStore(path=p, cleanup=False)
+    materialize_prepared_records(writer, _sample_df(), signature="sig-ro-read")
+    writer.close()
+
+    store = PreparedRecordStore(path=p, cleanup=False, read_only=True)
+    try:
+        loaded = load_prepared_records(store, signature="sig-ro-read")
+        assert loaded is not None
+        assert set(loaded.iter_rows()) == set(_sample_df().iter_rows())
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary

Phase 1 of Component 3 (Distributed Plan v1). Prereq for Phase 2's worker-side reads.

Adds \`read_only: bool = False\` kwarg to \`PreparedRecordStore.__init__\`. Forwards to \`duckdb.connect(..., read_only=read_only)\`. When \`True\`, multiple processes can open the same \`.duckdb\` file concurrently without write-lock contention.

Driver (single writer) stays \`read_only=False\` (the default). Workers in Phase 2+ will pass \`read_only=True\`.

## Test plan

- [x] 3 new tests pass (default-is-False / read_only allows read / read_only rejects writes).
- [x] 9 existing Component 1 tests stay green.
- [x] Component 2 Phase 1 + Phase 2 tests stay green (no regression).
- [x] ruff clean.
- [ ] CI green on the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)