### PR TITLE
perf(block-analyzer): sample at scale to fix 5M auto_suggest hang

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
@@ -350,6 +350,10 @@ class BlockingSuggestion:
 # ── Main analyzer ────────────────────────────────────────────────────────────
 
 
+_SCORE_SAMPLE_THRESHOLD = 100_000
+_SCORE_SAMPLE_SIZE = 100_000
+
+
 def analyze_blocking(
     df: pl.DataFrame,
     matchkey_columns: list[str],
@@ -368,10 +372,23 @@ def analyze_blocking(
     """
     candidates = generate_candidates(matchkey_columns)
 
+    # At scale, per-candidate scoring runs a Python-UDF `map_elements` over the
+    # full df. With ~260 candidates that's a multi-GB, multi-minute hang at 5M
+    # rows. Block-size distribution is shape-only; sample is sufficient.
+    n_full = df.height
+    if n_full > _SCORE_SAMPLE_THRESHOLD:
+        score_df = df.sample(_SCORE_SAMPLE_SIZE, seed=42)
+        logger.info(
+            "analyze_blocking: sampling %d rows from %d for candidate scoring",
+            _SCORE_SAMPLE_SIZE, n_full,
+        )
+    else:
+        score_df = df
+
     # Score each candidate
     scored = []
     for cand in candidates:
-        metrics = score_candidate(df, cand, target_block_size=target_block_size)
+        metrics = score_candidate(score_df, cand, target_block_size=target_block_size)
         if metrics["group_count"] == 0:
             continue
         scored.append((cand, metrics))

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -768,25 +768,39 @@ def _run_dedupe_pipeline(
 
     # ── Step 1.5b: STANDARDIZE ──
     if config.standardization and config.standardization.rules:
-        combined_lf = apply_standardization(combined_lf, config.standardization.rules)
+        with stage("standardize"):
+            combined_lf = apply_standardization(combined_lf, config.standardization.rules)
 
     # ── Step 1.5c: DOMAIN FEATURE EXTRACTION ──
-    combined_lf = _apply_domain_extraction(combined_lf, config)
+    with stage("domain_extraction"):
+        combined_lf = _apply_domain_extraction(combined_lf, config)
 
     # ── Learning Memory: pre-scoring learner overlay ──
-    _apply_memory_pre(memory_store, config, matchkeys)
+    with stage("memory_pre_overlay"):
+        _apply_memory_pre(memory_store, config, matchkeys)
 
     # ── Step 2: TRANSFORM ──
-    combined_lf = compute_matchkeys(combined_lf, matchkeys)
+    with stage("compute_matchkeys"):
+        combined_lf = compute_matchkeys(combined_lf, matchkeys)
 
     # ── Step 2.5: AUTO-SUGGEST blocking keys ──
     # Hoist matchkey transforms onto the materialized df once — eliminates
     # one .select() per (block × matchkey field) during scoring (folds into
     # the existing collect; no extra materialization). See spec
     # docs/superpowers/specs/2026-05-04-hoist-matchkey-transforms.md.
-    collected_df = precompute_matchkey_transforms(combined_lf.collect(), matchkeys)
+    #
+    # NEW (2026-05-18): two distinct stages so the heartbeat-stream can
+    # tell us whether the LazyFrame collect or the precompute step is
+    # the long pole at 5M scale. Prior runner runs had a ~5 min black
+    # hole between auto_configure_df returning and any fuzzy stage
+    # entering -- this instrumentation closes it.
+    with stage("combined_lf_collect"):
+        _collected_pre_mk = combined_lf.collect()
+    with stage("precompute_matchkey_transforms"):
+        collected_df = precompute_matchkey_transforms(_collected_pre_mk, matchkeys)
     combined_lf = collected_df.lazy()
-    _run_auto_suggest(collected_df, config)
+    with stage("auto_suggest_blocking"):
+        _run_auto_suggest(collected_df, config)
 
     # ── Step 3: BLOCK + COMPARE (cascading: exact first, then fuzzy) ──
     all_pairs: list[tuple[int, int, float]] = []


### PR DESCRIPTION
## Summary
- `analyze_blocking` runs `pl.col().map_elements(apply_transforms)` (Python UDF) over the full df once per candidate. With ~6 name-typed matchkey columns that's ~260 candidates x 5M rows of per-row Python work.
- PR #309 instrumentation caught `auto_suggest_blocking` holding the wall open while RSS climbed 1.6 GB / 30s on the 5M bench.
- Sample to 100K rows for `score_candidate` when `df.height > 100K`. Block-size distribution is shape-only; sampling preserves rank order across candidates.

## Test plan
- [x] Local smoke: `analyze_blocking` still returns ranked suggestions
- [ ] 5M bench: `auto_suggest_blocking` stage closes in < 30s instead of hanging
- [ ] Full pipeline reaches scoring (bucket scorer from PR #308)

🤖 Generated with [Claude Code](https://claude.com/claude-code)