### PR TITLE
fix(#378): stream sync read chunks to staging parquet (avoid double materialization)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -106,14 +106,38 @@ def run_sync(
 
 
 def _read_all(connector: DatabaseConnector, table: str, chunk_size: int) -> pl.DataFrame:
-    """Read entire table into DataFrame."""
-    chunks = []
-    for chunk in connector.read_table(table, chunk_size):
-        chunks.append(chunk)
-    # how="diagonal_relaxed" defends against any chunk where a column
-    # is all-NULL (Null dtype) slipping past _normalize_chunk_schema in
-    # the connector. See #363.
-    return pl.concat(chunks, how="diagonal_relaxed") if chunks else pl.DataFrame()
+    """Read entire table into a DataFrame, staging chunks to disk first.
+
+    Streams chunks from the connector to a temporary parquet directory
+    one chunk at a time, then reads them back as a single DataFrame via
+    ``pl.read_parquet`` glob. Peak memory during the read drops from
+    ~2x the raw frame size (chunks list + ``pl.concat`` materialization)
+    to ~1 chunk + the final read-back. On a 1.13M-row x 58-col Postgres
+    view this was the difference between an 8 GB sandbox OOMing at
+    ``pl.concat`` time vs landing the read step cleanly (#378).
+
+    The staging directory is removed once the DataFrame is loaded;
+    callers don't have to manage cleanup.
+    """
+    import shutil
+    import tempfile
+    from pathlib import Path
+
+    staging = Path(tempfile.mkdtemp(prefix="gm_sync_read_"))
+    try:
+        n_chunks = 0
+        for i, chunk in enumerate(connector.read_table(table, chunk_size)):
+            chunk.write_parquet(staging / f"chunk_{i:06d}.parquet")
+            n_chunks += 1
+        if n_chunks == 0:
+            return pl.DataFrame()
+        # Read all staged chunks back via Polars' multi-file scan +
+        # collect. Polars unifies schemas across files (matches the
+        # prior how="diagonal_relaxed" semantics for #363's Null->Utf8
+        # case when paired with _normalize_chunk_schema in connector.py).
+        return pl.read_parquet(staging / "chunk_*.parquet")
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
 
 
 def _read_incremental(

--- a/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
+++ b/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
@@ -204,5 +204,91 @@ def test_postgres_read_table_uses_server_side_cursor():
     )
 
 
+# ----------------------------------------------------------------------
+# #378 -- _read_all stages chunks to disk, avoids double materialization
+# ----------------------------------------------------------------------
+
+
+def test_read_all_stages_chunks_to_disk_not_python_list():
+    """#378: _read_all must not accumulate chunks in a Python list +
+    pl.concat them -- that doubles peak memory during the read step.
+    On a 1.13M-row x 58-col Postgres view the prior behavior hit 6.6 GB
+    peak, OOMing an 8 GB sandbox.
+
+    Structural guard: the source should NOT contain `chunks = []` /
+    `chunks.append(chunk)` / `pl.concat(chunks` patterns. It should
+    stage to a tempfile parquet via `write_parquet` and read back via
+    `read_parquet`.
+    """
+    import inspect
+
+    from goldenmatch.db import sync
+
+    src = inspect.getsource(sync._read_all)
+    # Strip comment lines so historical-context comments can mention
+    # the old behavior without tripping the guard.
+    code_lines = [
+        ln for ln in src.splitlines()
+        if not ln.lstrip().startswith("#")
+    ]
+    code = "\n".join(code_lines)
+
+    assert "chunks.append" not in code, (
+        "_read_all should not accumulate chunks in a Python list -- "
+        "stream chunks to a temp parquet instead. See #378."
+    )
+    assert "pl.concat(chunks" not in code, (
+        "_read_all should not pl.concat a list of chunks -- that "
+        "doubles peak memory during the read step. See #378."
+    )
+    assert "write_parquet" in code and "read_parquet" in code, (
+        "_read_all should stage chunks to a temp parquet via "
+        "write_parquet and read them back via read_parquet. See #378."
+    )
+
+
+def test_read_all_round_trips_data_from_streaming_connector():
+    """End-to-end smoke: _read_all should still return a DataFrame
+    with the right rows / cols when the connector streams in chunks.
+    """
+    from collections.abc import Iterator
+
+    from goldenmatch.db.connector import DatabaseConnector
+    from goldenmatch.db.sync import _read_all
+
+    class _FakeConnector(DatabaseConnector):
+        """Yields three pre-built chunks; ignores chunk_size."""
+
+        def __init__(self, chunks: list[pl.DataFrame]):
+            self._chunks = chunks
+
+        def connect(self) -> None: ...
+        def close(self) -> None: ...
+        def read_table(
+            self, table: str, chunk_size: int = 10000,
+        ) -> Iterator[pl.DataFrame]:
+            yield from self._chunks
+        def read_query(self, query: str) -> pl.DataFrame:
+            return pl.DataFrame()
+        def write_dataframe(self, df, table, mode="append") -> int:
+            return 0
+        def execute(self, sql, params=None) -> None: ...
+        def table_exists(self, table: str) -> bool:
+            return False
+        def get_row_count(self, table: str) -> int:
+            return 0
+
+    chunks = [
+        pl.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]}),
+        pl.DataFrame({"id": [4, 5], "name": ["d", "e"]}),
+        pl.DataFrame({"id": [6], "name": ["f"]}),
+    ]
+    connector = _FakeConnector(chunks)
+    df = _read_all(connector, "ignored", chunk_size=10)
+    assert df.height == 6
+    assert sorted(df["id"].to_list()) == [1, 2, 3, 4, 5, 6]
+    assert sorted(df["name"].to_list()) == ["a", "b", "c", "d", "e", "f"]
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes #378. The prior `_read_all` accumulated chunks in a Python list and called `pl.concat` -- two simultaneous full-frame materializations. On a 1.13M-row x 58-col Postgres view that hit ~6.6 GB peak, OOMing an 8 GB sandbox at the read step. PR #369 fixed the Postgres-side streaming; this PR fixes the client-side equivalent.

Fix: stream each chunk to a temp parquet via `write_parquet`, then read back via `pl.read_parquet` glob. Peak memory drops from ~2x raw frame to ~1x.

## Caveat (called out in commit)

Downstream blocking/scoring still materialize the full frame once. That's a separate streaming-pipeline refactor. This PR ONLY fixes the read step's double materialization, which is what the user observed as the OOM trigger (10-min OOM at the "Full scan: reading" log line).

## Tests

- Structural: `_read_all` source must not use chunks+concat pattern; must use write_parquet + read_parquet.
- E2E smoke: fake connector yielding 3 chunks round-trips correctly.

## Refs

#378, #376 (lazy block filter, made the read step the next bottleneck), #369 (psycopg3 server-side cursor), #368 (the original read-step OOM thread).