### PR TITLE
fix(#381): unify chunk schema before staging parquet write

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -125,19 +125,57 @@ def _read_all(connector: DatabaseConnector, table: str, chunk_size: int) -> pl.D
 
     staging = Path(tempfile.mkdtemp(prefix="gm_sync_read_"))
     try:
+        # Unified schema across all chunks. The first non-empty chunk
+        # establishes the canonical dtype for each column; subsequent
+        # chunks cast columns to that schema before write. Without this,
+        # Polars infers Null dtype on a chunk where a column is 100%
+        # NULL (e.g. a sparse bigint column with no values in the first
+        # 10K rows) and Int64 on a later chunk that does have values,
+        # then pl.read_parquet rejects the cross-file mismatch with
+        # "data type mismatch for column X: incoming: Null != target:
+        # Int64" (#381 -- regression introduced by the staging-parquet
+        # rewrite for #379).
+        unified_schema: dict[str, pl.DataType] | None = None
         n_chunks = 0
         for i, chunk in enumerate(connector.read_table(table, chunk_size)):
+            if unified_schema is None:
+                # First chunk seeds the schema. Promote any Null-dtype
+                # columns to Utf8 so they're castable later -- matches
+                # the _normalize_chunk_schema behavior in connector.py
+                # but applied here so the unified schema is concrete.
+                unified_schema = {
+                    name: pl.Utf8 if dt == pl.Null else dt
+                    for name, dt in chunk.schema.items()
+                }
+            chunk = _cast_to_schema(chunk, unified_schema)
             chunk.write_parquet(staging / f"chunk_{i:06d}.parquet")
             n_chunks += 1
         if n_chunks == 0:
             return pl.DataFrame()
-        # Read all staged chunks back via Polars' multi-file scan +
-        # collect. Polars unifies schemas across files (matches the
-        # prior how="diagonal_relaxed" semantics for #363's Null->Utf8
-        # case when paired with _normalize_chunk_schema in connector.py).
         return pl.read_parquet(staging / "chunk_*.parquet")
     finally:
         shutil.rmtree(staging, ignore_errors=True)
+
+
+def _cast_to_schema(
+    df: pl.DataFrame,
+    schema: dict[str, pl.DataType],
+) -> pl.DataFrame:
+    """Cast ``df`` columns to the unified ``schema``, narrowing dtypes
+    where Polars inferred something looser (Null -> Utf8, Int64 -> the
+    canonical Int64, etc.). Missing columns are added as all-null with
+    the target dtype; extras are kept as-is so callers can still see
+    schema drift on read-back.
+    """
+    exprs = []
+    for name, dtype in schema.items():
+        if name not in df.columns:
+            exprs.append(pl.lit(None).cast(dtype).alias(name))
+        elif df.schema[name] != dtype:
+            exprs.append(pl.col(name).cast(dtype, strict=False))
+    if not exprs:
+        return df
+    return df.with_columns(exprs).select(list(schema.keys()))
 
 
 def _read_incremental(

--- a/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
+++ b/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
@@ -290,5 +290,69 @@ def test_read_all_round_trips_data_from_streaming_connector():
     assert sorted(df["name"].to_list()) == ["a", "b", "c", "d", "e", "f"]
 
 
+# ----------------------------------------------------------------------
+# #381 -- _read_all unifies schema across chunks before staging
+# ----------------------------------------------------------------------
+
+
+def test_read_all_unifies_dtype_drift_across_chunks():
+    """#381: when chunk1 infers Null for an all-NULL column and chunk2
+    infers Int64 (or any other concrete type), _read_all must NOT let
+    that drift propagate to the staging parquet files. The prior
+    behavior (post-#379) failed at read-back with:
+
+        data type mismatch for column dm_npi:
+        incoming: Null != target: Int64
+
+    Fix: first non-empty chunk seeds the unified schema; subsequent
+    chunks cast columns to it before write.
+    """
+    from collections.abc import Iterator
+
+    from goldenmatch.db.connector import DatabaseConnector
+    from goldenmatch.db.sync import _read_all
+
+    class _DriftyConnector(DatabaseConnector):
+        """Chunk 1: dm_npi all-NULL (Polars infers Null dtype).
+        Chunk 2: dm_npi has Int64 values."""
+
+        def __init__(self, chunks: list[pl.DataFrame]):
+            self._chunks = chunks
+
+        def connect(self) -> None: ...
+        def close(self) -> None: ...
+        def read_table(
+            self, table: str, chunk_size: int = 10000,
+        ) -> Iterator[pl.DataFrame]:
+            yield from self._chunks
+        def read_query(self, query: str) -> pl.DataFrame:
+            return pl.DataFrame()
+        def write_dataframe(self, df, table, mode="append") -> int:
+            return 0
+        def execute(self, sql, params=None) -> None: ...
+        def table_exists(self, table: str) -> bool:
+            return False
+        def get_row_count(self, table: str) -> int:
+            return 0
+
+    chunk1 = pl.DataFrame(
+        {"id": [1, 2, 3], "dm_npi": [1234567890, 9876543210, 5555555555]},
+    )
+    chunk2 = pl.DataFrame(
+        {"id": [4, 5], "dm_npi": [None, None]},
+        schema={"id": pl.Int64, "dm_npi": pl.Null},  # the drift case
+    )
+    connector = _DriftyConnector([chunk1, chunk2])
+
+    # Without the schema-unify fix, this raised at the pl.read_parquet
+    # multi-file step. With the fix, the read-back succeeds and the
+    # resulting frame keeps Int64 dtype for dm_npi.
+    df = _read_all(connector, "ignored", chunk_size=10)
+    assert df.height == 5
+    assert df.schema["dm_npi"] == pl.Int64, (
+        f"dm_npi should retain Int64 dtype from the first chunk; got {df.schema['dm_npi']}"
+    )
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #381. #379's streaming-parquet rewrite lost the diagonal_relaxed schema-unification semantics. When chunks drift in dtype (chunk1 Null for an all-NULL sparse bigint column, chunk2 Int64 once values appear), pl.read_parquet over the glob rejected the mismatch. Fix: first non-empty chunk seeds a unified schema; subsequent chunks cast to it before write.