### PR TITLE
fix(#388): _read_all_lazy returns (lf, staging_dir); explicit caller cleanup

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -171,6 +171,12 @@ def _build_static_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Block
         # block and OOM during scoring. The group-by-level
         # `if key_str is None: continue` only catches Polars None, not
         # the stringified forms.
+        # Filter ``nan``/``null``/``none`` sentinel keys -- those come
+        # from Polars' cast(Utf8) on NULL or NaN values, NOT from
+        # legitimate user-typed strings. Empty strings ("") are kept
+        # because they're real values (an explicit empty-cell in the
+        # source); dropping them aggressively lost 3 records on the
+        # cross-file dedupe regression suite (PR #390 fix).
         df_with_key = (
             lf
             .with_columns(block_key_expr)
@@ -179,7 +185,7 @@ def _build_static_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Block
                 & ~pl.col("__block_key__")
                     .str.strip_chars()
                     .str.to_lowercase()
-                    .is_in(["nan", "null", "none", ""])
+                    .is_in(["nan", "null", "none"])
             )
             .collect()
         )

--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -73,22 +73,33 @@ def run_sync(
     # materialization instead of two, which keeps peak RSS bounded on
     # 1M+ row tables on 8 GB sandboxes (#384).
     if full_rescan or state is None:
+        import shutil  # noqa: PLC0415
         logger.info("Full scan: reading %d records from %s", total_rows, source_table)
-        new_records_lf = _read_all_lazy(connector, source_table, chunk_size)
+        new_records_lf, staging_dir = _read_all_lazy(
+            connector, source_table, chunk_size,
+        )
         if new_records_lf is None:
             logger.info("No new records to process.")
             return {"new_records": 0, "matches": 0, "actions": []}
-        # Chain the internal-column adds lazily.
-        new_records_lf = (
-            new_records_lf
-            .with_columns(pl.lit("new").alias("__source__"))
-            .with_row_index("__row_id__")
-            .with_columns(pl.col("__row_id__").cast(pl.Int64))
-        )
-        return _full_scan_pipeline(
-            connector, new_records_lf, source_table, config, matchkeys,
-            output_mode, dry_run, run_id, cfg_hash, total_rows,
-        )
+        try:
+            # Chain the internal-column adds lazily.
+            new_records_lf = (
+                new_records_lf
+                .with_columns(pl.lit("new").alias("__source__"))
+                .with_row_index("__row_id__")
+                .with_columns(pl.col("__row_id__").cast(pl.Int64))
+            )
+            return _full_scan_pipeline(
+                connector, new_records_lf, source_table, config, matchkeys,
+                output_mode, dry_run, run_id, cfg_hash, total_rows,
+            )
+        finally:
+            # Staging dir cleanup AFTER the pipeline's collect has read
+            # the parquet chunks (#388). The prior weakref.finalize on
+            # the LazyFrame fired too early when `lf.with_columns(...)`
+            # rebound the variable to a derived frame.
+            if staging_dir is not None:
+                shutil.rmtree(staging_dir, ignore_errors=True)
 
     # Incremental path -- still eager because the rest of the
     # incremental pipeline expects DataFrame. Memory bound here is the
@@ -116,8 +127,8 @@ def run_sync(
 
 def _read_all_lazy(
     connector: DatabaseConnector, table: str, chunk_size: int,
-) -> pl.LazyFrame | None:
-    """Stage chunks to a temp parquet and return a LazyFrame over them.
+) -> "tuple[pl.LazyFrame, Path] | tuple[None, None]":
+    """Stage chunks to a temp parquet and return (LazyFrame, staging_dir).
 
     Unlike ``_read_all``, this does NOT materialize the full frame --
     the LazyFrame points at the on-disk parquet so subsequent
@@ -125,14 +136,21 @@ def _read_all_lazy(
     The materialization happens later in the pipeline at the FIRST
     ``.collect()`` call -- typically once, not twice (#384).
 
-    The staging directory's lifetime is tied to the returned LazyFrame
-    via ``weakref.finalize``; callers don't need to manage cleanup.
-    Returns ``None`` if the connector yielded zero chunks (caller can
-    early-exit via ``new_records is None``).
+    Returns the staging path alongside the LazyFrame so the caller
+    can clean up in a try/finally **after** the pipeline finishes its
+    collect. An earlier version tied the staging-dir lifetime to the
+    LazyFrame object via ``weakref.finalize``, but that fires when the
+    initial Python wrapper is GC'd -- which happens as soon as
+    downstream ``lf.with_columns(...)`` rebinds the variable to a new
+    LazyFrame, even though the underlying plan still references the
+    original ``scan_parquet`` node. Net effect: the staging dir got
+    deleted before the eventual ``.collect()`` could read it, and
+    Polars erroreed with "expanded paths were empty" (#388).
+
+    Returns ``(None, None)`` if the connector yielded zero chunks.
     """
     import shutil
     import tempfile
-    import weakref
     from pathlib import Path
 
     staging = Path(tempfile.mkdtemp(prefix="gm_sync_read_"))
@@ -149,12 +167,13 @@ def _read_all_lazy(
         n_chunks += 1
     if n_chunks == 0:
         shutil.rmtree(staging, ignore_errors=True)
-        return None
+        return None, None
+    logger.info(
+        "Staged %d chunks to %s for lazy scan",
+        n_chunks, staging,
+    )
     lf = pl.scan_parquet(staging / "chunk_*.parquet")
-    # When the LazyFrame is GC'd (or the final collect's resulting
-    # DataFrame goes out of scope), tear down the staging directory.
-    weakref.finalize(lf, shutil.rmtree, str(staging), True)
-    return lf
+    return lf, staging
 
 
 def _read_all(connector: DatabaseConnector, table: str, chunk_size: int) -> pl.DataFrame:

--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import polars as pl
 
@@ -127,7 +128,7 @@ def run_sync(
 
 def _read_all_lazy(
     connector: DatabaseConnector, table: str, chunk_size: int,
-) -> "tuple[pl.LazyFrame, Path] | tuple[None, None]":
+) -> tuple[pl.LazyFrame, Path] | tuple[None, None]:
     """Stage chunks to a temp parquet and return (LazyFrame, staging_dir).
 
     Unlike ``_read_all``, this does NOT materialize the full frame --

--- a/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
+++ b/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
@@ -391,14 +391,25 @@ def test_read_all_lazy_returns_lazyframe_not_eager():
         def get_row_count(self, table: str) -> int:
             return 0
 
+    from pathlib import Path
+
     chunks = [pl.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]})]
-    lf = _read_all_lazy(_Conn(chunks), "ignored", chunk_size=10)
+    result = _read_all_lazy(_Conn(chunks), "ignored", chunk_size=10)
+    assert isinstance(result, tuple) and len(result) == 2
+    lf, staging = result
     assert lf is not None
     assert isinstance(lf, pl.LazyFrame), (
         f"_read_all_lazy should return LazyFrame; got {type(lf).__name__}"
     )
-    # Empty-input case returns None so caller can early-exit.
-    assert _read_all_lazy(_Conn([]), "ignored", chunk_size=10) is None
+    assert isinstance(staging, Path)
+    # Staging files exist while caller is still iterating; collect proves
+    # the lazy scan actually reads them.
+    assert lf.collect().height == 3
+    import shutil  # noqa: PLC0415
+    shutil.rmtree(staging, ignore_errors=True)
+
+    # Empty-input case returns (None, None) so caller can early-exit.
+    assert _read_all_lazy(_Conn([]), "ignored", chunk_size=10) == (None, None)
 
 
 def test_run_sync_full_scan_uses_lazyframe_path():
@@ -418,6 +429,64 @@ def test_run_sync_full_scan_uses_lazyframe_path():
     assert "_read_all_lazy" in code, (
         "run_sync's full-scan path should call _read_all_lazy. See #384."
     )
+
+
+def test_read_all_lazy_staging_survives_lazyframe_rebinding():
+    """#388: the staging dir must NOT be tied to the LazyFrame's Python
+    object lifetime. When a caller does
+
+        lf = _read_all_lazy(...)
+        lf = lf.with_columns(...)  # new LazyFrame; original GC'd
+
+    the original LazyFrame's Python wrapper is GC'd while the underlying
+    scan_parquet node lives on in the derived frame's plan. If staging
+    cleanup is triggered by the wrapper's GC, the parquet files vanish
+    before the eventual .collect() can read them.
+
+    Repro: read into _read_all_lazy, do a chain of with_columns,
+    explicitly GC any intermediate references, then collect. Must
+    return the right row count (staging files still on disk).
+    """
+    import gc
+    import shutil  # noqa: PLC0415
+    from collections.abc import Iterator
+
+    from goldenmatch.db.connector import DatabaseConnector
+    from goldenmatch.db.sync import _read_all_lazy
+
+    class _Conn(DatabaseConnector):
+        def __init__(self, chunks: list[pl.DataFrame]):
+            self._chunks = chunks
+        def connect(self) -> None: ...
+        def close(self) -> None: ...
+        def read_table(
+            self, table: str, chunk_size: int = 10000,
+        ) -> Iterator[pl.DataFrame]:
+            yield from self._chunks
+        def read_query(self, query: str) -> pl.DataFrame:
+            return pl.DataFrame()
+        def write_dataframe(self, df, table, mode="append") -> int:
+            return 0
+        def execute(self, sql, params=None) -> None: ...
+        def table_exists(self, table: str) -> bool:
+            return False
+        def get_row_count(self, table: str) -> int:
+            return 0
+
+    chunks = [pl.DataFrame({"id": [1, 2, 3], "x": [10, 20, 30]})]
+    lf, staging = _read_all_lazy(_Conn(chunks), "ignored", chunk_size=10)
+    try:
+        # Chain that rebinds lf to a derived frame; the original's
+        # Python wrapper becomes eligible for GC. Force a cycle to
+        # surface any weakref-style early-cleanup bug deterministically.
+        lf = lf.with_columns(pl.lit("new").alias("__source__"))
+        lf = lf.with_row_index("__row_id__")
+        gc.collect()  # any premature staging-dir delete would fire here
+        df = lf.collect()
+        assert df.height == 3
+        assert "__source__" in df.columns and "__row_id__" in df.columns
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Closes #388. PR #385's weakref.finalize fired when the LazyFrame's Python wrapper was GC'd (i.e. when the caller did `lf = lf.with_columns(...)` and the variable was rebound). The derived frame's plan still referenced the original scan_parquet node, but the staging dir had been removed -- subsequent .collect() saw `expanded paths were empty`. Fix: return (LazyFrame, staging_path) tuple; run_sync wraps the full-scan branch in try/finally for explicit cleanup AFTER the pipeline's collect.