### PR TITLE
feat(phase3): bench pre-scores via dedupe_df so cluster_wall is measurable

### DIFF
--- a/.github/workflows/bench-distributed-stack.yml
+++ b/.github/workflows/bench-distributed-stack.yml
@@ -276,12 +276,14 @@ jobs:
           retention-days: 30
 
   bench-phase3-cluster:
-    name: "bench Phase 3 distributed cluster (wall < 60s @ 25M pairs)"
+    name: "bench Phase 3 distributed cluster (wall < 60s @ 25M)"
     # Phase 3 of the Splink-Spark roadmap. Kill criterion: cluster wall < 60s
-    # at 25M pairs on 16c/64GB. Requires a pre-scored pairs parquet at
-    # bench-dataset/pairs_<rows>.parquet (generated separately).
+    # at 25M pairs on 16c/64GB. Uses the existing bench_<rows>.parquet (raw
+    # records); the bench script pre-scores via dedupe_df then times only
+    # the distributed cluster stage. prescore_wall_sec is reported
+    # separately and is NOT part of the kill criterion.
     runs-on: large-new-64GB
-    timeout-minutes: 90
+    timeout-minutes: 180  # pre-score at 25M is ~5-7 min; cluster + overhead
     steps:
       - uses: actions/checkout@v4
         with:
@@ -295,7 +297,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[ray]"
           pip install psutil pandas scipy
-      - name: Download pre-scored pairs dataset
+      - name: Download raw records dataset
         if: inputs.dataset_tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -304,27 +306,26 @@ jobs:
           mkdir -p bench-dataset
           gh release download "${{ inputs.dataset_tag }}" \
             --repo "$GITHUB_REPOSITORY" \
-            --pattern "pairs_${{ inputs.rows }}.parquet" \
-            --dir bench-dataset/ || echo "(no pre-scored pairs file)"
-          ls -lh bench-dataset/ || true
-      - name: Run Phase 3 kill-criterion bench
+            --pattern "bench_${{ inputs.rows }}.parquet" \
+            --dir bench-dataset/
+          ls -lh bench-dataset/
+      - name: Run Phase 3 kill-criterion bench (pre-score + cluster)
         working-directory: packages/python/goldenmatch
         env:
           GOLDENMATCH_ENABLE_DISTRIBUTED_RAY: "1"
+          GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
           MALLOC_ARENA_MAX: "2"
         run: |
           set -o pipefail
           mkdir -p bench-out
-          PAIRS="bench-dataset/pairs_${{ inputs.rows }}.parquet"
-          if [ ! -f "$PAIRS" ]; then
-            echo "ERROR: pairs dataset $PAIRS not found. Phase 3 bench needs"
-            echo "a pre-scored pair list. Generate one and attach to the"
-            echo "${{ inputs.dataset_tag }} release as pairs_${{ inputs.rows }}.parquet"
-            echo "with columns id_a:int64, id_b:int64, score:float64."
+          INPUT="bench-dataset/bench_${{ inputs.rows }}.parquet"
+          if [ ! -f "$INPUT" ]; then
+            echo "ERROR: dataset $INPUT not found."
             exit 1
           fi
           python scripts/bench_phase3_cluster.py \
-            --pairs "$PAIRS" \
+            --input "$INPUT" \
+            --scratch-pairs bench-out/phase3_pairs.parquet \
             2>&1 | tee bench-out/phase3_cluster.log
           echo '## bench-phase3-cluster results' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/packages/python/goldenmatch/scripts/bench_phase3_cluster.py
+++ b/packages/python/goldenmatch/scripts/bench_phase3_cluster.py
@@ -1,13 +1,24 @@
 """Phase 3 kill criterion: cluster stage < 60s at 25M pairs.
 
-Loads pre-scored pairs from parquet, runs `build_clusters_distributed`
-end-to-end, asserts cluster wall < 60s.
+Two modes:
+
+1. ``--pairs <parquet>`` — clusters a pre-scored pairs parquet. Columns:
+   ``id_a:int64, id_b:int64, score:float64``. Fast path for repeated bench
+   runs once the score artifact is built.
+
+2. ``--input <parquet>`` — raw records parquet (the bench-dataset-v1 shape:
+   ``first_name``, ``last_name``, ``email``, ``zip``). The script runs
+   ``goldenmatch.dedupe_df`` to score in-memory, then times JUST the
+   distributed cluster stage on the resulting pair list. The pre-score
+   time is reported separately as ``prescore_wall_sec``; the kill
+   criterion is on ``cluster_wall_sec``.
 
 Run:
     GOLDENMATCH_ENABLE_DISTRIBUTED_RAY=1 \
     python scripts/bench_phase3_cluster.py \
-        --pairs bench-dataset-v1/pairs_25000000.parquet
+        --input bench-dataset-v1/bench_25000000.parquet
 """
+
 from __future__ import annotations
 
 import argparse
@@ -20,13 +31,54 @@ import psutil
 KILL_WALL_SEC = 60.0
 
 
+def _prescore(input_path: str) -> tuple[list[tuple[int, int, float]], float]:
+    """Run dedupe_df to produce scored pairs. Returns (pairs, wall_sec).
+
+    Uses the in-memory pipeline. This is intentionally the slow path —
+    the bench is measuring the DISTRIBUTED cluster stage, not the scorer.
+    """
+    import polars as pl
+    from goldenmatch import dedupe_df
+
+    t0 = time.perf_counter()
+    df = pl.read_parquet(input_path)
+    result = dedupe_df(df, confidence_required=False)
+    elapsed = time.perf_counter() - t0
+    return result.scored_pairs, elapsed
+
+
+def _write_pairs_parquet(
+    pairs: list[tuple[int, int, float]], path: str
+) -> None:
+    import polars as pl
+
+    pl.DataFrame(
+        {
+            "id_a": [a for a, _, _ in pairs],
+            "id_b": [b for _, b, _ in pairs],
+            "score": [s for _, _, s in pairs],
+        }
+    ).write_parquet(path)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument(
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument(
         "--pairs",
         type=str,
-        required=True,
-        help="Parquet path: columns id_a:int64, id_b:int64, score:float64",
+        help="Parquet of pre-scored pairs (id_a, id_b, score).",
+    )
+    src.add_argument(
+        "--input",
+        type=str,
+        help="Raw records parquet; the bench will pre-score it via dedupe_df.",
+    )
+    ap.add_argument(
+        "--scratch-pairs",
+        type=str,
+        default="bench-out/phase3_pairs.parquet",
+        help="Where to write the intermediate pairs parquet when using --input.",
     )
     ap.add_argument("--kill-wall-sec", type=float, default=KILL_WALL_SEC)
     args = ap.parse_args()
@@ -39,8 +91,19 @@ def main() -> int:
     proc = psutil.Process()
     baseline = proc.memory_info().rss
 
+    prescore_wall = 0.0
+    if args.input is not None:
+        os.makedirs(os.path.dirname(args.scratch_pairs) or ".", exist_ok=True)
+        pairs, prescore_wall = _prescore(args.input)
+        _write_pairs_parquet(pairs, args.scratch_pairs)
+        pairs_path = args.scratch_pairs
+        print(f"prescore_wall_sec={prescore_wall:.1f}")
+        print(f"pairs_written={len(pairs)} -> {pairs_path}")
+    else:
+        pairs_path = args.pairs
+
     t_load = time.perf_counter()
-    pairs_ds = read_parquet_partitioned(args.pairs, n_partitions=64)
+    pairs_ds = read_parquet_partitioned(pairs_path, n_partitions=64)
     ids: set[int] = set()
     for row in pairs_ds.take_all():
         ids.add(row["id_a"])


### PR DESCRIPTION
## Summary

Phase 3 shipped (PR #346) but the bench job required a pre-scored \`pairs_<rows>.parquet\` that doesn't exist on the bench-dataset-v1 release. This PR makes the bench script handle the pre-scoring itself so the kill criterion (\`cluster_wall_sec < 60s\`) actually gets measured.

## What changed

\`scripts/bench_phase3_cluster.py\` now accepts EITHER:

1. \`--pairs <parquet>\` (existing fast path) — clusters a pre-scored pairs file.
2. \`--input <parquet>\` (new) — raw bench-dataset-v1 records. Runs \`goldenmatch.dedupe_df\` in-memory to produce \`result.scored_pairs\`, writes them to a scratch parquet, then times JUST \`build_clusters_distributed\` on the result.

The pre-score wall is reported separately as \`prescore_wall_sec\`. **The kill criterion stays on \`cluster_wall_sec\` only.**

Workflow update:
- \`bench-phase3-cluster\` downloads the existing \`bench_<rows>.parquet\` (raw records, same artifact Phase 1 + Phase 2 already use) instead of a separate pairs file.
- \`timeout-minutes\` 90 → 180 to accommodate the in-memory pre-score (~5-7 min at 25M based on bucket-backend bench).

## Why this approach

Pre-scoring inside the bench is wasteful (we end up clustering once in \`dedupe_df\` and once in \`build_clusters_distributed\`) but it's a one-line wiring change that gets us a real measurement TODAY without needing a separate score-then-publish artifact pipeline. The kill criterion measures only the distributed step, so the wasted in-memory clustering doesn't pollute the number.

Once a pre-scored parquet exists on the release, switching back to \`--pairs\` is a one-line workflow change.

## Test plan

- [ ] CI \`python (goldenmatch)\` + \`pyright\` green (script change only).
- [ ] After merge: trigger \`bench-distributed-stack.yml\` with \`rows=25000000 dataset_tag=bench-dataset-v1\`. The Phase 3 lane should report \`prescore_wall_sec\` (informational) and \`cluster_wall_sec\` (vs 60s kill).