### PR TITLE
feat(ts): goldenmatch v0.10.0 — Identity Graph on CLI + REST API

### DIFF
--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to goldenmatch-js are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
+## [0.10.0] - 2026-05-19
+
+Identity Graph on the CLI and REST API surfaces. The v0.9.0 persistent backend lit up the storage layer; v0.10.0 lights up two of the four user-facing surfaces Python ships (`web` UI is Python-only, TUI has no identity tab in Python either).
+
+### Added — CLI
+
+- New `goldenmatch identity` subgroup with 6 subcommands, mirroring `packages/python/goldenmatch/goldenmatch/cli/identity.py`:
+  - `goldenmatch identity list [--dataset] [--status] [--limit] [--offset] [--json]`
+  - `goldenmatch identity show <entity-id> [--json]`
+  - `goldenmatch identity history <entity-id> [--limit] [--json]`
+  - `goldenmatch identity conflicts [--dataset] [--json]`
+  - `goldenmatch identity merge <source-id> <target-id>` (target stays, source absorbed)
+  - `goldenmatch identity split <entity-id> <record-ids...>`
+- All commands accept `--path <path>` (default `.goldenmatch/identity.db`). The store is opened lazily per command via the v0.9.0 `SqliteIdentityStore`.
+
+### Added — REST API
+
+- `setServerIdentityStore(store)` binder mirrors `setServerMemoryStore`. When set, the following routes are live; otherwise 503 with a hint.
+  - `GET /identities?dataset&status&limit&offset` → list
+  - `GET /identities/:id` → node + records + edges + events (full `IdentityView`)
+  - `GET /identities/:id/history?limit` → event log
+  - `GET /identities/conflicts?dataset` → conflict edges
+  - `POST /identities/merge` body=`{keep, absorb}` → manualMerge
+  - `POST /identities/split` body=`{entity_id, record_ids[]}` → manualSplit
+- 9 new integration tests under `tests/unit/api-identity.test.ts` exercising every route plus the 503-when-unbound path.
+
+### Not ported (Python deltas with no TS analogue)
+
+- **Web UI Identities tab.** TS port doesn't ship a React workbench — the Python web UI at `packages/python/goldenmatch/web/frontend/` is the only one. Out of scope.
+- **TUI Identities tab.** Python TUI has no identity tab either (controller tab landed v1.14, no identity tab on the roadmap).
+- **`resolve` CLI subcommand.** Python ships it because the pipeline writes identity events post-cluster. The TS pipeline doesn't yet wire `resolveClusters`; deferred to a future wave.
+- **MCP identity tools.** Six tools (`identity_list/show/resolve/history/conflicts/merge/split`) on the Python MCP server. TS port can ship these in a follow-up now that the API surface is stable; not in this PR to keep scope tight.
+
+### Test counts
+877 → 886 (+9 API identity).
+
 ## [0.9.0] - 2026-05-19
 
 Persistent Identity Graph backend (Python `goldenmatch.identity.IdentityStore(backend="sqlite")` parity).

--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -1,6 +1,6 @@
 # goldenmatch (TypeScript)
 
-npm package `goldenmatch`. Parity port of the Python sibling at `packages/python/goldenmatch/`. Currently at **v0.9.0** (Identity Graph persistent backend; Python v1.15 + persistent IdentityStore parity). Python sibling is at v1.16; v1.13/v1.14/v1.16 are explicitly not-ported (see CHANGELOG.md for the per-version rationale).
+npm package `goldenmatch`. Parity port of the Python sibling at `packages/python/goldenmatch/`. Currently at **v0.10.0** (Identity Graph CLI + REST API; Python v1.15 surface parity). Python sibling is at v1.16; v1.13/v1.14/v1.16 are explicitly not-ported (see CHANGELOG.md for the per-version rationale).
 
 ## Wave history
 | npm | Python parity | Headline |
@@ -11,6 +11,7 @@ npm package `goldenmatch`. Parity port of the Python sibling at `packages/python
 | 0.7.0 | v1.11 + v1.12 | NegativeEvidenceField + Path Y (exact-MK post-filter) |
 | 0.8.0 | v1.15 (partial) | Identity Graph edge-safe core (`InMemoryIdentityStore` + query helpers). Persistent SQLite backend + pipeline-driven population deferred to a future wave. |
 | 0.9.0 | v1.15 + persistent IdentityStore | `SqliteIdentityStore` in `src/node/identity/` — full IdentityStore interface (19 methods), schema byte-identical with Python so a `.goldenmatch/identity.db` is cross-toolkit readable. Pipeline-driven population + MCP identity tools deferred to v0.10. |
+| 0.10.0 | v1.15 CLI + REST surface | `goldenmatch identity {list,show,history,conflicts,merge,split}` CLI subcommands + matching `/identities/*` REST routes (bound via `setServerIdentityStore`). Web UI / TUI / MCP-identity-tools / pipeline-driven `resolveClusters` still deferred. |
 
 Each wave's spec/plan: `docs/superpowers/specs/2026-05-10-ts-parity-arc-design.md` + per-wave plans.
 
@@ -22,7 +23,7 @@ Each wave's spec/plan: `docs/superpowers/specs/2026-05-10-ts-parity-arc-design.m
 ## Commands
 ```bash
 cd packages/typescript/goldenmatch
-pnpm --filter goldenmatch test      # vitest (877 tests at v0.9.0)
+pnpm --filter goldenmatch test      # vitest (886 tests at v0.10.0)
 pnpm --filter goldenmatch typecheck # tsc --noEmit (strict)
 pnpm --filter goldenmatch build     # tsup (5 entry points)
 npx vitest run tests/parity/        # parity-only suite

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -620,6 +620,237 @@ memoryCmd
     process.stdout.write(`  created_at:     ${c.createdAt.toISOString()}\n`);
   });
 
+// ---------- identity ----------
+// Mirrors `goldenmatch identity ...` in Python (cli/identity.py). Wraps the
+// SqliteIdentityStore for inspecting nodes, source records, edges, events,
+// and aliases. `resolve` is intentionally NOT yet shipped -- it depends on
+// the pipeline-driven `resolveClusters` hook which is deferred to a future
+// wave per CHANGELOG.md v0.10.0 deferred items.
+const identityCmd = program
+  .command("identity")
+  .description("Inspect and manage the Identity Graph");
+
+const DEFAULT_IDENTITY_PATH = ".goldenmatch/identity.db";
+
+async function openIdentityStoreForCli(path: string) {
+  const { existsSync } = await import("node:fs");
+  if (!existsSync(path)) {
+    process.stderr.write(`Identity DB not found: ${path}\n`);
+    process.exit(2);
+  }
+  const { SqliteIdentityStore } = await import("./node/identity/sqlite-store.js");
+  return SqliteIdentityStore.open({ path });
+}
+
+identityCmd
+  .command("list")
+  .description("List identities (most recently updated first)")
+  .option("--path <path>", "Identity DB path", DEFAULT_IDENTITY_PATH)
+  .option("--dataset <name>", "Filter by dataset")
+  .option(
+    "--status <status>",
+    "Filter by status (active | merged_into | split | retired)",
+  )
+  .option("--limit <n>", "Max rows", "50")
+  .option("--offset <n>", "Pagination offset", "0")
+  .option("--json", "Emit JSON instead of a table")
+  .action(
+    async (opts: {
+      path: string;
+      dataset?: string;
+      status?: string;
+      limit: string;
+      offset: string;
+      json?: boolean;
+    }) => {
+      const store = await openIdentityStoreForCli(opts.path);
+      try {
+        const listOpts: {
+          dataset?: string;
+          status?: "active" | "merged_into" | "split" | "retired";
+          limit?: number;
+          offset?: number;
+        } = {
+          limit: Number(opts.limit),
+          offset: Number(opts.offset),
+        };
+        if (opts.dataset) listOpts.dataset = opts.dataset;
+        if (opts.status) {
+          listOpts.status = opts.status as
+            | "active"
+            | "merged_into"
+            | "split"
+            | "retired";
+        }
+        const rows = await store.listIdentities(listOpts);
+        if (opts.json) {
+          process.stdout.write(JSON.stringify(rows, null, 2) + "\n");
+          return;
+        }
+        process.stdout.write(`Identities (${rows.length})\n`);
+        for (const r of rows) {
+          const conf = r.confidence !== null ? r.confidence.toFixed(3) : "-";
+          process.stdout.write(
+            `  ${r.entityId.substring(0, 8)}...  ${r.status}  conf=${conf}  ` +
+              `dataset=${r.dataset ?? "-"}  updated=${r.updatedAt.toISOString()}\n`,
+          );
+        }
+      } finally {
+        await store.close();
+      }
+    },
+  );
+
+identityCmd
+  .command("show")
+  .description("Show an identity with members, edges, and recent events")
+  .argument("<entity-id>", "Entity ID")
+  .option("--path <path>", "Identity DB path", DEFAULT_IDENTITY_PATH)
+  .option("--json", "Emit JSON instead of a summary")
+  .action(async (entityId: string, opts: { path: string; json?: boolean }) => {
+    const store = await openIdentityStoreForCli(opts.path);
+    try {
+      const node = await store.getIdentity(entityId);
+      if (!node) {
+        process.stderr.write(`Not found: ${entityId}\n`);
+        process.exit(1);
+      }
+      const records = await store.getRecordsForEntity(entityId);
+      const edges = await store.edgesForEntity(entityId);
+      const events = await store.history(entityId);
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({ node, records, edges, events }, null, 2) + "\n",
+        );
+        return;
+      }
+      const conf = node?.confidence !== null ? String(node?.confidence) : "-";
+      process.stdout.write(`${node?.entityId}  status=${node?.status}\n`);
+      process.stdout.write(`  confidence: ${conf}\n`);
+      process.stdout.write(`  dataset:    ${node?.dataset ?? "-"}\n`);
+      process.stdout.write(
+        `  records:    ${records.length}, edges: ${edges.length}, events: ${events.length}\n`,
+      );
+      for (const r of records) {
+        process.stdout.write(
+          `    - ${r.recordId}  source=${r.source}  hash=${r.recordHash.substring(0, 12)}\n`,
+        );
+      }
+    } finally {
+      await store.close();
+    }
+  });
+
+identityCmd
+  .command("history")
+  .description("Show event log for an identity")
+  .argument("<entity-id>", "Entity ID")
+  .option("--path <path>", "Identity DB path", DEFAULT_IDENTITY_PATH)
+  .option("--limit <n>", "Max events", "50")
+  .option("--json", "Emit JSON")
+  .action(
+    async (
+      entityId: string,
+      opts: { path: string; limit: string; json?: boolean },
+    ) => {
+      const store = await openIdentityStoreForCli(opts.path);
+      try {
+        const events = await store.history(entityId, Number(opts.limit));
+        if (opts.json) {
+          process.stdout.write(JSON.stringify(events, null, 2) + "\n");
+          return;
+        }
+        process.stdout.write(`Events (${events.length})\n`);
+        for (const e of events) {
+          process.stdout.write(
+            `  ${e.recordedAt.toISOString()}  ${e.kind}  run=${e.runName ?? "-"}\n`,
+          );
+        }
+      } finally {
+        await store.close();
+      }
+    },
+  );
+
+identityCmd
+  .command("conflicts")
+  .description("List conflict edges (kind=conflicts_with)")
+  .option("--path <path>", "Identity DB path", DEFAULT_IDENTITY_PATH)
+  .option("--dataset <name>", "Filter by dataset")
+  .option("--json", "Emit JSON")
+  .action(
+    async (opts: { path: string; dataset?: string; json?: boolean }) => {
+      const store = await openIdentityStoreForCli(opts.path);
+      try {
+        const conflicts = await store.findConflicts(opts.dataset);
+        if (opts.json) {
+          process.stdout.write(JSON.stringify(conflicts, null, 2) + "\n");
+          return;
+        }
+        process.stdout.write(`Conflicts (${conflicts.length})\n`);
+        for (const c of conflicts) {
+          process.stdout.write(
+            `  ${c.recordedAt.toISOString()}  entity=${c.entityId.substring(0, 8)}` +
+              `  pair=${c.recordAId},${c.recordBId}  score=${c.score ?? "-"}\n`,
+          );
+        }
+      } finally {
+        await store.close();
+      }
+    },
+  );
+
+identityCmd
+  .command("merge")
+  .description("Manually merge two identities (source -> target)")
+  .argument("<source-id>", "Source entity ID")
+  .argument("<target-id>", "Target entity ID")
+  .option("--path <path>", "Identity DB path", DEFAULT_IDENTITY_PATH)
+  .action(
+    async (
+      sourceId: string,
+      targetId: string,
+      opts: { path: string },
+    ) => {
+      const store = await openIdentityStoreForCli(opts.path);
+      try {
+        const { manualMerge } = await import("./core/identity/query.js");
+        // manualMerge(store, keep, absorb) -- target stays, source is absorbed.
+        const result = await manualMerge(store, targetId, sourceId);
+        process.stdout.write(`Merged ${sourceId} -> ${targetId}\n`);
+        process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+      } finally {
+        await store.close();
+      }
+    },
+  );
+
+identityCmd
+  .command("split")
+  .description("Manually split records into a new identity")
+  .argument("<entity-id>", "Source entity ID")
+  .argument("<record-ids...>", "Record IDs to move into a new identity")
+  .option("--path <path>", "Identity DB path", DEFAULT_IDENTITY_PATH)
+  .action(
+    async (
+      entityId: string,
+      recordIds: string[],
+      opts: { path: string },
+    ) => {
+      const store = await openIdentityStoreForCli(opts.path);
+      try {
+        const { manualSplit } = await import("./core/identity/query.js");
+        const result = await manualSplit(store, entityId, recordIds);
+        process.stdout.write(
+          `Split ${recordIds.length} record(s) from ${entityId}\n`,
+        );
+        process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+      } finally {
+        await store.close();
+      }
+    },
+  );
+
 // ---------- mcp-serve ----------
 program
   .command("mcp-serve")

--- a/packages/typescript/goldenmatch/src/node/api/server.ts
+++ b/packages/typescript/goldenmatch/src/node/api/server.ts
@@ -100,6 +100,21 @@ export function setServerMemoryStore(
   serverMemoryStore = store;
 }
 
+// Identity store (Phase 2.5): bound by `setServerIdentityStore`. When set,
+// the `/identities/*` routes are live; otherwise they return 503.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let serverIdentityStore: any = null;
+
+/**
+ * Bind an `IdentityStore` to the REST server. When set, `GET /identities`,
+ * `GET /identities/:id`, etc. are live. Pass `null` to disable.
+ */
+export function setServerIdentityStore(
+  store: import("../../core/identity/types.js").IdentityStore | null,
+): void {
+  serverIdentityStore = store;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -419,6 +434,100 @@ async function handleRequest(
         rowB,
       });
       sendJson(res, 200, { item });
+      return;
+    }
+
+    // ----- Identity Graph routes ------------------------------------------
+    // Mirrors `goldenmatch.web.routers.identity` (Python). Routes guard on
+    // serverIdentityStore being bound; otherwise 503 with hint.
+    if (pathname.startsWith("/identities") && method === "GET") {
+      if (!serverIdentityStore) {
+        sendJson(res, 503, {
+          error: "IdentityStore not bound to server",
+          hint: "call setServerIdentityStore(store) at startup",
+        });
+        return;
+      }
+      const sub = pathname.slice("/identities".length);
+      // Order matters: more-specific paths before /:id wildcard.
+      if (sub === "/conflicts") {
+        const dataset = url.searchParams.get("dataset") ?? undefined;
+        const conflicts = await serverIdentityStore.findConflicts(dataset);
+        sendJson(res, 200, { conflicts });
+        return;
+      }
+      if (sub === "" || sub === "/") {
+        const dataset = url.searchParams.get("dataset") ?? undefined;
+        const status = url.searchParams.get("status") ?? undefined;
+        const limit = Number(url.searchParams.get("limit") ?? "50");
+        const offset = Number(url.searchParams.get("offset") ?? "0");
+        const opts: Record<string, unknown> = { limit, offset };
+        if (dataset !== undefined) opts["dataset"] = dataset;
+        if (status !== undefined) opts["status"] = status;
+        const items = await serverIdentityStore.listIdentities(opts);
+        sendJson(res, 200, { items, limit, offset });
+        return;
+      }
+      // /identities/:id  or  /identities/:id/history
+      const parts = sub.split("/").filter((s) => s.length > 0);
+      const entityId = parts[0];
+      if (entityId && parts.length === 1) {
+        const node = await serverIdentityStore.getIdentity(entityId);
+        if (!node) {
+          sendJson(res, 404, { error: `Not found: ${entityId}` });
+          return;
+        }
+        const records = await serverIdentityStore.getRecordsForEntity(entityId);
+        const edges = await serverIdentityStore.edgesForEntity(entityId);
+        const events = await serverIdentityStore.history(entityId);
+        sendJson(res, 200, { node, records, edges, events });
+        return;
+      }
+      if (entityId && parts[1] === "history" && parts.length === 2) {
+        const limit = Number(url.searchParams.get("limit") ?? "50");
+        const events = await serverIdentityStore.history(entityId, limit);
+        sendJson(res, 200, { events });
+        return;
+      }
+    }
+
+    if (pathname === "/identities/merge" && method === "POST") {
+      if (!serverIdentityStore) {
+        sendJson(res, 503, { error: "IdentityStore not bound to server" });
+        return;
+      }
+      const body = await readJsonBody(req);
+      const keep = typeof body["keep"] === "string" ? (body["keep"] as string) : "";
+      const absorb =
+        typeof body["absorb"] === "string" ? (body["absorb"] as string) : "";
+      if (!keep || !absorb) {
+        throw new Error("'keep' and 'absorb' entity IDs are required");
+      }
+      const { manualMerge } = await import("../../core/identity/query.js");
+      const result = await manualMerge(serverIdentityStore, keep, absorb);
+      sendJson(res, 200, result);
+      return;
+    }
+
+    if (pathname === "/identities/split" && method === "POST") {
+      if (!serverIdentityStore) {
+        sendJson(res, 503, { error: "IdentityStore not bound to server" });
+        return;
+      }
+      const body = await readJsonBody(req);
+      const entityId =
+        typeof body["entity_id"] === "string" ? (body["entity_id"] as string) : "";
+      const rawRecordIds = body["record_ids"];
+      if (!Array.isArray(rawRecordIds)) {
+        throw new Error("'record_ids' must be an array");
+      }
+      const recordIds = rawRecordIds.map((v) => String(v));
+      if (!entityId || recordIds.length === 0) {
+        throw new Error("'entity_id' and non-empty 'record_ids' are required");
+      }
+      const { manualSplit } = await import("../../core/identity/query.js");
+      const result = await manualSplit(serverIdentityStore, entityId, recordIds);
+      sendJson(res, 200, result);
       return;
     }
 

--- a/packages/typescript/goldenmatch/src/node/index.ts
+++ b/packages/typescript/goldenmatch/src/node/index.ts
@@ -59,7 +59,12 @@ export type {
 
 // Servers (MCP / REST / A2A)
 export { startMcpServer, handleTool, TOOLS } from "./mcp/server.js";
-export { startApiServer, ReviewQueue } from "./api/server.js";
+export {
+  startApiServer,
+  ReviewQueue,
+  setServerMemoryStore,
+  setServerIdentityStore,
+} from "./api/server.js";
 export type { StartApiOptions } from "./api/server.js";
 export { startA2aServer, AGENT_CARD } from "./a2a/server.js";
 export type { StartA2aOptions, AgentSkill } from "./a2a/server.js";

--- a/packages/typescript/goldenmatch/tests/unit/api-identity.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/api-identity.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Identity Graph REST API tests.
+ *
+ * Binds an in-memory IdentityStore via setServerIdentityStore (so we don't
+ * need a real .goldenmatch/identity.db on disk for these tests) and
+ * exercises the GET / POST routes.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { Server } from "node:http";
+
+import {
+  InMemoryIdentityStore,
+  type EvidenceEdge,
+  type IdentityNode,
+} from "../../src/core/identity/index.js";
+import {
+  setServerIdentityStore,
+  startApiServer,
+} from "../../src/node/api/server.js";
+
+const store = new InMemoryIdentityStore();
+let server: Server;
+let baseUrl: string;
+
+function makeNode(entityId: string, dataset = "test"): IdentityNode {
+  const now = new Date();
+  return {
+    entityId,
+    status: "active",
+    mergedInto: null,
+    goldenRecord: { name: entityId },
+    confidence: 0.9,
+    dataset,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+beforeAll(async () => {
+  await store.upsertIdentity(makeNode("e-1"));
+  await store.upsertIdentity(makeNode("e-2"));
+  await store.upsertRecord({
+    recordId: "csv:r1",
+    source: "csv:test",
+    sourcePk: "r1",
+    recordHash: "hash-r1",
+    entityId: "e-1",
+    payload: null,
+    dataset: "test",
+    firstSeenAt: new Date(),
+    lastSeenAt: new Date(),
+  });
+  const edge: EvidenceEdge = {
+    edgeId: null,
+    entityId: "e-1",
+    recordAId: "csv:r1",
+    recordBId: "csv:r2",
+    kind: "conflicts_with",
+    score: 0.5,
+    matchkeyName: "identity",
+    fieldScores: null,
+    negativeEvidence: null,
+    controllerSnapshot: null,
+    runName: "test-run",
+    dataset: "test",
+    recordedAt: new Date(),
+  };
+  await store.addEdge(edge);
+
+  setServerIdentityStore(store);
+  server = startApiServer({ port: 0, host: "127.0.0.1" });
+  await new Promise<void>((r) => {
+    if (server.listening) r();
+    else server.once("listening", () => r());
+  });
+  const addr = server.address();
+  const port =
+    typeof addr === "object" && addr !== null && "port" in addr ? addr.port : 8000;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  setServerIdentityStore(null);
+  if (server) {
+    await new Promise<void>((r, j) => {
+      server.close((err) => (err ? j(err) : r()));
+    });
+  }
+});
+
+describe("REST API /identities", () => {
+  it("GET /identities returns items + paging", async () => {
+    const res = await fetch(`${baseUrl}/identities?limit=10`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      items: IdentityNode[];
+      limit: number;
+      offset: number;
+    };
+    expect(body.items.length).toBe(2);
+    expect(body.limit).toBe(10);
+  });
+
+  it("GET /identities?dataset filters", async () => {
+    const res = await fetch(`${baseUrl}/identities?dataset=test`);
+    const body = (await res.json()) as { items: IdentityNode[] };
+    expect(body.items.length).toBe(2);
+  });
+
+  it("GET /identities/:id returns node + records + edges + events", async () => {
+    const res = await fetch(`${baseUrl}/identities/e-1`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      node: IdentityNode;
+      records: Array<{ recordId: string }>;
+      edges: Array<{ kind: string }>;
+      events: unknown[];
+    };
+    expect(body.node.entityId).toBe("e-1");
+    expect(body.records.length).toBe(1);
+    expect(body.records[0]?.recordId).toBe("csv:r1");
+    expect(body.edges.length).toBe(1);
+  });
+
+  it("GET /identities/:id 404s on missing", async () => {
+    const res = await fetch(`${baseUrl}/identities/missing`);
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /identities/conflicts returns conflict edges", async () => {
+    const res = await fetch(`${baseUrl}/identities/conflicts`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { conflicts: Array<{ kind: string }> };
+    expect(body.conflicts.length).toBe(1);
+    expect(body.conflicts[0]?.kind).toBe("conflicts_with");
+  });
+
+  it("GET /identities/:id/history returns events", async () => {
+    // Emit an event so history is non-empty.
+    await store.emitEvent({
+      eventId: null,
+      entityId: "e-1",
+      kind: "created",
+      payload: null,
+      runName: "test-run",
+      dataset: "test",
+      recordedAt: new Date(),
+    });
+    const res = await fetch(`${baseUrl}/identities/e-1/history`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: unknown[] };
+    expect(body.events.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("POST /identities/merge calls manualMerge", async () => {
+    const res = await fetch(`${baseUrl}/identities/merge`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ keep: "e-1", absorb: "e-2" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      keep: string;
+      absorbed: string;
+    };
+    expect(body.keep).toBe("e-1");
+    expect(body.absorbed).toBe("e-2");
+  });
+
+  it("POST /identities/split calls manualSplit", async () => {
+    // Re-create state for split — set up a fresh entity with members.
+    await store.upsertIdentity(makeNode("e-3"));
+    await store.upsertRecord({
+      recordId: "csv:r3",
+      source: "csv:test",
+      sourcePk: "r3",
+      recordHash: "hash-r3",
+      entityId: "e-3",
+      payload: null,
+      dataset: "test",
+      firstSeenAt: new Date(),
+      lastSeenAt: new Date(),
+    });
+    const res = await fetch(`${baseUrl}/identities/split`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ entity_id: "e-3", record_ids: ["csv:r3"] }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      newEntityId: string;
+      moved: string[];
+    };
+    expect(typeof body.newEntityId).toBe("string");
+    expect(body.moved).toEqual(["csv:r3"]);
+  });
+
+  it("returns 503 when store is not bound", async () => {
+    setServerIdentityStore(null);
+    const res = await fetch(`${baseUrl}/identities`);
+    expect(res.status).toBe(503);
+    // Restore for any subsequent tests
+    setServerIdentityStore(store);
+  });
+});


### PR DESCRIPTION
## What

Lights up two of the four user-facing surfaces Python ships for the Identity Graph. v0.9.0 shipped the persistent storage layer (\`SqliteIdentityStore\`); this PR makes it actually reachable.

## CLI

New \`goldenmatch identity\` subgroup with 6 subcommands mirroring \`packages/python/goldenmatch/goldenmatch/cli/identity.py\`:

| Command | Description |
|---|---|
| \`identity list\` | List identities (most recently updated first), filtered by dataset / status |
| \`identity show <id>\` | Node + records + edges + events summary (or full JSON via \`--json\`) |
| \`identity history <id>\` | Event log |
| \`identity conflicts\` | List conflict edges (kind=conflicts_with) |
| \`identity merge <src> <tgt>\` | Manually merge two identities (target stays, source absorbed) |
| \`identity split <id> <records...>\` | Split records into a new identity |

All accept \`--path\` (default \`.goldenmatch/identity.db\`). Read commands accept \`--json\`.

## REST API

\`setServerIdentityStore(store)\` binder mirrors \`setServerMemoryStore\`. When bound, these routes are live (else 503 with hint):

| Route | Body / params |
|---|---|
| \`GET /identities\` | \`?dataset&status&limit&offset\` |
| \`GET /identities/:id\` | Node + records + edges + events |
| \`GET /identities/:id/history\` | \`?limit\` |
| \`GET /identities/conflicts\` | \`?dataset\` |
| \`POST /identities/merge\` | \`{keep, absorb}\` |
| \`POST /identities/split\` | \`{entity_id, record_ids[]}\` |

## Deliberately not in this PR

- **Web UI Identities tab** — TS port doesn't ship a React workbench; the Python workbench at \`packages/python/goldenmatch/web/frontend/\` is the only one. Out of scope.
- **TUI Identities tab** — Python TUI has no identity tab either.
- **\`resolve\` CLI subcommand** — requires the pipeline-driven \`resolveClusters\` hook, deferred to a future wave.
- **6 MCP identity tools** — straightforward follow-up now that the API surface is stable.

## Test plan
- [x] 9/9 new API identity tests pass (\`tests/unit/api-identity.test.ts\`)
- [x] \`pnpm --filter goldenmatch test\` — 886/886
- [x] \`pnpm --filter goldenmatch typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)