### PR TITLE
feat(distributed): Component 3 / Phase 2 -- key-mode Ray dispatch

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
@@ -11,10 +11,39 @@ Usage:
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+
+import polars as pl
 
 logger = logging.getLogger(__name__)
 
 _ray = None
+
+
+_PAIR_BYTES_ESTIMATE = 80
+"""Approx bytes per scored pair (3-tuple of int, int, float) in a flat
+list. CPython tuple header ~56 bytes + ints + float. Conservative;
+underestimating would let the driver-OOM guard fire late.
+
+Used by Phase 3's incremental ray.wait gather to project cumulative
+pair memory against psutil.virtual_memory().available * 0.5.
+"""
+
+
+@dataclass(frozen=True)
+class _KeyModeBlock:
+    """Minimal block shim used by the key-mode Ray task (defined inside
+    score_blocks_ray).
+
+    _score_one_block (core/scorer.py) only reads .block_key + .df +
+    .pre_scored_pairs; this matches that contract without dragging in
+    BlockResult's multi-pass fields (strategy, depth, parent_key)
+    which key-mode v1 doesn't support. Module-level so Ray pickling
+    resolves it on workers — a nested class breaks serialization.
+    """
+    block_key: str
+    df: pl.LazyFrame
+    pre_scored_pairs: list | None = None
 
 
 def _ensure_ray():
@@ -41,11 +70,14 @@ def _ensure_ray():
 
 def score_blocks_ray(
     blocks: list,
-    mk: MatchkeyConfig,  # noqa: F821  # forward ref, resolved lazily via __future__ annotations
+    mk,  # noqa: F821  # forward ref, resolved lazily via __future__ annotations
     matched_pairs: set[tuple[int, int]],
     across_files_only: bool = False,
     source_lookup: dict[int, str] | None = None,
     target_ids: set[int] | None = None,
+    *,
+    store_path: str | None = None,
+    signature: str | None = None,
 ) -> list[tuple[int, int, float]]:
     """Score all blocks using Ray distributed tasks.
 
@@ -60,14 +92,23 @@ def score_blocks_ray(
         across_files_only: Filter to cross-source pairs only.
         source_lookup: Row ID to source name mapping.
         target_ids: For match mode — filter to target/ref cross pairs.
+        store_path: Optional path to a PreparedRecordStore .duckdb file.
+            When set together with ``signature``, enables key-mode dispatch:
+            workers receive block keys and open the store themselves instead
+            of receiving materialized DataFrames from the driver.
+        signature: Cache signature matching the one used when the store was
+            written (via materialize_blocks). Must be set alongside
+            ``store_path`` to activate key-mode.
 
     Returns:
         All fuzzy pairs found across blocks.
     """
-    ray = _ensure_ray()
-
+    # Short-circuit BEFORE _ensure_ray() so callers with no blocks (and
+    # potentially no Ray install) don't trigger a lazy Ray import + init.
     if not blocks:
         return []
+
+    ray = _ensure_ray()
 
     # For very small block counts, use the regular scorer (no Ray overhead)
     if len(blocks) <= 4:
@@ -98,30 +139,86 @@ def score_blocks_ray(
             source_lookup=src_lookup,
         )
 
-    # Submit all blocks as Ray tasks
-    futures = []
-    for block in blocks:
-        # Collect the lazy DataFrame before sending to Ray
-        if hasattr(block, 'df') and hasattr(block.df, 'collect'):
-            collected_block = type(block)(
-                block_key=block.block_key,
-                df=block.df.collect().lazy(),
-                strategy=block.strategy,
-                depth=getattr(block, 'depth', 0),
-                parent_key=getattr(block, 'parent_key', None),
-                pre_scored_pairs=getattr(block, 'pre_scored_pairs', None),
-            )
-        else:
-            collected_block = block
-
-        future = _score_block_remote.remote(
-            collected_block, mk_ref, exclude_ref,
-            across_files_only, source_ref,
+    @ray.remote(max_retries=0)
+    def _score_block_remote_by_key(
+        block_key: str,
+        store_path_inner: str,
+        signature_inner: str,
+        mk_config,
+        exclude,
+        src_lookup,
+        across_only: bool,
+    ):
+        """Component 3 key-mode Ray task: worker opens the store and
+        loads its block by key. Driver only ships strings."""
+        from goldenmatch.core.scorer import _score_one_block as _sob
+        from goldenmatch.distributed.record_store import (
+            PreparedRecordStore,
+            load_block,
         )
-        futures.append(future)
 
-    logger.info("Submitted %d blocks to Ray (%d CPUs available)",
-                len(futures), int(ray.cluster_resources().get("CPU", 0)))
+        store = PreparedRecordStore(
+            path=store_path_inner, cleanup=False, read_only=True,
+        )
+        try:
+            block_df = load_block(
+                store, signature=signature_inner, block_key=block_key,
+            )
+            if block_df is None:
+                raise RuntimeError(
+                    f"Component 3: block_key={block_key!r} not found in "
+                    f"store at {store_path_inner} for signature="
+                    f"{signature_inner!r} -- likely cause is signature "
+                    f"drift between driver and worker (config mutated "
+                    f"mid-run) or off-by-one in block_assignments"
+                )
+            shim = _KeyModeBlock(block_key=block_key, df=block_df.lazy())
+            return _sob(
+                shim, mk_config, exclude,
+                across_files_only=across_only, source_lookup=src_lookup,
+            )
+        finally:
+            store.close()
+
+    use_key_mode = store_path is not None and signature is not None
+
+    futures = []
+    if use_key_mode:
+        for block in blocks:
+            future = _score_block_remote_by_key.remote(
+                block.block_key, store_path, signature,
+                mk_ref, exclude_ref, source_ref,
+                across_files_only,
+            )
+            futures.append(future)
+    else:
+        for block in blocks:
+            # Collect the lazy DataFrame before sending to Ray (existing
+            # df-mode behavior, preserved verbatim).
+            if hasattr(block, 'df') and hasattr(block.df, 'collect'):
+                collected_block = type(block)(
+                    block_key=block.block_key,
+                    df=block.df.collect().lazy(),
+                    strategy=block.strategy,
+                    depth=getattr(block, 'depth', 0),
+                    parent_key=getattr(block, 'parent_key', None),
+                    pre_scored_pairs=getattr(block, 'pre_scored_pairs', None),
+                )
+            else:
+                collected_block = block
+
+            future = _score_block_remote.remote(
+                collected_block, mk_ref, exclude_ref,
+                across_files_only, source_ref,
+            )
+            futures.append(future)
+
+    logger.info(
+        "Submitted %d blocks to Ray (%s mode, %d CPUs available)",
+        len(futures),
+        "key" if use_key_mode else "df",
+        int(ray.cluster_resources().get("CPU", 0)),
+    )
 
     # Collect results
     all_pairs = []

--- a/packages/python/goldenmatch/tests/test_distributed_scoring.py
+++ b/packages/python/goldenmatch/tests/test_distributed_scoring.py
@@ -1,0 +1,122 @@
+"""Unit + integration tests for Component 3 (distributed scoring).
+
+All tests gated on `ray` being importable; the file's collection
+falls through (no errors) when the [ray] extra isn't installed.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+ray = pytest.importorskip("ray")
+
+
+# ── Shared fixtures + helpers (used by Phase 2, 3, and 4 tests) ─────
+
+
+@pytest.fixture(scope="module")
+def _ray_local():
+    """Module-scoped Ray init so we pay startup once across all integration
+    tests. ignore_reinit_error in case earlier tests already touched ray."""
+    ray.init(
+        local_mode=False, ignore_reinit_error=True,
+        num_cpus=2, logging_level="WARNING",
+    )
+    yield
+    ray.shutdown()
+
+
+def _build_small_blocks(tmp_path: Path):
+    """Materialize a small df to a PreparedRecordStore split across 5 blocks
+    of 1-2 rows each. Returns (store_path, signature, blocks list).
+
+    Total blocks > 4 so the small-block fast path doesn't engage.
+    Used by Phase 3 (OOM guard) and Phase 4 (integration) tests.
+    """
+    from goldenmatch.core.blocker import BlockResult
+    from goldenmatch.distributed.record_store import (
+        PreparedRecordStore,
+        materialize_blocks,
+        materialize_prepared_records,
+    )
+    # Every block has 2 rows that share __mk_name__, so every block
+    # emits at least 1 pair. Required for the Phase 3 OOM test to be
+    # deterministic: if any block returned 0 pairs, the cumulative
+    # pair counter could stay at 0 long enough for the loop to drain
+    # without tripping the guard. 5 multi-row blocks > 4 -> key-mode
+    # engages (no small-block fallback).
+    df = pl.DataFrame({
+        "__row_id__":  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        "name":        ["alice", "alice2", "bob", "bob2", "carol", "carol2", "dan", "dan2", "eve", "eve2"],
+        "__mk_name__": ["alice", "alice",  "bob", "bob",  "carol", "carol",  "dan", "dan",  "eve", "eve"],
+    })
+    block_assignments = {
+        0: "A", 1: "A",
+        2: "B", 3: "B",
+        4: "C", 5: "C",
+        6: "D", 7: "D",
+        8: "E", 9: "E",
+    }
+
+    store_path = tmp_path / "store.duckdb"
+    with PreparedRecordStore(path=store_path, cleanup=False) as store:
+        materialize_prepared_records(store, df, signature="sig-v1")
+        materialize_blocks(
+            store, df, block_assignments=block_assignments, signature="sig-v1",
+        )
+
+    # Build BlockResult shells. df-mode reads .df; key-mode ignores it.
+    # BlockResult requires `strategy=` per its dataclass; pass "static".
+    blocks = [
+        BlockResult(
+            block_key=k,
+            df=df.filter(
+                pl.col("__row_id__").is_in(
+                    [r for r, v in block_assignments.items() if v == k]
+                )
+            ).lazy(),
+            strategy="static",
+        )
+        for k in sorted(set(block_assignments.values()))
+    ]
+    return str(store_path), "sig-v1", blocks
+
+
+# ── Unit tests (no real Ray runtime) ────────────────────────────────
+
+def test_key_mode_block_shim_exposes_required_attributes():
+    """_KeyModeBlock must satisfy the _score_one_block contract: .block_key
+    (str) and .df (LazyFrame). Module-level dataclass so Ray pickling
+    resolves it; a nested class breaks serialization."""
+    from goldenmatch.backends.ray_backend import _KeyModeBlock
+    df = pl.DataFrame({"__row_id__": [0], "name": ["a"]})
+    block = _KeyModeBlock(block_key="key-1", df=df.lazy())
+    assert block.block_key == "key-1"
+    assert block.df is not None
+    # Frozen dataclass: assignment must raise.
+    with pytest.raises(Exception):  # noqa: B017 -- frozen dataclass error class
+        block.block_key = "mutated"
+
+
+def test_pair_bytes_estimate_constant_is_module_level():
+    """_PAIR_BYTES_ESTIMATE must be importable + finite + > 0 (Phase 3
+    OOM guard depends on it). Anchors the constant against accidental
+    deletion."""
+    from goldenmatch.backends.ray_backend import _PAIR_BYTES_ESTIMATE
+    assert isinstance(_PAIR_BYTES_ESTIMATE, int)
+    assert _PAIR_BYTES_ESTIMATE > 0
+
+
+def test_score_blocks_ray_signature_accepts_new_kwargs():
+    """score_blocks_ray must accept store_path + signature kwargs without
+    raising TypeError, even when ray isn't actually initialized. Achieved
+    by short-circuiting on empty blocks list (returns [] early)."""
+    from goldenmatch.backends import ray_backend
+    result = ray_backend.score_blocks_ray(
+        [], mk=None, matched_pairs=set(),
+        store_path="/tmp/store.duckdb",
+        signature="sig-v1",
+    )
+    assert result == []


### PR DESCRIPTION
## Summary

Phase 2 of Component 3 (Distributed Plan v1). Phase 1 = #289.

Adds module-level \`_PAIR_BYTES_ESTIMATE\` constant + \`_KeyModeBlock\` dataclass + in-function \`_score_block_remote_by_key\` Ray task + key-mode branch in \`score_blocks_ray\`. New \`store_path\` + \`signature\` kwargs route to **key-mode**: workers receive block-key strings, call \`load_block\` on the disk store, return pairs. Driver only ships strings.

## Deviations from plan (caught during implementation)

Both required by the actual \`_score_one_block\` signature (\`core/scorer.py\`); spec missed them across 3 review rounds.

1. **\`_KeyModeBlock.df\` typed \`pl.LazyFrame\`, not \`pl.DataFrame\`** — \`_score_one_block\` calls \`block.df.collect()\` (line 775). Shim wraps loaded block via \`block_df.lazy()\`.
2. **\`_KeyModeBlock\` gained \`pre_scored_pairs: list | None = None\`** — \`_score_one_block\` reads \`block.pre_scored_pairs\` (line 785). Default \`None\` is the no-multi-pass case Phase 2 supports.

Both deviations preserve the spec's intent (minimal shim, only needed fields) — the spec just under-specified the contract.

## Test plan

- [x] 3 new unit tests pass (\`_KeyModeBlock\` shim, \`_PAIR_BYTES_ESTIMATE\` constant, new-kwargs accepted via empty-blocks short-circuit).
- [x] Component 1 + Component 2 tests stay green.
- [x] ruff clean.
- [ ] CI green on the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)