### PR TITLE
perf(25M): drop tracemalloc + release UnionFind state early

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -235,9 +235,17 @@ def build_clusters(
         uf.union(id_a, id_b)
 
     clusters = uf.get_clusters()
+    # Release UnionFind internals (parent + rank dicts). At 25M these hold
+    # ~2.5 GB combined; Python GC won't free them until `uf` falls out of
+    # scope, which is later in this function. Force-release now.
+    del uf
 
     member_to_cid: dict[int, int] = {}
     sorted_clusters = sorted(clusters, key=lambda s: min(s))
+    # `clusters` is the list-of-sets view returned by get_clusters(); after
+    # sorting we don't need the original list, only the sorted view.
+    del clusters
+
     for cluster_id, members in enumerate(sorted_clusters, start=1):
         for m in members:
             member_to_cid[m] = cluster_id
@@ -255,6 +263,10 @@ def build_clusters(
     for id_a, id_b, score in pairs:
         cid = member_to_cid[id_a]
         result[cid]["pair_scores"][(id_a, id_b)] = score
+    # member_to_cid + sorted_clusters held ~1.25 + 1.0 GB at 25M scale; once
+    # pair_scores is populated they aren't read again inside this function.
+    del member_to_cid
+    del sorted_clusters
 
     for cid, cinfo in result.items():
         conf = compute_cluster_confidence(cinfo["pair_scores"], cinfo["size"])

--- a/packages/python/goldenmatch/scripts/bench_distributed_stack.py
+++ b/packages/python/goldenmatch/scripts/bench_distributed_stack.py
@@ -13,7 +13,14 @@ import json
 import os
 import sys
 import threading
-import tracemalloc
+
+# tracemalloc was previously used to report peak Python-allocated memory.
+# At 25M scale its allocation-snapshot table itself holds ~5-10 GB of state
+# (every Python object allocation gets a stack frame stored), which pushes
+# the bench over the runner's 64 GB ceiling. Switched to psutil's RSS
+# high-watermark instead -- it's the OS-level view (closer to what the
+# kill criterion actually cares about) and adds zero per-allocation
+# overhead.
 from pathlib import Path
 from time import perf_counter
 
@@ -138,12 +145,31 @@ def _start_heartbeat(label: str, recorder, stop_event: threading.Event) -> threa
 
 def run_one(label: str, df: pl.DataFrame, *, backend: str, prepared_record_store: bool, partitioned_block_scoring: bool) -> dict:
     import goldenmatch as gm
+    import psutil
     from goldenmatch.core.autoconfig import auto_configure_df
     from goldenmatch.core.bench import bench_capture
-
-    tracemalloc.start()
+    proc = psutil.Process()
+    peak_rss_bytes = [proc.memory_info().rss]
     t0 = perf_counter()
     stop_event = threading.Event()
+    # Background sampler for peak RSS. psutil.memory_info() is cheap (~1us)
+    # so a 0.5s tick is well under our 30s heartbeat granularity. Replaces
+    # tracemalloc which itself held ~5-10 GB of allocation-tracking state
+    # at 25M scale.
+    rss_stop = threading.Event()
+
+    def _sample_rss():
+        while not rss_stop.wait(0.5):
+            try:
+                cur = proc.memory_info().rss
+                if cur > peak_rss_bytes[0]:
+                    peak_rss_bytes[0] = cur
+            except Exception:  # noqa: BLE001
+                pass
+
+    rss_thread = threading.Thread(target=_sample_rss, name="rss-peak", daemon=True)
+    rss_thread.start()
+
     with bench_capture() as rec:
         # Heartbeat must start AFTER bench_capture so it has the
         # context-var recorder; otherwise rec.to_dict() reads an
@@ -175,8 +201,9 @@ def run_one(label: str, df: pl.DataFrame, *, backend: str, prepared_record_store
             stop_event.set()
             hb.join(timeout=2)
     wall = perf_counter() - t0
-    _current, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
+    rss_stop.set()
+    rss_thread.join(timeout=2)
+    peak = peak_rss_bytes[0]
 
     # Metrics-only: do NOT touch result.clusters at scale. At 5M with 1.67M
     # clusters, materializing the Python dict (and walking .values() to count


### PR DESCRIPTION
## Why

25M Linux bench OOM'd at RSS 62 GB / 64 GB. Three holders of unnecessary memory at that scale:

| Holder | At 25M | Released by |
|---|---|---|
| \`tracemalloc\` allocation-snapshot table | 5-10 GB | this PR |
| \`UnionFind._parent + ._rank\` after \`get_clusters\` | ~2.5 GB | this PR |
| \`sorted_clusters\` + \`member_to_cid\` after \`pair_scores\` pop. | ~2.3 GB | this PR |

Total recoverable: ~10-15 GB. The 25M bench peaked 62 GB before these freed; should now stay below 50 GB.

## Changes

1. **bench: tracemalloc → psutil RSS sampler.** 0.5s-tick background thread captures peak RSS; same \`peak_rss_mb\` JSON field, OS-level (which is what the kill criterion actually measures anyway).
2. **\`cluster.py\`: explicit \`del\` of internals** at the earliest point each falls out of use. Same semantics, GC just runs sooner.

## Test plan

- [x] 20/20 cluster tests pass
- [ ] 25M bench completes without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)