### PR TITLE
bench(distributed): Component 3 / Phase 6 -- 5M kill checkpoint

### DIFF
--- a/.github/workflows/bench-distributed-stack.yml
+++ b/.github/workflows/bench-distributed-stack.yml
@@ -1,0 +1,55 @@
+name: bench-distributed-stack
+
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "Synthetic df row count"
+        required: false
+        default: "5000000"
+      ref:
+        description: "Branch / tag / SHA to bench (default: workflow ref)"
+        required: false
+
+jobs:
+  bench:
+    name: "bench distributed stack (chunked vs Component 1+2+3)"
+    runs-on: large-new-64GB
+    timeout-minutes: 180
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install goldenmatch with ray extra
+        working-directory: packages/python/goldenmatch
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[ray]"
+
+      - name: Run bench
+        working-directory: packages/python/goldenmatch
+        env:
+          GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+        run: |
+          mkdir -p bench-out
+          python scripts/bench_distributed_stack.py \
+            --rows "${{ inputs.rows }}" \
+            --store-dir bench-out/store \
+            --out bench-out/results.json
+          echo '## bench-distributed-stack results' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat bench-out/results.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-distributed-stack-${{ inputs.rows }}-rows
+          path: packages/python/goldenmatch/bench-out/results.json
+          retention-days: 30

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -917,6 +917,14 @@ def _run_dedupe_pipeline(
                 ):
                     key_mode_kwargs["store_path"] = str(_prep_store.path)
                     key_mode_kwargs["signature"] = _prep_cache_signature(config)
+                    # Windows (and some Linux file systems) hold an exclusive
+                    # write-lock on the DuckDB file for the driver process. Ray
+                    # workers in separate processes cannot open the same file
+                    # read-only while that lock is held. Release the driver
+                    # connection here -- all writes are already flushed to disk
+                    # by the time we reach the scoring stage -- so workers can
+                    # open the file concurrently.
+                    _prep_store.release_connection()
 
                 with stage("fuzzy_score_blocks"):
                     pairs = block_scorer(

--- a/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
@@ -96,6 +96,24 @@ class PreparedRecordStore:
             raise RuntimeError("PreparedRecordStore is closed")
         return self._con
 
+    def release_connection(self) -> None:
+        """Close the DuckDB connection without marking the store as closed
+        or deleting the file.
+
+        Used by the key-mode Ray dispatch path on Windows: DuckDB acquires
+        an exclusive write lock on the file even in the driver process.
+        Worker processes that open the same file read-only are blocked by
+        that lock. Calling release_connection() from the driver before
+        dispatching Ray tasks lets workers open the file concurrently.
+
+        The store object remains usable after this call for metadata access
+        (self.path, self._cleanup). The DB connection itself is gone; any
+        further call that needs self.connection will raise RuntimeError.
+        """
+        if self._con is not None:
+            self._con.close()
+            self._con = None
+
     def close(self) -> None:
         """Idempotent close. Removes the file when cleanup=True regardless
         of whether the store created the file (tempfile) or opened an

--- a/packages/python/goldenmatch/scripts/bench_distributed_stack.py
+++ b/packages/python/goldenmatch/scripts/bench_distributed_stack.py
@@ -1,0 +1,138 @@
+"""5M end-to-end bench comparing today's chunked backend against the full
+Component 1+2+3 stack (prepared_record_store + partitioned_block_scoring
++ backend=ray).
+
+Kill criterion: stack must show >= 20% wall AND >= 20% peak RSS
+improvement vs chunked or PRs #280-#283 + #287 + Component 3 PRs revert
+per project_distributed_plan_v1_kill_criterion.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tracemalloc
+from pathlib import Path
+from time import perf_counter
+
+import polars as pl
+
+
+def build_df(n: int) -> pl.DataFrame:
+    """Diverse-surname person-shape df. Per feedback_synthetic_surname_fixtures
+    each surname spans its own soundex bucket so blocking doesn't degenerate
+    into one O(N^2) block."""
+    surnames = [
+        "Smith", "Johnson", "Williams", "Brown", "Jones",
+        "Garcia", "Miller", "Davis", "Rodriguez", "Martinez",
+        "Hernandez", "Lopez", "Gonzalez", "Wilson", "Anderson",
+        "Thomas", "Taylor", "Moore", "Jackson", "Martin",
+    ]
+    first_names = [
+        "Alice", "Bob", "Charlie", "Dana", "Eve", "Frank",
+        "Grace", "Henry", "Iris", "Jack",
+    ]
+    rows = []
+    for i in range(n):
+        rows.append({
+            "first_name": first_names[i % len(first_names)],
+            "last_name":  surnames[i % len(surnames)],
+            "email":      f"u{i // 3}@example.com",
+            "zip":        f"{10000 + (i % 100):05d}",
+        })
+    return pl.DataFrame(rows)
+
+
+def run_one(label: str, df: pl.DataFrame, *, backend: str, prepared_record_store: bool, partitioned_block_scoring: bool) -> dict:
+    import goldenmatch as gm
+    from goldenmatch.core.autoconfig import auto_configure_df
+    from goldenmatch.core.bench import bench_capture
+
+    tracemalloc.start()
+    t0 = perf_counter()
+    with bench_capture() as rec:
+        cfg = auto_configure_df(df, confidence_required=False)
+        cfg.backend = backend
+        cfg.prepared_record_store = prepared_record_store
+        cfg.partitioned_block_scoring = partitioned_block_scoring
+        result = gm.dedupe_df(df, config=cfg, confidence_required=False)
+    wall = perf_counter() - t0
+    _current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    return {
+        "label": label,
+        "backend": backend,
+        "prepared_record_store": prepared_record_store,
+        "partitioned_block_scoring": partitioned_block_scoring,
+        "rows": df.height,
+        "wall_seconds": round(wall, 3),
+        "peak_rss_mb": round(peak / (1024 * 1024), 2),
+        "clusters": len(result.clusters),
+        "stage_timings_seconds": rec.to_dict()["stage_timings_seconds"],
+        "metrics": rec.to_dict()["metrics"],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, default=5_000_000)
+    parser.add_argument("--out", type=Path, default=Path("bench_distributed_stack.json"))
+    parser.add_argument("--store-dir", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    if args.store_dir is not None:
+        args.store_dir.mkdir(parents=True, exist_ok=True)
+        os.environ["GOLDENMATCH_PREPARED_RECORD_STORE_DIR"] = str(args.store_dir)
+        os.environ["GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST"] = "1"
+
+    print(f"Building synthetic df ({args.rows:,} rows)...", flush=True)
+    df = build_df(args.rows)
+
+    print("Run 1/2: baseline (backend=chunked)...", flush=True)
+    baseline = run_one("baseline", df, backend="chunked", prepared_record_store=False, partitioned_block_scoring=False)
+    print(f"  wall = {baseline['wall_seconds']}s; peak = {baseline['peak_rss_mb']} MB", flush=True)
+
+    print("Run 2/2: treatment (full stack: ray + store + partitioned)...", flush=True)
+    treatment = run_one("treatment", df, backend="ray", prepared_record_store=True, partitioned_block_scoring=True)
+    print(f"  wall = {treatment['wall_seconds']}s; peak = {treatment['peak_rss_mb']} MB", flush=True)
+
+    wall_delta = baseline["wall_seconds"] - treatment["wall_seconds"]
+    rss_delta = baseline["peak_rss_mb"] - treatment["peak_rss_mb"]
+    wall_pct = (-wall_delta / baseline["wall_seconds"]) * 100 if baseline["wall_seconds"] else 0.0
+    rss_pct = (-rss_delta / baseline["peak_rss_mb"]) * 100 if baseline["peak_rss_mb"] else 0.0
+
+    # Kill criterion check.
+    KILL_THRESHOLD_PCT = -20.0  # negative because pct_change is the "treatment relative to baseline" signed delta
+    kill_verdict = "PASS" if (wall_pct <= KILL_THRESHOLD_PCT and rss_pct <= KILL_THRESHOLD_PCT) else "FAIL"
+
+    out = {
+        "rows": args.rows,
+        "baseline": baseline,
+        "treatment": treatment,
+        "diff": {
+            "wall_saved_seconds": round(wall_delta, 3),
+            "wall_pct_change": round(wall_pct, 2),
+            "peak_rss_saved_mb": round(rss_delta, 2),
+            "peak_rss_pct_change": round(rss_pct, 2),
+        },
+        "kill_criterion": {
+            "threshold_pct": KILL_THRESHOLD_PCT,
+            "verdict": kill_verdict,
+            "note": "PASS = both wall and peak RSS improved by >= 20% (Component 1+2+3 stack stays). FAIL = revert PRs #280-#283 + #287 + Component 3 PRs.",
+        },
+    }
+    args.out.write_text(json.dumps(out, indent=2))
+    print(f"\nWrote {args.out}.", flush=True)
+    print(json.dumps(out["diff"], indent=2), flush=True)
+    print(f"\nKill criterion: {kill_verdict}", flush=True)
+    # Non-zero exit on FAIL so the workflow run status surfaces the
+    # verdict (visible in the GitHub Actions UI without opening the
+    # artifact). PASS exits 0.
+    return 0 if kill_verdict == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase 6 of Component 3 (Distributed Plan v1). Phases 1-5 (PRs #289-#291 + #293-#294) merged. **The kill checkpoint.**

- \`scripts/bench_distributed_stack.py\`: 5M baseline-vs-treatment bench. Baseline = \`backend="chunked"\` + both flags off. Treatment = \`backend="ray"\` + \`prepared_record_store=True\` + \`partitioned_block_scoring=True\`. Computes diff + kill verdict (PASS iff wall ≤ -20% AND peak RSS ≤ -20%). Exit 0 on PASS, 1 on FAIL.
- \`.github/workflows/bench-distributed-stack.yml\`: \`workflow_dispatch\` on \`large-new-64GB\`, 180-min timeout. Installs \`pip install -e ".[ray]"\`. Posts JSON to \`\$GITHUB_STEP_SUMMARY\` + uploads as 30-day artifact.

## Drive-by fix (spec gap discovered during 1K smoke)

DuckDB holds an exclusive write lock on the prepared-record-store file while the driver process has it open. Ray workers in separate processes can't open the same file \`read_only=True\` while that lock is held — \`IOException: The process cannot access the file\`. Spec §Error handling §3 anticipated concurrent *reader* contention but missed the writer-then-readers case.

Fix: \`PreparedRecordStore.release_connection()\` closes the driver's DB connection (without deleting the file or marking the store closed) before Ray dispatch. Called from \`pipeline.py\` at the key-mode dispatch site, after all writes complete and before \`score_blocks_ray\` runs.

Existing tests (19 store-related) stay green. Phase 4's cross-process test passed CI because it uses a file the writer had already closed — didn't cover writer-still-alive-during-reader-opens.

## Smoke at 1K (Windows local)

Numbers are noisy at this scale; only the wiring matters:
- Baseline (chunked): ~7s wall, ~22 MB peak RSS.
- Treatment (full stack): ~25s wall, ~55 MB peak RSS.
- Verdict: FAIL (Ray startup dominates at small N).

5M will tell us the real story.

## Trigger plan post-merge

\`\`\`
gh workflow run bench-distributed-stack.yml --ref main -f rows=5000000
\`\`\`

Verdict is binding: PASS → memo result + plan Component 4; FAIL → revert PRs #280-#283 + #287 + #289-#291 + #293-#294 + this PR per the kill criterion.

## Test plan

- [x] Local 1K smoke completes end-to-end; JSON has \`baseline\`, \`treatment\`, \`diff\`, \`kill_criterion\` blocks.
- [x] 19 existing PreparedRecordStore tests stay green.
- [x] ruff clean.
- [ ] CI green.
- [ ] **5M bench run triggered post-merge; verdict recorded.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)