### PR TITLE
feat(distributed): Component 3 / Phase 3 -- driver-OOM guard

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
@@ -220,19 +220,40 @@ def score_blocks_ray(
         int(ray.cluster_resources().get("CPU", 0)),
     )
 
-    # Collect results
-    all_pairs = []
-    results = ray.get(futures)
-    for pairs in results:
+    # Incremental gather with driver-OOM guard.
+    import psutil
+    budget_bytes = psutil.virtual_memory().available * 0.5
+    budget_pairs = int(budget_bytes // _PAIR_BYTES_ESTIMATE)
+
+    all_pairs: list[tuple[int, int, float]] = []
+    remaining = list(futures)
+    n_pairs = 0
+    while remaining:
+        ready, remaining = ray.wait(remaining, num_returns=1)
+        block_pairs = ray.get(ready[0])
         if target_ids is not None:
-            pairs = [
-                (a, b, s) for a, b, s in pairs
+            block_pairs = [
+                (a, b, s) for a, b, s in block_pairs
                 if (a in target_ids) != (b in target_ids)
             ]
-        all_pairs.extend(pairs)
-        for a, b, s in pairs:
+        all_pairs.extend(block_pairs)
+        for a, b, s in block_pairs:
             matched_pairs.add((min(a, b), max(a, b)))
-
+        n_pairs += len(block_pairs)
+        if n_pairs > budget_pairs:
+            for f in remaining:
+                try:
+                    ray.cancel(f)
+                except Exception:  # noqa: BLE001 -- best-effort cleanup
+                    pass
+            raise MemoryError(
+                f"Component 3: scored pairs ({n_pairs:,}) would exceed "
+                f"50% of available driver RAM "
+                f"({int(budget_bytes // (1024 * 1024))} MB budget, "
+                f"~{_PAIR_BYTES_ESTIMATE} bytes/pair) -- switch to "
+                f"backend='chunked' or wait for Component 4 "
+                f"(streaming pair store)"
+            )
     return all_pairs
 
 

--- a/packages/python/goldenmatch/tests/test_distributed_scoring.py
+++ b/packages/python/goldenmatch/tests/test_distributed_scoring.py
@@ -120,3 +120,59 @@ def test_score_blocks_ray_signature_accepts_new_kwargs():
         signature="sig-v1",
     )
     assert result == []
+
+
+def test_driver_oom_guard_raises_when_budget_exceeded(_ray_local, tmp_path: Path, monkeypatch):
+    """End-to-end: with psutil claiming near-zero available memory, the
+    incremental gather must trip the OOM guard and raise MemoryError
+    citing 'scored pairs'.
+
+    Uses real Ray + real PreparedRecordStore so the guard's interaction
+    with ray.wait + ray.cancel + ray.get is exercised, not stubbed."""
+    import psutil
+    from goldenmatch.backends import ray_backend
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    store_path, sig, blocks = _build_small_blocks(tmp_path)
+    # Score on __mk_name__ with exact scorer -- within each block both rows
+    # share an identical __mk_name__ value, so every block emits exactly 1
+    # pair. This guarantees n_pairs > 0 regardless of psutil state.
+    mk = MatchkeyConfig(
+        name="mk_exact", type="weighted", threshold=0.5,
+        fields=[MatchkeyField(field="__mk_name__", scorer="exact", weight=1.0)],
+    )
+
+    # Pretend the system has 80 bytes of available memory total ->
+    # budget_pairs = 80 * 0.5 / 80 = 0. Any non-empty pair list trips.
+    class FakeMem:
+        available = 80
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: FakeMem)
+
+    with pytest.raises(MemoryError, match="scored pairs"):
+        ray_backend.score_blocks_ray(
+            blocks, mk, set(),
+            store_path=store_path, signature=sig,
+        )
+
+
+def test_driver_oom_guard_passes_under_normal_memory(_ray_local, tmp_path: Path):
+    """Sanity: with real psutil reporting actual system memory, the
+    guard does NOT fire on a tiny test fixture. Anchors that the guard
+    isn't pathologically tight."""
+    from goldenmatch.backends import ray_backend
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    store_path, sig, blocks = _build_small_blocks(tmp_path)
+    # Score on __mk_name__ -- same as the OOM test so both tests exercise
+    # the same code path; guard difference is purely the psutil mock.
+    mk = MatchkeyConfig(
+        name="mk_exact", type="weighted", threshold=0.5,
+        fields=[MatchkeyField(field="__mk_name__", scorer="exact", weight=1.0)],
+    )
+    # Should return normally (pairs depend on fixture content; just
+    # assert no exception).
+    pairs = ray_backend.score_blocks_ray(
+        blocks, mk, set(),
+        store_path=store_path, signature=sig,
+    )
+    assert isinstance(pairs, list)


### PR DESCRIPTION
## Summary

Phase 3 of Component 3 (Distributed Plan v1). Phases 1 (#289) + 2 (#290) merged.

Replaces the existing \`ray.get([futures])\` gather in \`score_blocks_ray\` with an incremental \`ray.wait\` loop. After each completed task, cumulative scored-pair count is compared to a budget: \`psutil.virtual_memory().available * 0.5 / _PAIR_BYTES_ESTIMATE\` (~80 bytes/pair). When the cumulative count exceeds budget, remaining futures are cancelled (best-effort) and the driver raises \`MemoryError\` with a message pointing to \`backend='chunked'\` or Component 4.

\`target_ids\` filter + \`matched_pairs.add()\` semantics preserved inside the new loop body.

## Deviations from plan

1. **Test scorer field changed from \`name\` to \`__mk_name__\`.** The plan's tests used \`scorer="exact"\` on \`field="name"\`, but the \`_build_small_blocks\` fixture has unique \`name\` values across the 2-row blocks (\`alice\` vs \`alice2\`). Exact-on-\`name\` returns 0 pairs and the guard never fires. \`__mk_name__\` is duplicated within each block (both rows have \`"alice"\` etc.) so each block emits exactly 1 pair — matches the fixture comment's stated invariant.
2. ASCII \`--\` instead of em-dash in the \`MemoryError\` message (project-wide convention).

## Test plan

- [x] 2 new tests pass (\`test_driver_oom_guard_raises_when_budget_exceeded\`, \`test_driver_oom_guard_passes_under_normal_memory\`).
- [x] Phase 2's 3 tests stay green.
- [x] All Component 1+2 tests stay green (23 passed in regression slice).
- [x] ruff clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)