### PR TITLE
fix(phase4): bench adds __row_id__ explicitly (avoid ColumnNotFoundError)

### DIFF
--- a/packages/python/goldenmatch/scripts/bench_phase4_golden.py
+++ b/packages/python/goldenmatch/scripts/bench_phase4_golden.py
@@ -41,6 +41,13 @@ def main() -> int:
 
     t_load = time.perf_counter()
     df = pl.read_parquet(args.input)
+    # bench-dataset-v1 doesn't carry __row_id__; goldenmatch adds it
+    # internally inside dedupe_df. Add it explicitly so we can match
+    # cluster members back to source rows after the dedupe call.
+    if "__row_id__" not in df.columns:
+        df = df.with_row_index("__row_id__").with_columns(
+            pl.col("__row_id__").cast(pl.Int64)
+        )
     load_wall = time.perf_counter() - t_load
 
     # Pre-pipeline via in-memory bucket backend (same as Phase 3 bench).


### PR DESCRIPTION
## Summary

Run [26129290865](https://github.com/benseverndev-oss/goldenmatch/actions/runs/26129290865) Phase 4 bench failed with:

\`\`\`
polars.exceptions.ColumnNotFoundError: unable to find column \"__row_id__\";
valid columns: [\"first_name\", \"last_name\", \"email\", \"zip\"]
\`\`\`

The bench assumed \`__row_id__\` would exist on \`bench_25000000.parquet\`. It doesn't — goldenmatch's pipeline adds it internally inside \`dedupe_df\`. To reconstruct \`multi_df\` after the dedupe call, the bench needs the row_id BEFORE calling dedupe so the cluster members map back to source rows.

## Fix

Add \`__row_id__\` to the DataFrame via \`with_row_index\` after reading the parquet and before calling \`dedupe_df\`:

\`\`\`python
df = pl.read_parquet(args.input)
if \"__row_id__\" not in df.columns:
    df = df.with_row_index(\"__row_id__\").with_columns(pl.col(\"__row_id__\").cast(pl.Int64))
\`\`\`

## Test plan

- [ ] CI green (script change only).
- [ ] After merge: re-trigger \`bench-distributed-stack.yml\` with \`rows=25000000\`. Phase 4 lane should now produce real \`golden_wall_sec\` numbers against the 180s threshold.