### PR TITLE
fix(bench-phase5-simulated): install pandas (ray.data runtime dep)

### DIFF
--- a/.github/workflows/bench-distributed-stack.yml
+++ b/.github/workflows/bench-distributed-stack.yml
@@ -649,6 +649,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[ray,postgres]"
+          # pandas is a runtime dep of ray.data (not declared in the
+          # [ray] extra). Without it, the parquet read errors with
+          # ModuleNotFoundError before the bench can produce any output.
+          # Same gotcha as the other Phase X bench jobs in this file.
+          pip install psutil pandas
       - name: Apply Alembic baseline (identity variant only)
         if: inputs.run_phase5_simulated_identity == true
         working-directory: packages/python/goldenmatch


### PR DESCRIPTION
Run 26183452562 crashed with `ModuleNotFoundError: No module named pandas` at the very start of the bench script. ray.data requires pandas as a runtime dep but it isn't in the [ray] extra. This is already a documented gotcha in CLAUDE.md and already handled by the other Phase X bench jobs in this file via a follow-up pip install psutil pandas step. The simulated job was missing that step.