### PR TITLE
fix(phase4): cap repartition count at 4x cpu_count (was 166666, hung)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/distributed/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/golden.py
@@ -80,10 +80,21 @@ def build_golden_records_distributed(
     if not ray.is_initialized():
         ray.init(ignore_reinit_error=True, log_to_driver=False)
 
-    total_rows = multi_ds.count()
-    # One partition per ~max_cluster_size rows, so each partition roughly
-    # holds one cluster worth of rows. Minimum 1.
-    num_partitions = max(1, total_rows // max(max_cluster_size, 1))
+    del max_cluster_size  # kept in signature for API stability; partition
+    # count is no longer tied to it — see comment below.
+
+    # Partition count tuned for Ray's shuffle overhead: too few partitions
+    # underutilizes the cluster; too many create O(N²) shuffle coordination
+    # cost. Run 26130317522 stuck at Shuffle 0/? for 25 min on 166666
+    # partitions (one per ~max_cluster_size rows). Cap at ~4x cpu_count so
+    # each partition does meaningful work and shuffle stays manageable.
+    import os
+
+    cpu_count = os.cpu_count() or 16
+    # 4x cpu_count gives parallelism with reasonable per-partition work;
+    # capped at 256 for very large workers. Min 4 for parallelism on
+    # small inputs.
+    num_partitions = min(256, max(4, cpu_count * 4))
 
     # Hash-partition by __cluster_id__ so all rows for a cluster co-locate.
     repartitioned = multi_ds.repartition(num_partitions, keys=["__cluster_id__"])


### PR DESCRIPTION
## Summary

Run [26130317522](https://github.com/benseverndev-oss/goldenmatch/actions/runs/26130317522) Phase 4 golden bench hung 25+ minutes at \`Shuffle: 0/?\` on the 25M dataset and was cancelled.

Root cause: \`build_golden_records_distributed\` computed
\`\`\`python
num_partitions = total_rows // max_cluster_size  # = 16.6M / 100 = 166,666
\`\`\`

166,666 output partitions on \`repartition(num_partitions, keys=[...])\` overwhelms Ray's shuffle coordination on a 16-core box (O(N²) coordination cost). The streaming executor's progress bar stayed at \`Tasks: 1\` for the entire run with zero rows output.

## Fix

Cap num_partitions at \`min(256, max(4, cpu_count * 4))\` — 64 partitions on the 16c bench runner. Each partition holds many clusters; per-partition \`build_golden_records_batch\` already groups by \`__cluster_id__\` internally via the Polars fast path, so coarse partitioning is fine.

\`max_cluster_size\` stays in the public signature for API stability but no longer drives partitioning; explicit \`del\` to silence pyright.

## Test plan

- [ ] CI green (golden.py change only; existing tests cover the partition logic at small scale and didn't catch this because they used \`total_rows < 100\`).
- [ ] After merge: re-trigger \`bench-distributed-stack.yml\` with \`rows=25000000\`. Phase 4 lane should now finish well under the 180s threshold (8M-row map_batches with 64 partitions ≈ several seconds; existing in-memory golden was 72.5s).