### PR TITLE
bench: _skip_finalize=True so controller doesn't run full pipeline (real 5M hang)

### DIFF
--- a/packages/python/goldenmatch/scripts/bench_distributed_stack.py
+++ b/packages/python/goldenmatch/scripts/bench_distributed_stack.py
@@ -151,7 +151,14 @@ def run_one(label: str, df: pl.DataFrame, *, backend: str, prepared_record_store
         hb = _start_heartbeat(label, rec, stop_event)
         try:
             print(f"[run_one {label}] calling auto_configure_df...", flush=True)
-            cfg = auto_configure_df(df, confidence_required=False)
+            # _skip_finalize=True: controller would otherwise run the full
+            # pipeline once with the committed config and the controller's
+            # CHOSEN backend (not the bucket override the bench sets below).
+            # That double-run was the actual 5M hang -- it ran a full chunked
+            # / polars-direct pipeline before the bench got to call dedupe_df
+            # with backend="bucket". Skip it; the bench measures the real
+            # bucket pipeline below.
+            cfg = auto_configure_df(df, confidence_required=False, _skip_finalize=True)
             print(f"[run_one {label}] auto_configure_df returned at t={perf_counter()-t0:.1f}s", flush=True)
             cfg.backend = backend
             cfg.prepared_record_store = prepared_record_store


### PR DESCRIPTION
## What PR #315's diag prints showed

\`\`\`
[controller.run] t=2.8s: entering iteration loop
[controller.run] t=6.6s: iter 0 _run_pipeline_sample done in 3.8s
[controller.run] t=10.5s: iter 1 _run_pipeline_sample done in 3.7s
<-- no more diag prints, RSS climbs from 4 GB to 44 GB -->
\`\`\`

Sample iterations are fast. The loop converges after iter 1. Then \`_finalize\` fires the **full pipeline with the controller's CHOSEN backend** (chunked / polars-direct), which is what's hanging. The bench's \`cfg.backend = \"bucket\"\` override happens AFTER \`auto_configure_df\` returns — too late.

PRs #310-#314 fixed real bugs in the **bucket** scoring path. But the **controller's full-pipeline call inside auto_configure_df** uses whatever backend the v3 planner picked, NOT bucket. That's the path that's been eating 5M.

## Fix

Pass \`_skip_finalize=True\` (existing kwarg, used by 3 existing tests) so the controller commits the config and returns without running the full pipeline. The bench's own \`dedupe_df\` call below then measures the real \`backend=\"bucket\"\` path.

## Test plan
- [x] 3/3 \`_skip_finalize\`-related tests pass
- [ ] Next 5M Linux bench: \`auto_configure_df\` returns in seconds, \`dedupe_df\` then runs the bucket path with the existing instrumentation, kill criterion gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)