### PR TITLE
feat(#386): streaming-block sync for 10M+ row tables

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -83,6 +83,26 @@ def run_sync(
             logger.info("No new records to process.")
             return {"new_records": 0, "matches": 0, "actions": []}
         try:
+            # Step 4 (#386): route to streaming-block path above the
+            # configurable row threshold. Below threshold = legacy
+            # single-collect (faster, fits comfortably in 16 GB up to
+            # 5M-ish rows). Above threshold = streaming (lower RSS,
+            # slower per-row).
+            import os  # noqa: PLC0415
+            streaming_threshold = int(
+                os.environ.get("GOLDENMATCH_SYNC_STREAMING_THRESHOLD", "5000000"),
+            )
+            if total_rows > streaming_threshold:
+                logger.info(
+                    "Routing to streaming-block sync (rows=%d > threshold=%d). "
+                    "Set GOLDENMATCH_SYNC_STREAMING_THRESHOLD to override. See #386.",
+                    total_rows, streaming_threshold,
+                )
+                return _full_scan_streaming(
+                    connector, staging_dir, source_table, config, matchkeys,
+                    output_mode, dry_run, run_id, cfg_hash, total_rows,
+                )
+
             # Chain the internal-column adds lazily.
             new_records_lf = (
                 new_records_lf
@@ -573,3 +593,303 @@ def _embed_next_chunk(
     except Exception as e:
         logger.warning("Progressive embedding failed: %s", e)
         return 0
+
+
+# ---------------------------------------------------------------------------
+# Streaming-block sync (#386)
+#
+# Bounds peak RSS at any dataset size by scanning one block at a time from
+# the staging parquet instead of materializing the full frame. Gated by
+# GOLDENMATCH_SYNC_STREAMING_THRESHOLD (default 5_000_000); below the
+# threshold, the legacy _full_scan_pipeline single-collect path is faster.
+#
+# Spec: docs/superpowers/specs/2026-05-21-streaming-block-sync-design.md
+# Plan: docs/superpowers/plans/2026-05-21-streaming-block-sync.md
+# ---------------------------------------------------------------------------
+
+
+def _index_block_sizes(
+    staging_dir: Path,
+    config: GoldenMatchConfig,
+) -> pl.DataFrame:
+    """Stream-aggregate block sizes from the staging parquet.
+
+    Returns a ``{__block_key__, count}`` DataFrame sorted descending by
+    count so the per-block loop fails fast on hot blocks. Memory is
+    bounded by the group-by streaming engine, not the dataset size.
+
+    For multi-pass blocking (``config.blocking.keys`` length > 1), the
+    first key drives the index; multi-pass union is a follow-up.
+    Spec calls this out as a v1 simplification.
+
+    For ``config.blocking is None``, returns a degenerate single-block
+    index covering every row. Callers should warn the user — running
+    sync at 10M+ rows without blocking is not the path streaming sync
+    optimises.
+    """
+    from goldenmatch.core.blocker import _build_block_key_expr
+
+    parquet_glob = staging_dir / "chunk_*.parquet"
+    scan = pl.scan_parquet(parquet_glob)
+
+    if config.blocking is None or not config.blocking.keys:
+        # Degenerate single-block path. Still returns a real index frame
+        # (with one row) so downstream code can iterate uniformly.
+        n = scan.select(pl.len()).collect().item()
+        return pl.DataFrame({
+            "__block_key__": ["__all__"],
+            "count": [int(n)],
+        })
+
+    primary_key = config.blocking.keys[0]
+    block_key_expr = _build_block_key_expr(primary_key)
+
+    # Filter NULL block keys -- they don't form valid blocks (matches the
+    # gate in core.blocker._build_static_blocks). Streaming group-by keeps
+    # memory bounded; the result is small (~num distinct block keys).
+    return (
+        scan
+        .with_columns(block_key_expr)
+        .filter(pl.col("__block_key__").is_not_null())
+        .filter(pl.col("__block_key__") != "")
+        .group_by("__block_key__")
+        .agg(pl.len().alias("count"))
+        .sort("count", descending=True)
+        .collect(engine="streaming")
+    )
+
+
+def _score_block_streaming(
+    staging_dir: Path,
+    block_key: str,
+    config: GoldenMatchConfig,
+    matched_pairs: set[tuple[int, int]],
+) -> list[tuple[int, int, float]]:
+    """Score a single block by scan-filter-collect against the staging
+    parquet. Reuses ``_score_partition_with_config`` from #397 so the
+    streaming sync path and distributed scoring share the same kernel.
+
+    ``matched_pairs`` is mutated in-place (canonical ``(min, max)``
+    tuples added for every new pair). The set lives on the driver
+    across all blocks so cross-block dedup works without re-walking
+    pairs.
+
+    Returns the new pairs from this block (after de-duping against
+    ``matched_pairs``). Empty list if the block has < 2 rows or no
+    pairs cross the matchkey threshold.
+    """
+    from goldenmatch.core.blocker import _build_block_key_expr
+    from goldenmatch.core.pipeline import _score_partition_with_config
+
+    parquet_glob = staging_dir / "chunk_*.parquet"
+    scan = pl.scan_parquet(parquet_glob)
+
+    # Add __row_id__ BEFORE filtering so the kernel sees global row ids
+    # (position in the full staging parquet), not local-to-block ids.
+    # Without this, the same pair (0,1) emerges from every block and
+    # matched_pairs's cross-block dedup collapses them into one entry.
+    scan_with_ids = scan.with_row_index("__row_id__").with_columns(
+        pl.col("__row_id__").cast(pl.Int64),
+    )
+
+    if config.blocking is None or not config.blocking.keys:
+        # Degenerate single-block path -- whole frame is one block.
+        # The index pass assigns block_key="__all__"; honor that here
+        # by reading everything.
+        block_df = scan_with_ids.collect()
+    else:
+        primary_key = config.blocking.keys[0]
+        block_key_expr = _build_block_key_expr(primary_key)
+        block_df = (
+            scan_with_ids
+            .with_columns(block_key_expr)
+            .filter(pl.col("__block_key__") == block_key)
+            .drop("__block_key__")
+            .collect()
+        )
+
+    if block_df.height < 2:
+        return []
+
+    # Force bucket backend -- same posture as distributed scoring. The
+    # kernel will do its own matchkey + scoring work; clustering and
+    # golden are driver-side responsibilities.
+    if hasattr(config, "model_copy"):
+        local_cfg = config.model_copy()
+    else:
+        import copy as _copy
+        local_cfg = _copy.deepcopy(config)
+    local_cfg.backend = "bucket"
+
+    pairs = _score_partition_with_config(block_df, local_cfg)
+
+    # De-dup against the global matched_pairs set. Canonicalize each
+    # pair as (min, max) for the set entry to match the project-wide
+    # invariant.
+    new_pairs: list[tuple[int, int, float]] = []
+    for a, b, s in pairs:
+        canonical = (min(a, b), max(a, b))
+        if canonical in matched_pairs:
+            continue
+        matched_pairs.add(canonical)
+        new_pairs.append((a, b, s))
+    return new_pairs
+
+
+def _full_scan_streaming(
+    connector,
+    staging_dir: Path,
+    source_table: str,
+    config: GoldenMatchConfig,
+    matchkeys: list,
+    output_mode: str,
+    dry_run: bool,
+    run_id: str,
+    cfg_hash: str,
+    total_rows: int,
+) -> dict:
+    """Streaming-block sync orchestrator (#386).
+
+    Walks the staging parquet one block at a time. Peak RSS is bounded
+    by the largest individual block's scoring footprint, not by the
+    total dataset size.
+
+    Used when ``total_rows > GOLDENMATCH_SYNC_STREAMING_THRESHOLD``
+    (default 5_000_000). Below that, the legacy single-collect path
+    via ``_full_scan_pipeline`` is faster per-row and fits comfortably.
+
+    Returns the same shape as ``_full_scan_pipeline`` so callers see no
+    difference at the dict level.
+    """
+    from goldenmatch.core.cluster import build_clusters
+    from goldenmatch.core.golden import build_golden_record
+
+    logger.info(
+        "Streaming pipeline: %d matchkeys configured (%s)",
+        len(matchkeys),
+        ", ".join(f"{mk.name}:{mk.type}" for mk in matchkeys) if matchkeys else "<none>",
+    )
+
+    if config.blocking is None or not config.blocking.keys:
+        logger.warning(
+            "Streaming sync invoked with no blocking config. The whole "
+            "frame is one degenerate block; expect single-collect memory "
+            "characteristics. Configure blocking for true per-block "
+            "streaming. See #386.",
+        )
+
+    # Index pass -- bounded memory, returns the sorted block list.
+    logger.info("Streaming pipeline: indexing block sizes...")
+    block_index = _index_block_sizes(staging_dir, config)
+    logger.info(
+        "Streaming pipeline: indexed %d blocks; largest = %d rows",
+        block_index.height,
+        block_index["count"].max() if block_index.height > 0 else 0,
+    )
+
+    all_pairs: list[tuple[int, int, float]] = []
+    matched_pairs: set[tuple[int, int]] = set()
+
+    # Per-block scoring loop. Match log writes incrementally so a long
+    # run is visible in the gm_matches table as blocks complete.
+    for i, row in enumerate(block_index.iter_rows(named=True)):
+        block_key = row["__block_key__"]
+        block_n = row["count"]
+        if block_n < 2:
+            continue
+        logger.info(
+            "Streaming pipeline: block %d/%d (key=%r, size=%d)",
+            i + 1, block_index.height, block_key, block_n,
+        )
+        pairs = _score_block_streaming(
+            staging_dir, block_key, config, matched_pairs,
+        )
+        all_pairs.extend(pairs)
+        if pairs and not dry_run:
+            log_matches_batch(
+                connector,
+                [(int(a), int(b), float(s), "merged") for a, b, s in pairs],
+                run_id,
+            )
+
+    logger.info(
+        "Streaming pipeline: scored %d pairs across %d blocks",
+        len(all_pairs), block_index.height,
+    )
+
+    # Cluster on the merged pair set. Driver-side, O(pairs).
+    # all_ids comes from a cheap projection across the staging parquet:
+    # only the __row_id__ column is read. Polars streams the select.
+    parquet_glob = staging_dir / "chunk_*.parquet"
+    all_ids_df = (
+        pl.scan_parquet(parquet_glob)
+        .with_row_index("__row_id__")
+        .select(pl.col("__row_id__").cast(pl.Int64))
+        .collect(engine="streaming")
+    )
+    all_ids = all_ids_df["__row_id__"].to_list()
+    logger.info(
+        "Streaming pipeline: clustering %d records from %d pairs",
+        len(all_ids), len(all_pairs),
+    )
+    clusters = build_clusters(all_pairs, all_ids, max_cluster_size=100)
+
+    # Per-cluster golden -- only multi-member clusters need a golden
+    # record. Mega-clusters are already capped by max_cluster_size=100.
+    golden_rules = config.golden_rules
+    golden_records: list[dict] = []
+    for cluster_id, cluster_info in clusters.items():
+        if cluster_info["size"] <= 1 or cluster_info.get("oversized"):
+            continue
+        member_ids = cluster_info["members"]
+        cluster_df = (
+            pl.scan_parquet(parquet_glob)
+            .with_row_index("__row_id__")
+            .with_columns(pl.col("__row_id__").cast(pl.Int64))
+            .filter(pl.col("__row_id__").is_in(member_ids))
+            .collect()
+        )
+        if cluster_df.height == 0:
+            continue
+        golden = build_golden_record(cluster_df, golden_rules)
+        if golden:
+            golden["__cluster_id__"] = cluster_id
+            golden_records.append(golden)
+
+    golden_df = pl.DataFrame(golden_records) if golden_records else None
+
+    match_actions = [
+        (int(a), int(b), float(s), "merged") for a, b, s in all_pairs
+    ]
+
+    if not dry_run:
+        write_golden_records(
+            connector, clusters, golden_df, source_table, output_mode,
+        )
+        update_state(
+            connector, source_table, cfg_hash=cfg_hash, record_count=total_rows,
+        )
+
+    multi_clusters = {k: v for k, v in clusters.items() if v["size"] > 1}
+    golden_count = golden_df.height if golden_df is not None else 0
+    logger.info(
+        "Streaming sync complete: %d records, %d pairs, %d multi-member "
+        "clusters, %d golden records",
+        total_rows, len(all_pairs), len(multi_clusters), golden_count,
+    )
+    if total_rows > 0 and not all_pairs and not multi_clusters:
+        logger.warning(
+            "Streaming sync produced zero pairs and zero clusters across "
+            "%d records. Possible causes: empty matchkey config, all-NULL "
+            "blocking column, scorer threshold too high.",
+            total_rows,
+        )
+
+    return {
+        "new_records": total_rows,
+        "matches": len(all_pairs),
+        "clusters": len(multi_clusters),
+        "golden_records": golden_count,
+        "actions": match_actions,
+        "run_id": run_id,
+    }

--- a/packages/python/goldenmatch/tests/test_sync_streaming.py
+++ b/packages/python/goldenmatch/tests/test_sync_streaming.py
@@ -1,0 +1,518 @@
+"""Tests for the streaming-block sync code path (#386).
+
+Spec: docs/superpowers/specs/2026-05-21-streaming-block-sync-design.md
+Plan: docs/superpowers/plans/2026-05-21-streaming-block-sync.md
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+
+@pytest.fixture
+def staging_with_blocks(tmp_path) -> Path:
+    """Write a small synthetic staging parquet with known block sizes.
+
+    Three blocks by last_name, sizes [5, 3, 1] = 9 rows total. Lets us
+    pin both the aggregation and the descending sort order.
+    """
+    df = pl.DataFrame({
+        "last_name": (
+            ["smith"] * 5 +
+            ["jones"] * 3 +
+            ["doe"] * 1
+        ),
+        "first_name": [f"f{i}" for i in range(9)],
+        "id": list(range(9)),
+    })
+    df.write_parquet(tmp_path / "chunk_000000.parquet")
+    return tmp_path
+
+
+def _config_with_blocking(field: str = "last_name"):
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+    )
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=[field])]),
+    )
+
+
+def test_index_block_sizes_streaming_groups_correctly(staging_with_blocks):
+    """Step 1: _index_block_sizes returns one row per distinct block key
+    with the correct count, sorted descending."""
+    from goldenmatch.db.sync import _index_block_sizes
+
+    cfg = _config_with_blocking()
+    index = _index_block_sizes(staging_with_blocks, cfg)
+
+    assert index.height == 3
+    counts = index["count"].to_list()
+    keys = index["__block_key__"].to_list()
+    # Sorted desc by count
+    assert counts == [5, 3, 1]
+    # Sanity-check the keys correspond
+    by_key = dict(zip(keys, counts))
+    assert by_key["smith"] == 5
+    assert by_key["jones"] == 3
+    assert by_key["doe"] == 1
+
+
+def test_index_block_sizes_filters_null_block_keys(tmp_path):
+    """NULL block keys are excluded from the index. Matches the existing
+    blocker._build_static_blocks behaviour: NULL keys don't form valid
+    blocks, so they shouldn't appear in the streaming index either."""
+    from goldenmatch.db.sync import _index_block_sizes
+
+    df = pl.DataFrame({
+        "last_name": ["smith", "smith", None, None, "jones"],
+        "id": list(range(5)),
+    })
+    df.write_parquet(tmp_path / "chunk_000000.parquet")
+
+    cfg = _config_with_blocking()
+    index = _index_block_sizes(tmp_path, cfg)
+
+    assert "smith" in index["__block_key__"].to_list()
+    assert "jones" in index["__block_key__"].to_list()
+    assert None not in index["__block_key__"].to_list()
+    # The two NULL rows must not appear under any key.
+    assert index["count"].sum() == 3
+
+
+def test_index_block_sizes_handles_no_blocking_config(tmp_path):
+    """config.blocking is None -> single degenerate '__all__' block
+    covering every row. Callers can iterate uniformly."""
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    from goldenmatch.db.sync import _index_block_sizes
+
+    df = pl.DataFrame({"id": list(range(7))})
+    df.write_parquet(tmp_path / "chunk_000000.parquet")
+
+    cfg = GoldenMatchConfig()  # no blocking
+    index = _index_block_sizes(tmp_path, cfg)
+
+    assert index.height == 1
+    assert index["__block_key__"].to_list() == ["__all__"]
+    assert index["count"].to_list() == [7]
+
+
+def test_index_block_sizes_streams_across_multiple_chunks(tmp_path):
+    """Staging dir has multiple parquet chunks (the real shape after
+    _read_all_lazy stages 100s of chunks). The index pass must aggregate
+    across all chunks."""
+    from goldenmatch.db.sync import _index_block_sizes
+
+    # Three chunks, "smith" spans 1 and 2; "jones" spans 2 and 3.
+    pl.DataFrame({"last_name": ["smith"] * 3, "id": [0, 1, 2]}).write_parquet(
+        tmp_path / "chunk_000000.parquet",
+    )
+    pl.DataFrame({
+        "last_name": ["smith", "jones", "jones"],
+        "id": [3, 4, 5],
+    }).write_parquet(tmp_path / "chunk_000001.parquet")
+    pl.DataFrame({"last_name": ["jones", "doe"], "id": [6, 7]}).write_parquet(
+        tmp_path / "chunk_000002.parquet",
+    )
+
+    cfg = _config_with_blocking()
+    index = _index_block_sizes(tmp_path, cfg)
+
+    by_key = dict(zip(
+        index["__block_key__"].to_list(),
+        index["count"].to_list(),
+    ))
+    assert by_key["smith"] == 4   # 3 from chunk 0 + 1 from chunk 1
+    assert by_key["jones"] == 3   # 2 from chunk 1 + 1 from chunk 2
+    assert by_key["doe"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Step 2: _score_block_streaming
+# ---------------------------------------------------------------------------
+
+
+def _kernel_config(df: pl.DataFrame, block_field: str = "last_name"):
+    """Build a driver-committed config the streaming kernel can use.
+
+    Mirrors what the run_sync orchestrator does in the streaming path:
+    auto-configures once on the input, then ships the committed config
+    to per-block scoring.
+    """
+    from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    cfg = auto_configure_df(
+        df, confidence_required=False, _skip_finalize=True,
+    )
+    # Force a known blocking key so test fixtures are predictable.
+    cfg.blocking = BlockingConfig(keys=[BlockingKeyConfig(fields=[block_field])])
+    cfg.backend = "bucket"
+    return cfg
+
+
+def test_score_block_streaming_only_reads_one_block(tmp_path):
+    """The per-block scorer must filter to ONE block_key. Pairs returned
+    must only involve rows from that block, never cross-block."""
+    from goldenmatch.db.sync import _score_block_streaming
+
+    # Two blocks. smith records share first_name "alice" (should match
+    # within block); jones records share first_name "bob" (also match).
+    # If the scorer leaks across blocks, alice-vs-bob pairs would emerge.
+    df = pl.DataFrame({
+        "last_name": ["smith"] * 4 + ["jones"] * 4,
+        "first_name": ["alice"] * 4 + ["bob"] * 4,
+        "id": list(range(8)),
+    })
+    df.write_parquet(tmp_path / "chunk_000000.parquet")
+
+    cfg = _kernel_config(df)
+    matched_pairs: set[tuple[int, int]] = set()
+    pairs = _score_block_streaming(tmp_path, "smith", cfg, matched_pairs)
+
+    # Every pair's row_ids must come from the smith block (rows 0-3).
+    # The kernel uses scan-local row_ids (with_row_index inside the
+    # kernel), so the IDs start at 0 within the block frame -- the
+    # invariant we test is "all row_ids are < 4" since the smith block
+    # is 4 rows.
+    assert len(pairs) > 0
+    for a, b, _s in pairs:
+        assert 0 <= a < 4
+        assert 0 <= b < 4
+
+
+def test_score_block_streaming_mutates_matched_pairs(tmp_path):
+    """matched_pairs is the driver-side cross-block dedup set. The
+    streaming primitive must add to it in place."""
+    from goldenmatch.db.sync import _score_block_streaming
+
+    df = pl.DataFrame({
+        "last_name": ["smith"] * 4,
+        "first_name": ["alice"] * 4,
+        "id": list(range(4)),
+    })
+    df.write_parquet(tmp_path / "chunk_000000.parquet")
+
+    cfg = _kernel_config(df)
+    matched_pairs: set[tuple[int, int]] = set()
+    pairs = _score_block_streaming(tmp_path, "smith", cfg, matched_pairs)
+
+    assert len(matched_pairs) == len(pairs)
+    # Every canonical pair from the result is in the set.
+    for a, b, _s in pairs:
+        assert (min(a, b), max(a, b)) in matched_pairs
+
+
+def test_score_block_streaming_dedupes_against_matched_pairs(tmp_path):
+    """Pairs that already exist in matched_pairs (from a prior block's
+    scoring or an external seed) must be filtered out of the new return."""
+    from goldenmatch.db.sync import _score_block_streaming
+
+    df = pl.DataFrame({
+        "last_name": ["smith"] * 4,
+        "first_name": ["alice"] * 4,
+        "id": list(range(4)),
+    })
+    df.write_parquet(tmp_path / "chunk_000000.parquet")
+
+    cfg = _kernel_config(df)
+
+    # First call: learn what pairs the kernel emits for this block.
+    matched_pairs1: set[tuple[int, int]] = set()
+    pairs1 = _score_block_streaming(tmp_path, "smith", cfg, matched_pairs1)
+    assert len(pairs1) > 0
+
+    # Second call with the same set already populated: should dedupe to []
+    matched_pairs2 = set(matched_pairs1)
+    pairs2 = _score_block_streaming(tmp_path, "smith", cfg, matched_pairs2)
+    assert pairs2 == []
+    assert matched_pairs2 == matched_pairs1  # set unchanged
+
+
+def test_score_block_streaming_skips_singleton_blocks(tmp_path):
+    """A block with < 2 rows can't produce pairs. Return empty list
+    fast without invoking the scoring kernel."""
+    from goldenmatch.db.sync import _score_block_streaming
+
+    df = pl.DataFrame({
+        "last_name": ["smith"] * 3 + ["doe"],
+        "first_name": ["alice", "alice", "alice", "bob"],
+        "id": [0, 1, 2, 3],
+    })
+    df.write_parquet(tmp_path / "chunk_000000.parquet")
+
+    cfg = _kernel_config(df)
+    matched_pairs: set[tuple[int, int]] = set()
+    pairs = _score_block_streaming(tmp_path, "doe", cfg, matched_pairs)
+    assert pairs == []
+
+
+# ---------------------------------------------------------------------------
+# Step 3: _full_scan_streaming orchestrator (equivalence + return shape)
+# ---------------------------------------------------------------------------
+
+
+class _FakeConnector:
+    """Mock DatabaseConnector that captures writes without actually
+    hitting Postgres. Lets us assert match_log + golden_records were
+    called without standing up testing.postgresql."""
+
+    def __init__(self):
+        self.match_log_calls: list[list] = []
+        self.golden_calls: list = []
+        self.state_calls: list = []
+
+    # The minimal surface _full_scan_streaming touches.
+    def execute(self, *args, **kwargs):
+        return None
+
+    def close(self):
+        pass
+
+
+def _capture_log_matches_batch(monkeypatch, fake_conn):
+    """Patch log_matches_batch so we can assert it was called."""
+    from goldenmatch.db import sync as sync_mod
+
+    def fake(connector, actions, run_id):
+        fake_conn.match_log_calls.append(actions)
+
+    monkeypatch.setattr(sync_mod, "log_matches_batch", fake)
+
+
+def _capture_writes(monkeypatch, fake_conn):
+    """Patch write_golden_records + update_state too."""
+    from goldenmatch.db import sync as sync_mod
+
+    def fake_golden(connector, clusters, golden_df, source_table, output_mode):
+        fake_conn.golden_calls.append((clusters, golden_df))
+
+    def fake_state(connector, source_table, **kwargs):
+        fake_conn.state_calls.append(kwargs)
+
+    monkeypatch.setattr(sync_mod, "write_golden_records", fake_golden)
+    monkeypatch.setattr(sync_mod, "update_state", fake_state)
+
+
+def test_full_scan_streaming_returns_expected_dict_shape(tmp_path, monkeypatch):
+    """Step 3: orchestrator returns the same dict shape as
+    _full_scan_pipeline so callers see no API difference."""
+    from goldenmatch.db.sync import _full_scan_streaming
+
+    df = pl.DataFrame({
+        "last_name": ["smith"] * 4 + ["jones"] * 4,
+        "first_name": ["alice"] * 4 + ["bob"] * 4,
+        "id": list(range(8)),
+    })
+    df.write_parquet(tmp_path / "chunk_000000.parquet")
+
+    cfg = _kernel_config(df)
+    fake_conn = _FakeConnector()
+    _capture_log_matches_batch(monkeypatch, fake_conn)
+    _capture_writes(monkeypatch, fake_conn)
+
+    result = _full_scan_streaming(
+        connector=fake_conn,
+        staging_dir=tmp_path,
+        source_table="test_table",
+        config=cfg,
+        matchkeys=cfg.get_matchkeys(),
+        output_mode="separate",
+        dry_run=False,
+        run_id="run_1",
+        cfg_hash="hash_1",
+        total_rows=8,
+    )
+
+    # Shape contract from _full_scan_pipeline.
+    assert set(result.keys()) >= {
+        "new_records", "matches", "clusters", "golden_records",
+        "actions", "run_id",
+    }
+    assert result["new_records"] == 8
+    assert result["run_id"] == "run_1"
+    # Two distinct blocks each with intra-block matches -> > 0 pairs.
+    assert result["matches"] > 0
+
+
+def test_full_scan_streaming_writes_incrementally(tmp_path, monkeypatch):
+    """Step 3: match log writes fire per-block, not once at the end.
+    Lets a long sync show progress as blocks finish."""
+    from goldenmatch.db.sync import _full_scan_streaming
+
+    # Three distinct blocks of 3 rows each -- 3 calls to log_matches_batch
+    # if streaming writes correctly.
+    df = pl.DataFrame({
+        "last_name": ["a"] * 3 + ["b"] * 3 + ["c"] * 3,
+        "first_name": ["x"] * 9,
+        "id": list(range(9)),
+    })
+    df.write_parquet(tmp_path / "chunk_000000.parquet")
+
+    cfg = _kernel_config(df)
+    fake_conn = _FakeConnector()
+    _capture_log_matches_batch(monkeypatch, fake_conn)
+    _capture_writes(monkeypatch, fake_conn)
+
+    _full_scan_streaming(
+        connector=fake_conn,
+        staging_dir=tmp_path,
+        source_table="t",
+        config=cfg,
+        matchkeys=cfg.get_matchkeys(),
+        output_mode="separate",
+        dry_run=False,
+        run_id="r",
+        cfg_hash="h",
+        total_rows=9,
+    )
+
+    # At least 3 calls (one per block with multi-member matches). Could
+    # be exactly 3 or fewer if a block emits zero pairs; just assert
+    # that more than one batch fired -- proves incremental writes.
+    assert len(fake_conn.match_log_calls) >= 2, (
+        "streaming sync must write match log incrementally per block; "
+        f"got {len(fake_conn.match_log_calls)} call(s)"
+    )
+
+
+def test_full_scan_streaming_dry_run_skips_writes(tmp_path, monkeypatch):
+    """dry_run=True: no writes to log/golden/state."""
+    from goldenmatch.db.sync import _full_scan_streaming
+
+    df = pl.DataFrame({
+        "last_name": ["a"] * 3,
+        "first_name": ["x"] * 3,
+        "id": [0, 1, 2],
+    })
+    df.write_parquet(tmp_path / "chunk_000000.parquet")
+
+    cfg = _kernel_config(df)
+    fake_conn = _FakeConnector()
+    _capture_log_matches_batch(monkeypatch, fake_conn)
+    _capture_writes(monkeypatch, fake_conn)
+
+    _full_scan_streaming(
+        connector=fake_conn,
+        staging_dir=tmp_path,
+        source_table="t",
+        config=cfg,
+        matchkeys=cfg.get_matchkeys(),
+        output_mode="separate",
+        dry_run=True,
+        run_id="r",
+        cfg_hash="h",
+        total_rows=3,
+    )
+
+    assert fake_conn.match_log_calls == []
+    assert fake_conn.golden_calls == []
+    assert fake_conn.state_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Step 4: threshold routing in run_sync
+# ---------------------------------------------------------------------------
+
+
+def test_run_sync_routes_to_streaming_above_threshold(monkeypatch):
+    """Step 4: total_rows > GOLDENMATCH_SYNC_STREAMING_THRESHOLD ->
+    _full_scan_streaming is called, not _full_scan_pipeline."""
+    from unittest.mock import MagicMock
+
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    from goldenmatch.db import sync as sync_mod
+
+    monkeypatch.setenv("GOLDENMATCH_SYNC_STREAMING_THRESHOLD", "100")
+
+    # Mock the underlying pipelines so we can detect which one fired.
+    streaming_called = {"count": 0}
+    legacy_called = {"count": 0}
+
+    def fake_streaming(*a, **kw):
+        streaming_called["count"] += 1
+        return {"new_records": 0, "matches": 0, "actions": []}
+
+    def fake_legacy(*a, **kw):
+        legacy_called["count"] += 1
+        return {"new_records": 0, "matches": 0, "actions": []}
+
+    monkeypatch.setattr(sync_mod, "_full_scan_streaming", fake_streaming)
+    monkeypatch.setattr(sync_mod, "_full_scan_pipeline", fake_legacy)
+
+    # Mock the read step so we don't need a Postgres connector.
+    fake_lf = pl.DataFrame({"id": [1, 2, 3]}).lazy()
+    staging_path = Path(tempfile.mkdtemp(prefix="gm_route_test_"))
+    monkeypatch.setattr(
+        sync_mod, "_read_all_lazy",
+        lambda *a, **kw: (fake_lf, staging_path),
+    )
+    monkeypatch.setattr(sync_mod, "ensure_metadata_tables", lambda *a, **kw: None)
+    monkeypatch.setattr(sync_mod, "get_state", lambda *a, **kw: None)
+
+    fake_conn = MagicMock()
+    fake_conn.get_row_count.return_value = 1000  # > threshold of 100
+
+    sync_mod.run_sync(
+        connector=fake_conn,
+        source_table="t",
+        config=GoldenMatchConfig(),
+        full_rescan=True,
+    )
+
+    assert streaming_called["count"] == 1, "should have routed to streaming"
+    assert legacy_called["count"] == 0, "should NOT have called legacy"
+
+
+def test_run_sync_uses_legacy_path_below_threshold(monkeypatch):
+    """Step 4: total_rows <= threshold -> _full_scan_pipeline (legacy)."""
+    from unittest.mock import MagicMock
+
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    from goldenmatch.db import sync as sync_mod
+
+    monkeypatch.setenv("GOLDENMATCH_SYNC_STREAMING_THRESHOLD", "10000")
+
+    streaming_called = {"count": 0}
+    legacy_called = {"count": 0}
+
+    monkeypatch.setattr(
+        sync_mod, "_full_scan_streaming",
+        lambda *a, **kw: streaming_called.__setitem__("count", streaming_called["count"] + 1) or {},
+    )
+    monkeypatch.setattr(
+        sync_mod, "_full_scan_pipeline",
+        lambda *a, **kw: legacy_called.__setitem__("count", legacy_called["count"] + 1) or {},
+    )
+
+    fake_lf = pl.DataFrame({"id": [1, 2, 3]}).lazy()
+    staging_path = Path(tempfile.mkdtemp(prefix="gm_route_test_"))
+    monkeypatch.setattr(
+        sync_mod, "_read_all_lazy",
+        lambda *a, **kw: (fake_lf, staging_path),
+    )
+    monkeypatch.setattr(sync_mod, "ensure_metadata_tables", lambda *a, **kw: None)
+    monkeypatch.setattr(sync_mod, "get_state", lambda *a, **kw: None)
+
+    fake_conn = MagicMock()
+    fake_conn.get_row_count.return_value = 1000  # < threshold of 10000
+
+    sync_mod.run_sync(
+        connector=fake_conn,
+        source_table="t",
+        config=GoldenMatchConfig(),
+        full_rescan=True,
+    )
+
+    assert legacy_called["count"] == 1
+    assert streaming_called["count"] == 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Bounds `run_sync` peak RSS at any dataset size. Today's single-collect path peaks at ~1x raw frame RSS — fine through ~5M rows on 16 GB, OOMs at 10M+. The streaming-block path walks one block at a time so peak RSS is bounded by the largest individual block, not the dataset total.

Closes #386.

## Architecture

Four functions in `db/sync.py`:

1. `_index_block_sizes` — streaming group-by over staging parquet, returns sorted `{block_key, count}`.
2. `_score_block_streaming` — per-block `scan_parquet().filter().collect()` + the narrow scoring kernel from #397. Global `__row_id__` injection so cross-block pair dedup works.
3. `_full_scan_streaming` — orchestrator. Index → per-block scoring → cluster on merged pairs → per-cluster golden via `is_in(member_ids)` filter.
4. Threshold routing in `run_sync`: env-var-gated (`GOLDENMATCH_SYNC_STREAMING_THRESHOLD`, default 5_000_000).

The streaming kernel REUSES `_score_partition_with_config` from PR #397, so streaming sync and distributed scoring share the same scoring primitive. Two paths, one kernel.

## Test plan

- [x] 13 new tests in `tests/test_sync_streaming.py` covering all four pieces (index aggregation across chunks, NULL block-key filter, single-block degenerate, per-block scan correctness, matched_pairs mutation, cross-block dedup, dry-run skip, threshold routing both directions).
- [x] 41/41 across `test_sync_streaming` + `test_sync_bug_cluster` + `test_score_partition_kernel` + `test_pipeline`.
- [x] `uv run ruff check` clean.
- [ ] Real-world 5M sync with peak RSS < 4 GB — Step 5 of the plan, follow-up workflow_dispatch bench.

## Notes

- V1 is non-resumable. Mid-run failure means re-run from scratch. Resumable state is a documented V2 follow-up in the spec.
- DuckDB-staged variant is a documented alternative if parquet predicate pushdown profiles slow at scale. Same interface, swap-in.