### PR TITLE
perf(bucket): bucket scorer eliminates per-block LazyFrame at 5M scale

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1,0 +1,177 @@
+"""In-process bucketed block scorer.
+
+Architectural pivot from the per-block LazyFrame model:
+
+  OLD (score_blocks_parallel / score_blocks_duckdb):
+    build_blocks(combined_lf, blocking) -> list[BlockResult]
+      where each BlockResult.df is a `combined_lf.filter(blocking_key == K)`
+      LazyFrame. At 5M rows / 1.67M blocks of 3 rows each, the LIST of
+      1.67M filter-LazyFrames + any per-block `.collect()`/`.select()` chains
+      explode Polars arena memory. Documented in heartbeats:
+      runs 25998537828, 26000789629, 26002766443, 26004842882, 26006853280,
+      26008682481, 26012579494 -- all hung at 62.99 GB RSS plateau on Linux
+      without ever reaching real scoring.
+
+  NEW (score_buckets):
+    prepared_df (eager) + blocking_config -> in one Polars pass:
+      with_columns(__block_key__ = key_expr, __bucket__ = hash(__block_key__) % N)
+    -> partition_by("__bucket__", as_dict=True)   # ≤ N eager bucket dfs
+    -> partition_by("__block_key__", as_dict=True) within each bucket
+    -> _score_one_block on each per-block eager df
+
+    No LazyFrames carrying filter expressions. No materialization of millions
+    of small frames. Two partition_by operations + N rapidfuzz calls.
+
+Hard invariant: at scale, this module must never call ``.collect()`` on a
+filter-LazyFrame. The single eager materialization happens once via
+``prepared_df = combined_lf.collect()`` at the pipeline call site BEFORE
+this scorer runs.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import polars as pl
+
+from goldenmatch.config.schemas import BlockingConfig, MatchkeyConfig
+from goldenmatch.core.bench import record_metrics, stage
+from goldenmatch.core.blocker import _build_block_key_expr
+from goldenmatch.core.scorer import _score_one_block
+
+logger = logging.getLogger(__name__)
+
+
+BUCKET_HASH_SEED = 0xC2B5C0BBE7ED5E5D
+"""Same constant as goldenmatch.distributed.record_store. Deterministic
+xxHash seed so block_key -> bucket assignment is stable across runs."""
+
+
+def _default_n_buckets() -> int:
+    """Default bucket count. min(cpu_count() * 4, 1024). Same heuristic as
+    Component 2 v2's materialize_bucketed_blocks."""
+    return min((os.cpu_count() or 4) * 4, 1024)
+
+
+class _BlockShim:
+    """BlockResult-shaped wrapper around an eager per-block DataFrame.
+
+    `_score_one_block` reads `.block_key`, `.df`, and `.pre_scored_pairs`.
+    Multi-pass blocking (pre_scored_pairs) is not supported in bucket mode
+    v1; pass None.
+    """
+    __slots__ = ("block_key", "df", "pre_scored_pairs")
+
+    def __init__(self, block_key: str, df: pl.DataFrame):
+        self.block_key = block_key
+        # _score_one_block does `block.df.collect()` first; passing an
+        # eager df via .lazy() makes the collect a no-op. Cheaper than
+        # threading a separate eager-aware path through scorer.py.
+        self.df = df.lazy()
+        self.pre_scored_pairs: list[tuple[int, int, float]] | None = None
+
+
+def score_buckets(
+    prepared_df: pl.DataFrame,
+    blocking_config: BlockingConfig,
+    mk: MatchkeyConfig,
+    matched_pairs: set[tuple[int, int]],
+    n_buckets: int | None = None,
+    across_files_only: bool = False,
+    source_lookup: dict[int, str] | None = None,
+    target_ids: set[int] | None = None,
+) -> list[tuple[int, int, float]]:
+    """Score all blocks via hash-bucketed partition_by, no per-block LazyFrame.
+
+    Args:
+        prepared_df: Eager Polars DataFrame, already materialized. Must
+            contain ``__row_id__`` and all columns referenced by ``mk`` +
+            ``blocking_config``.
+        blocking_config: Source for the block-key expression.
+            ``keys[0]`` is used; multi-key blocking is not supported in
+            bucket mode v1.
+        mk: Matchkey configuration.
+        matched_pairs: Set of already-matched (min_id, max_id) pairs;
+            mutated in-place as new pairs are emitted (mirrors
+            score_blocks_parallel's contract).
+        n_buckets: Hash bucket count. None -> ``min(cpu_count() * 4, 1024)``.
+        across_files_only: Filter to cross-source pairs only.
+        source_lookup: Row ID -> source name mapping.
+        target_ids: For match mode -- filter to target/ref cross pairs.
+
+    Returns:
+        All fuzzy pairs as (id_a, id_b, score) tuples.
+    """
+    if prepared_df.height == 0:
+        return []
+    if not blocking_config.keys:
+        return []
+
+    if n_buckets is None:
+        n_buckets = _default_n_buckets()
+
+    key_expr = _build_block_key_expr(blocking_config.keys[0])
+
+    with stage("bucket_assign"):
+        keyed = prepared_df.with_columns(key_expr)
+        bucketed = keyed.with_columns(
+            (pl.col("__block_key__").hash(seed=BUCKET_HASH_SEED) % n_buckets)
+            .alias("__bucket__")
+        )
+
+    with stage("bucket_partition"):
+        # First-level partition: N eager DataFrames keyed by bucket id.
+        # Polars >= 1.0 returns tuple-keyed dict when as_dict=True with a
+        # single partition column; unwrap below.
+        buckets_dict: dict[Any, pl.DataFrame] = bucketed.partition_by(
+            "__bucket__", as_dict=True,
+        )
+
+    frozen_exclude = frozenset(matched_pairs)
+    all_pairs: list[tuple[int, int, float]] = []
+    total_blocks_scored = 0
+    n_non_empty_buckets = 0
+
+    with stage("bucket_score"):
+        for _bucket_key, bucket_df in buckets_dict.items():
+            if bucket_df.height == 0:
+                continue
+            n_non_empty_buckets += 1
+            # Second-level partition: per-block eager DataFrames.
+            block_groups: dict[Any, pl.DataFrame] = bucket_df.partition_by(
+                "__block_key__", as_dict=True,
+            )
+            for block_key, block_df in block_groups.items():
+                if block_df.height < 2:
+                    continue
+                # Polars >= 1.0 partition_by with single column returns
+                # tuple keys ("k",) -- unwrap.
+                if isinstance(block_key, tuple):
+                    block_key = block_key[0]
+                shim = _BlockShim(block_key=str(block_key), df=block_df)
+                pairs = _score_one_block(
+                    shim, mk, frozen_exclude,
+                    across_files_only=across_files_only,
+                    source_lookup=source_lookup,
+                )
+                if target_ids is not None:
+                    pairs = [
+                        (a, b, s) for a, b, s in pairs
+                        if (a in target_ids) != (b in target_ids)
+                    ]
+                all_pairs.extend(pairs)
+                for a, b, _s in pairs:
+                    matched_pairs.add((min(a, b), max(a, b)))
+                total_blocks_scored += 1
+
+    record_metrics({
+        "bucket_count": n_non_empty_buckets,
+        "bucket_n_target": n_buckets,
+        "block_count_scored": total_blocks_scored,
+    })
+    logger.info(
+        "score_buckets: %d non-empty buckets (target N=%d), %d blocks scored, %d pairs",
+        n_non_empty_buckets, n_buckets, total_blocks_scored, len(all_pairs),
+    )
+    return all_pairs

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -843,6 +843,30 @@ def _run_dedupe_pipeline(
             if mk.type == "weighted":
                 if config.blocking is None:
                     continue
+                # Bucket backend: skip build_blocks entirely. The bucket
+                # scorer derives block-key + bucket assignment from
+                # `collected_df` in a single eager pass and partitions
+                # twice (bucket, then key) -- no per-block LazyFrame
+                # construction at all. Designed for 5M+ tiny-block
+                # workloads where the historical build_blocks +
+                # per-block .collect() chain explodes Polars arena
+                # memory on Linux runners (7 consecutive 5M bench runs
+                # hung at 62.99 GB RSS plateau before reaching real
+                # scoring).
+                if config.backend == "bucket":
+                    from goldenmatch.backends.score_buckets import score_buckets
+                    pairs = score_buckets(
+                        collected_df,
+                        config.blocking,
+                        mk,
+                        matched_pairs,
+                        n_buckets=config.n_buckets,
+                        across_files_only=across_files_only,
+                        source_lookup=source_lookup if across_files_only else None,
+                    )
+                    all_pairs.extend(pairs)
+                    fuzzy_pair_count += len(pairs)
+                    continue  # skip the legacy build_blocks path below
                 with stage("fuzzy_build_blocks"):
                     blocks = build_blocks(combined_lf, config.blocking)
                 # Component 2 v2: materialize blocks to hash-bucketed Parquet

--- a/packages/python/goldenmatch/scripts/bench_distributed_stack.py
+++ b/packages/python/goldenmatch/scripts/bench_distributed_stack.py
@@ -215,8 +215,15 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Building synthetic df ({args.rows:,} rows) in-script...", flush=True)
         df = build_df(args.rows)
 
-    print("Run 1/2: baseline (backend=chunked)...", flush=True)
-    baseline = run_one("baseline", df, backend="chunked", prepared_record_store=False, partitioned_block_scoring=False)
+    # Baseline switched from "chunked" -> "bucket" 2026-05-18: the legacy
+    # chunked path hangs at 62.99 GB RSS on Linux runners with realistic
+    # 1.67M-block fixtures (7 consecutive runs since #296). The bucket
+    # backend (added in this PR) replaces the per-block LazyFrame fan-out
+    # with a two-level partition_by over an eager prepared df. See
+    # goldenmatch/backends/score_buckets.py module docstring for the
+    # full rationale + run IDs.
+    print("Run 1/2: baseline (backend=bucket)...", flush=True)
+    baseline = run_one("baseline", df, backend="bucket", prepared_record_store=False, partitioned_block_scoring=False)
     # Echo the full per-run JSON to stdout so the data is in the workflow
     # logs even when the upload-artifact step is skipped (e.g. when the
     # script exits 1 on FAIL). Critical for post-mortem investigation.


### PR DESCRIPTION
## Summary

Per the architectural decision: at 5M / 1.67M blocks the legacy \`build_blocks -> list[BlockResult-with-filter-LazyFrame]\` chain hangs Linux runners at 62.99 GB RSS plateau. **7 consecutive bench runs** since the realistic fixture landed in #296 — none reached real scoring. MALLOC_ARENA_MAX=2 didn't help. Bench-instrumented stages all closed quickly while wall sat for 40+ minutes inside chunked/score_blocks_duckdb internals.

**Local 500K on Windows completes both arms cleanly** (treatment -27% vs baseline) so the algorithm is fine — the legacy block representation is the scaling boundary.

## New path: \`backend="bucket"\`

\`goldenmatch/backends/score_buckets.py\` — single-file scorer that:

1. Single eager \`with_columns\` attaches \`__block_key__\` + \`__bucket__\` to the prepared df.
2. \`partition_by("__bucket__", as_dict=True)\` → ≤ N eager bucket dfs.
3. \`partition_by("__block_key__", as_dict=True)\` within each bucket → per-block eager dfs.
4. \`_score_one_block\` on each (eager, not Lazy).

**Hard invariant: no \`.collect()\` on a filter-LazyFrame at scale.** Single eager materialization is the existing \`combined_lf.collect()\` at pipeline.py:787.

## Pipeline.py integration

Forks at the fuzzy-scoring loop. When \`config.backend == "bucket"\`, **\`build_blocks\` is skipped entirely** — the legacy 1.67M-LazyFrame fan-out never happens.

## Bench harness change

\`bench_distributed_stack.py\` baseline switched from \`backend="chunked"\` → \`backend="bucket"\`. Next 5M runner bench actually exercises the new path.

## Test plan

- [x] 80 scorer + pipeline tests pass.
- [x] Local 60-row smoke: bucket scorer emits expected pairs.
- [ ] CI green.
- [ ] **5M runner bench POST-MERGE: does it complete?** If yes, we have the runner-side win. If no, the architectural boundary is somewhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)