### PR TITLE
fix(#372): drop NULL/NaN-keyed records from blocks; clearer oversized warning

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -159,6 +159,23 @@ def _build_static_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Block
         # Add block key column and collect
         df_with_key = lf.with_columns(block_key_expr).collect()
 
+        # Filter records whose block key is null or stringifies as a
+        # missing-value sentinel ("nan", "null", "none", ""). NULLs in a
+        # blocking column mean "we don't know" -- those records shouldn't
+        # cluster together. The cast(Utf8) in _build_block_key_expr turns
+        # Polars NaN into the literal string "NaN", which a downstream
+        # lowercase transform then collapses to "nan" -- all such
+        # records ended up in a single ~12K-record block at 1.13M scale,
+        # OOMing the runner during scoring (#372). The group_by-level
+        # `if key_str is None: continue` only catches Polars None, not
+        # the stringified forms.
+        df_with_key = df_with_key.filter(
+            pl.col("__block_key__").is_not_null()
+            & ~pl.col("__block_key__").str.strip_chars().str.to_lowercase().is_in(
+                ["nan", "null", "none", ""]
+            )
+        )
+
         # Group by block key
         groups = df_with_key.group_by("__block_key__")
 
@@ -237,9 +254,19 @@ def _build_static_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Block
                     hot_blocks_skipped += 1
                     continue
                 else:
-                    logger.warning(
+                    # skip_oversized=False -- the caller explicitly opted
+                    # into processing oversized blocks. We honor that but
+                    # log at ERROR so the OOM-vs-correctness tradeoff is
+                    # obvious in the run log. The actionable recovery is
+                    # always `skip_oversized=True` (drops the offending
+                    # block but lets the rest of the run land).
+                    logger.error(
                         f"Block {key_str!r} has {size} records "
-                        f"(exceeds max_block_size={config.max_block_size}). Processing anyway."
+                        f"(exceeds max_block_size={config.max_block_size}, "
+                        f"~{size * (size - 1) // 2:,} pairs to score). "
+                        f"Processing anyway because skip_oversized=False; "
+                        f"set blocking.skip_oversized=True to skip oversized "
+                        f"blocks instead of risking OOM. See #372."
                     )
 
             results.append(BlockResult(

--- a/packages/python/goldenmatch/tests/test_blocker.py
+++ b/packages/python/goldenmatch/tests/test_blocker.py
@@ -362,3 +362,55 @@ class TestSortedNeighborhood:
 
         for r in results:
             assert r.strategy == "sorted_neighborhood"
+
+
+class TestNullBlockKeyFilter:
+    """Records whose blocking column is NULL / NaN / stringifies to a
+    missing-value sentinel should not be grouped together. (#372)"""
+
+    def test_null_blocking_column_drops_records_from_all_blocks(self):
+        """A column with NULL values should not produce a 'null' block."""
+        config = BlockingConfig(
+            keys=[BlockingKeyConfig(fields=["last_name"], transforms=[])],
+            max_block_size=1000,
+        )
+        # 3 records share last_name=Smith (valid block), 4 have None
+        # (should drop). Without the filter, the 4 nulls would group
+        # under the literal string "null" or "nan" depending on Polars
+        # cast path.
+        df = pl.DataFrame({
+            "id": [1, 2, 3, 4, 5, 6, 7],
+            "last_name": ["Smith", "Smith", "Smith", None, None, None, None],
+        })
+        results = build_blocks(df.lazy(), config)
+        keys = {r.block_key for r in results}
+        assert "null" not in keys
+        assert "nan" not in keys
+        assert "none" not in keys
+        assert "" not in keys
+        # The Smith block should still be there.
+        assert any(r.block_key.lower() == "smith" for r in results)
+
+    def test_nan_float_blocking_column_drops_records(self):
+        """A Float64 column with NaN values gets stringified as 'NaN'
+        by Polars' cast(Utf8) and then collapsed to 'nan' by a
+        downstream lowercase transform. Records with NaN must be
+        filtered before grouping."""
+        config = BlockingConfig(
+            keys=[BlockingKeyConfig(
+                fields=["score_bucket"],
+                transforms=["lowercase"],
+            )],
+            max_block_size=1000,
+        )
+        df = pl.DataFrame({
+            "id": [1, 2, 3, 4, 5],
+            # Float64 with explicit NaN -- this is the bug surface.
+            "score_bucket": [1.0, 1.0, float("nan"), float("nan"), float("nan")],
+        })
+        results = build_blocks(df.lazy(), config)
+        keys = {r.block_key.lower() for r in results}
+        assert "nan" not in keys, (
+            f"Found 'nan' block in {keys}: NaN records should be "
+            "filtered before group_by. See #372."
+        )


### PR DESCRIPTION
## Summary

Closes #372. After #369 fixed the psycopg3 OOM at the read step, the next bench hit the OOM in the blocking phase. Two coupled bugs:

1. **NULL-keyed records aggregated into a 'nan' block.** Polars cast(Utf8) on a column with NULL/NaN values produces the literal string 'NaN'; a lowercase transform collapses that to 'nan'. All 11,633 NULL records ended up in one block, exceeded max_block_size 2.3x, OOMed scoring. The existing `if key_str is None: continue` only caught Polars None, not the stringified form.

   Fix: filter records whose stripped+lowercased __block_key__ is in {nan, null, none, ""} BEFORE group_by.

2. **`Processing anyway` warning was a no-op.** When skip_oversized=False, an oversized block logged WARNING then processed -- "warn and do the dangerous thing."

   Fix: log at ERROR level with the (n choose 2) pair count + the exact recovery flag (skip_oversized=True). Processing behavior unchanged.

## Tests

Two new tests in TestNullBlockKeyFilter:
- test_null_blocking_column_drops_records_from_all_blocks
- test_nan_float_blocking_column_drops_records

Regression: 34 existing blocker tests still pass.

## Refs

#372, #368 (which uncovered this once the read-step OOM was fixed)