### PR TITLE
bench(distributed): C2 v2 Phase 3 -- 300-min timeout for kill checkpoint

### DIFF
--- a/.github/workflows/bench-distributed-stack.yml
+++ b/.github/workflows/bench-distributed-stack.yml
@@ -19,7 +19,13 @@ jobs:
   bench:
     name: "bench distributed stack (chunked vs Component 1+2+3)"
     runs-on: large-new-64GB
-    timeout-minutes: 180
+    # 300 min = baseline (~160 min observed in run 25980529866) +
+    # treatment-target (~128 min if it beats baseline by 20%) +
+    # 12 min buffer. If treatment runs longer than 128 min, that's
+    # already the kill criterion failing on wall_pct alone -- the
+    # workflow timing out IS the FAIL signal. Do NOT extend further
+    # without justifying against measured numbers.
+    timeout-minutes: 300
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Bumps \`bench-distributed-stack.yml\` timeout from 180 → 300 min. The 180-min cap couldn't hold two 2.5-hour passes (baseline alone was 160 min in PR #295's run on the fixed fixture, treatment got cancelled).

**300 min = baseline (~160) + treatment-target-20%-better (~128) + 12-min buffer.** If treatment runs > 128 min wall, that itself is the kill criterion failing on wall_pct alone — the workflow timing out IS the FAIL signal. Do not extend further without justifying against measured numbers.

After merge, trigger the kill-checkpoint bench:

\`\`\`
gh workflow run bench-distributed-stack.yml --ref main -f rows=5000000 -f dataset_tag=bench-dataset-v1
\`\`\`

Per the binding kill criterion: ≥ 20% wall AND ≥ 20% peak RSS improvement vs \`backend="chunked"\` or revert PRs #280-#297 + #298 + #299 + this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)