### PR TITLE
fix(deps): add scipy>=1.10 to goldenmatch dependencies

### DIFF
--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "psutil>=5.9",
     "duckdb>=0.9",
     "pyarrow>=10",
+    "scipy>=1.10",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Why

PR #323 (cluster scipy.csgraph) introduced \`from scipy.sparse import coo_matrix; from scipy.sparse.csgraph import connected_components\` in \`core/cluster.py::build_clusters\` but scipy wasn't in pyproject.toml dependencies.

5M Linux bench run 26062645515 crashed at \`build_clusters\` with \`ModuleNotFoundError: No module named 'scipy'\`. Main CI failure (intermittent xdist test plus this) confirms.

## Fix

Add \`scipy>=1.10\`. scipy is already a transitive dep of many polars-ecosystem packages so the install size impact is nil — this just makes the import explicit.

## Test plan

- [ ] CI green
- [ ] 5M Linux bench completes without ModuleNotFoundError

🤖 Generated with [Claude Code](https://claude.com/claude-code)