### PR TITLE
fix(#394): drop pre-existing __row_id__/__source__ before dedupe_df dispatch (re-apply)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -312,6 +312,19 @@ def _full_scan_pipeline(
     df = df_or_lf.collect() if isinstance(df_or_lf, pl.LazyFrame) else df_or_lf
     logger.info("Pipeline: materialized %d rows x %d cols", df.height, df.width)
 
+    # dedupe_df adds its own __source__ and __row_id__ unconditionally
+    # (core/pipeline.py::run_dedupe_df → _add_row_ids). run_sync attaches
+    # these upstream so the legacy hand-rolled pipeline could correlate
+    # rows; the dispatch path doesn't need them and re-adding via
+    # with_columns raises "duplicate column name __row_id__" (#394).
+    bookkeeping_cols = [c for c in ("__row_id__", "__source__") if c in df.columns]
+    if bookkeeping_cols:
+        df = df.drop(bookkeeping_cols)
+        logger.info(
+            "Pipeline: dropped pre-existing bookkeeping cols %s "
+            "(dedupe_df re-adds internally)", bookkeeping_cols,
+        )
+
     logger.info("Pipeline: dispatching to dedupe_df (routes through v3 planner)...")
     result = dedupe_df(df, config=config, confidence_required=False)
     clusters = result.clusters

--- a/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
+++ b/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
@@ -489,5 +489,65 @@ def test_read_all_lazy_staging_survives_lazyframe_rebinding():
         shutil.rmtree(staging, ignore_errors=True)
 
 
+def test_full_scan_pipeline_drops_existing_row_id_before_dedupe_df():
+    """#394: run_sync attaches __row_id__ + __source__ to the LazyFrame
+    before calling _full_scan_pipeline. dedupe_df adds its own
+    __row_id__ unconditionally via _add_row_ids, so passing a frame that
+    already has the column raises "duplicate column name __row_id__"
+    from Polars' with_columns step.
+
+    Repro: hand _full_scan_pipeline a frame that already has both
+    bookkeeping columns. It must dispatch to dedupe_df successfully
+    instead of raising.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from goldenmatch._api import DedupeResult
+    from goldenmatch.config.schemas import (
+        GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+    )
+    from goldenmatch.db.sync import _full_scan_pipeline
+
+    df = pl.DataFrame({
+        "name": ["alice", "alice", "bob", "carol"],
+        "city": ["nyc", "nyc", "la", "sf"],
+        "__source__": ["new"] * 4,
+        "__row_id__": [0, 1, 2, 3],
+    })
+
+    config = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="exact_name", type="exact",
+            fields=[MatchkeyField(field="name")],
+        )],
+    )
+
+    fake_result = DedupeResult(
+        golden=None,
+        clusters={},
+        dupes=None,
+        unique=None,
+        stats={},
+        scored_pairs=[],
+    )
+
+    connector = MagicMock()
+    with patch("goldenmatch._api.dedupe_df", return_value=fake_result) as mock_dedupe:
+        _full_scan_pipeline(
+            connector, df, "src_table", config, config.get_matchkeys(),
+            "separate", True, "run_1", "cfg_hash", 4,
+        )
+
+    passed_df = mock_dedupe.call_args[0][0]
+    assert "__row_id__" not in passed_df.columns, (
+        "_full_scan_pipeline must strip __row_id__ before dispatching to "
+        "dedupe_df -- dedupe_df re-adds it internally. See #394."
+    )
+    assert "__source__" not in passed_df.columns, (
+        "_full_scan_pipeline must strip __source__ before dispatching to "
+        "dedupe_df -- dedupe_df re-adds it internally. See #394."
+    )
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
+++ b/packages/python/goldenmatch/tests/test_sync_bug_cluster.py
@@ -504,7 +504,9 @@ def test_full_scan_pipeline_drops_existing_row_id_before_dedupe_df():
 
     from goldenmatch._api import DedupeResult
     from goldenmatch.config.schemas import (
-        GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
     )
     from goldenmatch.db.sync import _full_scan_pipeline
 


### PR DESCRIPTION
## Summary

Re-applies the orphaned #394 fix. PR #393 was squash-merged before the follow-up commit `039a73d7` reached main, so the duplicate-column-name error still fires when `_full_scan_pipeline` dispatches to `dedupe_df`.

`run_sync` attaches `__source__` + `__row_id__` to the LazyFrame before calling `_full_scan_pipeline` (legacy contract from the hand-rolled pipeline). `dedupe_df` then runs `_add_row_ids` unconditionally and the `.with_columns` step raises "duplicate column name __row_id__".

Strip both bookkeeping columns from the materialized frame before dispatching; `dedupe_df` re-adds them internally. Logged at INFO so the strip is visible in sync traces.

Closes #394.

## Test plan

- [x] `tests/test_sync_bug_cluster.py` -- 14 passed (includes new regression test `test_full_scan_pipeline_drops_existing_row_id_before_dedupe_df`)