### PR TITLE
bench(phase5.5): --skip-label-prop flag for clean Two-Phase WCC validation

### DIFF
--- a/.github/workflows/bench-distributed-stack.yml
+++ b/.github/workflows/bench-distributed-stack.yml
@@ -22,6 +22,10 @@ on:
         description: "Run Phase 5.5 WCC head-to-head (Two-Phase vs label_propagation on adversarial chain)"
         type: boolean
         default: false
+      phase5_5_skip_label_prop:
+        description: "Skip label_propagation in the Phase 5.5 bench (it does not finish in 30 min at 5M chain scale by design; this is the validation mode for Two-Phase WCC alone)"
+        type: boolean
+        default: false
       run_phase6_identity:
         description: "Run Phase 6 identity bench (driver vs distributed against Postgres)"
         type: boolean
@@ -510,6 +514,7 @@ jobs:
           set -o pipefail
           python scripts/bench_phase5_5_wcc.py \
             --pairs bench-out/chains_50m.parquet \
+            ${{ inputs.phase5_5_skip_label_prop && '--skip-label-prop' || '' }} \
             2>&1 | tee bench-out/phase5_5_wcc.log
           echo '## bench-phase5-5-wcc results' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/packages/python/goldenmatch/scripts/bench_phase5_5_wcc.py
+++ b/packages/python/goldenmatch/scripts/bench_phase5_5_wcc.py
@@ -35,6 +35,16 @@ def main() -> int:
         default=300.0,
         help="Cap label_propagation iterations to avoid hanging on chains.",
     )
+    ap.add_argument(
+        "--skip-label-prop",
+        action="store_true",
+        help=(
+            "Skip the label_propagation comparison entirely. At >= 5M pairs "
+            "label_prop's HashAggregate-per-iter is the whole point of the "
+            "Two-Phase WCC switch (it does not finish in the 30 min job cap). "
+            "Set this when validating Two-Phase WCC against current-main."
+        ),
+    )
     args = ap.parse_args()
 
     os.environ.setdefault("GOLDENMATCH_ENABLE_DISTRIBUTED_RAY", "1")
@@ -60,6 +70,12 @@ def main() -> int:
     tp_wall = time.perf_counter() - t_tp
     tp_partitions = _partitions_from_labels(tp_rows)
     print(f"two_phase_wcc: {tp_wall:.1f}s, {len(tp_partitions)} components")
+
+    if args.skip_label_prop:
+        print("label_propagation: skipped (--skip-label-prop)")
+        print(f"two_phase_wcc_wall_s={tp_wall:.1f}")
+        print(f"two_phase_wcc_components={len(tp_partitions)}")
+        return 0
 
     # Label propagation (with iteration cap so it doesn't hang forever on chains)
     t_lp = time.perf_counter()


### PR DESCRIPTION
## Summary

Run 26168230208 (post-columnar fix #361) timed out at 30 min not
because Two-Phase WCC was slow (it cleared 5M chain in ~2 min), but
because the head-to-head ran label_propagation second and label_prop
is exactly what motivated the Two-Phase switch. The comparison is
asymmetric by design at >= 5M scale.

Adds --skip-label-prop CLI flag + phase5_5_skip_label_prop workflow
input. Default false. Setting true gives a clean Two-Phase wall on
the 5M chain.

## Refs
PR #361 (columnar refactor), run 26168230208 (timed-out head-to-head)