### PR TITLE
fix(bench): Phase 1 bench script uses real bench-dataset-v1 columns

### DIFF
--- a/packages/python/goldenmatch/scripts/bench_phase1_loader.py
+++ b/packages/python/goldenmatch/scripts/bench_phase1_loader.py
@@ -62,13 +62,19 @@ def main() -> int:
     sampler = threading.Thread(target=_sample_rss, name="rss-peak", daemon=True)
     sampler.start()
 
+    # Transform column names match the bench-dataset-v1 schema
+    # (first_name, last_name, email, zip). Multiple ops per column give
+    # the per-partition Python path a non-trivial workload.
     t0 = time.perf_counter()
     ds = read_partitioned(args.input, n_partitions=args.partitions)
     ds = apply_transforms_distributed(
         ds,
         [
-            TransformPlan(column="name", op="lower"),
-            TransformPlan(column="name", op="strip_punctuation"),
+            TransformPlan(column="first_name", op="lower"),
+            TransformPlan(column="first_name", op="strip_punctuation"),
+            TransformPlan(column="last_name", op="lower"),
+            TransformPlan(column="last_name", op="strip_punctuation"),
+            TransformPlan(column="email", op="lower"),
         ],
     )
     count = ds.count()


### PR DESCRIPTION
## Summary

Run 26099688922 — the first run after the parquet fix — got past the read step and crashed inside the transform stage with:

\`\`\`
polars.exceptions.ColumnNotFoundError: unable to find column \"name\"; valid columns: [\"first_name\", \"last_name\", \"email\", \"zip\"]
\`\`\`

The bench-dataset-v1 schema is \`first_name | last_name | email | zip\`, not a single \`name\` column. The script transforms now match: lower + strip_punctuation on both first_name and last_name, plus lower on email. 5 ops total — gives the per-partition Python path a non-trivial workload for the bench.

This is the **third bench fix in a row** for the same workflow run, each surfaced because the prior fix exposed the next issue:
1. PR #338 — pandas + pipefail
2. PR #339 — parquet support
3. PR #340 — real columns

Good news: the loader works, ray executed, parquet read succeeded, transforms started. We're now down to dataset-shape issues, not infrastructure issues.

## Test plan

- [ ] CI doc-filter routes through (workflow-only file change... actually script change, so the python lane runs).
- [ ] After merge, re-trigger \`bench-distributed-stack.yml\` with \`rows=25000000 dataset_tag=bench-dataset-v1\` for the real kill-criterion number.