### PR TITLE
fix(#368): PostgresConnector psycopg3 migration + server-side cursor

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/db/connector.py
+++ b/packages/python/goldenmatch/goldenmatch/db/connector.py
@@ -6,6 +6,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
+from typing import Any
 
 import polars as pl
 
@@ -56,7 +57,19 @@ class DatabaseConnector(ABC):
 
 
 class PostgresConnector(DatabaseConnector):
-    """PostgreSQL connector using psycopg2."""
+    """PostgreSQL connector using psycopg3.
+
+    psycopg3 is the supported driver (the [postgres] extra pins
+    `psycopg[binary]>=3.1` since the Phase 6 IdentityStore migration).
+    The default psycopg3 server-side portal cursor streams rows from
+    Postgres instead of buffering the full result set client-side,
+    which is what bit a 16 GB sandbox on a 1.13M-row read (#368).
+    """
+
+    # _conn is typed Any to short-circuit psycopg3's LiteralString-narrowing
+    # on cursor.execute -- the dynamic SQL we build via f-strings would
+    # otherwise need a Composed wrapper at every call site.
+    _conn: Any
 
     def __init__(self, connection_string: str):
         self.connection_string = connection_string
@@ -64,14 +77,15 @@ class PostgresConnector(DatabaseConnector):
 
     def connect(self) -> None:
         try:
-            import psycopg2
-        except ImportError:
+            import psycopg
+        except ImportError as e:
             raise ImportError(
-                "Postgres support requires psycopg2. "
-                "Install with: pip install goldenmatch[postgres]"
-            )
-        self._conn = psycopg2.connect(self.connection_string)
-        self._conn.autocommit = False
+                "Postgres support requires psycopg3. "
+                "Install with: pip install 'goldenmatch[postgres]'"
+            ) from e
+        # autocommit=False matches the prior psycopg2 default; commits are
+        # explicit via self.conn.commit() in write paths.
+        self._conn = psycopg.connect(self.connection_string, autocommit=False)
         logger.info("Connected to PostgreSQL")
 
     def close(self) -> None:
@@ -80,14 +94,23 @@ class PostgresConnector(DatabaseConnector):
             self._conn = None
 
     @property
-    def conn(self):
+    def conn(self) -> Any:
         if self._conn is None:
             raise RuntimeError("Not connected. Call connect() first.")
         return self._conn
 
     def read_table(self, table: str, chunk_size: int = 10000) -> Iterator[pl.DataFrame]:
-        """Read table in chunks."""
-        cursor = self.conn.cursor()
+        """Read table in chunks via a server-side cursor.
+
+        The named cursor (`name="gm_sync_read"`) tells Postgres to declare
+        a server-side portal -- rows stream into the client `chunk_size`
+        at a time instead of materializing the full result set in the
+        psycopg connection buffer. Required to avoid OOM on multi-million
+        row reads (#368). Server-side cursors only work inside a
+        transaction; autocommit=False from connect() satisfies that.
+        """
+        cursor = self.conn.cursor(name="gm_sync_read")
+        cursor.itersize = chunk_size
         try:
             cursor.execute(f"SELECT * FROM {_quote_ident(table)}")
             columns = [desc[0] for desc in cursor.description]

--- a/packages/python/goldenmatch/goldenmatch/db/metadata.py
+++ b/packages/python/goldenmatch/goldenmatch/db/metadata.py
@@ -154,13 +154,15 @@ def log_matches_batch(
     """Batch log match decisions."""
     if not matches:
         return
+    # psycopg3 dropped psycopg2.extras.execute_values; the documented
+    # replacement is executemany on a parameterized INSERT. psycopg3's
+    # executemany is also pipelined (single round-trip per N rows) so
+    # the throughput is comparable to the old VALUES-batched form.
     cursor = connector.conn.cursor()
     try:
-        from psycopg2.extras import execute_values
-        execute_values(
-            cursor,
+        cursor.executemany(
             "INSERT INTO gm_match_log (record_id_a, record_id_b, score, action, run_id) "
-            "VALUES %s",
+            "VALUES (%s, %s, %s, %s, %s)",
             [(a, b, s, action, run_id) for a, b, s, action in matches],
         )
         connector.conn.commit()

--- a/packages/python/goldenmatch/tests/_pg_helpers.py
+++ b/packages/python/goldenmatch/tests/_pg_helpers.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import os
 import uuid
 from collections.abc import Iterator
+from typing import Any, cast
 from urllib.parse import urlparse, urlunparse
 
 import pytest
@@ -29,9 +30,9 @@ import pytest
 _ADMIN_URL_ENV = "GOLDENMATCH_TEST_DATABASE_URL"
 
 
-def _has_psycopg2() -> bool:
+def _has_psycopg() -> bool:
     try:
-        import psycopg2  # noqa: F401
+        import psycopg  # noqa: F401
         return True
     except Exception:
         return False
@@ -49,7 +50,7 @@ def _has_testing_postgresql() -> bool:
 # True when *either* a services-container admin URL is configured OR
 # `testing.postgresql` is importable locally.
 HAS_POSTGRES = bool(os.environ.get(_ADMIN_URL_ENV)) or (
-    _has_testing_postgresql() and _has_psycopg2()
+    _has_testing_postgresql() and _has_psycopg()
 )
 
 
@@ -65,15 +66,16 @@ class _UrlHolder:
 
 def _provision_db_from_admin_url(admin_url: str) -> tuple[_UrlHolder, str, str]:
     """Create a fresh database off the admin URL. Returns (holder, db_name, admin_url)."""
-    import psycopg2
+    import psycopg
 
     parsed = urlparse(admin_url)
     db_name = f"gm_test_{uuid.uuid4().hex[:12]}"
 
     # Connect to the admin DB (typically 'postgres') to issue CREATE DATABASE.
-    admin_conn = psycopg2.connect(admin_url)
+    # autocommit is set on the connection up front -- CREATE DATABASE can't
+    # run inside a transaction block.
+    admin_conn = cast(Any, psycopg.connect(admin_url, autocommit=True))
     try:
-        admin_conn.autocommit = True
         with admin_conn.cursor() as cur:
             cur.execute(f'CREATE DATABASE "{db_name}"')
     finally:
@@ -85,14 +87,13 @@ def _provision_db_from_admin_url(admin_url: str) -> tuple[_UrlHolder, str, str]:
 
 
 def _drop_db(admin_url: str, db_name: str) -> None:
-    import psycopg2
+    import psycopg
 
-    admin_conn = psycopg2.connect(admin_url)
+    admin_conn = cast(Any, psycopg.connect(admin_url, autocommit=True))
     try:
-        admin_conn.autocommit = True
         with admin_conn.cursor() as cur:
-            # Terminate any leftover connections (psycopg2 sometimes leaves one
-            # in flight when a connector close errored on Windows etc.).
+            # Terminate any leftover connections (occasionally a connector
+            # close errors on Windows etc. and leaves a session open).
             cur.execute(
                 "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
                 "WHERE datname = %s AND pid <> pg_backend_pid()",
@@ -107,7 +108,7 @@ def pg_url_fixture() -> Iterator[_UrlHolder]:
     """Generator suitable for use inside a pytest fixture (`yield from`)."""
     admin_url = os.environ.get(_ADMIN_URL_ENV)
     if admin_url:
-        if not _has_psycopg2():
+        if not _has_psycopg():
             pytest.skip("psycopg2 not installed")
         holder, db_name, admin = _provision_db_from_admin_url(admin_url)
         try:
@@ -117,7 +118,7 @@ def pg_url_fixture() -> Iterator[_UrlHolder]:
         return
 
     # Local fallback: testing.postgresql.
-    if not (_has_testing_postgresql() and _has_psycopg2()):
+    if not (_has_testing_postgresql() and _has_psycopg()):
         pytest.skip(
             "PostgreSQL not available "
             f"(set {_ADMIN_URL_ENV} or install testing.postgresql + psycopg2)"

--- a/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
+++ b/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
@@ -158,5 +158,51 @@ def test_most_complete_picks_longest_string():
     assert by_cluster[2] == "Alice"   # longest among Alice/Al
 
 
+# ----------------------------------------------------------------------
+# #368 -- psycopg3 migration + server-side cursor for streaming reads
+# ----------------------------------------------------------------------
+
+
+def test_postgres_connector_imports_psycopg3_not_psycopg2():
+    """#368: PostgresConnector must require psycopg3, matching the
+    [postgres] extra. The legacy psycopg2 path was the root cause of
+    the install regression on slim Python builds + the OOM on 1.13M
+    row reads (psycopg2's client-side cursor buffered the full result
+    set before fetchmany could iterate).
+    """
+    import inspect
+
+    from goldenmatch.db import connector
+
+    src = inspect.getsource(connector)
+    assert "import psycopg2" not in src, (
+        "PostgresConnector still imports psycopg2; the [postgres] extra "
+        "ships psycopg3 only since the Phase 6 IdentityStore migration. See #368."
+    )
+    assert "import psycopg" in src
+    # Error message should also reference psycopg3 (the actual extra-installed driver).
+    assert "psycopg3" in src or "psycopg[binary]" in src
+
+
+def test_postgres_read_table_uses_server_side_cursor():
+    """#368: read_table must declare a server-side cursor (named cursor)
+    so Postgres streams rows from a portal instead of psycopg buffering
+    them all client-side. Required to read a 1.13M-row table inside a
+    16 GB sandbox without OOM.
+    """
+    import inspect
+
+    from goldenmatch.db.connector import PostgresConnector
+
+    src = inspect.getsource(PostgresConnector.read_table)
+    # A named cursor (name="...") is what asks psycopg3 to use a server-
+    # side portal. Without a name, the default cursor caches results in
+    # the connection buffer regardless of fetchmany() size.
+    assert 'name="gm_sync_read"' in src or "name='gm_sync_read'" in src, (
+        "read_table should open a named server-side cursor; without it the "
+        "1.13M-row read OOMs the client process before fetchmany iterates. See #368."
+    )
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes #368. Two distinct user-reported problems, one root cause: PostgresConnector held a stale psycopg2 import after Phase 6 migrated everything else to psycopg3.

- **Install regression**: pip install 'goldenmatch[postgres]' pulls psycopg3 only (matching the extras pin), then sync errors with 'requires psycopg2.' Migrated db/connector.py, db/metadata.py, and tests/_pg_helpers.py to psycopg3. execute_values replaced with cursor.executemany (psycopg3 pipelines it; throughput parity).
- **OOM at 1.13M rows on a 16 GB sandbox**: psycopg2 buffered the entire result set client-side before fetchmany could iterate. psycopg3's default cursor also buffers; the actual fix is conn.cursor(name='gm_sync_read') which declares a server-side portal and streams rows in chunk_size batches.

Two structural regression tests in test_sync_bug_cluster.py guard against drift back to psycopg2 / non-streaming cursor.

## Out of scope (filed as a follow-up note)

db/sync.py::_read_all still does pl.concat across chunks before any further processing. The cursor fix is what closes the 16 GB OOM (psycopg2's buffer was the kill), but a fully-streaming sync write pipeline is a separate architectural change worth its own ticket.

## Test plan

- [x] 67 identity + sync tests pass locally
- [x] New regression test guarding psycopg3 import
- [x] New regression test guarding server-side cursor (name=)
- [ ] CI green