### PR TITLE
perf(scorer): skip candidate-count loop at scale to fix OOM

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -882,24 +882,46 @@ def score_blocks_parallel(
     # Snapshot exclude_pairs so threads see a frozen copy
     frozen_exclude = frozenset(matched_pairs)
 
-    # Total candidate pairs across all blocks. Historical implementation
-    # called `block.df.collect().height` per block, which materializes
-    # every row of every block just to read row count. At 1.67M blocks
-    # of 3 rows that's 5M row materializations of pure overhead before
-    # any scoring runs. Switch to `select(pl.len())` -- a metadata-level
-    # operation Polars resolves without materializing rows. On lazy
-    # frames it's a plan transformation; on already-collected frames
-    # it's effectively O(1) field access.
+    # Total candidate pairs across all blocks -- a single stat that feeds
+    # ScoringProfile.candidates_compared. Historical loops materialized
+    # every block via `.collect().height` or `.select(pl.len()).collect()`
+    # just to read row count. At 1.67M tiny-block workloads (real-shape
+    # 5M auto-config on email), BOTH variants caused runner OOM-kills
+    # around ~70 min wall: each LazyFrame here is a filter expression
+    # over the 5M parent df, and 1.67M `.collect()` calls accumulate
+    # Polars arena memory faster than it's released.
     #
-    # Each block IS still collected separately inside _score_one_block;
-    # this loop's only job is the ScoringProfile.candidates_compared stat.
-    total_candidates = 0
-    for block in blocks:
-        try:
-            n = int(block.df.select(pl.len()).collect().item())
-        except Exception:
-            n = 0
-        total_candidates += n * (n - 1) // 2
+    # Bench run history (5M / 1.67M-blocks on large-new-64GB):
+    #   PR #295 (.collect().height, max_workers=4): 160 min, 4.5 GB peak. OK.
+    #   PR #301 (.select(pl.len()), max_workers=16): RSS climbs to 60+ GB
+    #     before scoring starts, OOM-killed. Bumped workers blamed; reverted.
+    #   PR #303 (.select(pl.len()), max_workers=4 revert): same OOM.
+    #     -> the candidate-count loop ITSELF is the leak at this scale.
+    #
+    # Cheapest fix: skip the count loop entirely when there are more
+    # than _CANDIDATE_COUNT_SKIP_THRESHOLD blocks. The stat becomes 0
+    # at scale; profile readers should treat 0 as "skipped at scale,
+    # not literally zero candidates." For small-N workloads (the actual
+    # use case for the stat -- debugging, diagnostics) we still compute
+    # it cheaply because there are few blocks.
+    _CANDIDATE_COUNT_SKIP_THRESHOLD = 10_000
+    _n_blocks_for_count_gate = len(blocks)
+    if _n_blocks_for_count_gate <= _CANDIDATE_COUNT_SKIP_THRESHOLD:
+        total_candidates = 0
+        for block in blocks:
+            try:
+                n = int(block.df.select(pl.len()).collect().item())
+            except Exception:
+                n = 0
+            total_candidates += n * (n - 1) // 2
+    else:
+        # Skip -- the stat isn't load-bearing for scoring correctness.
+        logger.info(
+            "Skipping candidate-count loop at scale: %d blocks > %d threshold "
+            "(ScoringProfile.candidates_compared will be 0)",
+            _n_blocks_for_count_gate, _CANDIDATE_COUNT_SKIP_THRESHOLD,
+        )
+        total_candidates = 0
 
     all_pairs = []
     total_blocks = len(blocks)


### PR DESCRIPTION
## Summary

Three consecutive 5M bench runs hit runner-OOM around the 70-min mark, even after reverting #301's worker-count bump in #303. Heartbeats from PR #302 nailed the smoking gun:

| t | RSS | Stages |
|---|---|---|
| 30s | 4 GB | fuzzy_build_blocks=5.2s |
| 5 min | 15 GB | no scoring progress |
| 10 min | 35 GB | no scoring progress |
| 20 min | **62 GB** | no scoring progress |
| ~76 min | OOM-killed | |

Wall is stuck **IN A PRE-SCORING LOOP** while RSS climbs ~3 GB/min for 20+ minutes. \`fuzzy_score_blocks\` never starts.

The culprit is the candidate-count gather at \`score_blocks_parallel\` lines 860-866: 1.67M iterations of \`block.df.select(pl.len()).collect().item()\` against filter-LazyFrames over the 5M parent df. Each \`.collect()\` doesn't short-circuit through the filter, and Polars' arena allocator accumulates intermediates across 1.67M collects faster than they release.

PR #295's run (before #301's switch to \`select(pl.len())\`) didn't OOM because it ran against a degenerate fixture where every block had 3 fully-different identities — same loop ran but the underlying LazyFrames materialized more cheaply on that data. The realistic fixture from \`bench-dataset-v1\` kills it.

## Fix

Skip the loop entirely when \`len(blocks) > 10K\`. The loop's only consumer is the \`ScoringProfile.candidates_compared\` stat — not load-bearing for scoring correctness. Profile readers should treat \`candidates_compared=0\` as "skipped at scale, not literally zero candidates." Small-N workloads still compute it cheaply.

## Test plan

- [x] 80 scorer + pipeline tests pass.
- [ ] CI green.
- [ ] Re-run 5M bench under py-spy post-merge; should complete this time, AND we'll get the flamegraph artifact for the actual scoring bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)