### PR TITLE
feat(distributed): Component 2 v2 / Phase 2 -- pipeline + Ray rewiring

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
@@ -92,11 +92,13 @@ def score_blocks_ray(
         across_files_only: Filter to cross-source pairs only.
         source_lookup: Row ID to source name mapping.
         target_ids: For match mode — filter to target/ref cross pairs.
-        store_path: Reserved for Component 2 v2 Phase 2 bucket-mode dispatch.
-            Passing a non-None value currently raises NotImplementedError
-            (Phase 1 stub). Will activate bucket-mode in Phase 2.
-        signature: Reserved for Component 2 v2 Phase 2. Must be set alongside
-            ``store_path`` to activate bucket-mode (Phase 2).
+        store_path: Path to the PreparedRecordStore DuckDB file. When set
+            (alongside ``signature``), activates bucket-mode dispatch: each
+            Ray task loads one bucket Parquet from the sibling ``buckets_*``
+            directory instead of receiving an in-memory block.
+        signature: Config signature used to locate the ``buckets_<sig>``
+            directory. Must be set alongside ``store_path`` to activate
+            bucket-mode.
 
     Returns:
         All fuzzy pairs found across blocks.
@@ -137,21 +139,61 @@ def score_blocks_ray(
             source_lookup=src_lookup,
         )
 
-    use_key_mode = store_path is not None and signature is not None
-    if use_key_mode:
-        raise NotImplementedError(
-            "Component 2 v2 Phase 1: key-mode dispatch removed; "
-            "bucket-mode dispatch lands in Phase 2. Pass "
-            "store_path=None/signature=None for df-mode."
-        )
+    @ray.remote(max_retries=0)  # type: ignore[misc]
+    def _score_block_remote_by_bucket(
+        bucket_path: str,
+        mk_config,  # pyright: ignore[reportMissingParameterType]
+        exclude,  # pyright: ignore[reportMissingParameterType]
+        src_lookup,  # pyright: ignore[reportMissingParameterType]
+        across_only: bool,
+    ):
+        """Component 2 v2 / Component 3: worker loads one bucket
+        Parquet, recovers per-block grouping via partition_by, scores
+        each block, returns concatenated pairs."""
+        from pathlib import Path as _Path
+
+        from goldenmatch.core.scorer import _score_one_block
+        from goldenmatch.distributed.record_store import load_bucket
+
+        bucket_df = load_bucket(_Path(bucket_path))
+        all_pairs: list[tuple[int, int, float]] = []
+        for block_key, block_df in bucket_df.partition_by(
+            "__block_key__", as_dict=True,
+        ).items():
+            # block_key arrives as tuple under Polars >= 1.0 partition_by.
+            if isinstance(block_key, tuple):
+                block_key = block_key[0]
+            shim = _KeyModeBlock(block_key=str(block_key), df=block_df.lazy())
+            all_pairs.extend(
+                _score_one_block(
+                    shim, mk_config, exclude,
+                    across_files_only=across_only, source_lookup=src_lookup,
+                )
+            )
+        return all_pairs
+
+    use_bucket_mode = store_path is not None and signature is not None
 
     futures = []
-    if False:  # noqa: SIM210 -- Phase 2 will replace this with bucket-mode
-        pass
+    if use_bucket_mode:
+        from pathlib import Path as _Path
+
+        from goldenmatch.distributed.record_store import (
+            _sanitize_signature,
+            iter_buckets,
+        )
+        sig_hash = _sanitize_signature(signature)  # type: ignore[arg-type]
+        bucket_dir = _Path(store_path).parent / f"buckets_{sig_hash}"  # type: ignore[arg-type]
+        for _bucket_id, bucket_path in iter_buckets(bucket_dir):
+            future = _score_block_remote_by_bucket.remote(  # type: ignore[attr-defined]
+                str(bucket_path),
+                mk_ref, exclude_ref, source_ref,
+                across_files_only,
+            )
+            futures.append(future)
     else:
+        # df-mode unchanged from Component 3 v1.
         for block in blocks:
-            # Collect the lazy DataFrame before sending to Ray (existing
-            # df-mode behavior, preserved verbatim).
             if hasattr(block, 'df') and hasattr(block.df, 'collect'):
                 collected_block = type(block)(
                     block_key=block.block_key,
@@ -163,16 +205,17 @@ def score_blocks_ray(
                 )
             else:
                 collected_block = block
-
-            future = _score_block_remote.remote(
+            future = _score_block_remote.remote(  # type: ignore[attr-defined]
                 collected_block, mk_ref, exclude_ref,
                 across_files_only, source_ref,
             )
             futures.append(future)
 
     logger.info(
-        "Submitted %d blocks to Ray (df mode, %d CPUs available)",
+        "Submitted %d %s to Ray (%s mode, %d CPUs available)",
         len(futures),
+        "buckets" if use_bucket_mode else "blocks",
+        "bucket" if use_bucket_mode else "df",
         int(ray.cluster_resources().get("CPU", 0)),
     )
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -845,25 +845,56 @@ def _run_dedupe_pipeline(
                     continue
                 with stage("fuzzy_build_blocks"):
                     blocks = build_blocks(combined_lf, config.blocking)
-                # Phase 2 of Component 2: materialize blocks to disk
-                # store as a side effect (default off). Pure scaffolding
-                # for Component 3; no in-process scoring change.
-                #
-                # NOTE: a row in multiple overlapping blocks (multi-pass
-                # blocking) gets its assignment overwritten in the dict.
-                # That's acceptable for Phase 2 -- Component 3 will need
-                # to handle multi-pass differently anyway.
+                # Component 2 v2: materialize blocks to hash-bucketed Parquet
+                # (default off). Phase 2 wiring: replaces Phase 1's
+                # NotImplementedError stub. Workers load one bucket Parquet
+                # and recover per-block grouping in-worker via partition_by.
                 if (
                     config.prepared_record_store
                     and config.partitioned_block_scoring
                     and _prep_store is not None
                 ):
-                    raise NotImplementedError(
-                        "Component 2 v2 Phase 1: v1 materialize_blocks API "
-                        "removed; v2 materialize_bucketed_blocks wiring "
-                        "lands in Phase 2. Disable partitioned_block_scoring "
-                        "for now."
+                    from goldenmatch.distributed.record_store import (
+                        materialize_bucketed_blocks,
                     )
+                    # Component 2 v2: build the (row_id, block_key)
+                    # assignment table fully vectorized in Polars. v1's
+                    # dict-comprehension at 5M / 1.67M blocks was the
+                    # bottleneck v2 exists to avoid; this path stays in
+                    # Arrow/Rust the whole way.
+                    #
+                    # Multi-pass blocking semantics: a row that appears in
+                    # blocks A then B then C ends up with block_key = "C".
+                    # The .unique(subset=["__row_id__"], keep="last")
+                    # enforces last-write-wins by deduplicating ON the
+                    # row_id with the trailing block_key. After unique(),
+                    # the row -> block_key map is single-valued, so the
+                    # downstream inner join in materialize_bucketed_blocks
+                    # has no ambiguity.
+                    assignment_parts = []
+                    for blk in blocks:
+                        lf = blk.df if isinstance(blk.df, pl.LazyFrame) else blk.df.lazy()
+                        assignment_parts.append(
+                            lf.select("__row_id__").with_columns(
+                                pl.lit(blk.block_key).alias("__block_key__"),
+                            )
+                        )
+                    assignments_df = (
+                        pl.concat(assignment_parts)
+                        .unique(subset=["__row_id__"], keep="last")
+                        .collect()
+                    )
+
+                    n_buckets = config.n_buckets or max((os.cpu_count() or 1) * 4, 64)
+                    n_buckets = min(n_buckets, 1024)
+                    with stage("partition_blocks_to_buckets"):
+                        materialize_bucketed_blocks(
+                            _prep_store,
+                            combined_lf.collect(),
+                            block_assignments=assignments_df,
+                            n_buckets=n_buckets,
+                            signature=_prep_cache_signature(config),
+                        )
                 total_blocks += len(blocks)
                 # Cheap sampling: collect block sizes for the histogram
                 # metric. Most blocks arrive as LazyFrames; do a

--- a/packages/python/goldenmatch/tests/test_distributed_scoring.py
+++ b/packages/python/goldenmatch/tests/test_distributed_scoring.py
@@ -89,9 +89,11 @@ def test_key_mode_block_shim_exposes_required_attributes():
     block = _KeyModeBlock(block_key="key-1", df=df.lazy())
     assert block.block_key == "key-1"
     assert block.df is not None
-    # Frozen dataclass: assignment must raise.
+    # Frozen dataclass: assignment must raise at runtime. Pyright also
+    # flags it statically -- that's the point of frozen dataclasses, so
+    # suppress the static warning rather than work around it.
     with pytest.raises(Exception):  # noqa: B017 -- frozen dataclass error class
-        block.block_key = "mutated"
+        block.block_key = "mutated"  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def test_pair_bytes_estimate_constant_is_module_level():

--- a/packages/python/goldenmatch/tests/test_distributed_scoring.py
+++ b/packages/python/goldenmatch/tests/test_distributed_scoring.py
@@ -3,9 +3,8 @@
 All tests gated on `ray` being importable; the file's collection
 falls through (no errors) when the [ray] extra isn't installed.
 
-Phase 1 note: tests that exercised v1 key-mode dispatch
-(_build_small_blocks / materialize_blocks / load_block / _score_block_remote_by_key)
-are deleted here. They will be re-added in Phase 2 as bucket-mode tests.
+Phase 2: bucket-mode dispatch tests added. _build_small_blocks helper
+updated to write buckets via materialize_bucketed_blocks (v2 API).
 """
 from __future__ import annotations
 
@@ -28,6 +27,55 @@ def _ray_local():
     )
     yield
     ray.shutdown()
+
+
+def _build_small_blocks(tmp_path):
+    """Materialize a small df to bucketed Parquet (Component 2 v2).
+    Returns (store_path, signature, blocks_list) for backward compat
+    with existing tests. blocks_list is the in-memory BlockResult list
+    df-mode uses; bucket-mode reads buckets via the store_path."""
+    from goldenmatch.core.blocker import BlockResult
+    from goldenmatch.distributed.record_store import (
+        PreparedRecordStore,
+        materialize_bucketed_blocks,
+        materialize_prepared_records,
+    )
+
+    df = pl.DataFrame({
+        "__row_id__":  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        "name":        ["alice", "alice2", "bob", "bob2", "carol", "carol2", "dan", "dan2", "eve", "eve2"],
+        "__mk_name__": ["alice", "alice",  "bob", "bob",  "carol", "carol",  "dan", "dan",  "eve", "eve"],
+    })
+    block_assignments = {
+        0: "A", 1: "A",
+        2: "B", 3: "B",
+        4: "C", 5: "C",
+        6: "D", 7: "D",
+        8: "E", 9: "E",
+    }
+    store_path = tmp_path / "store.duckdb"
+    with PreparedRecordStore(path=store_path, cleanup=False) as store:
+        materialize_prepared_records(store, df, signature="sig-v1")
+        materialize_bucketed_blocks(
+            store, df,
+            block_assignments=block_assignments,
+            n_buckets=8,
+            signature="sig-v1",
+        )
+
+    blocks = [
+        BlockResult(
+            block_key=k,
+            df=df.filter(
+                pl.col("__row_id__").is_in(
+                    [r for r, v in block_assignments.items() if v == k]
+                )
+            ).lazy(),
+            strategy="static",
+        )
+        for k in sorted(set(block_assignments.values()))
+    ]
+    return str(store_path), "sig-v1", blocks
 
 
 # ── Unit tests (no real Ray runtime) ────────────────────────────────
@@ -66,3 +114,102 @@ def test_score_blocks_ray_signature_accepts_new_kwargs():
         signature="sig-v1",
     )
     assert result == []
+
+
+# ── Integration tests (require real Ray runtime) ─────────────────────
+
+
+def test_bucket_mode_equivalence_with_df_mode(_ray_local, tmp_path):
+    """Same input -> same canonical pair set whether df-mode or bucket-mode.
+    Set comparison, not list -- ordering is non-deterministic across
+    buckets (spec §Testing)."""
+    from goldenmatch.backends import ray_backend
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    store_path, sig, blocks = _build_small_blocks(tmp_path)
+    mk = MatchkeyConfig(
+        name="name_exact", type="weighted", threshold=0.5,
+        fields=[MatchkeyField(field="__mk_name__", scorer="exact", weight=1.0)],
+    )
+
+    pairs_df = ray_backend.score_blocks_ray(blocks, mk, set())
+    pairs_bucket = ray_backend.score_blocks_ray(
+        blocks, mk, set(),
+        store_path=store_path, signature=sig,
+    )
+
+    def canon(p):
+        a, b, s = p
+        return (min(a, b), max(a, b), round(s, 6))
+    assert {canon(p) for p in pairs_bucket} == {canon(p) for p in pairs_df}
+
+
+def test_bucket_mode_dispatches_n_tasks(_ray_local, tmp_path, caplog):
+    """Driver submits one Ray task per non-empty bucket, not per block.
+
+    Captured via the `logger.info("Submitted %d ... Ray ...")` line in
+    score_blocks_ray. The actual count of futures is internal to the
+    function (in-function @ray.remote task can't be monkey-patched from
+    outside the function scope), so we assert via the structured log
+    line that's emitted right after futures are built.
+    """
+    import logging
+    import re
+
+    from goldenmatch.backends import ray_backend
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    store_path, sig, blocks = _build_small_blocks(tmp_path)
+    mk = MatchkeyConfig(
+        name="name_exact", type="weighted", threshold=0.5,
+        fields=[MatchkeyField(field="__mk_name__", scorer="exact", weight=1.0)],
+    )
+
+    with caplog.at_level(logging.INFO, logger="goldenmatch.backends.ray_backend"):
+        ray_backend.score_blocks_ray(
+            blocks, mk, set(),
+            store_path=store_path, signature=sig,
+        )
+
+    # Find the "Submitted N buckets ... bucket mode" line.
+    submitted_lines = [
+        r for r in caplog.records
+        if "Submitted" in r.getMessage() and "bucket mode" in r.getMessage()
+    ]
+    assert len(submitted_lines) == 1, (
+        f"expected exactly one 'Submitted ... bucket mode' log line; "
+        f"got {len(submitted_lines)}. Records: "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )
+    # The fixture has 5 distinct block_keys (A..E) and n_buckets=8;
+    # actual bucket count is <= 5 due to empty-bucket skipping. Just
+    # assert it's <= len(blocks) and > 0.
+    submitted_msg = submitted_lines[0].getMessage()
+    n_submitted = int(re.search(r"Submitted (\d+)", submitted_msg).group(1))
+    assert 0 < n_submitted <= len(blocks), (
+        f"submitted {n_submitted} tasks; expected 0 < n <= len(blocks)={len(blocks)}"
+    )
+
+
+def test_oom_guard_fires_at_bucket_granularity(_ray_local, tmp_path, monkeypatch):
+    """Spec §Error handling #6: OOM guard still works when N futures
+    are buckets instead of blocks."""
+    import psutil
+    from goldenmatch.backends import ray_backend
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+    store_path, sig, blocks = _build_small_blocks(tmp_path)
+    mk = MatchkeyConfig(
+        name="name_exact", type="weighted", threshold=0.5,
+        fields=[MatchkeyField(field="__mk_name__", scorer="exact", weight=1.0)],
+    )
+
+    class FakeMem:
+        available = 80
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: FakeMem)
+
+    with pytest.raises(MemoryError, match="scored pairs"):
+        ray_backend.score_blocks_ray(
+            blocks, mk, set(),
+            store_path=store_path, signature=sig,
+        )

--- a/packages/python/goldenmatch/tests/test_partitioned_block_scoring_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_partitioned_block_scoring_pipeline.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import polars as pl
-import pytest
 from goldenmatch.config.schemas import GoldenMatchConfig
 
 
@@ -60,13 +59,37 @@ def test_flag_off_path_unchanged(tmp_path: Path, monkeypatch):
     # No assertion on numbers -- just the path completes.
 
 
-@pytest.mark.skip(reason="Component 2 v2 Phase 2 -- rewrite against iter_buckets")
 def test_flag_on_materializes_blocks_to_store(tmp_path: Path, monkeypatch):
-    """Phase 1 stub. Phase 2 rewrites the body against the v2 iter_buckets
-    API (v1's list_blocks was removed in C2 v2 Phase 1)."""
+    """With prepared_record_store + partitioned_block_scoring both on,
+    the pipeline materializes bucketed Parquet files via
+    materialize_bucketed_blocks. Verified via iter_buckets."""
+    import goldenmatch as gm
+    from goldenmatch.core.autoconfig import auto_configure_df
+    from goldenmatch.core.pipeline import _prep_cache_signature
+    from goldenmatch.distributed.record_store import _sanitize_signature, iter_buckets
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    monkeypatch.setenv("GOLDENMATCH_PREPARED_RECORD_STORE_DIR", str(tmp_path))
+    monkeypatch.setenv("GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST", "1")
+
+    df = _diverse_df()
+    cfg = auto_configure_df(df, confidence_required=False)
+    cfg.prepared_record_store = True
+    cfg.partitioned_block_scoring = True
+    gm.dedupe_df(df, config=cfg, confidence_required=False)
+
+    # At least one bucket dir must exist under tmp_path after the pipeline runs.
+    sig_hash = _sanitize_signature(_prep_cache_signature(cfg))
+    bucket_dirs = list(tmp_path.glob(f"buckets_{sig_hash}"))
+    assert bucket_dirs, (
+        f"expected a buckets_<sig> dir under {tmp_path}; "
+        f"found: {list(tmp_path.iterdir())}"
+    )
+    # At least one bucket file must have been written.
+    bucket_files = list(iter_buckets(bucket_dirs[0]))
+    assert bucket_files, "expected at least one bucket=K/data.parquet file"
 
 
-@pytest.mark.skip(reason="Component 2 v2 Phase 2")
 def test_pipeline_passes_store_path_when_all_flags_on(tmp_path: Path, monkeypatch):
     """When backend=ray + prepared_record_store + partitioned_block_scoring
     are all on, the pipeline must pass store_path + signature kwargs to
@@ -112,6 +135,43 @@ def test_pipeline_passes_store_path_when_all_flags_on(tmp_path: Path, monkeypatc
     assert "signature" in captured
     assert captured["store_path"] is not None
     assert captured["signature"] is not None
+
+
+def test_pipeline_uses_bucketed_materialize_on_flag_on(tmp_path: Path, monkeypatch):
+    """Spec §Testing pipeline integration: with all flags on, pipeline
+    calls materialize_bucketed_blocks (not v1 materialize_blocks)."""
+    import goldenmatch as gm
+    import goldenmatch.distributed.record_store as rs
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    monkeypatch.setenv("GOLDENMATCH_PREPARED_RECORD_STORE_DIR", str(tmp_path))
+    monkeypatch.setenv("GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST", "1")
+
+    captured: dict = {}
+    original = rs.materialize_bucketed_blocks
+    def fake_materialize(store, df, *, block_assignments, n_buckets, signature):
+        captured["called"] = True
+        captured["n_buckets"] = n_buckets
+        captured["n_rows"] = df.height
+        return original(store, df, block_assignments=block_assignments,
+                        n_buckets=n_buckets, signature=signature)
+    # Patch on the source module ONLY. pipeline.py does
+    # `from goldenmatch.distributed.record_store import materialize_bucketed_blocks`
+    # inside the `if` block, so the import re-reads the module attribute
+    # on every dedupe call -- the rs.* patch is sufficient. Patching
+    # `goldenmatch.core.pipeline.materialize_bucketed_blocks` would only
+    # work if the import were module-level (it isn't).
+    monkeypatch.setattr(rs, "materialize_bucketed_blocks", fake_materialize)
+
+    df = _diverse_df()
+    cfg = auto_configure_df(df, confidence_required=False)
+    cfg.prepared_record_store = True
+    cfg.partitioned_block_scoring = True
+    gm.dedupe_df(df, config=cfg, confidence_required=False)
+
+    assert captured.get("called"), "pipeline must call materialize_bucketed_blocks"
+    assert 1 <= captured["n_buckets"] <= 1024
 
 
 def test_pipeline_does_not_pass_store_path_when_disk_store_off(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary

Phase 2 of Component 2 v2. Wires the v2 bucketed primitives into the pipeline and Ray backend. Phase 1 (#298) shipped the primitives + \`NotImplementedError\` stubs at the v1 import sites; this PR replaces the stubs with the real v2 dispatch.

- **\`pipeline.py\`:** v1 hook replaced with v2 hook. \`assignments_df\` built via vectorized \`pl.concat\` + \`unique(subset=["__row_id__"], keep="last")\` — no Python row loop (this was the bottleneck v2 exists to avoid). \`materialize_bucketed_blocks(..., block_assignments=assignments_df, n_buckets=...)\` inside \`stage("partition_blocks_to_buckets")\`.
- **\`ray_backend.py\`:** new in-function \`_score_block_remote_by_bucket\` task. Loads bucket Parquet → \`partition_by("__block_key__")\` recovers per-block grouping → \`_score_one_block\` per block → return concatenated pairs. Dispatch loop iterates \`iter_buckets(bucket_dir)\` (N ≤ 1024 tasks) instead of per-block (could be millions).
- **Tests:** rewrote \`_build_small_blocks\` fixture for v2; added 3 integration tests (equivalence, dispatch count via caplog, OOM guard at bucket granularity); unskipped + rewrote the two Phase-1-deferred wiring tests; added \`test_pipeline_uses_bucketed_materialize_on_flag_on\`.

## Test plan

- [x] 40 passed / 1 skipped on the full v2 test slice (3 new bucket-mode integration tests pass under real Ray).
- [x] ruff clean.
- [x] Pyright clean against the project's curated include list (\`pyrightconfig.json\` doesn't include \`record_store.py\` or \`ray_backend.py\`).
- [ ] CI green.

Plus a follow-up commit suppressing one Pyright warning on the frozen-dataclass-write test — testing the \`frozen=True\` invariant by definition needs a static write that fails at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)