### PR TITLE
feat(distributed): read_parquet_partitioned + read_partitioned dispatcher (Phase 1 bench fix)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/distributed/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/__init__.py
@@ -10,9 +10,13 @@ distributed clustering, planner integration) ship as their own sub-projects.
 from goldenmatch.distributed.dataset import (
     apply_transforms_distributed,
     read_csv_partitioned,
+    read_parquet_partitioned,
+    read_partitioned,
 )
 
 __all__ = [
     "apply_transforms_distributed",
     "read_csv_partitioned",
+    "read_parquet_partitioned",
+    "read_partitioned",
 ]

--- a/packages/python/goldenmatch/goldenmatch/distributed/dataset.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/dataset.py
@@ -41,6 +41,44 @@ def read_csv_partitioned(
     return ds.repartition(n_partitions)
 
 
+def read_parquet_partitioned(
+    path: str | list[str],
+    n_partitions: int,
+    schema: dict[str, str] | None = None,
+) -> Dataset:
+    """Read parquet file(s) into a Ray Dataset partitioned into n_partitions blocks.
+
+    Same contract as :func:`read_csv_partitioned` but for parquet input.
+    Same laziness guarantee: driver never holds the full frame.
+    """
+    import ray
+
+    if not ray.is_initialized():
+        ray.init(ignore_reinit_error=True, log_to_driver=False)
+    paths = path if isinstance(path, list) else [path]
+    ds = ray.data.read_parquet(paths)
+    if schema is not None:
+        ds = ds.select_columns(list(schema.keys()))
+    return ds.repartition(n_partitions)
+
+
+def read_partitioned(
+    path: str | list[str],
+    n_partitions: int,
+    schema: dict[str, str] | None = None,
+) -> Dataset:
+    """Dispatch to read_csv_partitioned or read_parquet_partitioned by suffix.
+
+    Convenience wrapper for callers that don't know the format up front (e.g.
+    bench scripts). Uses the first path's suffix to pick the reader.
+    """
+    first = path[0] if isinstance(path, list) else path
+    suffix = first.rsplit(".", 1)[-1].lower()
+    if suffix == "parquet":
+        return read_parquet_partitioned(path, n_partitions, schema)
+    return read_csv_partitioned(path, n_partitions, schema)
+
+
 def _apply_plans_to_arrow_batch(batch: Any, plans: list) -> Any:
     """Convert pyarrow batch -> Polars -> apply plans -> back to pyarrow."""
     import polars as pl

--- a/packages/python/goldenmatch/scripts/bench_phase1_loader.py
+++ b/packages/python/goldenmatch/scripts/bench_phase1_loader.py
@@ -1,6 +1,6 @@
 """Phase 1 kill criterion: driver RSS < 8 GB during prep stage.
 
-Loads N rows via `goldenmatch.distributed.read_csv_partitioned`, applies a
+Loads N rows via `goldenmatch.distributed.read_partitioned`, applies a
 two-step TransformPlan chain, and measures peak driver RSS via a psutil
 sampler thread. Exits non-zero if peak RSS >= 8 GB.
 
@@ -45,7 +45,7 @@ def main() -> int:
 
     from goldenmatch.distributed import (
         apply_transforms_distributed,
-        read_csv_partitioned,
+        read_partitioned,
     )
     from goldenmatch.distributed.transforms import TransformPlan
 
@@ -63,7 +63,7 @@ def main() -> int:
     sampler.start()
 
     t0 = time.perf_counter()
-    ds = read_csv_partitioned(args.input, n_partitions=args.partitions)
+    ds = read_partitioned(args.input, n_partitions=args.partitions)
     ds = apply_transforms_distributed(
         ds,
         [

--- a/packages/python/goldenmatch/tests/test_distributed_dataset.py
+++ b/packages/python/goldenmatch/tests/test_distributed_dataset.py
@@ -106,3 +106,27 @@ def test_loader_driver_rss_does_not_grow_with_input_size(tmp_path):
     after = proc.memory_info().rss
     growth_mb = (after - baseline) / 1024 / 1024
     assert growth_mb < 200, f"driver RSS grew {growth_mb:.0f} MB — loader is materializing on driver"
+
+
+def test_read_parquet_partitioned_round_trip(tmp_path):
+    import polars as pl
+    from goldenmatch.distributed import read_parquet_partitioned
+
+    p = tmp_path / "people.parquet"
+    pl.DataFrame({"id": range(500), "name": ["x"] * 500}).write_parquet(p)
+
+    ds = read_parquet_partitioned(str(p), n_partitions=4)
+    assert ds.count() == 500
+
+
+def test_read_partitioned_dispatches_by_suffix(tmp_path):
+    import polars as pl
+    from goldenmatch.distributed import read_partitioned
+
+    csv = tmp_path / "in.csv"
+    pl.DataFrame({"id": range(50), "name": ["x"] * 50}).write_csv(csv)
+    pq = tmp_path / "in.parquet"
+    pl.DataFrame({"id": range(30), "name": ["x"] * 30}).write_parquet(pq)
+
+    assert read_partitioned(str(csv), n_partitions=2).count() == 50
+    assert read_partitioned(str(pq), n_partitions=2).count() == 30


### PR DESCRIPTION
## Summary

Phase 1 25M kill-criterion bench (\`bench-distributed-stack.yml\`) feeds the loader a parquet file (\`bench_25000000.parquet\` from the bench-dataset-v1 release asset), but the Phase 1 loader landed in PR #337 hardcodes \`ray.data.read_csv\`. Run 26099129339 (the rerun after PR #338's pipefail fix) surfaced this:

\`\`\`
ValueError: Failed to read CSV file: bench-dataset/bench_25000000.parquet
\`\`\`

## What changed

- \`goldenmatch.distributed.dataset\`:
  - \`read_parquet_partitioned(path, n_partitions, schema=None)\` — same contract as \`read_csv_partitioned\` but via \`ray.data.read_parquet\`.
  - \`read_partitioned(path, n_partitions, schema=None)\` — convenience dispatcher; picks the reader by file suffix.
- \`scripts/bench_phase1_loader.py\` switches to \`read_partitioned()\` so it works on both CSV and parquet inputs.
- Two new tests: parquet round-trip + dispatcher dispatches by suffix. **9 tests green** in \`tests/test_distributed_dataset.py\` (was 7).
- Local smoke at 1K parquet rows: PASS at 0.20 GB driver RSS.

## Test plan

- [ ] CI \`python (goldenmatch)\` green.
- [ ] After merge, re-trigger \`bench-distributed-stack.yml\` with \`rows=25000000 dataset_tag=bench-dataset-v1\` to get the real Phase 1 kill-criterion number.