### PR TITLE
perf(pipeline): skip block-size sampling at scale (the actual OOM site)

### DIFF
--- a/.github/workflows/bench-distributed-stack.yml
+++ b/.github/workflows/bench-distributed-stack.yml
@@ -82,10 +82,14 @@ jobs:
           # leaves a partial profile. --rate 50 = 50 Hz sampling (low
           # overhead at minute-scale walls). --idle includes blocked
           # threads (useful for "where do workers wait" analysis).
+          # --rate 10 (was 50): on run 26006853280 py-spy fell ~1400s
+          # behind in sampling. Lower rate keeps it tracking the
+          # bench process without the kernel starving its read syscalls
+          # under the bench's own memory pressure.
           py-spy record \
             --output bench-out/profile.svg \
             --format flamegraph \
-            --rate 50 \
+            --rate 10 \
             --idle \
             --subprocesses \
             -- \

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -896,22 +896,40 @@ def _run_dedupe_pipeline(
                             signature=_prep_cache_signature(config),
                         )
                 total_blocks += len(blocks)
-                # Cheap sampling: collect block sizes for the histogram
-                # metric. Most blocks arrive as LazyFrames; do a
-                # zero-row-materialization peek via `select(pl.len())`
-                # which is O(1) for already-collected frames and a cheap
-                # plan operation for lazy ones. We need the sizes to
-                # surface the P99/max that drives hot-block decisions.
-                for blk in blocks:
-                    try:
-                        df_blk = blk.df
-                        if isinstance(df_blk, pl.LazyFrame):
-                            size = int(df_blk.select(pl.len()).collect().item())
-                        else:
-                            size = int(df_blk.height)
-                        block_size_samples.append(size)
-                    except Exception:  # pragma: no cover — defensive
-                        continue
+                # Block-size sampling for the histogram metric.
+                # Despite the historical "cheap O(1) plan operation"
+                # comment, at 1.67M filter-LazyFrames over a 5M parent
+                # the `.select(pl.len()).collect().item()` per block
+                # accumulates Polars arena memory at ~3 GB/min --
+                # observed via heartbeat instrumentation on bench runs
+                # 25998537828, 26000789629, 26002766443, 26004842882,
+                # 26006853280 (all OOM-killed before scoring started
+                # at 60+ GB RSS by t~20 min).
+                #
+                # Skip the sampling loop at scale: P50/P95/P99/max are
+                # diagnostic metrics, not load-bearing for scoring.
+                # Profile readers should treat the absence of these
+                # keys as "skipped at scale (>10K blocks)", not as
+                # zero-sized blocks. Small-N workloads still get the
+                # full histogram cheaply.
+                _BLOCK_SAMPLE_SKIP_THRESHOLD = 10_000
+                if len(blocks) <= _BLOCK_SAMPLE_SKIP_THRESHOLD:
+                    for blk in blocks:
+                        try:
+                            df_blk = blk.df
+                            if isinstance(df_blk, pl.LazyFrame):
+                                size = int(df_blk.select(pl.len()).collect().item())
+                            else:
+                                size = int(df_blk.height)
+                            block_size_samples.append(size)
+                        except Exception:  # pragma: no cover -- defensive
+                            continue
+                else:
+                    logger.info(
+                        "Skipping block-size sampling at scale: %d blocks "
+                        "> %d threshold (block_size_p* metrics will be absent)",
+                        len(blocks), _BLOCK_SAMPLE_SKIP_THRESHOLD,
+                    )
                 block_scorer = _get_block_scorer(config)
 
                 # Component 3: when all three gating flags are on AND we have a live


### PR DESCRIPTION
## Summary

PR #305 patched \`score_blocks_parallel\`'s candidate-count loop, but bench run 26006853280 STILL OOM-killed at ~48 min with the same signature:

- RSS 62.9 GB at t=2895s (heartbeat)
- \`fuzzy_build_blocks\` done at 6s
- \`fuzzy_score_blocks\` still at 0.36s (never advanced)
- py-spy "1400+s behind in sampling" (kernel starving its read syscalls under bench memory pressure)

Root cause: an **identical** \`for blk in blocks: blk.df.select(pl.len()).collect().item()\` loop in \`pipeline.py\` (the block-size histogram sampling at lines 899-914) was missed. Same pathology as #305 — at 1.67M filter-LazyFrames over the 5M parent df, every collect re-evaluates the filter and Polars' arena allocator accumulates across iterations.

Same fix: skip when \`len(blocks) > 10K\`. The \`block_size_p*\` metrics become absent in that case — diagnostic only, not load-bearing.

Also: lower py-spy \`--rate\` from 50 → 10 Hz. py-spy falling 1400s behind in sampling under the bench's syscall pressure made the previous flamegraph useless anyway.

## Test plan

- [x] 8 pipeline tests pass.
- [ ] CI green.
- [ ] Re-run 5M bench post-merge — this should be the final pre-scoring OOM fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)