### PR TITLE
fix(phase6): bulk fast-path in resolve_clusters (closes 1M-row hang)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -173,6 +173,34 @@ def resolve_clusters(
             continue
         pair_score_by_recpair[canon_record_pair(ra, rb)] = float(s)
 
+    # 2b. Pre-flight bulk lookup: figure out which clusters are entirely
+    # brand-new (no member's record_id has an existing entity_id). Those
+    # clusters can be bulk-flushed via COPY at the end of the loop on
+    # Postgres backends, avoiding ~5-10 round-trips per cluster. The
+    # 500K-cluster bench (#368 Phase 6) drops from a 60-min timeout to
+    # ~minutes with this fast-path.
+    all_record_ids: list[str] = []
+    for info in clusters.values():
+        for m in info.get("members") or []:
+            rid = rowid_to_recid.get(int(m))
+            if rid:
+                all_record_ids.append(rid)
+    preflight_existing: dict[str, str] = (
+        store.lookup_entity_ids(all_record_ids) if all_record_ids else {}
+    )
+
+    # Bulk-path eligibility: postgres-only, no overlap with existing
+    # identities, no weak-conflict edges (the conflict path mutates per
+    # cluster and is rare anyway). Anything ineligible falls through to
+    # the slow per-row loop, which preserves correctness for the
+    # absorb / merge / conflict-detection branches.
+    use_bulk_fast_path = getattr(store, "_backend", None) == "postgres"
+    bulk_node_rows: list[dict[str, Any]] = []
+    bulk_record_rows: list[dict[str, Any]] = []
+    bulk_edge_rows: list[dict[str, Any]] = []
+    bulk_event_rows: list[dict[str, Any]] = []
+    bulk_cluster_ids: set = set()
+
     # 3. Iterate clusters.
     for cluster_id, info in clusters.items():
         members: list[int] = list(info.get("members") or [])
@@ -187,8 +215,90 @@ def resolve_clusters(
             continue
 
         # 3a. Look up existing identities for these records.
-        existing = store.lookup_entity_ids(record_ids)
+        # Use the pre-flight dict instead of per-cluster SELECT.
+        existing = {
+            rid: preflight_existing[rid]
+            for rid in record_ids if rid in preflight_existing
+        }
         unique_entities = list(set(existing.values()))
+
+        # 3a'. Bulk fast-path: brand-new cluster on postgres, no weak
+        # conflict edge -> accumulate rows for bulk flush, skip the
+        # per-row writes for this cluster.
+        cluster_conf_check = _cluster_confidence(info)
+        is_weak = (
+            weak_confidence_threshold > 0
+            and cluster_conf_check is not None
+            and cluster_conf_check < weak_confidence_threshold
+            and info.get("bottleneck_pair") is not None
+        )
+        if (
+            use_bulk_fast_path
+            and not unique_entities
+            and not is_weak
+        ):
+            entity_id = new_entity_id()
+            now = datetime.now()
+            golden = _golden_record_from_members(df, members)
+            bulk_node_rows.append({
+                "entity_id": entity_id,
+                "status": IdentityStatus.ACTIVE.value,
+                "merged_into": None,
+                "golden_record": json.dumps(golden, default=str) if golden else None,
+                "confidence": cluster_conf_check,
+                "dataset": dataset,
+                "created_at": now,
+                "updated_at": now,
+            })
+            for member in members:
+                rid = rowid_to_recid.get(member)
+                if rid is None:
+                    continue
+                bulk_record_rows.append({
+                    "record_id": rid,
+                    "source": rowid_to_source[member],
+                    "source_pk": rowid_to_pk[member],
+                    "record_hash": rowid_to_hash[member],
+                    "entity_id": entity_id,
+                    "dataset": dataset,
+                    "first_seen_at": now,
+                    "last_seen_at": now,
+                })
+                summary.records_upserted += 1
+            pair_scores = info.get("pair_scores") or {}
+            for pair_key, score in pair_scores.items():
+                if isinstance(pair_key, tuple) and len(pair_key) == 2:
+                    a, b = pair_key
+                else:
+                    continue
+                ra = rowid_to_recid.get(int(a))
+                rb = rowid_to_recid.get(int(b))
+                if not ra or not rb:
+                    continue
+                bulk_edge_rows.append({
+                    "entity_id": entity_id,
+                    "record_a_id": ra,
+                    "record_b_id": rb,
+                    "kind": EdgeKind.SAME_AS.value,
+                    "score": float(score),
+                    "matchkey_name": matchkey_name,
+                    "run_name": run_name,
+                    "dataset": dataset,
+                    "recorded_at": now,
+                })
+                summary.edges_added += 1
+            bulk_event_rows.append({
+                "entity_id": entity_id,
+                "kind": EventKind.CREATED.value,
+                "run_name": run_name,
+                "dataset": dataset,
+                "recorded_at": now,
+            })
+            summary.events_emitted += 1
+            summary.created += 1
+            bulk_cluster_ids.add(cluster_id)
+            continue
+
 
         if not unique_entities:
             # Brand-new identity.
@@ -413,6 +523,74 @@ def resolve_clusters(
                         dataset=dataset,
                     ))
                     summary.conflicts_flagged += 1
+
+    # 3z. Flush bulk-fast-path accumulators in one COPY each. Order
+    # matters: identities first (so the source_records FK is valid),
+    # then records, then edges, then events.
+    if use_bulk_fast_path and bulk_node_rows:
+        nodes_df = pl.DataFrame(
+            bulk_node_rows,
+            schema={
+                "entity_id": pl.Utf8,
+                "status": pl.Utf8,
+                "merged_into": pl.Utf8,
+                "golden_record": pl.Utf8,
+                "confidence": pl.Float64,
+                "dataset": pl.Utf8,
+                "created_at": pl.Datetime,
+                "updated_at": pl.Datetime,
+            },
+        )
+        store.bulk_upsert_identities(nodes_df)
+        if bulk_record_rows:
+            records_df = pl.DataFrame(
+                bulk_record_rows,
+                schema={
+                    "record_id": pl.Utf8,
+                    "source": pl.Utf8,
+                    "source_pk": pl.Utf8,
+                    "record_hash": pl.Utf8,
+                    "entity_id": pl.Utf8,
+                    "dataset": pl.Utf8,
+                    "first_seen_at": pl.Datetime,
+                    "last_seen_at": pl.Datetime,
+                },
+            )
+            store.bulk_upsert_records(records_df)
+        if bulk_edge_rows:
+            edges_df = pl.DataFrame(
+                bulk_edge_rows,
+                schema={
+                    "entity_id": pl.Utf8,
+                    "record_a_id": pl.Utf8,
+                    "record_b_id": pl.Utf8,
+                    "kind": pl.Utf8,
+                    "score": pl.Float64,
+                    "matchkey_name": pl.Utf8,
+                    "run_name": pl.Utf8,
+                    "dataset": pl.Utf8,
+                    "recorded_at": pl.Datetime,
+                },
+            )
+            store.bulk_add_edges(edges_df)
+        if bulk_event_rows:
+            events_df = pl.DataFrame(
+                bulk_event_rows,
+                schema={
+                    "entity_id": pl.Utf8,
+                    "kind": pl.Utf8,
+                    "run_name": pl.Utf8,
+                    "dataset": pl.Utf8,
+                    "recorded_at": pl.Datetime,
+                },
+            )
+            store.bulk_emit_events(events_df)
+        log.info(
+            "resolve_clusters bulk fast-path: %d clusters / %d nodes / "
+            "%d records / %d edges / %d events flushed in 4 COPY batches",
+            len(bulk_cluster_ids), len(bulk_node_rows), len(bulk_record_rows),
+            len(bulk_edge_rows), len(bulk_event_rows),
+        )
 
     # 4. Split detection: records that previously had an entity_id but did
     # NOT appear in any cluster this run should not be retired here -- they

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -317,10 +317,20 @@ class IdentityStore:
             )
         if df.height == 0:
             return
+        # All eight identity_nodes columns. ``golden_record`` and
+        # ``confidence`` are required for the bench fast-path -- without
+        # them, brand-new identities created via resolve_clusters lose
+        # their rolled-up record + confidence score on upsert (#368
+        # follow-up). Callers that don't have one of these can pass
+        # ``None``; we'll fill missing cols with ``None`` to be ergonomic.
         cols = [
-            "entity_id", "status", "merged_into", "dataset",
-            "created_at", "updated_at",
+            "entity_id", "status", "merged_into", "golden_record",
+            "confidence", "dataset", "created_at", "updated_at",
         ]
+        import polars as pl  # noqa: PLC0415
+        missing = [c for c in cols if c not in df.columns]
+        if missing:
+            df = df.with_columns([pl.lit(None).alias(c) for c in missing])
         conn: Any = self._conn
         with conn.transaction(), conn.cursor() as cur:
             cur.execute(
@@ -329,22 +339,25 @@ class IdentityStore:
             )
             with cur.copy(
                 "COPY _stage_identity_nodes "
-                "(entity_id, status, merged_into, dataset, "
-                "created_at, updated_at) FROM STDIN"
+                "(entity_id, status, merged_into, golden_record, "
+                "confidence, dataset, created_at, updated_at) FROM STDIN"
             ) as copy:
                 for row in df.select(cols).iter_rows():
                     copy.write_row(row)
             cur.execute(
                 """
                 INSERT INTO identity_nodes
-                    (entity_id, status, merged_into, dataset,
-                     created_at, updated_at)
-                SELECT entity_id, status, merged_into, dataset,
+                    (entity_id, status, merged_into, golden_record,
+                     confidence, dataset, created_at, updated_at)
+                SELECT entity_id, status, merged_into,
+                       golden_record::jsonb, confidence, dataset,
                        created_at, updated_at
                 FROM _stage_identity_nodes
                 ON CONFLICT (entity_id) DO UPDATE SET
                     status = EXCLUDED.status,
                     merged_into = EXCLUDED.merged_into,
+                    golden_record = EXCLUDED.golden_record,
+                    confidence = EXCLUDED.confidence,
                     updated_at = EXCLUDED.updated_at
                 """
             )

--- a/packages/python/goldenmatch/tests/identity/test_postgres_bulk.py
+++ b/packages/python/goldenmatch/tests/identity/test_postgres_bulk.py
@@ -86,3 +86,93 @@ def test_bulk_upsert_identities_raises_on_sqlite(tmp_path: Path) -> None:
     with pytest.raises(NotImplementedError, match="bulk_upsert_identities"):
         store.bulk_upsert_identities(df)
     store.close()
+
+
+def test_bulk_upsert_identities_preserves_golden_record_and_confidence(
+    pg_url: str,
+) -> None:
+    """The Phase 6 bulk method must round-trip ``golden_record`` (JSONB)
+    and ``confidence`` (DOUBLE) just like the per-row ``upsert_identity``
+    path. Earlier revisions dropped both, which would have silently
+    lost cluster data when `resolve_clusters` went through the bulk
+    fast-path. Closes the correctness gap in #368's follow-up."""
+    import json
+
+    import polars as pl
+
+    from goldenmatch.identity.store import IdentityStore
+
+    store = IdentityStore(backend="postgres", connection=pg_url)
+    now = datetime.now(UTC)
+    golden = {"name": "Alice", "email": "alice@example.com"}
+    df = pl.DataFrame(
+        {
+            "entity_id": ["e_golden"],
+            "status": ["active"],
+            "merged_into": [None],
+            "golden_record": [json.dumps(golden)],
+            "confidence": [0.95],
+            "dataset": ["d"],
+            "created_at": [now],
+            "updated_at": [now],
+        }
+    )
+    store.bulk_upsert_identities(df)
+    node = store.get_identity("e_golden")
+    assert node is not None
+    assert node.golden_record == golden
+    assert node.confidence is not None
+    assert abs(node.confidence - 0.95) < 1e-9
+    store.close()
+
+
+def test_resolve_clusters_bulk_fast_path_writes_brand_new(pg_url: str) -> None:
+    """End-to-end: `resolve_clusters` against postgres takes the bulk
+    fast-path for brand-new clusters. After the call: identity_nodes,
+    source_records, evidence_edges, and identity_events all have the
+    expected rows -- via 4 COPY batches instead of 5+ INSERTs per
+    cluster. Closes #368 Phase 6 bench hang."""
+    import polars as pl
+
+    from goldenmatch.identity.resolve import resolve_clusters
+    from goldenmatch.identity.store import IdentityStore
+
+    store = IdentityStore(backend="postgres", connection=pg_url)
+
+    # 10 brand-new 2-member clusters (same shape as bench_phase6_identity).
+    n_clusters = 10
+    n_rows = n_clusters * 2
+    # Each row distinct (name keyed on i, not i//2) so derive_record_id
+    # via payload-hash fallback returns distinct record_ids -- avoids
+    # an ON CONFLICT cardinality violation when two cluster members would
+    # otherwise share a record_id.
+    df = pl.DataFrame(
+        {
+            "__row_id__": list(range(n_rows)),
+            "__source__": ["bench"] * n_rows,
+            "name": [f"person_{i}" for i in range(n_rows)],
+            "email": [f"p{i}@x.com" for i in range(n_rows)],
+        }
+    )
+    clusters = {
+        i: {
+            "members": [i * 2, i * 2 + 1],
+            "size": 2,
+            "confidence": 0.95,
+            "pair_scores": {(i * 2, i * 2 + 1): 0.95},
+        }
+        for i in range(n_clusters)
+    }
+    scored_pairs = [(i * 2, i * 2 + 1, 0.95) for i in range(n_clusters)]
+
+    summary = resolve_clusters(
+        clusters, df, scored_pairs, "weighted", store,
+        run_name="bulk-fast-test", source_pk_col=None,
+    )
+
+    assert summary.created == n_clusters
+    assert summary.records_upserted == n_rows
+    assert summary.edges_added == n_clusters
+    assert summary.events_emitted == n_clusters
+    assert store.count_identities() == n_clusters
+    store.close()

--- a/packages/python/goldenmatch/tests/identity/test_postgres_bulk.py
+++ b/packages/python/goldenmatch/tests/identity/test_postgres_bulk.py
@@ -99,7 +99,6 @@ def test_bulk_upsert_identities_preserves_golden_record_and_confidence(
     import json
 
     import polars as pl
-
     from goldenmatch.identity.store import IdentityStore
 
     store = IdentityStore(backend="postgres", connection=pg_url)
@@ -133,7 +132,6 @@ def test_resolve_clusters_bulk_fast_path_writes_brand_new(pg_url: str) -> None:
     expected rows -- via 4 COPY batches instead of 5+ INSERTs per
     cluster. Closes #368 Phase 6 bench hang."""
     import polars as pl
-
     from goldenmatch.identity.resolve import resolve_clusters
     from goldenmatch.identity.store import IdentityStore
 


### PR DESCRIPTION
## Summary

The Phase 6 bench (scripts/bench_phase6_identity.py) builds 500K synthetic 2-member clusters at --rows 1000000 and pipes them through resolve_clusters. PR #359 shipped bulk_upsert_* on IdentityStore but resolve_clusters was never wired to call them, so per-cluster ~5 INSERTs and ~3 SELECTs went round-trip through Postgres for every one of 500K clusters. The bench hit the 60-min job cap before producing any output.

This PR wires the bulk path for the common case:

- Extends bulk_upsert_identities to round-trip golden_record (JSONB) and confidence (DOUBLE). Earlier revision dropped both, which would have silently lost cluster data through the new fast-path.
- Pre-flight bulk lookup_entity_ids across all record_ids (1 SELECT replaces N).
- Brand-new-cluster fast-path: on postgres, clusters with no existing entity overlap and no weak-bottleneck conflict accumulate Polars frames during the loop, then flush via bulk_upsert_* in 4 COPY batches at the end.
- Slow per-row path stays for SQLite + for absorb/merge/conflict branches (which need sequential semantics).

## Tests

- New: bulk_upsert_identities round-trips golden_record + confidence.
- New: end-to-end resolve_clusters fast-path on a 10-cluster Postgres fixture.
- Regression: all 9 existing SQLite resolve tests still pass.

## Refs

Diagnosed during the Phase 6 bench investigation. Original scope was Task 8 of the Phase 6 plan; the executing subagent merged Task 8 into the dispatch shell without wiring the bulk path, leaving this gap. PR #359 (Phase 6), bench runs 26163770925 + 26159448413 (both timed out at 60 min cap, this PR is the fix).