### PR TITLE
docs(ts): bring TS repo state into parity with shipped v0.8.0 code

### DIFF
--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to goldenmatch-js are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
+## [0.8.0] - 2026-05-12
+
+Identity Graph edge-safe core (Python `goldenmatch` v1.15 partial parity).
+
+### Added
+
+- **`goldenmatch.identity`** edge-safe surface mirroring the Python `goldenmatch.identity.*` module. All exports are safe to import from Vercel Edge, Cloudflare Workers, and other Web-Standards runtimes — no `node:*` imports.
+  - **Types:** `IdentityNode`, `SourceRecord`, `EvidenceEdge`, `IdentityEvent`, `IdentityAlias`, `IdentityStatus`, `EventKind`, `EdgeKind`, `IdentityView`, `IdentityStore` interface.
+  - **`newEntityId(prefix?)`** — UUIDv7 via Web Crypto; deterministic when seeded for tests.
+  - **`InMemoryIdentityStore`** — process-local store satisfying the full `IdentityStore` interface. Suitable for tests, edge-runtime scratch state, and code paths that don't require cross-call durability.
+  - **`findByRecord(store, record)` / `getEntity(store, id)` / `listEntities(store)`** — read paths.
+  - **`manualMerge(store, sourceId, targetId, ...)` / `manualSplit(store, entityId, recordIds, ...)`** — steward operations.
+- **TS parity tests** (13 cases) under `tests/identity/` covering the cluster-resolve absorb/merge/create branches, `findByRecord` semantics, manual merge/split idempotency, and `IdentityView` shape parity vs the Python `IdentityView` dataclass.
+
+### Not yet shipped (deferred to a future wave)
+
+- **Persistent SQLite-backed `IdentityStore`** in `src/node/identity/` — the Python `IdentityStore(backend="sqlite")` writes to `.goldenmatch/identity.db`. The TS port keeps the edge-safe interface but the Node-only persistent implementation is a future wave's work. Today, `InMemoryIdentityStore` resets on process restart.
+- **Pipeline-driven population** — the Python `resolve_clusters(...)` hook runs after dedupe clustering and writes identity events; the TS pipeline doesn't yet wire this hook.
+- **MCP identity tools** — Python ships 6 `identity_*` MCP tools backed by the persistent store. TS will follow after the persistent backend lands.
+
+### Python deltas NOT relevant to this wave
+
+- **Python v1.13 (release plumbing, typed accessors).** TypeScript's strict mode already enforces equivalent invariants without runtime accessor properties; the TS surface didn't drift.
+- **Python v1.14 (AutoConfigController surface-parity arc).** The arc threaded telemetry through TUI / CLI / Postgres / DuckDB surfaces that TS doesn't expose. TS already surfaces telemetry on its MCP server (added v0.5.0); the shared `serialize_telemetry` JSON shape is preserved.
+- **Python v1.16 (`backend="bucket"` 5M-on-one-node)**. Polars-only path; TS port runs edge-safe in Web Crypto and doesn't ship Polars. The `backend="bucket"` Python recommendation has no TS analogue and is intentionally not ported. The TS port's scale envelope is unchanged from v0.7.0 — single-node workloads, no out-of-core backend.
+
 ## [0.7.0] - 2026-05-10
 
 Negative-evidence parity with Python `goldenmatch` v1.11 + v1.12 (Path Y).

--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -1,6 +1,6 @@
 # goldenmatch (TypeScript)
 
-npm package `goldenmatch`. Three-wave parity port of the Python sibling at `packages/python/goldenmatch/`. Currently at **v0.7.0** (parity with Python v1.12).
+npm package `goldenmatch`. Parity port of the Python sibling at `packages/python/goldenmatch/`. Currently at **v0.8.0** (Identity Graph edge-safe core, Python v1.15 partial). Python sibling is at v1.16; v1.13/v1.14/v1.16 are explicitly not-ported (see CHANGELOG.md for the per-version rationale).
 
 ## Wave history
 | npm | Python parity | Headline |
@@ -9,13 +9,19 @@ npm package `goldenmatch`. Three-wave parity port of the Python sibling at `pack
 | 0.5.0 | v1.7 + v1.8 | AutoConfigController, ComplexityProfile, RunHistory, StopReason telemetry |
 | 0.6.0 | v1.9 + v1.10 | 5 complexity indicators + indicator-aware refit rules; scorer selection aligned with Python |
 | 0.7.0 | v1.11 + v1.12 | NegativeEvidenceField + Path Y (exact-MK post-filter) |
+| 0.8.0 | v1.15 (partial) | Identity Graph edge-safe core (`InMemoryIdentityStore` + query helpers). Persistent SQLite backend + pipeline-driven population deferred to a future wave. |
 
 Each wave's spec/plan: `docs/superpowers/specs/2026-05-10-ts-parity-arc-design.md` + per-wave plans.
+
+## Deliberately not ported (Python deltas)
+- **Python v1.13 (typed accessors).** TS strict mode (`noUncheckedIndexedAccess` + `exactOptionalPropertyTypes`) already enforces the same invariants at compile time.
+- **Python v1.14 (controller surface-parity arc).** Threaded telemetry through TUI / CLI / Postgres / DuckDB surfaces that TS doesn't expose. TS already surfaces telemetry on its MCP server via the same `serialize_telemetry` JSON shape.
+- **Python v1.16 (`backend="bucket"` 5M-on-one-node).** Polars-only Python path. TS runs edge-safe in Web Crypto and doesn't ship Polars — no TS analogue planned.
 
 ## Commands
 ```bash
 cd packages/typescript/goldenmatch
-pnpm --filter goldenmatch test      # vitest (841 tests at v0.7.0)
+pnpm --filter goldenmatch test      # vitest (854 tests at v0.8.0)
 pnpm --filter goldenmatch typecheck # tsc --noEmit (strict)
 pnpm --filter goldenmatch build     # tsup (5 entry points)
 npx vitest run tests/parity/        # parity-only suite
@@ -37,13 +43,14 @@ npx vitest run tests/parity/        # parity-only suite
 - **Negative-evidence parity** (v0.7.0): 6 fixture datasets exercising Path Y filtering on exact MKs + weighted-MK NE. Live in `tests/parity/negative-evidence-fixtures.json`.
 - **Controller parity** (v0.5.0): structural-only on 4 of 6 fixtures, byte-equal on 2. Python-side `ModuleNotFoundError` on polars/sklearn in the divergent 4 — TS doesn't replicate that import wart.
 
-## Public API surface (v0.7.0)
+## Public API surface (v0.8.0)
 - `dedupeFile`, `dedupe`, `matchFile`, `match` — all return Promises.
 - `autoConfigureRows` (sync, single-pass) and `autoConfigureRowsIterate` (Promise, full controller).
 - `AutoConfigController`, `RunHistory`, `ComplexityProfile`, `HealthVerdict`, `StopReason`.
 - `NegativeEvidenceField`, `applyNegativeEvidence`, `applyNegativeEvidenceToExactPairs`, `promoteNegativeEvidence`.
 - Memory mirror: `getMemory`, `addCorrection`, `learn`, `memoryStats`.
-- MCP tool count: 24 (19 base + 5 memory). Description literal at `src/node/mcp/server.ts:6` — keep in sync via the existing regex test.
+- **Identity Graph (v0.8.0, edge-safe core):** `InMemoryIdentityStore`, `newEntityId`, `findByRecord`, `getEntity`, `listEntities`, `manualMerge`, `manualSplit`, `IdentityView`, types (`IdentityNode`, `SourceRecord`, `EvidenceEdge`, `IdentityEvent`, `IdentityAlias`, `IdentityStatus`, `EventKind`, `EdgeKind`, `IdentityStore`).
+- MCP tool count: 24 (19 base + 5 memory). Description literal at `src/node/mcp/server.ts:6` — keep in sync via the existing regex test. Identity MCP tools will be added alongside the persistent backend in a future wave.
 
 ## Build outputs
 - tsup with 5 entry points: `index`, `core/index`, `node/index`, `cli`, `node/backends/score-worker` (piscina worker).

--- a/packages/typescript/goldenmatch/src/core/identity/index.ts
+++ b/packages/typescript/goldenmatch/src/core/identity/index.ts
@@ -1,9 +1,11 @@
 /**
  * Identity Graph -- public surface (edge-safe).
  *
- * Persistent (Node-only) SQLite backend lives at `src/node/identity/`. Both
- * implementations satisfy the same `IdentityStore` interface so consumers
- * stay backend-agnostic.
+ * Today only ``InMemoryIdentityStore`` is shipped. A persistent (Node-only)
+ * SQLite backend is planned at ``src/node/identity/`` to satisfy the same
+ * ``IdentityStore`` interface; that work is deferred to a future wave (see
+ * CHANGELOG.md v0.8.0 "Not yet shipped"). Consumers should code against the
+ * ``IdentityStore`` interface so they can swap implementations later.
  */
 
 export * from "./types.js";


### PR DESCRIPTION
## What this brings into parity

The TS port shipped v0.8.0 (Identity Graph edge-safe core, Python v1.15 partial parity) in PR #201 — but the docs didn't follow:

- \`CHANGELOG.md\` was **missing the v0.8.0 entry entirely**.
- \`CLAUDE.md\` claimed v0.7.0 / Python v1.12 parity.
- \`src/core/identity/index.ts\` docstring said the **persistent SQLite backend lives at \`src/node/identity/\`** — that directory doesn't exist; the persistent backend is deferred.

## What this PR does

1. **\`CHANGELOG.md\`** gets a full \`[0.8.0]\` entry covering the shipped Identity Graph TS surface (\`InMemoryIdentityStore\` + query helpers + types) and explicitly enumerates what's deferred (persistent SQLite, pipeline population, MCP identity tools).
2. **\`CLAUDE.md\`** picks up the v0.8.0 wave row, the new public-API surface, the corrected test count (854), and a **Deliberately not ported** section explaining why Python v1.13 / v1.14 / v1.16 don't get a TS wave:
   - **v1.13 (typed accessors)** — TS strict mode (\`noUncheckedIndexedAccess\` + \`exactOptionalPropertyTypes\`) already enforces the same invariants at compile time.
   - **v1.14 (controller surface arc)** — threaded telemetry through TUI / CLI / Postgres / DuckDB surfaces that TS doesn't expose; TS already surfaces telemetry on its MCP server via the same \`serialize_telemetry\` JSON shape.
   - **v1.16 (\`backend=\"bucket\"\` 5M-on-one-node)** — Polars-only path; TS runs edge-safe in Web Crypto and doesn't ship Polars. No TS analogue planned.
3. The identity index docstring is corrected so consumers don't trust a path that doesn't exist.

## Test plan

- [x] 854/854 TS tests pass (\`pnpm --filter goldenmatch test\`)
- [x] \`pnpm --filter goldenmatch typecheck\` clean
- [x] No code surface changes — pure docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)