### PR TITLE
feat(distributed): Component 3 / Phase 5 -- pipeline.py wiring

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -903,11 +903,27 @@ def _run_dedupe_pipeline(
                     except Exception:  # pragma: no cover — defensive
                         continue
                 block_scorer = _get_block_scorer(config)
+
+                # Component 3: when all three gating flags are on AND we have a live
+                # _prep_store, hand the backend the store_path + signature so the Ray
+                # key-mode dispatch path can fire. Backend ignores these kwargs in
+                # df-mode and the non-Ray scorers.
+                key_mode_kwargs: dict[str, str] = {}
+                if (
+                    config.backend == "ray"
+                    and config.prepared_record_store
+                    and config.partitioned_block_scoring
+                    and _prep_store is not None
+                ):
+                    key_mode_kwargs["store_path"] = str(_prep_store.path)
+                    key_mode_kwargs["signature"] = _prep_cache_signature(config)
+
                 with stage("fuzzy_score_blocks"):
                     pairs = block_scorer(
                         blocks, mk, matched_pairs,
                         across_files_only=across_files_only,
                         source_lookup=source_lookup if across_files_only else None,
+                        **key_mode_kwargs,
                     )
                 all_pairs.extend(pairs)
                 fuzzy_pair_count += len(pairs)

--- a/packages/python/goldenmatch/tests/test_partitioned_block_scoring_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_partitioned_block_scoring_pipeline.py
@@ -98,3 +98,81 @@ def test_flag_on_materializes_blocks_to_store(tmp_path: Path, monkeypatch):
         f"expected partitioned_block_scoring=True to write at least one "
         f"block to the store; got 0. sig={sig}"
     )
+
+
+def test_pipeline_passes_store_path_when_all_flags_on(tmp_path: Path, monkeypatch):
+    """When backend=ray + prepared_record_store + partitioned_block_scoring
+    are all on, the pipeline must pass store_path + signature kwargs to
+    score_blocks_ray. Monkeypatch score_blocks_ray to record kwargs --
+    we don't need ray actually installed to assert pipeline-side wiring."""
+    import goldenmatch as gm
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    monkeypatch.setenv("GOLDENMATCH_PREPARED_RECORD_STORE_DIR", str(tmp_path))
+    monkeypatch.setenv("GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST", "1")
+
+    df = _diverse_df()
+    cfg = auto_configure_df(df, confidence_required=False)
+    cfg.prepared_record_store = True
+    cfg.partitioned_block_scoring = True
+    cfg.backend = "ray"
+
+    captured: dict = {}
+    def fake_score_blocks_ray(blocks, mk, matched_pairs, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    # The pipeline imports score_blocks_ray via _get_block_scorer, which
+    # may resolve to a different name at runtime. Patch at the module
+    # import point.
+    monkeypatch.setattr(
+        "goldenmatch.backends.ray_backend.score_blocks_ray",
+        fake_score_blocks_ray,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "goldenmatch.core.pipeline._get_block_scorer",
+        lambda config: fake_score_blocks_ray,
+    )
+
+    gm.dedupe_df(df, config=cfg, confidence_required=False)
+
+    assert "store_path" in captured, (
+        f"pipeline must pass store_path kwarg to score_blocks_ray when "
+        f"all three flags are on; got kwargs={captured!r}"
+    )
+    assert "signature" in captured
+    assert captured["store_path"] is not None
+    assert captured["signature"] is not None
+
+
+def test_pipeline_does_not_pass_store_path_when_disk_store_off(tmp_path: Path, monkeypatch):
+    """backend=ray but prepared_record_store=False -> no store_path kwarg.
+    Ensures df-mode is unaffected for users who picked Ray but not the
+    disk store."""
+    import goldenmatch as gm
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+
+    df = _diverse_df()
+    cfg = auto_configure_df(df, confidence_required=False)
+    cfg.prepared_record_store = False
+    cfg.partitioned_block_scoring = False
+    cfg.backend = "ray"
+
+    captured: dict = {}
+    def fake_score_blocks_ray(blocks, mk, matched_pairs, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        "goldenmatch.core.pipeline._get_block_scorer",
+        lambda config: fake_score_blocks_ray,
+    )
+
+    gm.dedupe_df(df, config=cfg, confidence_required=False)
+
+    assert captured.get("store_path") is None
+    assert captured.get("signature") is None


### PR DESCRIPTION
## Summary

Phase 5 of Component 3 (Distributed Plan v1). Phases 1-4 (PRs #289-#291 + #293) merged.

When \`config.backend == "ray"\` AND \`config.prepared_record_store\` AND \`config.partitioned_block_scoring\` AND \`_prep_store is not None\`, the pipeline passes \`store_path\` + \`signature\` kwargs to \`score_blocks_ray\` so the key-mode Ray dispatch path can fire. Gated by \`backend == "ray"\`, so non-Ray scorers never see the kwargs.

**Dedupe path only.** The \`block_scorer\` call site in \`_run_match_pipeline\` (line ~1508) is intentionally NOT wired — \`_prep_store\` isn't in scope there; match-path support is a v2 followup.

## Test plan

- [x] 2 new tests pass (\`test_pipeline_passes_store_path_when_all_flags_on\` + \`test_pipeline_does_not_pass_store_path_when_disk_store_off\`).
- [x] All 4 pre-existing partitioned_block_scoring tests + Phase 1-4 tests stay green.
- [x] Positive-case test doesn't require ray installed — monkeypatches \`_get_block_scorer\`.
- [x] ruff clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)