### PR TITLE
fix(#401): drop streaming threshold default 5M -> 500K

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -83,25 +83,48 @@ def run_sync(
             logger.info("No new records to process.")
             return {"new_records": 0, "matches": 0, "actions": []}
         try:
-            # Step 4 (#386): route to streaming-block path above the
-            # configurable row threshold. Below threshold = legacy
-            # single-collect (faster, fits comfortably in 16 GB up to
-            # 5M-ish rows). Above threshold = streaming (lower RSS,
-            # slower per-row).
+            # Route to streaming-block path above a row-count floor.
+            #
+            # Default threshold = 500K rows. Reasoning: at 500K * 60 cols
+            # * ~50 bytes/cell, the eager collect inside _full_scan_pipeline
+            # is ~1.5 GB. dedupe_df then doubles+triples that for matchkey
+            # columns, scoring matrices, candidate pair sets, and
+            # auto-fix's intermediate frames -- another 3-5 GB. On an
+            # 8 GB sandbox (#401 trace) the dispatch boundary OOMs at
+            # 1.13M rows. 500K leaves a margin even on memory-constrained
+            # hosts; smaller datasets prefer the legacy path's faster
+            # per-row throughput.
+            #
+            # The prior 5M default (#386) was tuned for 16 GB+ hosts and
+            # failed open on 8 GB sandboxes. See #401.
+            #
+            # Override via GOLDENMATCH_SYNC_STREAMING_THRESHOLD for
+            # hosts where you'd rather take the perf hit / win.
             import os  # noqa: PLC0415
             streaming_threshold = int(
-                os.environ.get("GOLDENMATCH_SYNC_STREAMING_THRESHOLD", "5000000"),
+                os.environ.get("GOLDENMATCH_SYNC_STREAMING_THRESHOLD", "500000"),
             )
             if total_rows > streaming_threshold:
                 logger.info(
-                    "Routing to streaming-block sync (rows=%d > threshold=%d). "
-                    "Set GOLDENMATCH_SYNC_STREAMING_THRESHOLD to override. See #386.",
+                    "Sync backend selected: STREAMING-BLOCK "
+                    "(rows=%d > threshold=%d). Per-block scan keeps RSS "
+                    "bounded by largest block, not dataset size. "
+                    "Set GOLDENMATCH_SYNC_STREAMING_THRESHOLD to override. "
+                    "See #386, #401.",
                     total_rows, streaming_threshold,
                 )
                 return _full_scan_streaming(
                     connector, staging_dir, source_table, config, matchkeys,
                     output_mode, dry_run, run_id, cfg_hash, total_rows,
                 )
+
+            logger.info(
+                "Sync backend selected: LEGACY single-collect "
+                "(rows=%d <= threshold=%d). Faster per-row but materializes "
+                "the full frame; ensure the host has >= rows * cols * "
+                "~250 bytes free RAM for the dedupe_df dispatch. See #386, #401.",
+                total_rows, streaming_threshold,
+            )
 
             # Chain the internal-column adds lazily.
             new_records_lf = (

--- a/packages/python/goldenmatch/tests/test_sync_streaming.py
+++ b/packages/python/goldenmatch/tests/test_sync_streaming.py
@@ -514,5 +514,107 @@ def test_run_sync_uses_legacy_path_below_threshold(monkeypatch):
     assert streaming_called["count"] == 0
 
 
+def test_default_threshold_routes_million_row_table_to_streaming(monkeypatch):
+    """#401: with the env var UNSET (default threshold), a real-world
+    1.13M-row sync must route to streaming-block. Pins the default
+    against future regressions that re-raise the threshold and break
+    8 GB sandbox users.
+
+    The historical default of 5M (from #386) failed open on 8 GB hosts;
+    the 500K default keeps memory bounded for any meaningful table.
+    """
+    from unittest.mock import MagicMock
+
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    from goldenmatch.db import sync as sync_mod
+
+    # Explicitly DELETE the env var so we exercise the default.
+    monkeypatch.delenv("GOLDENMATCH_SYNC_STREAMING_THRESHOLD", raising=False)
+
+    streaming_called = {"count": 0}
+    legacy_called = {"count": 0}
+
+    monkeypatch.setattr(
+        sync_mod, "_full_scan_streaming",
+        lambda *a, **kw: streaming_called.__setitem__("count", streaming_called["count"] + 1) or {},
+    )
+    monkeypatch.setattr(
+        sync_mod, "_full_scan_pipeline",
+        lambda *a, **kw: legacy_called.__setitem__("count", legacy_called["count"] + 1) or {},
+    )
+
+    fake_lf = pl.DataFrame({"id": [1, 2, 3]}).lazy()
+    staging_path = Path(tempfile.mkdtemp(prefix="gm_route_test_"))
+    monkeypatch.setattr(
+        sync_mod, "_read_all_lazy",
+        lambda *a, **kw: (fake_lf, staging_path),
+    )
+    monkeypatch.setattr(sync_mod, "ensure_metadata_tables", lambda *a, **kw: None)
+    monkeypatch.setattr(sync_mod, "get_state", lambda *a, **kw: None)
+
+    fake_conn = MagicMock()
+    fake_conn.get_row_count.return_value = 1_131_769  # #401's actual table size
+
+    sync_mod.run_sync(
+        connector=fake_conn,
+        source_table="t",
+        config=GoldenMatchConfig(),
+        full_rescan=True,
+    )
+
+    assert streaming_called["count"] == 1, (
+        "1.13M-row sync must route to streaming with the default threshold. "
+        "If this fails, the default has crept back up past 1.13M and 8 GB "
+        "sandbox users will OOM again. See #401."
+    )
+    assert legacy_called["count"] == 0
+
+
+def test_default_threshold_keeps_small_tables_on_legacy_path(monkeypatch):
+    """Companion to the #401 default-threshold test: a small table
+    (< 500K rows) still routes to the faster legacy path with the
+    default threshold."""
+    from unittest.mock import MagicMock
+
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    from goldenmatch.db import sync as sync_mod
+
+    monkeypatch.delenv("GOLDENMATCH_SYNC_STREAMING_THRESHOLD", raising=False)
+
+    streaming_called = {"count": 0}
+    legacy_called = {"count": 0}
+
+    monkeypatch.setattr(
+        sync_mod, "_full_scan_streaming",
+        lambda *a, **kw: streaming_called.__setitem__("count", streaming_called["count"] + 1) or {},
+    )
+    monkeypatch.setattr(
+        sync_mod, "_full_scan_pipeline",
+        lambda *a, **kw: legacy_called.__setitem__("count", legacy_called["count"] + 1) or {},
+    )
+
+    fake_lf = pl.DataFrame({"id": [1, 2, 3]}).lazy()
+    staging_path = Path(tempfile.mkdtemp(prefix="gm_route_test_"))
+    monkeypatch.setattr(
+        sync_mod, "_read_all_lazy",
+        lambda *a, **kw: (fake_lf, staging_path),
+    )
+    monkeypatch.setattr(sync_mod, "ensure_metadata_tables", lambda *a, **kw: None)
+    monkeypatch.setattr(sync_mod, "get_state", lambda *a, **kw: None)
+
+    fake_conn = MagicMock()
+    fake_conn.get_row_count.return_value = 100_000  # well below 500K
+
+    sync_mod.run_sync(
+        connector=fake_conn,
+        source_table="t",
+        config=GoldenMatchConfig(),
+        full_rescan=True,
+    )
+
+    assert legacy_called["count"] == 1
+    assert streaming_called["count"] == 0
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

The 5M default from #386 failed open on 8 GB sandboxes (#401's reporter has a 1.13M-row table; legacy path materializes ~5-8 GB and dedupe_df pushes past 8 GB at the dispatch boundary).

500K * 60 cols * ~50 bytes/cell ≈ 1.5 GB collected, leaves room for dedupe_df's matchkey + scoring matrix allocations on an 8 GB host. Tables above the floor stream block-by-block via #400's path.

Also adds a backend-selection log line at the routing boundary (issue #401 option 3) so future OOM traces show which path ran without inference.

Closes #401.

## Test plan

- [x] `test_default_threshold_routes_million_row_table_to_streaming` pins the new default — 1.13M routes to streaming with the env var unset.
- [x] `test_default_threshold_keeps_small_tables_on_legacy_path` — 100K still uses legacy.
- [x] 35/35 across `test_sync_streaming` + `test_sync_bug_cluster` + `test_score_partition_kernel`.
- [x] `uv run ruff check` clean.

## Override

`GOLDENMATCH_SYNC_STREAMING_THRESHOLD=<rows>` for hosts that prefer the legacy speed or have generous RAM.