### PR TITLE
fix(ci): Phase 1 bench installs pandas + pipefail propagates exit code

### DIFF
--- a/.github/workflows/bench-distributed-stack.yml
+++ b/.github/workflows/bench-distributed-stack.yml
@@ -158,7 +158,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[ray]"
-          pip install psutil
+          # pandas is a runtime dep of ray.data (not declared in the
+          # [ray] extra). Without it, `ray.data.read_csv` errors with
+          # ModuleNotFoundError before the bench can produce any output.
+          pip install psutil pandas
 
       - name: Download pre-generated dataset
         if: inputs.dataset_tag != ''
@@ -178,7 +181,13 @@ jobs:
         env:
           GOLDENMATCH_ENABLE_DISTRIBUTED_RAY: "1"
           MALLOC_ARENA_MAX: "2"
+        # set -o pipefail so the script's exit code propagates past
+        # `tee`. Without this, a script crash returns 0 to the runner
+        # and the kill-criterion check silently turns into a no-op.
+        # Bit us once already (run 26098279854 reported success on a
+        # ModuleNotFoundError exit).
         run: |
+          set -o pipefail
           mkdir -p bench-out
           INPUT="bench-dataset/bench_${{ inputs.rows }}.parquet"
           if [ ! -f "$INPUT" ]; then
@@ -189,7 +198,7 @@ jobs:
             --input "$INPUT" \
             --rows "${{ inputs.rows }}" \
             --partitions 64 \
-            | tee bench-out/phase1_loader.log
+            2>&1 | tee bench-out/phase1_loader.log
           echo '## bench-phase1-loader results' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           cat bench-out/phase1_loader.log >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Run 26098279854 reported success on the Phase 1 25M kill-criterion bench, but the bench script never actually ran — it crashed with \`ModuleNotFoundError: No module named 'pandas'\` (ray.data requires pandas, not declared in \`[ray]\` extra) and the \`| tee\` pipe swallowed the non-zero exit code.

Two fixes:

1. \`pip install pandas\` in the Phase 1 bench install step.
2. \`set -o pipefail\` so a script crash actually flips the step status to failed. Also \`2>&1\` so stderr lands in the artifact log next time.

After merge, re-trigger \`bench-distributed-stack.yml\` with \`rows=25000000 dataset_tag=bench-dataset-v1\` to actually measure the kill criterion. The Phase 2 gate stays closed until then.

## Test plan

- [ ] CI doc-filter green (workflow file change).
- [ ] After merge: bench re-trigger produces real numbers (driver_peak_rss_gb, prep_stage_wall_sec).