### PR TITLE
fix(sync): four-issue cluster blocking goldenmatch sync end-to-end (#362-365)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -8,6 +8,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ### Fixed
 
+- `goldenmatch sync` cluster: four user-visible bugs that all surfaced
+  from one Postgres sync run against a 1.13M-row table on a slim Python
+  build.
+  - #362: `golden.py` no longer calls `top_k_by(..., reverse=False)`,
+    which mis-binds args on newer Polars versions. Replaced with
+    `sort_by(descending=True).first()`.
+  - #363: chunked Postgres reads now cast `Null`-dtype columns to
+    `Utf8` before `pl.concat`, fixing `type String is incompatible
+    with expected type Null` on sparse-column tables. Defensive
+    `how="diagonal_relaxed"` on the concat call too.
+  - #364: `sqlite3` is now lazy-imported inside `ReviewQueue`,
+    `MemoryStore`, and `IdentityStore`. `import goldenmatch` and the
+    CLI no longer require `_sqlite3` on minimal Python builds (Vercel
+    Sandbox, slim Docker, etc.).
+  - #365: `_quote_ident("schema.table")` now produces
+    `"schema"."table"`, allowing `goldenmatch sync --table gm.foo`
+    against non-public schemas without a search_path workaround.
+
 - `two_phase_wcc` no longer rehydrates a 475 MiB Python `dict[int, int]`
   in every worker. Phase B's lookup table now travels as a Polars frame
   via `ray.put`, zero-copy mapped from plasma into worker address space

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -205,7 +205,10 @@ def _build_golden_records_polars_native(
             # Polars 0.20+. See #362.
             agg_exprs.append(
                 pl.col(col).filter(pl.col(col).is_not_null())
-                .sort_by(len_col_aliases[col], descending=True)
+                .sort_by(
+                    pl.col(len_col_aliases[col]).filter(pl.col(col).is_not_null()),
+                    descending=True,
+                )
                 .first().alias(f"__val_{col}__")
             )
             agg_exprs.append(

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -198,9 +198,14 @@ def _build_golden_records_polars_native(
         ])
         agg_exprs: list = []
         for col in user_cols:
+            # sort_by(descending=True).first() picks the longest non-null
+            # value, matching the prior top_k_by(by=..., k=1, reverse=False)
+            # intent. top_k_by mis-binds args on newer Polars where
+            # 'reverse' is no longer a kwarg; sort_by is stable across
+            # Polars 0.20+. See #362.
             agg_exprs.append(
                 pl.col(col).filter(pl.col(col).is_not_null())
-                .top_k_by(by=len_col_aliases[col], k=1, reverse=False)
+                .sort_by(len_col_aliases[col], descending=True)
                 .first().alias(f"__val_{col}__")
             )
             agg_exprs.append(

--- a/packages/python/goldenmatch/goldenmatch/core/memory/store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/store.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import logging
-import sqlite3
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
@@ -117,6 +116,7 @@ class MemoryStore:
         self._backend = backend
         if backend == "sqlite":
             import os
+            import sqlite3  # noqa: PLC0415 -- lazy, see #364
             os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
             self._conn = sqlite3.connect(path)
             self._conn.row_factory = sqlite3.Row

--- a/packages/python/goldenmatch/goldenmatch/core/review_queue.py
+++ b/packages/python/goldenmatch/goldenmatch/core/review_queue.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
+    import sqlite3
+
     import polars as pl
 
     from goldenmatch.core.memory.store import MemoryStore
@@ -225,7 +227,7 @@ class _SQLiteBackend:
                 parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
 
-    def _connect(self) -> "sqlite3.Connection":
+    def _connect(self) -> sqlite3.Connection:
         import sqlite3  # noqa: PLC0415 -- lazy, see #364
         return sqlite3.connect(str(self._db_path))
 

--- a/packages/python/goldenmatch/goldenmatch/core/review_queue.py
+++ b/packages/python/goldenmatch/goldenmatch/core/review_queue.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -226,7 +225,8 @@ class _SQLiteBackend:
                 parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
 
-    def _connect(self) -> sqlite3.Connection:
+    def _connect(self) -> "sqlite3.Connection":
+        import sqlite3  # noqa: PLC0415 -- lazy, see #364
         return sqlite3.connect(str(self._db_path))
 
     def _init_db(self) -> None:

--- a/packages/python/goldenmatch/goldenmatch/db/connector.py
+++ b/packages/python/goldenmatch/goldenmatch/db/connector.py
@@ -180,9 +180,19 @@ class PostgresConnector(DatabaseConnector):
 
 
 def _quote_ident(name: str) -> str:
-    """Quote a SQL identifier to prevent injection."""
-    # Simple quoting — replace any double quotes and wrap
-    return '"' + name.replace('"', '""') + '"'
+    """Quote a SQL identifier to prevent injection.
+
+    Splits a single ``schema.table`` arg into ``"schema"."table"`` so
+    callers can pass non-public schemas via ``sync --table gm.foo``.
+    See #365.
+
+    Edge case: tables with literal dots in the name are split on the
+    FIRST dot only -- yielding ``"odd_schema"."weird.name"``. Two-dot
+    identifiers are vanishingly rare in practice and there is no
+    portable escape syntax for them through a CLI flag.
+    """
+    parts = name.split(".", 1)  # max one split: schema.table
+    return ".".join('"' + p.replace('"', '""') + '"' for p in parts)
 
 
 def create_connector(config: dict) -> DatabaseConnector:

--- a/packages/python/goldenmatch/goldenmatch/db/connector.py
+++ b/packages/python/goldenmatch/goldenmatch/db/connector.py
@@ -97,7 +97,7 @@ class PostgresConnector(DatabaseConnector):
                 if not rows:
                     break
                 data = {col: [row[i] for row in rows] for i, col in enumerate(columns)}
-                yield pl.DataFrame(data)
+                yield _normalize_chunk_schema(pl.DataFrame(data))
         finally:
             cursor.close()
 
@@ -177,6 +177,25 @@ class PostgresConnector(DatabaseConnector):
             return cursor.fetchone()[0]
         finally:
             cursor.close()
+
+
+def _normalize_chunk_schema(df: pl.DataFrame) -> pl.DataFrame:
+    """Cast Null-dtype columns to Utf8 so vstack across chunks succeeds.
+
+    When a chunked Postgres read hits a chunk where a column is 100%
+    NULL, Polars infers ``Null`` dtype for it. A later chunk with real
+    values infers ``String``, and ``pl.concat`` rejects the mismatch
+    with 'type String is incompatible with expected type Null'.
+
+    Casting all-null ``Null`` columns to ``Utf8`` at the chunk boundary
+    sidesteps the issue. Utf8 is the lowest-cost fallback when we can't
+    know the true Postgres type from the cursor alone -- subsequent
+    chunks carry the real values. See #363.
+    """
+    null_cols = [c for c, dt in df.schema.items() if dt == pl.Null]
+    if not null_cols:
+        return df
+    return df.with_columns([pl.col(c).cast(pl.Utf8) for c in null_cols])
 
 
 def _quote_ident(name: str) -> str:

--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -110,7 +110,10 @@ def _read_all(connector: DatabaseConnector, table: str, chunk_size: int) -> pl.D
     chunks = []
     for chunk in connector.read_table(table, chunk_size):
         chunks.append(chunk)
-    return pl.concat(chunks) if chunks else pl.DataFrame()
+    # how="diagonal_relaxed" defends against any chunk where a column
+    # is all-NULL (Null dtype) slipping past _normalize_chunk_schema in
+    # the connector. See #363.
+    return pl.concat(chunks, how="diagonal_relaxed") if chunks else pl.DataFrame()
 
 
 def _read_incremental(

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import sqlite3
 import time
 import uuid
 from collections.abc import Iterable
@@ -141,6 +140,7 @@ class IdentityStore:
         # legacy per-store single-conn behavior the existing tests rely on.
         self._pool = pool
         if backend == "sqlite":
+            import sqlite3  # noqa: PLC0415 -- lazy, see #364
             # Canonicalize path early so logs / errors see the resolved form
             # and the parent-dir create cannot escape via "..". Path is a
             # trusted-config value supplied by the embedding application,

--- a/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
+++ b/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
@@ -10,8 +10,7 @@ import builtins
 import sys
 
 import polars as pl
-import pytest
-
+import pytest  # noqa: F401 -- used via __main__ block
 
 # ----------------------------------------------------------------------
 # #364 -- lazy sqlite3 import in ReviewQueue

--- a/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
+++ b/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
@@ -1,0 +1,157 @@
+"""Regression tests for the `goldenmatch sync` bug cluster (#362-#365).
+
+Each test pins one of the four bugs that surfaced together from a single
+sync run against a 1.13M-row Postgres table on a slim Python build.
+"""
+
+from __future__ import annotations
+
+import builtins
+import sys
+
+import polars as pl
+import pytest
+
+
+# ----------------------------------------------------------------------
+# #364 -- lazy sqlite3 import in ReviewQueue
+# ----------------------------------------------------------------------
+
+
+def test_goldenmatch_imports_without_sqlite3(monkeypatch):
+    """#364: top-level imports must not require _sqlite3.
+
+    Simulates a slim Python build (Vercel Sandbox, minimal Docker)
+    where the sqlite3 stdlib module is missing.
+    """
+    # Stash cached modules so we can force a fresh import chain.
+    cached = {
+        k: v for k, v in list(sys.modules.items())
+        if k.startswith(("goldenmatch", "sqlite3"))
+    }
+    for k in list(cached):
+        del sys.modules[k]
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "sqlite3" or name.startswith("sqlite3."):
+            raise ModuleNotFoundError("No module named '_sqlite3'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    try:
+        import goldenmatch  # noqa: F401 -- must not raise
+        from goldenmatch.cli.main import app  # noqa: F401 -- CLI entry must not raise
+        assert app is not None
+    finally:
+        # Restore the cached modules so other tests see a normal env.
+        monkeypatch.setattr(builtins, "__import__", real_import)
+        for k in list(sys.modules):
+            if k.startswith("goldenmatch"):
+                del sys.modules[k]
+        for k, v in cached.items():
+            sys.modules[k] = v
+
+
+# ----------------------------------------------------------------------
+# #365 -- _quote_ident splits schema.table
+# ----------------------------------------------------------------------
+
+
+def test_quote_ident_splits_schema_and_table():
+    """#365: schema.table must quote as 'schema'.'table', not 'schema.table'."""
+    from goldenmatch.db.connector import _quote_ident
+
+    assert _quote_ident("gm.pubrecord_pub1") == '"gm"."pubrecord_pub1"'
+    assert _quote_ident("pubrecord_pub1") == '"pubrecord_pub1"'
+    # Double-quote escape (existing behavior, must not regress).
+    assert _quote_ident('weird"name') == '"weird""name"'
+    assert _quote_ident('gm.weird"name') == '"gm"."weird""name"'
+
+
+# ----------------------------------------------------------------------
+# #363 -- chunked Postgres reads cast Null-dtype columns to Utf8
+# ----------------------------------------------------------------------
+
+
+def test_concat_chunks_with_null_dtype_column_promotes_to_utf8():
+    """#363: chunks where a column is all-NULL in the first chunk and
+    has String values in a later chunk must concat cleanly. Without the
+    normalization, ``pl.concat`` raises 'type String is incompatible
+    with expected type Null'.
+    """
+    from goldenmatch.db.connector import _normalize_chunk_schema
+
+    chunk_all_null = pl.DataFrame({
+        "id": [1, 2, 3],
+        "sparse_col": [None, None, None],
+    })
+    chunk_with_values = pl.DataFrame({
+        "id": [4, 5],
+        "sparse_col": ["foo", "bar"],
+    })
+
+    normalized = [
+        _normalize_chunk_schema(chunk_all_null),
+        _normalize_chunk_schema(chunk_with_values),
+    ]
+    out = pl.concat(normalized)
+    assert out.height == 5
+    assert out.schema["sparse_col"] == pl.Utf8
+
+
+# ----------------------------------------------------------------------
+# #362 -- replace top_k_by(reverse=...) with sort_by(descending=...)
+# ----------------------------------------------------------------------
+
+
+def test_most_complete_strategy_uses_sort_by_not_top_k_by():
+    """#362: the most-complete golden record builder must avoid
+    ``top_k_by(..., reverse=False)`` because newer Polars versions don't
+    accept ``reverse`` as a kwarg and silently mis-bind the args.
+
+    Structural check: the polars-native builder source should use
+    ``sort_by(...).first()`` not ``top_k_by(...)``.
+    """
+    import inspect
+
+    from goldenmatch.core import golden
+
+    src = inspect.getsource(golden._build_golden_records_polars_native)
+    assert "top_k_by" not in src, (
+        "top_k_by(by=..., k=1, reverse=False) breaks on newer Polars; "
+        "use sort_by(col, descending=True).first() instead. See #362."
+    )
+    assert "sort_by(" in src
+
+
+def test_most_complete_picks_longest_string():
+    """End-to-end: the most-complete strategy must still pick the
+    longest non-null string per cluster after the top_k_by -> sort_by
+    rewrite.
+    """
+    from goldenmatch.config.schemas import GoldenRulesConfig
+    from goldenmatch.core.golden import build_golden_records_batch
+
+    df = pl.DataFrame({
+        "__cluster_id__": [1, 1, 1, 2, 2],
+        "__row_id__": [0, 1, 2, 3, 4],
+        "name": ["Bob", "Robert", "Rob", "Alice", "Al"],
+    })
+    rules = GoldenRulesConfig(default_strategy="most_complete")
+    out = build_golden_records_batch(df, rules)
+    by_cluster = {}
+    for r in out:
+        v = r["name"]
+        # build_golden_records_batch wraps each field as {value, confidence}
+        if isinstance(v, dict):
+            v = v.get("value")
+        by_cluster[r["__cluster_id__"]] = v
+    assert by_cluster[1] == "Robert"  # longest among Bob/Robert/Rob
+    assert by_cluster[2] == "Alice"   # longest among Alice/Al
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
+++ b/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
@@ -120,11 +120,17 @@ def test_most_complete_strategy_uses_sort_by_not_top_k_by():
     from goldenmatch.core import golden
 
     src = inspect.getsource(golden._build_golden_records_polars_native)
-    assert "top_k_by" not in src, (
+    # Strip comment lines so the historical-context comment can stay.
+    code_lines = [
+        ln for ln in src.splitlines()
+        if not ln.lstrip().startswith("#")
+    ]
+    code = "\n".join(code_lines)
+    assert "top_k_by(" not in code, (
         "top_k_by(by=..., k=1, reverse=False) breaks on newer Polars; "
         "use sort_by(col, descending=True).first() instead. See #362."
     )
-    assert "sort_by(" in src
+    assert "sort_by(" in code
 
 
 def test_most_complete_picks_longest_string():


### PR DESCRIPTION
## Summary

Closes #362, #363, #364, #365. Four independent code fixes in one PR
because they all blocked the same `goldenmatch sync` workflow:

- #364 (lazy sqlite3): `import goldenmatch` now succeeds on slim Python
  builds without `_sqlite3`. Lazy-imported in `ReviewQueue`,
  `MemoryStore`, and `IdentityStore`.
- #365 (schema.table quoting): `--table gm.foo` works on non-public schemas.
- #363 (Null-dtype vstack): chunked reads of sparse-string columns no
  longer crash on `pl.concat`. `_normalize_chunk_schema` casts Null to
  Utf8 at the chunk boundary; `_read_all` uses `how='diagonal_relaxed'`
  as defense in depth.
- #362 (top_k_by API drift): autoconfig controller v0 history build no
  longer errors on every iteration. `top_k_by(reverse=...)` replaced
  with `sort_by(descending=...).first()`.

Each fix is a separate commit so it can be reverted individually if
needed. No cross-cutting refactor.

## Test plan

- [x] New `tests/test_sync_bug_cluster.py` with one test per issue
- [x] Regression: `test_golden.py`, `test_golden_partition_perf.py`,
      `test_review_queue.py`, `test_memory_store.py`, `tests/identity/`
      all pass
- [ ] Manual smoke: `goldenmatch sync --table gm.foo` on a 1M-row
      Postgres with a 100%-NULL-in-first-chunk column

## Refs

#362, #363, #364, #365