### PR TITLE
perf(blocker): native polars chain for _build_block_key_expr (root 5M hang)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -99,18 +99,32 @@ class BlockResult:
 def _build_block_key_expr(key_config: BlockingKeyConfig) -> pl.Expr:
     """Build a block key expression from a BlockingKeyConfig.
 
-    Transforms each field and concatenates with || separator.
+    Transforms each field and concatenates with || separator. Uses native
+    Polars expressions when every configured transform is vectorizable
+    (lowercase, strip, substring, etc. -- see matchkey._try_native_transform).
+    Falls back to map_elements only for transforms that need Python
+    (soundex, metaphone). The native fast path matters at scale: a 5M-row
+    blocking key with map_elements is 10M Python calls and was the root
+    cause of the 5M bench hang (RSS climbed 1.5 GB / 30s with no instrumented
+    stage closing).
     """
-    field_exprs = []
+    from goldenmatch.core.matchkey import _try_native_chain
+
+    field_exprs: list[pl.Expr] = []
     for field_name in key_config.fields:
-        if key_config.transforms:
-            expr = pl.col(field_name).map_elements(
-                lambda val, transforms=key_config.transforms: apply_transforms(val, transforms),
-                return_dtype=pl.Utf8,
+        transforms = key_config.transforms or []
+        native = _try_native_chain(field_name, transforms) if transforms else None
+        if native is not None:
+            field_exprs.append(native)
+        elif transforms:
+            field_exprs.append(
+                pl.col(field_name).map_elements(
+                    lambda val, transforms=transforms: apply_transforms(val, transforms),
+                    return_dtype=pl.Utf8,
+                )
             )
         else:
-            expr = pl.col(field_name).cast(pl.Utf8)
-        field_exprs.append(expr)
+            field_exprs.append(pl.col(field_name).cast(pl.Utf8))
 
     if len(field_exprs) == 1:
         return field_exprs[0].alias("__block_key__")


### PR DESCRIPTION
## The actual root cause of the 5M Linux hang

`_build_block_key_expr` was using `pl.col().map_elements(apply_transforms)` per row. At 5M rows with a 2-field blocking key (autoconfig picks `[email, last_name]` with `[lowercase, strip]`), that's **10M Python calls single-threaded**.

This is what's been hiding behind every "score_buckets is slow" / "bucket_assign is hanging" diagnosis since PR #308. The bench heartbeat shows `bucket_*` substages never closing because `bucket_assign` itself was running the `map_elements` call.

Same pathology as PR #310 (`block_analyzer.py::_apply_candidate_transforms`); this completes the sweep of `map_elements`-over-full-df in pre-fuzzy stages.

## Fix

`core/matchkey.py::_try_native_chain` already handles every transform the autoconfig blocking flow emits (`lowercase`, `strip`, `substring`, `normalize_whitespace`, `digits_only`, `alpha_only`). Use it. Fall back to `map_elements` only when a Python-only transform (`soundex`, `metaphone`) is configured.

## Local validation

| n_rows | score_buckets before | score_buckets after | pair count |
|---|---|---|---|
| 500K | 53.0s | **49.6s** | 166,667 |
| 1M   | ~200s | **93.2s** | 333,333 |

Pair counts identical pre/post. 139/139 blocker tests pass.

## Test plan
- [x] 139/139 blocker tests pass
- [x] Local 500K + 1M: faster, identical pair count
- [ ] 5M Linux bench: `bucket_*` stages actually surface in heartbeat, RSS plateau, kill criterion gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)