### PR TITLE
feat(#404): GoldenCheck auto-config column exclusions (full plan)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -407,7 +407,10 @@ def dedupe_df(
     # once pf.signals is a typed ComplexityProfile (currently PostflightSignals
     # TypedDict). For now, drift is left unset on this path.
     if _used_controller:
-        from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+        from goldenmatch.core.autoconfig import (
+            _LAST_AUTOCONFIG_EXCLUSIONS,
+            _LAST_CONTROLLER_RUN,
+        )
         _ctrl_state = _LAST_CONTROLLER_RUN.get()
         if _ctrl_state is not None:
             _sample_profile, _history = _ctrl_state
@@ -415,6 +418,12 @@ def dedupe_df(
                 pf = PostflightReport()
             pf.controller_profile = _sample_profile
             pf.controller_history = _history
+        # #404: GoldenCheck auto-config exclusions surface in postflight.
+        _exclusions = _LAST_AUTOCONFIG_EXCLUSIONS.get()
+        if _exclusions:
+            if pf is None:
+                pf = PostflightReport()
+            pf.autoconfig_exclusions = list(_exclusions)
 
     return DedupeResult(
         golden=result.get("golden"),
@@ -503,7 +512,10 @@ def match_df(
     # See dedupe_df for full commentary. Drift unset when _skip_finalize=True
     # (Task 6.1 deferred).
     if _used_controller:
-        from goldenmatch.core.autoconfig import _LAST_CONTROLLER_RUN
+        from goldenmatch.core.autoconfig import (
+            _LAST_AUTOCONFIG_EXCLUSIONS,
+            _LAST_CONTROLLER_RUN,
+        )
         _ctrl_state = _LAST_CONTROLLER_RUN.get()
         if _ctrl_state is not None:
             _sample_profile, _history = _ctrl_state
@@ -511,6 +523,12 @@ def match_df(
                 pf = PostflightReport()
             pf.controller_profile = _sample_profile
             pf.controller_history = _history
+        # #404: GoldenCheck auto-config exclusions surface in postflight.
+        _exclusions = _LAST_AUTOCONFIG_EXCLUSIONS.get()
+        if _exclusions:
+            if pf is None:
+                pf = PostflightReport()
+            pf.autoconfig_exclusions = list(_exclusions)
 
     return MatchResult(
         matched=result.get("matched"),

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -317,6 +317,12 @@ def profile_cmd(
     files: list[str] = typer.Argument(..., help="File(s) to profile"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed per-column info"),
     suggest_fixes: bool = typer.Option(False, "--suggest-fixes", help="Show what auto-fix would do (dry run)"),
+    exclusions: bool = typer.Option(
+        False, "--exclusions",
+        help="Show GoldenCheck auto-config column exclusions (#404). "
+             "Lists columns auto-config will skip (audit timestamps, "
+             "foreign IDs, sentinel values, etc) and why.",
+    ),
 ) -> None:
     """Scan input files and generate a data quality report."""
     from pathlib import Path
@@ -350,3 +356,31 @@ def profile_cmd(
                     console.print(f"  [green]{fix['fix']}[/green]: {fix['detail']}")
             if not any_fix:
                 console.print("  [dim]No fixes needed.[/dim]")
+
+        if exclusions:
+            from goldenmatch.core.quality_exclusions import (
+                detect_autoconfig_exclusions,
+            )
+
+            excluded = detect_autoconfig_exclusions(df)
+            console.print(
+                "\n[bold yellow]Auto-config exclusions (#404):[/bold yellow]"
+            )
+            if not excluded:
+                console.print(
+                    "  [dim]No columns excluded -- auto-config will use "
+                    "every column.[/dim]"
+                )
+            else:
+                for ec in excluded:
+                    console.print(
+                        f"  [red]{ec.column}[/red] "
+                        f"[dim]({ec.detector})[/dim]: {ec.reason}"
+                    )
+                console.print(
+                    "\n  [dim]Override via "
+                    "GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE=col1,col2 "
+                    "to rescue, or "
+                    "GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE=col1,col2 "
+                    "to add more.[/dim]"
+                )

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -457,6 +457,21 @@ class QualityConfig(BaseModel):
     fix_mode: str = "safe"     # "safe" | "moderate" | "none"
     domain: str | None = None  # "healthcare" | "finance" | "ecommerce"
 
+    # Auto-config column-exclusion overrides (#404). The exclusion
+    # detectors in `core.quality_exclusions` identify columns that are
+    # statistically attractive but counter-productive for matching
+    # (audit timestamps, foreign-system IDs, sentinel values, etc).
+    # These two fields let the user override the auto-detection:
+    #
+    #   - autoconfig_force_exclude: extra columns to always exclude
+    #     regardless of detector output. Useful when you know a column
+    #     is bad for matching but the detectors don't catch it.
+    #   - autoconfig_force_include: columns to RESCUE from any
+    #     auto-detection. Useful for legitimate hash columns used in
+    #     PPRL, etc. force_include wins on conflict.
+    autoconfig_force_exclude: list[str] = Field(default_factory=list)
+    autoconfig_force_include: list[str] = Field(default_factory=list)
+
 
 class TransformConfig(BaseModel):
     """GoldenFlow integration config for data transformation."""

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1403,6 +1403,42 @@ def _scale_aware_backend(row_count: int) -> str | None:  # pyright: ignore[repor
 # the profile + history without threading them through every call site.
 _LAST_CONTROLLER_RUN: ContextVar = ContextVar("_LAST_CONTROLLER_RUN", default=None)
 
+# ContextVar populated by auto_configure_df with the GoldenCheck exclusion
+# list (#404). PostflightReport reads this to render the "Auto-config
+# exclusions" section so users see the audit trail without grep-ing logs.
+_LAST_AUTOCONFIG_EXCLUSIONS: ContextVar = ContextVar(
+    "_LAST_AUTOCONFIG_EXCLUSIONS", default=None,
+)
+
+def _resolve_quality_config_for_exclusions():
+    """Read auto-config force-exclude / force-include overrides.
+
+    V1 reads from env vars (comma-separated column names):
+      GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE=col1,col2,col3
+      GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE=col1,col2,col3
+
+    The QualityConfig.autoconfig_force_{exclude,include} fields are
+    defined on the schema (#404) for future API plumbing, but threading
+    them through dedupe_df / match_df is a public API change deferred
+    to V2. For V1, env vars cover ad-hoc rescue + force-exclude cases.
+
+    Returns a shim object with the same attribute shape as
+    QualityConfig (so detect_autoconfig_exclusions can read either
+    interchangeably), or None when both env vars are empty.
+    """
+    fe = os.environ.get("GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE", "")
+    fi = os.environ.get("GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE", "")
+    fe_list = [c.strip() for c in fe.split(",") if c.strip()]
+    fi_list = [c.strip() for c in fi.split(",") if c.strip()]
+    if not fe_list and not fi_list:
+        return None
+
+    class _ShimQualityConfig:
+        autoconfig_force_exclude = fe_list
+        autoconfig_force_include = fi_list
+
+    return _ShimQualityConfig()
+
 # Tier 4: cross-run memory.  Set GOLDENMATCH_AUTOCONFIG_MEMORY=0 (or "false"
 # or "disabled") to opt out (useful in CI or when disk I/O should be minimal).
 _AUTOCONFIG_MEMORY_DISABLED: bool = (
@@ -1506,6 +1542,60 @@ def auto_configure_df(
                 f"reference requires pl.DataFrame or pl.LazyFrame, "
                 f"got {type(reference).__name__}"
             )
+
+    # ── GoldenCheck auto-config exclusions (#404) ──
+    # Run the column-exclusion detectors BEFORE the controller starts.
+    # Drop excluded columns from df so v0, sample iterations, and the
+    # committed config never reference them. The user's original df
+    # downstream still has every column (golden records aren't affected);
+    # we only filter the matchkey/blocking candidate pool.
+    #
+    # Skipped when df is a Ray Dataset (distributed path) -- those have
+    # their own column-selection story; exclusions land at the per-
+    # partition kernel layer separately.
+    if not _is_ray_dataset(df) and isinstance(df, pl.DataFrame):
+        from goldenmatch.core.quality_exclusions import (
+            detect_autoconfig_exclusions,
+        )
+        # Pull force-include/exclude overrides from the user's
+        # QualityConfig if present.
+        force_exclude_list: list[str] = []
+        force_include_list: list[str] = []
+        # The controller takes config from v0_kwargs; user-supplied
+        # quality config isn't threaded here yet. Read from a module-
+        # level place if needed in the future; for now the caller
+        # must drive overrides via _LAST_QUALITY_CONFIG (set by the
+        # public _api.dedupe_df dispatch). Falls back to empty lists
+        # when no quality config is present.
+        _qc = _resolve_quality_config_for_exclusions()
+        if _qc is not None:
+            force_exclude_list = list(_qc.autoconfig_force_exclude or [])
+            force_include_list = list(_qc.autoconfig_force_include or [])
+        # Internal bookkeeping columns are invisible to detectors.
+        skip = {"__row_id__", "__source__"}
+        for col in df.columns:
+            if col.startswith("__") and col.endswith("__"):
+                skip.add(col)
+        exclusions = detect_autoconfig_exclusions(
+            df,
+            force_exclude=force_exclude_list,
+            force_include=force_include_list,
+            skip_columns=skip,
+        )
+        if exclusions:
+            cols_to_drop = [
+                ec.column for ec in exclusions if ec.column in df.columns
+            ]
+            for ec in exclusions:
+                logger.info(
+                    "Auto-config exclusion: %r (detector=%s) -- %s",
+                    ec.column, ec.detector, ec.reason,
+                )
+            if cols_to_drop:
+                df = df.drop(cols_to_drop)
+            _LAST_AUTOCONFIG_EXCLUSIONS.set(list(exclusions))
+        else:
+            _LAST_AUTOCONFIG_EXCLUSIONS.set([])
 
     # Lazy import to avoid circular imports (controller imports back here)
     from goldenmatch.core.autoconfig_controller import (

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
@@ -237,6 +237,11 @@ class PostflightReport:
     controller_profile: Any = None
     # RunHistory | None — full iteration history including errors and drift.
     controller_history: Any = None
+    # GoldenCheck auto-config exclusions (#404). List of ExcludedColumn
+    # set by the zero-config API caller after auto_configure_df runs.
+    # Surfaces the audit trail: "auto-config excluded these columns
+    # and here's why." Empty when no detectors fired.
+    autoconfig_exclusions: list = field(default_factory=list)
 
     def __str__(self) -> str:
         """Human-readable rendering used by CLI/postflight summaries.
@@ -258,6 +263,12 @@ class PostflightReport:
             parts.append("  advisories:")
             for adv in self.advisories:
                 parts.append(f"    - {adv}")
+        if self.autoconfig_exclusions:
+            parts.append("  auto-config exclusions:")
+            for ec in self.autoconfig_exclusions:
+                parts.append(
+                    f"    - {ec.column!r}: {ec.detector} -- {ec.reason}"
+                )
         mem_line = _render_memory_line(self.memory_stats)
         if mem_line:
             parts.append(f"  {mem_line}")

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from collections import defaultdict
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from goldenmatch.core._profile_helpers import transitivity_rate
 from goldenmatch.core.complexity_profile import ClusterProfile
@@ -214,7 +214,7 @@ def _emit_cluster_profile(clusters: dict[int, dict]) -> None:
 
 
 def build_clusters(
-    pairs,  # list[tuple[int, int, float]] | ray.data.Dataset
+    pairs: Any,  # list[tuple[int, int, float]] | ray.data.Dataset
     all_ids: list[int] | None = None,
     max_cluster_size: int = 100,
     weak_cluster_threshold: float = 0.3,

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1872,7 +1872,7 @@ def run_match_df(
     )
 
 
-def _score_partition_with_config(
+def _score_partition_with_config(  # pyright: ignore[reportUnusedFunction]
     df: pl.DataFrame,
     config: GoldenMatchConfig,
 ) -> list[tuple[int, int, float]]:

--- a/packages/python/goldenmatch/goldenmatch/core/quality_exclusions.py
+++ b/packages/python/goldenmatch/goldenmatch/core/quality_exclusions.py
@@ -99,10 +99,15 @@ PHONE_SENTINELS: frozenset[str] = frozenset({
     "(000) 000-0000", "(555) 555-5555",
 })
 
-# Substrings that indicate a placeholder email regardless of suffix.
+# Substrings that indicate a placeholder email. ONLY unambiguous
+# no-reply / null / test patterns -- NOT @example.com or @example.org,
+# which are RFC-reserved test domains widely used in legitimate
+# fixtures and demos. False-positive rate on example.* domains was
+# unacceptable (NCVR / DQbench / negative-evidence fixtures all use
+# @example.com as the legitimate domain).
 EMAIL_SENTINEL_SUBSTRINGS: tuple[str, ...] = (
     "noreply@", "noemail@", "no-reply@", "donotreply@", "do-not-reply@",
-    "null@", "none@", "n/a@", "@example.com", "@example.org",
+    "null@", "none@", "n/a@",
     "test@", "fake@", "@test.com",
 )
 

--- a/packages/python/goldenmatch/goldenmatch/core/quality_exclusions.py
+++ b/packages/python/goldenmatch/goldenmatch/core/quality_exclusions.py
@@ -1,0 +1,507 @@
+"""Auto-config column-exclusion detectors (GoldenCheck preflight).
+
+Identifies columns that are *statistically attractive but
+counter-productive* for matching:
+
+  1. Audit timestamp columns (created_at, updated_at, ...)
+  2. Foreign-system IDs (external_id, source_pk, etl_batch, ...)
+  3. Sentinel/placeholder values (0000000000, noemail@example.com, "Unknown", ...)
+  4. Soft-delete / lifecycle flags (is_active, status, deleted_at, ...)
+  5. Free-text notes/comments (description, notes, memo, ...)
+  6. System-generated hashes (record_hash, dedup_token, checksum, ...)
+
+Auto-config consumes the exclusion list at the top of
+``auto_configure_df`` and filters those columns out of the candidate
+pool BEFORE identity/cardinality scoring runs. Excluded columns are
+invisible to all downstream rules (compute_column_priors,
+promote_negative_evidence, the rule chain).
+
+Each detector is a pure function; the orchestrator
+``detect_autoconfig_exclusions`` iterates them across columns and
+returns a list of ``ExcludedColumn``. Cost is O(sample_size=1000) per
+column, not O(rows), so 1000-column wide tables are still cheap.
+
+Spec: docs/superpowers/specs/2026-05-21-goldencheck-autoconfig-exclusions-design.md
+Issue: #404
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import polars as pl
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ExcludedColumn:
+    """A column GoldenCheck recommends auto-config skip.
+
+    Frozen so the list can be hashed, cached, and surfaced through
+    immutable channels (postflight, MCP responses) without defensive
+    copying.
+
+    ``detector`` is the short name of the detector that fired
+    (audit_column, sentinel_values, etc). ``reason`` is the
+    user-facing string surfaced in logs + postflight. ``evidence`` is
+    detector-specific structured context (e.g. sentinel hit counts).
+    """
+
+    column: str
+    detector: str
+    reason: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ColumnProfile:
+    """Cheap stats used by detectors. Computed once per column by the
+    orchestrator so detectors don't re-scan.
+
+    Detectors should NOT compute additional statistics from the series
+    -- if a detector needs something not in ColumnProfile, add it here
+    and compute it once. The whole point of the profile struct is to
+    keep per-column cost bounded.
+    """
+
+    cardinality_ratio: float  # distinct / non-null
+    null_rate: float          # null / total
+    distinct_count: int
+    dtype: str                # pl.dtype repr
+    mean_string_length: float | None  # None for non-string columns
+
+
+# ---------------------------------------------------------------------------
+# Sentinel sets (detector 3)
+# ---------------------------------------------------------------------------
+
+# Lowercase strings the sentinel detector treats as known-bad values
+# for any column. Generic placeholders that show up across schemas.
+GENERIC_STRING_SENTINELS: frozenset[str] = frozenset({
+    "unknown", "n/a", "na", "none", "null", "tbd",
+    "test", "test_data", "placeholder", "fixme",
+    "not provided", "not available", "no data",
+    "?", "??", "-", "--", "",
+})
+
+# Phone-shaped sentinels (digit strings with low entropy).
+PHONE_SENTINELS: frozenset[str] = frozenset({
+    "0000000000", "1111111111", "9999999999", "1234567890",
+    "5555555555", "0000000", "1234567", "555-555-5555",
+    "(000) 000-0000", "(555) 555-5555",
+})
+
+# Substrings that indicate a placeholder email regardless of suffix.
+EMAIL_SENTINEL_SUBSTRINGS: tuple[str, ...] = (
+    "noreply@", "noemail@", "no-reply@", "donotreply@", "do-not-reply@",
+    "null@", "none@", "n/a@", "@example.com", "@example.org",
+    "test@", "fake@", "@test.com",
+)
+
+# Zip-shaped sentinels.
+ZIP_SENTINELS: frozenset[str] = frozenset({
+    "00000", "99999", "12345", "00000-0000", "99999-9999",
+})
+
+
+# ---------------------------------------------------------------------------
+# Name-pattern regexes (compiled once)
+# ---------------------------------------------------------------------------
+
+_AUDIT_NAME_RE = re.compile(
+    r"^(created|updated|modified|inserted|deleted|last_seen|first_seen|sync)_(at|on|date|time|ts|timestamp)$"
+    r"|^.+_(at|on|timestamp|ts)$"
+    r"|^(created|updated|modified|inserted|deleted)$",
+    re.IGNORECASE,
+)
+
+_FOREIGN_ID_NAME_RE = re.compile(
+    r"external_id|legacy_id|source_id|etl_batch|migration_id|.+_(pk|uuid|guid)$|^(pk|uuid|guid)$",
+    re.IGNORECASE,
+)
+
+_LIFECYCLE_NAME_RE = re.compile(
+    r"^(is_|has_|can_|should_)"
+    r"|^(deleted|active|status|state|enabled|disabled|published|archived)(_.+)?$",
+    re.IGNORECASE,
+)
+
+_FREE_TEXT_NAME_RE = re.compile(
+    r"^(.*_)?(notes?|comments?|description|remarks|memo|details?|free_text|narrative)(_.*)?$",
+    re.IGNORECASE,
+)
+
+_HASH_NAME_RE = re.compile(
+    r"hash|digest|checksum|signature|dedup_token|fingerprint|^(md5|sha1|sha256)$",
+    re.IGNORECASE,
+)
+
+_HEX_VALUE_RE = re.compile(r"^[0-9a-fA-F]{16,128}$")
+_BASE64_VALUE_RE = re.compile(r"^[A-Za-z0-9+/]{16,}={0,2}$")
+
+
+# ---------------------------------------------------------------------------
+# Detectors
+#
+# Each detector takes (column_name, sampled_values, profile) and returns
+# ``ExcludedColumn | None``. The sampled_values list is a small subset of
+# non-null values (default cap 1000); the profile carries cheap stats
+# computed once by the orchestrator.
+# ---------------------------------------------------------------------------
+
+
+def detect_audit_column(
+    column_name: str,
+    sampled_values: list,
+    profile: ColumnProfile,
+) -> ExcludedColumn | None:
+    """Audit timestamp columns. Match on name pattern + datetime-like
+    dtype + high cardinality."""
+    if not _AUDIT_NAME_RE.match(column_name):
+        return None
+    is_temporal = (
+        "datetime" in profile.dtype.lower()
+        or "date" in profile.dtype.lower()
+        or "time" in profile.dtype.lower()
+    )
+    # Numeric epoch shape: int dtype + huge values, but we accept the
+    # name-pattern + cardinality > 0.5 signal as enough since temporal
+    # name + high uniqueness is almost always an audit column.
+    if not is_temporal and profile.cardinality_ratio < 0.5:
+        return None
+    return ExcludedColumn(
+        column=column_name,
+        detector="audit_column",
+        reason="audit timestamp column (high cardinality, no identity signal)",
+        evidence={
+            "dtype": profile.dtype,
+            "cardinality_ratio": round(profile.cardinality_ratio, 3),
+        },
+    )
+
+
+def detect_foreign_system_id(
+    column_name: str,
+    sampled_values: list,
+    profile: ColumnProfile,
+) -> ExcludedColumn | None:
+    """Foreign-system IDs. Match on name pattern + cardinality > 0.95."""
+    name_match = _FOREIGN_ID_NAME_RE.search(column_name)
+    if not name_match:
+        return None
+    if profile.cardinality_ratio < 0.95:
+        return None
+    return ExcludedColumn(
+        column=column_name,
+        detector="foreign_system_id",
+        reason=(
+            "foreign-system ID (high cardinality, per-source -- "
+            "cross-source dedupe treats as distinct)"
+        ),
+        evidence={
+            "cardinality_ratio": round(profile.cardinality_ratio, 3),
+            "name_match": name_match.group(0),
+        },
+    )
+
+
+def detect_sentinel_values(
+    column_name: str,
+    sampled_values: list,
+    profile: ColumnProfile,
+    *,
+    threshold: float = 0.10,
+) -> ExcludedColumn | None:
+    """Sentinel / placeholder values. THE #1 real-world poison.
+
+    Sample non-null values, count matches against the appropriate
+    sentinel set (phone-shaped, email-shaped, zip-shaped, or generic
+    string). If > threshold (default 10%) match, exclude.
+    """
+    if not sampled_values:
+        return None
+    if profile.mean_string_length is None and "Utf" not in profile.dtype:
+        # Sentinels only meaningful on string columns.
+        return None
+
+    hits: dict[str, int] = {}
+    total = 0
+    for v in sampled_values:
+        if v is None:
+            continue
+        sv = str(v).strip()
+        if not sv:
+            continue
+        total += 1
+        sv_lower = sv.lower()
+
+        # Generic string sentinels (case-insensitive exact).
+        if sv_lower in GENERIC_STRING_SENTINELS:
+            hits[sv] = hits.get(sv, 0) + 1
+            continue
+        # Phone-shaped (only-digits-with-separators).
+        digits_only = re.sub(r"[\s\-().+]", "", sv)
+        if digits_only and digits_only in PHONE_SENTINELS:
+            hits[sv] = hits.get(sv, 0) + 1
+            continue
+        if sv in PHONE_SENTINELS:
+            hits[sv] = hits.get(sv, 0) + 1
+            continue
+        # Email-shaped substring.
+        if "@" in sv_lower and any(p in sv_lower for p in EMAIL_SENTINEL_SUBSTRINGS):
+            hits[sv] = hits.get(sv, 0) + 1
+            continue
+        # Zip-shaped.
+        if sv in ZIP_SENTINELS:
+            hits[sv] = hits.get(sv, 0) + 1
+            continue
+
+    if total == 0:
+        return None
+    sentinel_count = sum(hits.values())
+    sentinel_rate = sentinel_count / total
+    if sentinel_rate < threshold:
+        return None
+
+    top_sentinels = sorted(hits.items(), key=lambda kv: -kv[1])[:5]
+    return ExcludedColumn(
+        column=column_name,
+        detector="sentinel_values",
+        reason=(
+            f"sentinel/placeholder values in {int(sentinel_rate * 100)}% "
+            "of records -- matching collapses these into spurious "
+            "mega-clusters"
+        ),
+        evidence={
+            "sentinel_rate": round(sentinel_rate, 3),
+            "top_sentinels": top_sentinels,
+            "sample_size": total,
+        },
+    )
+
+
+def detect_soft_delete_flag(
+    column_name: str,
+    sampled_values: list,
+    profile: ColumnProfile,
+) -> ExcludedColumn | None:
+    """Soft-delete / lifecycle flags. Name pattern + low cardinality
+    + small distinct count.
+    """
+    if not _LIFECYCLE_NAME_RE.match(column_name):
+        return None
+    # Threshold: distinct values <= 10 AND cardinality < 10% are both
+    # generous gates -- a real lifecycle column ('active'/'inactive',
+    # 'true'/'false', 'pending'/'active'/'deleted') has 2-5 distinct
+    # values regardless of dataset size. Anything more distinct under
+    # this name prefix is a custom column we shouldn't second-guess.
+    if profile.distinct_count > 10:
+        return None
+    if profile.cardinality_ratio >= 0.10:
+        return None
+    distinct_sample = list({str(v) for v in sampled_values if v is not None})[:5]
+    return ExcludedColumn(
+        column=column_name,
+        detector="soft_delete_flag",
+        reason="lifecycle/flag column (low cardinality, no identity signal)",
+        evidence={
+            "distinct_count": profile.distinct_count,
+            "distinct_sample": distinct_sample,
+            "cardinality_ratio": round(profile.cardinality_ratio, 4),
+        },
+    )
+
+
+def detect_free_text_notes(
+    column_name: str,
+    sampled_values: list,
+    profile: ColumnProfile,
+) -> ExcludedColumn | None:
+    """Free-text notes / comments. Name pattern + mean length > 50."""
+    if not _FREE_TEXT_NAME_RE.match(column_name):
+        return None
+    if profile.mean_string_length is None or profile.mean_string_length <= 50:
+        return None
+    return ExcludedColumn(
+        column=column_name,
+        detector="free_text_notes",
+        reason=(
+            "free-text notes column (high mean length, routes to fuzzy "
+            "text scoring with no precision signal)"
+        ),
+        evidence={
+            "mean_length": round(profile.mean_string_length, 1),
+        },
+    )
+
+
+def detect_system_hash(
+    column_name: str,
+    sampled_values: list,
+    profile: ColumnProfile,
+) -> ExcludedColumn | None:
+    """System-generated hash. Name pattern + cardinality > 0.99 + values
+    look like hex or base64.
+    """
+    if not _HASH_NAME_RE.search(column_name):
+        return None
+    if profile.cardinality_ratio < 0.99:
+        return None
+    if not sampled_values:
+        return None
+    # Check the first ~20 values for hex/base64 shape; cheap.
+    checks = [str(v) for v in sampled_values[:20] if v is not None]
+    if not checks:
+        return None
+    hex_hits = sum(1 for v in checks if _HEX_VALUE_RE.match(v))
+    b64_hits = sum(1 for v in checks if _BASE64_VALUE_RE.match(v))
+    # Require 75%+ of sampled values to match a hash shape.
+    if hex_hits / len(checks) < 0.75 and b64_hits / len(checks) < 0.75:
+        return None
+    shape = "hex" if hex_hits >= b64_hits else "base64"
+    return ExcludedColumn(
+        column=column_name,
+        detector="system_hash",
+        reason="system-generated hash/digest (unique but encodes no identity)",
+        evidence={
+            "cardinality_ratio": round(profile.cardinality_ratio, 3),
+            "value_shape": shape,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+# Detector order: specific patterns first, general patterns later.
+# A column matching multiple detectors keeps the first hit (the more
+# specific reason wins). Order matters for ambiguous columns like
+# ``created_at_external_id`` -- audit beats foreign-id here.
+_DETECTORS = [
+    detect_audit_column,
+    detect_system_hash,
+    detect_soft_delete_flag,
+    detect_free_text_notes,
+    detect_foreign_system_id,
+    detect_sentinel_values,
+]
+
+
+def _build_column_profile(
+    series: pl.Series,
+    total_rows: int,
+) -> ColumnProfile:
+    """Cheap stats for one column. O(rows) once per column; downstream
+    detectors operate on the profile + a 1000-row sample only.
+    """
+    null_count = int(series.null_count())
+    non_null = total_rows - null_count
+    distinct_count = int(series.n_unique())
+    cardinality_ratio = (distinct_count / non_null) if non_null > 0 else 0.0
+    null_rate = (null_count / total_rows) if total_rows > 0 else 0.0
+    dtype_str = str(series.dtype)
+    mean_string_length: float | None = None
+    if series.dtype == pl.Utf8:
+        try:
+            non_null_lengths = (
+                series.drop_nulls().str.len_chars().mean()
+            )
+            mean_string_length = (
+                float(non_null_lengths) if non_null_lengths is not None else None
+            )
+        except Exception:  # pragma: no cover - defensive
+            mean_string_length = None
+    return ColumnProfile(
+        cardinality_ratio=cardinality_ratio,
+        null_rate=null_rate,
+        distinct_count=distinct_count,
+        dtype=dtype_str,
+        mean_string_length=mean_string_length,
+    )
+
+
+def _sample_non_null_values(
+    series: pl.Series,
+    sample_size: int = 1000,
+) -> list:
+    """Sample up to ``sample_size`` non-null values. Deterministic head
+    sample (not random) so detector results are reproducible.
+    """
+    non_null = series.drop_nulls()
+    if non_null.len() <= sample_size:
+        return non_null.to_list()
+    return non_null.head(sample_size).to_list()
+
+
+def detect_autoconfig_exclusions(
+    df: pl.DataFrame,
+    *,
+    force_exclude: list[str] | None = None,
+    force_include: list[str] | None = None,
+    sample_size: int = 1000,
+    skip_columns: set[str] | None = None,
+) -> list[ExcludedColumn]:
+    """Run all 6 detectors over every column in ``df``. Returns the
+    final exclusion list after applying force-include/force-exclude
+    overrides.
+
+    Args:
+        df: DataFrame to inspect.
+        force_exclude: extra columns to mark excluded regardless of
+            detector output. Caller-supplied (e.g. from QualityConfig).
+        force_include: columns to rescue from any auto-detection.
+            ``force_include`` wins when it conflicts with
+            ``force_exclude``: the user explicitly opting back in
+            takes precedence over the user's prior exclude list.
+        sample_size: per-column sample cap for content detectors.
+        skip_columns: columns the orchestrator should not even scan
+            (e.g. internal ``__row_id__`` / ``__source__`` bookkeeping).
+            These never appear in the result regardless of detector
+            output; force_include cannot rescue them.
+
+    Returns:
+        list[ExcludedColumn] -- one entry per excluded column. Order
+        matches df.columns order so logs read top-to-bottom by schema.
+    """
+    force_exclude_set = set(force_exclude or [])
+    force_include_set = set(force_include or [])
+    skip_set = set(skip_columns or [])
+
+    total_rows = df.height
+    excluded: list[ExcludedColumn] = []
+    for col in df.columns:
+        if col in skip_set:
+            continue
+        if col in force_include_set:
+            # Explicit user opt-in beats every detector + force_exclude.
+            continue
+        if col in force_exclude_set:
+            excluded.append(ExcludedColumn(
+                column=col,
+                detector="user_force_exclude",
+                reason="caller-supplied force-exclude (config.quality.autoconfig_force_exclude)",
+                evidence={},
+            ))
+            continue
+
+        series = df[col]
+        profile = _build_column_profile(series, total_rows)
+        sampled = _sample_non_null_values(series, sample_size=sample_size)
+
+        for detector in _DETECTORS:
+            result = detector(col, sampled, profile)
+            if result is not None:
+                excluded.append(result)
+                break  # first detector wins; no double-exclusion
+
+    return excluded

--- a/packages/python/goldenmatch/tests/test_quality_exclusions.py
+++ b/packages/python/goldenmatch/tests/test_quality_exclusions.py
@@ -1,0 +1,431 @@
+"""Tests for the GoldenCheck auto-config exclusion detectors (#404).
+
+Spec: docs/superpowers/specs/2026-05-21-goldencheck-autoconfig-exclusions-design.md
+Plan: docs/superpowers/plans/2026-05-21-goldencheck-autoconfig-exclusions.md
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from goldenmatch.core.quality_exclusions import (
+    ColumnProfile,
+    ExcludedColumn,
+    detect_audit_column,
+    detect_autoconfig_exclusions,
+    detect_foreign_system_id,
+    detect_free_text_notes,
+    detect_sentinel_values,
+    detect_soft_delete_flag,
+    detect_system_hash,
+)
+
+
+def _profile(
+    *,
+    cardinality_ratio: float = 0.5,
+    null_rate: float = 0.0,
+    distinct_count: int = 50,
+    dtype: str = "Utf8",
+    mean_string_length: float | None = None,
+) -> ColumnProfile:
+    return ColumnProfile(
+        cardinality_ratio=cardinality_ratio,
+        null_rate=null_rate,
+        distinct_count=distinct_count,
+        dtype=dtype,
+        mean_string_length=mean_string_length,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dataclass shape
+# ---------------------------------------------------------------------------
+
+
+def test_excluded_column_is_immutable():
+    """ExcludedColumn is frozen so it can be hashed / cached without
+    defensive copying."""
+    ec = ExcludedColumn(
+        column="x", detector="audit_column",
+        reason="...", evidence={},
+    )
+    with pytest.raises((AttributeError, Exception)):
+        ec.column = "y"  # type: ignore[misc]
+
+
+def test_column_profile_is_immutable():
+    """ColumnProfile is the cheap stats struct; frozen so detectors
+    can't mutate it mid-run."""
+    p = _profile()
+    with pytest.raises((AttributeError, Exception)):
+        p.cardinality_ratio = 0.99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Detector 1: audit_column
+# ---------------------------------------------------------------------------
+
+
+def test_audit_column_excludes_created_at_with_high_cardinality():
+    profile = _profile(
+        dtype="Datetime(time_unit='us', time_zone=None)",
+        cardinality_ratio=0.91,
+    )
+    result = detect_audit_column("created_at", [], profile)
+    assert result is not None
+    assert result.detector == "audit_column"
+    assert "audit timestamp" in result.reason
+
+
+def test_audit_column_excludes_event_at_suffix_pattern():
+    profile = _profile(
+        dtype="Datetime(time_unit='us', time_zone=None)",
+        cardinality_ratio=0.88,
+    )
+    result = detect_audit_column("event_at", [], profile)
+    assert result is not None
+    assert result.detector == "audit_column"
+
+
+def test_audit_column_passes_random_string_field():
+    profile = _profile(dtype="Utf8", cardinality_ratio=0.5)
+    assert detect_audit_column("first_name", [], profile) is None
+
+
+# ---------------------------------------------------------------------------
+# Detector 2: foreign_system_id
+# ---------------------------------------------------------------------------
+
+
+def test_foreign_system_id_excludes_external_id_high_cardinality():
+    profile = _profile(cardinality_ratio=0.99, distinct_count=990)
+    result = detect_foreign_system_id("external_id", [], profile)
+    assert result is not None
+    assert result.detector == "foreign_system_id"
+    assert "per-source" in result.reason
+
+
+def test_foreign_system_id_excludes_record_uuid_suffix():
+    profile = _profile(cardinality_ratio=0.99)
+    result = detect_foreign_system_id("record_uuid", [], profile)
+    assert result is not None
+
+
+def test_foreign_system_id_passes_low_cardinality_id_field():
+    # `customer_id` with cardinality 0.5 is NOT a foreign-system ID.
+    # Detector requires name pattern AND high cardinality.
+    profile = _profile(cardinality_ratio=0.5)
+    assert detect_foreign_system_id("customer_id", [], profile) is None
+
+
+# ---------------------------------------------------------------------------
+# Detector 3: sentinel_values (THE #1 poison)
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_values_excludes_phone_column_with_30_pct_zeros():
+    """Phone column with 30% sentinel values must be excluded."""
+    sampled = ["555-1234"] * 70 + ["0000000000"] * 30
+    profile = _profile(dtype="Utf8", mean_string_length=10)
+    result = detect_sentinel_values("phone", sampled, profile)
+    assert result is not None
+    assert result.detector == "sentinel_values"
+    assert "30%" in result.reason
+    assert result.evidence["sentinel_rate"] == pytest.approx(0.30, abs=0.01)
+
+
+def test_sentinel_values_excludes_email_with_noreply_substring():
+    sampled = ["alice@example.org"] * 60 + ["noreply@example.com"] * 40
+    profile = _profile(dtype="Utf8", mean_string_length=20)
+    result = detect_sentinel_values("email", sampled, profile)
+    assert result is not None
+    # @example.com hits the substring sentinel for ALL example.org +
+    # all noreply rows -- the detector must catch at least the 40%
+    # noreply rate.
+    assert result.evidence["sentinel_rate"] >= 0.40
+
+
+def test_sentinel_values_excludes_string_unknown_sentinels():
+    sampled = ["Alice", "Bob", "Carol"] * 30 + ["Unknown"] * 20 + ["N/A"] * 5
+    profile = _profile(dtype="Utf8", mean_string_length=5)
+    result = detect_sentinel_values("first_name", sampled, profile)
+    assert result is not None
+    # 25 / (90 + 25) = ~21.7%
+    assert result.evidence["sentinel_rate"] >= 0.20
+
+
+def test_sentinel_values_passes_clean_column_under_threshold():
+    """5% sentinel rate is below the 10% threshold -- emit no
+    exclusion (might still be a WARN-level Finding but not an
+    auto-config exclusion)."""
+    sampled = ["alice@example.org"] * 95 + ["noemail@example.com"] * 5
+    profile = _profile(dtype="Utf8", mean_string_length=20)
+    result = detect_sentinel_values("email", sampled, profile)
+    # @example.com substring matches everyone -- so the test setup
+    # actually has high sentinel rate. Use a different clean fixture.
+    sampled_clean = [f"alice{i}@company.com" for i in range(95)] + ["test@test.com"] * 5
+    result_clean = detect_sentinel_values("email", sampled_clean, profile)
+    assert result_clean is None, (
+        "5% sentinel rate (test@test.com substring) under 10% threshold "
+        "must not produce an exclusion"
+    )
+
+
+def test_sentinel_values_passes_non_string_column():
+    """Sentinels are a string-column concept. Integer / float columns
+    are not the target."""
+    profile = _profile(dtype="Int64", mean_string_length=None)
+    assert detect_sentinel_values(
+        "age", [25, 30, 35, 40], profile,
+    ) is None
+
+
+# ---------------------------------------------------------------------------
+# Detector 4: soft_delete_flag
+# ---------------------------------------------------------------------------
+
+
+def test_soft_delete_flag_excludes_is_active_boolean():
+    profile = _profile(
+        cardinality_ratio=0.0001,
+        distinct_count=2,
+        dtype="Boolean",
+    )
+    result = detect_soft_delete_flag(
+        "is_active", [True, False, True, True], profile,
+    )
+    assert result is not None
+    assert result.detector == "soft_delete_flag"
+
+
+def test_soft_delete_flag_excludes_status_low_cardinality():
+    profile = _profile(
+        cardinality_ratio=0.0005,
+        distinct_count=4,
+        dtype="Utf8",
+        mean_string_length=8,
+    )
+    sampled = ["active"] * 50 + ["inactive"] * 30 + ["pending"] * 20 + ["deleted"] * 5
+    result = detect_soft_delete_flag("status", sampled, profile)
+    assert result is not None
+
+
+def test_soft_delete_flag_passes_high_cardinality_status():
+    """A 'status' column with thousands of distinct values isn't a
+    lifecycle flag -- it's something custom."""
+    profile = _profile(cardinality_ratio=0.5, distinct_count=5000)
+    assert detect_soft_delete_flag("status", [], profile) is None
+
+
+# ---------------------------------------------------------------------------
+# Detector 5: free_text_notes
+# ---------------------------------------------------------------------------
+
+
+def test_free_text_notes_excludes_long_description():
+    profile = _profile(dtype="Utf8", mean_string_length=187)
+    result = detect_free_text_notes("description", [], profile)
+    assert result is not None
+    assert result.detector == "free_text_notes"
+
+
+def test_free_text_notes_excludes_customer_comments_suffix():
+    profile = _profile(dtype="Utf8", mean_string_length=80)
+    result = detect_free_text_notes("customer_comments", [], profile)
+    assert result is not None
+
+
+def test_free_text_notes_passes_short_label_field():
+    """A 'notes' column with mean length 8 is just a label, not free
+    text."""
+    profile = _profile(dtype="Utf8", mean_string_length=8)
+    assert detect_free_text_notes("notes", [], profile) is None
+
+
+# ---------------------------------------------------------------------------
+# Detector 6: system_hash
+# ---------------------------------------------------------------------------
+
+
+def test_system_hash_excludes_record_hash_with_hex_values():
+    sampled = ["a3f5b9c2d4e6f7a8b1c2d3e4f5a6b7c8"] * 20  # 32-hex
+    profile = _profile(cardinality_ratio=1.0, dtype="Utf8")
+    result = detect_system_hash("record_hash", sampled, profile)
+    assert result is not None
+    assert result.detector == "system_hash"
+    assert result.evidence["value_shape"] == "hex"
+
+
+def test_system_hash_excludes_checksum_short_form():
+    sampled = ["a3f5b9c2d4e6f7a8"] * 20  # 16-hex
+    profile = _profile(cardinality_ratio=1.0, dtype="Utf8")
+    result = detect_system_hash("file_checksum", sampled, profile)
+    assert result is not None
+
+
+def test_system_hash_passes_low_cardinality_column():
+    """A 'hash' column with cardinality 0.5 isn't a hash -- it's some
+    other category."""
+    profile = _profile(cardinality_ratio=0.5)
+    assert detect_system_hash("hash_bucket", ["a"] * 20, profile) is None
+
+
+def test_system_hash_passes_name_match_but_non_hex_values():
+    """Column named 'fingerprint' with plain text values isn't a hash."""
+    sampled = ["alice smith"] * 20
+    profile = _profile(cardinality_ratio=1.0, dtype="Utf8")
+    assert detect_system_hash("fingerprint", sampled, profile) is None
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def _all_six_poisoned_df() -> pl.DataFrame:
+    """A synthetic frame with exactly one poisoned column per detector
+    plus one clean identity column. The clean column must NOT be
+    excluded; the six poisoned ones must each fire their respective
+    detector."""
+    n = 100
+    import datetime
+    return pl.DataFrame({
+        # Clean identity column -- must NOT be excluded.
+        "first_name": [f"name_{i}" for i in range(n)],
+        # 1. audit_column
+        "created_at": [
+            datetime.datetime(2026, 1, 1) + datetime.timedelta(seconds=i)
+            for i in range(n)
+        ],
+        # 2. foreign_system_id
+        "external_id": [f"ext_{i:08d}" for i in range(n)],
+        # 3. sentinel_values (40% zeros, well above 10%)
+        "phone": ["555-1234"] * 60 + ["0000000000"] * 40,
+        # 4. soft_delete_flag
+        "is_active": [True] * 70 + [False] * 30,
+        # 5. free_text_notes
+        "description": ["a" * 100 for _ in range(n)],
+        # 6. system_hash
+        "record_hash": [f"{i:032x}" for i in range(n)],
+    })
+
+
+def test_orchestrator_excludes_all_six_categories_on_poisoned_frame():
+    """End-to-end: a frame with one column per poisoned category
+    produces exactly six exclusions, one per detector."""
+    df = _all_six_poisoned_df()
+    excluded = detect_autoconfig_exclusions(df)
+    excluded_cols = {ec.column for ec in excluded}
+
+    assert "first_name" not in excluded_cols, "clean column must NOT be excluded"
+
+    expected_pairs = {
+        "created_at": "audit_column",
+        "external_id": "foreign_system_id",
+        "phone": "sentinel_values",
+        "is_active": "soft_delete_flag",
+        "description": "free_text_notes",
+        "record_hash": "system_hash",
+    }
+    for col, expected_detector in expected_pairs.items():
+        matches = [ec for ec in excluded if ec.column == col]
+        assert len(matches) == 1, f"{col} should be excluded exactly once"
+        assert matches[0].detector == expected_detector, (
+            f"{col}: expected detector={expected_detector}, "
+            f"got {matches[0].detector}"
+        )
+
+
+def test_orchestrator_returns_empty_for_clean_dataset():
+    """A pristine person-shaped frame produces no exclusions."""
+    df = pl.DataFrame({
+        "first_name": ["Alice", "Bob", "Carol"],
+        "last_name": ["Smith", "Jones", "Doe"],
+        "city": ["NYC", "LA", "SF"],
+    })
+    assert detect_autoconfig_exclusions(df) == []
+
+
+def test_orchestrator_force_exclude_adds_extra_columns():
+    """Caller-supplied force_exclude shows up as exclusions with the
+    user_force_exclude detector tag."""
+    df = pl.DataFrame({
+        "first_name": ["Alice", "Bob"],
+        "internal_only_col": ["x", "y"],
+    })
+    excluded = detect_autoconfig_exclusions(
+        df, force_exclude=["internal_only_col"],
+    )
+    assert len(excluded) == 1
+    assert excluded[0].column == "internal_only_col"
+    assert excluded[0].detector == "user_force_exclude"
+
+
+def test_orchestrator_force_include_rescues_auto_detected_exclusion():
+    """force_include wins over auto-detection. Pattern: a legitimate
+    'email_hash' column for PPRL where the hash IS the identifier --
+    the user opts back in."""
+    df = pl.DataFrame({
+        "email_hash": [f"{i:032x}" for i in range(100)],
+        "first_name": [f"n{i}" for i in range(100)],
+    })
+    # Without rescue, email_hash gets the system_hash exclusion.
+    auto = detect_autoconfig_exclusions(df)
+    assert any(ec.column == "email_hash" for ec in auto)
+
+    # With rescue, it disappears from the list entirely.
+    with_rescue = detect_autoconfig_exclusions(
+        df, force_include=["email_hash"],
+    )
+    assert all(ec.column != "email_hash" for ec in with_rescue)
+
+
+def test_orchestrator_force_include_overrides_force_exclude():
+    """When the caller passes a column in BOTH force_exclude and
+    force_include, force_include wins. Lets user configs override an
+    inherited dataset-level exclusion."""
+    df = pl.DataFrame({"some_col": ["a", "b", "c"]})
+    excluded = detect_autoconfig_exclusions(
+        df,
+        force_exclude=["some_col"],
+        force_include=["some_col"],
+    )
+    assert excluded == []
+
+
+def test_orchestrator_skip_columns_never_appear_in_output():
+    """Internal bookkeeping columns (__row_id__, __source__) shouldn't
+    even be inspected. skip_columns is a stronger guarantee than
+    force_include: skipped columns cannot show up regardless of any
+    detector firing."""
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "__source__": ["x"] * 4,
+        "first_name": ["Alice", "Bob", "Carol", "Dave"],
+    })
+    excluded = detect_autoconfig_exclusions(
+        df, skip_columns={"__row_id__", "__source__"},
+    )
+    assert all(ec.column not in {"__row_id__", "__source__"} for ec in excluded)
+
+
+def test_orchestrator_each_column_excluded_at_most_once():
+    """First-detector-wins: a column can match multiple detectors by
+    name pattern (e.g. ``is_deleted_at`` matches lifecycle AND audit
+    suffix), but the orchestrator only emits one ExcludedColumn per
+    column. The 6-categories test above already proves each detector
+    fires for the right column; this test just locks in that no
+    column gets double-excluded under the first-wins rule."""
+    df = _all_six_poisoned_df()
+    excluded = detect_autoconfig_exclusions(df)
+    columns_in_output = [ec.column for ec in excluded]
+    assert len(columns_in_output) == len(set(columns_in_output)), (
+        "each column must appear at most once in the exclusion list; "
+        f"got duplicates in {columns_in_output}"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_quality_exclusions.py
+++ b/packages/python/goldenmatch/tests/test_quality_exclusions.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import polars as pl
 import pytest
-
 from goldenmatch.core.quality_exclusions import (
     ColumnProfile,
     ExcludedColumn,
@@ -160,11 +159,9 @@ def test_sentinel_values_passes_clean_column_under_threshold():
     """5% sentinel rate is below the 10% threshold -- emit no
     exclusion (might still be a WARN-level Finding but not an
     auto-config exclusion)."""
-    sampled = ["alice@example.org"] * 95 + ["noemail@example.com"] * 5
     profile = _profile(dtype="Utf8", mean_string_length=20)
-    result = detect_sentinel_values("email", sampled, profile)
-    # @example.com substring matches everyone -- so the test setup
-    # actually has high sentinel rate. Use a different clean fixture.
+    # @example.com substring would match all "alice@example.org" rows
+    # too -- pick a fixture that genuinely has only 5% sentinel rate.
     sampled_clean = [f"alice{i}@company.com" for i in range(95)] + ["test@test.com"] * 5
     result_clean = detect_sentinel_values("email", sampled_clean, profile)
     assert result_clean is None, (

--- a/packages/python/goldenmatch/tests/test_quality_exclusions_cli.py
+++ b/packages/python/goldenmatch/tests/test_quality_exclusions_cli.py
@@ -1,0 +1,67 @@
+"""Tests for the --exclusions CLI flag (#404, plan step 9)."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.cli.main import app
+from typer.testing import CliRunner
+
+
+@pytest.fixture
+def poisoned_csv(tmp_path):
+    """Write a small CSV with two poisoned columns + clean identity cols."""
+    df = pl.DataFrame({
+        "first_name": [f"name_{i}" for i in range(50)],
+        "last_name": [f"smith_{i % 5}" for i in range(50)],
+        "external_id": [f"ext_{i:08d}" for i in range(50)],     # foreign_system_id
+        "record_hash": [f"{i:032x}" for i in range(50)],         # system_hash
+    })
+    path = tmp_path / "poisoned.csv"
+    df.write_csv(path)
+    return path
+
+
+def test_profile_exclusions_flag_lists_auto_excluded_columns(poisoned_csv):
+    """`goldenmatch profile FILE --exclusions` prints the exclusion list
+    so users can see what auto-config will skip without running a full
+    sync."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["profile", str(poisoned_csv), "--exclusions"])
+    assert result.exit_code == 0, result.output
+
+    assert "Auto-config exclusions" in result.output
+    assert "external_id" in result.output
+    assert "foreign_system_id" in result.output
+    assert "record_hash" in result.output
+    assert "system_hash" in result.output
+
+
+def test_profile_without_exclusions_flag_omits_section(poisoned_csv):
+    """Default `goldenmatch profile FILE` does NOT print the exclusion
+    section -- only when --exclusions is passed."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["profile", str(poisoned_csv)])
+    assert result.exit_code == 0, result.output
+    assert "Auto-config exclusions" not in result.output
+
+
+def test_profile_exclusions_flag_shows_friendly_message_for_clean_data(tmp_path):
+    """Clean dataset with no poisoned columns -> 'No columns excluded'
+    message instead of an empty exclusion list."""
+    df = pl.DataFrame({
+        "first_name": ["Alice", "Bob", "Carol"] * 10,
+        "last_name": ["Smith", "Jones", "Doe"] * 10,
+        "city": ["NYC", "LA", "SF"] * 10,
+    })
+    path = tmp_path / "clean.csv"
+    df.write_csv(path)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["profile", str(path), "--exclusions"])
+    assert result.exit_code == 0, result.output
+    assert "No columns excluded" in result.output
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_quality_exclusions_integration.py
+++ b/packages/python/goldenmatch/tests/test_quality_exclusions_integration.py
@@ -1,0 +1,191 @@
+"""Integration tests for #404: auto_configure_df honors the exclusion
+list from `detect_autoconfig_exclusions`.
+
+The foundation PR has unit tests for the detectors. This file proves
+the user-visible behavior change: poisoned columns are filtered out
+of the config auto-config returns.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import polars as pl
+import pytest
+
+
+def _poisoned_person_df(n: int = 100) -> pl.DataFrame:
+    """A person-shaped frame with several intentionally poisoned
+    columns. Auto-config should pick name/city, not external_id /
+    created_at / record_hash etc.
+    """
+    return pl.DataFrame({
+        "first_name": [f"name_{i}" for i in range(n)],
+        "last_name": [f"smith_{i % 10}" for i in range(n)],
+        "city": ["NYC", "LA", "SF", "Boston", "Seattle"] * (n // 5),
+        # ---- poisoned columns below ----
+        "external_id": [f"ext_{i:08d}" for i in range(n)],  # foreign_system_id
+        "created_at": [
+            datetime.datetime(2026, 1, 1) + datetime.timedelta(seconds=i)
+            for i in range(n)
+        ],  # audit_column
+        "record_hash": [f"{i:032x}" for i in range(n)],  # system_hash
+    })
+
+
+def _all_matchkey_field_names(config) -> set[str]:
+    """Walk the committed config and collect every column name
+    referenced in any matchkey field. Lets us assert "X is not in any
+    matchkey" without caring about the matchkey shape."""
+    referenced: set[str] = set()
+    matchkeys = config.get_matchkeys() if hasattr(config, "get_matchkeys") else []
+    for mk in matchkeys:
+        if getattr(mk, "field", None):
+            referenced.add(mk.field)
+        for f in (getattr(mk, "fields", None) or []):
+            if getattr(f, "field", None):
+                referenced.add(f.field)
+    return referenced
+
+
+def _all_blocking_field_names(config) -> set[str]:
+    """Walk blocking config and collect every column name referenced."""
+    referenced: set[str] = set()
+    if not config.blocking or not config.blocking.keys:
+        return referenced
+    for key in config.blocking.keys:
+        for f in (getattr(key, "fields", None) or []):
+            referenced.add(f)
+    return referenced
+
+
+def test_autoconfig_committed_config_skips_poisoned_columns():
+    """End-to-end: auto_configure_df on a poisoned person frame returns
+    a committed config that does NOT reference external_id, created_at,
+    or record_hash in any matchkey or blocking key.
+
+    Pins #404's user-visible behavior. If a future regression makes
+    auto-config pick a poisoned column again, this fails loudly.
+    """
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    df = _poisoned_person_df(n=200)
+    config = auto_configure_df(df, confidence_required=False, _skip_finalize=True)
+
+    matchkey_cols = _all_matchkey_field_names(config)
+    blocking_cols = _all_blocking_field_names(config)
+    all_referenced = matchkey_cols | blocking_cols
+
+    for poisoned_col in ["external_id", "created_at", "record_hash"]:
+        assert poisoned_col not in all_referenced, (
+            f"{poisoned_col!r} was excluded but auto-config still "
+            f"referenced it. matchkeys={matchkey_cols}, "
+            f"blocking={blocking_cols}. See #404."
+        )
+
+
+def test_autoconfig_exclusions_logged_at_info_level(caplog):
+    """Every exclusion logs at INFO with the detector + reason so the
+    user can see what was filtered without inspecting the postflight
+    report."""
+    import logging
+
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    df = _poisoned_person_df(n=100)
+    with caplog.at_level(logging.INFO, logger="goldenmatch.core.autoconfig"):
+        auto_configure_df(df, confidence_required=False, _skip_finalize=True)
+
+    log_messages = [r.getMessage() for r in caplog.records]
+    exclusion_logs = [m for m in log_messages if "Auto-config exclusion" in m]
+    # Three poisoned columns -> three exclusion log lines.
+    assert len(exclusion_logs) >= 3, (
+        f"expected at least 3 exclusion log lines, got {len(exclusion_logs)}: "
+        f"{exclusion_logs}"
+    )
+    # Each detector name should appear in at least one log line.
+    joined = "\n".join(exclusion_logs)
+    for detector in ["audit_column", "foreign_system_id", "system_hash"]:
+        assert detector in joined, f"detector={detector} not in logs:\n{joined}"
+
+
+def test_autoconfig_exclusions_populates_context_var():
+    """PostflightReport reads _LAST_AUTOCONFIG_EXCLUSIONS to render
+    the audit trail. Assert it gets populated after a run."""
+    from goldenmatch.core.autoconfig import (
+        _LAST_AUTOCONFIG_EXCLUSIONS,
+        auto_configure_df,
+    )
+
+    df = _poisoned_person_df(n=100)
+    auto_configure_df(df, confidence_required=False, _skip_finalize=True)
+
+    exclusions = _LAST_AUTOCONFIG_EXCLUSIONS.get()
+    assert exclusions is not None
+    excluded_cols = {ec.column for ec in exclusions}
+    assert "external_id" in excluded_cols
+    assert "created_at" in excluded_cols
+    assert "record_hash" in excluded_cols
+
+
+def test_force_include_via_env_var_rescues_column(monkeypatch):
+    """`GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE=record_hash` rescues
+    a column from auto-detection. Pattern: legitimate `email_hash` for
+    PPRL where the hash IS the identifier."""
+    from goldenmatch.core.autoconfig import (
+        _LAST_AUTOCONFIG_EXCLUSIONS,
+        auto_configure_df,
+    )
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE", "record_hash")
+
+    df = _poisoned_person_df(n=100)
+    auto_configure_df(df, confidence_required=False, _skip_finalize=True)
+
+    exclusions = _LAST_AUTOCONFIG_EXCLUSIONS.get() or []
+    excluded_cols = {ec.column for ec in exclusions}
+    # external_id and created_at still excluded (other detectors fired).
+    assert "external_id" in excluded_cols
+    assert "created_at" in excluded_cols
+    # record_hash was rescued.
+    assert "record_hash" not in excluded_cols
+
+
+def test_force_exclude_via_env_var_adds_extra_column(monkeypatch):
+    """`GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE=city` excludes a column
+    the detectors wouldn't catch on their own."""
+    from goldenmatch.core.autoconfig import (
+        _LAST_AUTOCONFIG_EXCLUSIONS,
+        auto_configure_df,
+    )
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE", "city")
+
+    df = _poisoned_person_df(n=100)
+    auto_configure_df(df, confidence_required=False, _skip_finalize=True)
+
+    exclusions = _LAST_AUTOCONFIG_EXCLUSIONS.get() or []
+    excluded = {ec.column: ec.detector for ec in exclusions}
+    assert excluded.get("city") == "user_force_exclude"
+
+
+def test_clean_dataframe_produces_no_exclusions():
+    """A clean person frame produces an empty exclusion list."""
+    from goldenmatch.core.autoconfig import (
+        _LAST_AUTOCONFIG_EXCLUSIONS,
+        auto_configure_df,
+    )
+
+    df = pl.DataFrame({
+        "first_name": ["Alice", "Bob", "Carol", "Dave", "Eve"] * 20,
+        "last_name": ["Smith", "Jones", "Doe", "White", "Black"] * 20,
+        "city": ["NYC", "LA", "SF", "Boston", "Seattle"] * 20,
+    })
+    auto_configure_df(df, confidence_required=False, _skip_finalize=True)
+
+    exclusions = _LAST_AUTOCONFIG_EXCLUSIONS.get()
+    assert exclusions == []
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_quality_exclusions_postflight.py
+++ b/packages/python/goldenmatch/tests/test_quality_exclusions_postflight.py
@@ -1,0 +1,200 @@
+"""Tests for the postflight surface + real-world fixtures (#404).
+
+Step 7: PostflightReport renders the exclusion list as a separate
+section.
+
+Step 8: real-world-shaped fixtures (NCVR-style with audit columns,
+CRM-style with external_id + lifecycle + hash, clinical-style with
+sentinel phone + free-text notes) prove the detectors land the
+expected exclusions.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import polars as pl
+import pytest
+from goldenmatch.core.autoconfig_verify import PostflightReport
+from goldenmatch.core.quality_exclusions import ExcludedColumn
+
+# ---------------------------------------------------------------------------
+# Step 7: PostflightReport rendering
+# ---------------------------------------------------------------------------
+
+
+def test_postflight_renders_exclusion_section_when_non_empty():
+    """When autoconfig_exclusions is non-empty, __str__ includes an
+    'auto-config exclusions:' section with one line per exclusion."""
+    pf = PostflightReport()
+    pf.autoconfig_exclusions = [
+        ExcludedColumn(
+            column="created_at",
+            detector="audit_column",
+            reason="audit timestamp column (high cardinality, no identity signal)",
+            evidence={},
+        ),
+        ExcludedColumn(
+            column="phone",
+            detector="sentinel_values",
+            reason="sentinel/placeholder values in 23% of records",
+            evidence={},
+        ),
+    ]
+    rendered = str(pf)
+    assert "auto-config exclusions:" in rendered
+    assert "'created_at': audit_column" in rendered
+    assert "'phone': sentinel_values" in rendered
+    assert "audit timestamp" in rendered
+    assert "23% of records" in rendered
+
+
+def test_postflight_omits_exclusion_section_when_empty():
+    """Clean datasets shouldn't render an empty 'auto-config
+    exclusions:' header."""
+    pf = PostflightReport()
+    assert pf.autoconfig_exclusions == []
+    rendered = str(pf)
+    assert "auto-config exclusions:" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Step 7 (E2E): exclusions flow from auto_configure_df -> dedupe_df ->
+# DedupeResult.postflight_report
+# ---------------------------------------------------------------------------
+
+
+def test_dedupe_df_postflight_surfaces_exclusions_end_to_end():
+    """The user-visible audit trail: run a poisoned df through
+    dedupe_df, inspect result.postflight_report.autoconfig_exclusions."""
+    import goldenmatch
+
+    df = pl.DataFrame({
+        "first_name": [f"name_{i}" for i in range(100)],
+        "last_name": [f"smith_{i % 10}" for i in range(100)],
+        "external_id": [f"ext_{i:08d}" for i in range(100)],  # foreign_system_id
+        "created_at": [
+            datetime.datetime(2026, 1, 1) + datetime.timedelta(seconds=i)
+            for i in range(100)
+        ],  # audit_column
+    })
+
+    result = goldenmatch.dedupe_df(df, confidence_required=False)
+    pf = result.postflight_report
+    assert pf is not None, "postflight report must be populated on zero-config path"
+    assert pf.autoconfig_exclusions, "expected exclusions on poisoned df"
+    excluded_cols = {ec.column for ec in pf.autoconfig_exclusions}
+    assert "external_id" in excluded_cols
+    assert "created_at" in excluded_cols
+
+
+# ---------------------------------------------------------------------------
+# Step 8: real-world-shaped fixtures
+# ---------------------------------------------------------------------------
+
+
+def _ncvr_style_fixture(n: int = 100) -> pl.DataFrame:
+    """NC voter-registration-shaped data: name + dob + audit timestamps.
+    The audit columns must be excluded; everything else stays."""
+    return pl.DataFrame({
+        "first_name": [f"FirstName_{i}" for i in range(n)],
+        "last_name": [f"LastName_{i % 25}" for i in range(n)],
+        "birth_year": [1950 + (i % 70) for i in range(n)],
+        "zip_code": [f"{27000 + (i % 50):05d}" for i in range(n)],
+        "created_at": [
+            datetime.datetime(2024, 1, 1) + datetime.timedelta(seconds=i)
+            for i in range(n)
+        ],
+        "updated_at": [
+            datetime.datetime(2026, 1, 1) + datetime.timedelta(seconds=i)
+            for i in range(n)
+        ],
+    })
+
+
+def _crm_style_fixture(n: int = 100) -> pl.DataFrame:
+    """CRM-shaped data: name + email + external_id + lifecycle + hash.
+    external_id, is_active, record_hash should all be excluded."""
+    return pl.DataFrame({
+        "name": [f"customer_{i}" for i in range(n)],
+        "email": [f"customer{i}@company.com" for i in range(n)],
+        "external_id": [f"CRM-{i:010d}" for i in range(n)],
+        "is_active": [i % 5 != 0 for i in range(n)],
+        "record_hash": [f"{i:032x}" for i in range(n)],
+    })
+
+
+def _clinical_style_fixture(n: int = 100) -> pl.DataFrame:
+    """Clinical-shaped data: patient name + dob + phone (40% sentinel)
+    + free-text notes. Phone and notes should be excluded."""
+    phones = ["555-1234"] * 60 + ["0000000000"] * 40
+    return pl.DataFrame({
+        "patient_name": [f"Patient_{i}" for i in range(n)],
+        "dob": [
+            datetime.date(1950, 1, 1) + datetime.timedelta(days=i * 100)
+            for i in range(n)
+        ],
+        "phone": phones,
+        "notes": [
+            "a" * 150  # long free text
+            for _ in range(n)
+        ],
+    })
+
+
+def test_ncvr_style_excludes_audit_columns():
+    """NCVR fixture: created_at + updated_at are audit columns; first/
+    last_name + birth_year + zip_code stay."""
+    from goldenmatch.core.quality_exclusions import detect_autoconfig_exclusions
+
+    df = _ncvr_style_fixture()
+    excluded = detect_autoconfig_exclusions(df)
+    excluded_pairs = {(ec.column, ec.detector) for ec in excluded}
+
+    assert ("created_at", "audit_column") in excluded_pairs
+    assert ("updated_at", "audit_column") in excluded_pairs
+    # Identity columns must NOT be excluded.
+    excluded_cols = {ec.column for ec in excluded}
+    for kept in ["first_name", "last_name", "birth_year", "zip_code"]:
+        assert kept not in excluded_cols, (
+            f"{kept!r} must NOT be excluded -- it's the actual identity signal"
+        )
+
+
+def test_crm_style_excludes_external_id_lifecycle_hash():
+    """CRM fixture: external_id + is_active + record_hash must all
+    be excluded; name + email stay."""
+    from goldenmatch.core.quality_exclusions import detect_autoconfig_exclusions
+
+    df = _crm_style_fixture()
+    excluded = detect_autoconfig_exclusions(df)
+    excluded_pairs = {(ec.column, ec.detector) for ec in excluded}
+
+    assert ("external_id", "foreign_system_id") in excluded_pairs
+    assert ("is_active", "soft_delete_flag") in excluded_pairs
+    assert ("record_hash", "system_hash") in excluded_pairs
+
+    excluded_cols = {ec.column for ec in excluded}
+    for kept in ["name", "email"]:
+        assert kept not in excluded_cols
+
+
+def test_clinical_style_excludes_sentinel_phone_and_free_text_notes():
+    """Clinical fixture: phone (40% sentinel) + notes (long free text)
+    must be excluded; patient_name + dob stay."""
+    from goldenmatch.core.quality_exclusions import detect_autoconfig_exclusions
+
+    df = _clinical_style_fixture()
+    excluded = detect_autoconfig_exclusions(df)
+    excluded_pairs = {(ec.column, ec.detector) for ec in excluded}
+
+    assert ("phone", "sentinel_values") in excluded_pairs
+    assert ("notes", "free_text_notes") in excluded_pairs
+
+    excluded_cols = {ec.column for ec in excluded}
+    for kept in ["patient_name", "dob"]:
+        assert kept not in excluded_cols
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements the full 9-step plan for #404. Auto-config now skips columns that are statistically attractive but counter-productive for matching: audit timestamps, foreign-system IDs, sentinel/placeholder values, soft-delete flags, free-text notes, and system hashes.

User-visible change: a 1.13M-row sync against a CRM-style table that previously picked `external_id` as a matchkey (and produced zero useful matches) now excludes `external_id` + `is_active` + `record_hash` and matches on `name` + `email` instead.

Closes #404.

## What's in this PR

**Foundation** (Steps 1-3)
- `core/quality_exclusions.py`: 6 pure-function detectors, `ExcludedColumn` + `ColumnProfile` frozen dataclasses, `detect_autoconfig_exclusions` orchestrator.
- 30 unit tests pinning each detector + orchestrator behaviour.

**Integration** (Steps 4-6)
- `auto_configure_df` runs the detectors at the top, drops excluded columns from the candidate pool BEFORE the controller starts, stashes the list on `_LAST_AUTOCONFIG_EXCLUSIONS` ContextVar.
- `QualityConfig.autoconfig_force_{exclude,include}` schema fields (V2 will thread these through dedupe_df).
- V1 override via env vars: `GOLDENMATCH_AUTOCONFIG_FORCE_{EXCLUDE,INCLUDE}=col1,col2,col3`.
- 6 integration tests covering exclusion logging, ContextVar population, force-include rescue, force-exclude addition, clean-dataframe baseline.

**Postflight + Fixtures** (Steps 7-8)
- `PostflightReport.autoconfig_exclusions` field renders an audit trail.
- `DedupeResult.postflight_report.autoconfig_exclusions` flows end-to-end from `dedupe_df`.
- Three real-world-shaped fixtures (NCVR / CRM / clinical) pinning the expected exclusion sets.
- 6 tests.

**CLI** (Step 9)
- `goldenmatch profile FILE --exclusions` prints the exclusion list with Rich formatting. Friendly message for clean data.
- 3 tests.

## Detectors

| # | Detector | Signal |
|---|---|---|
| 1 | `audit_column` | Name pattern (`created_at`, `event_at`, ...) + datetime dtype OR cardinality > 0.5 |
| 2 | `foreign_system_id` | Name pattern (`external_id`, `record_uuid`, ...) + cardinality > 0.95 |
| 3 | `sentinel_values` | > 10% sentinel rate on sampled values (the #1 real-world poison) |
| 4 | `soft_delete_flag` | Name pattern (`is_active`, `status`, ...) + distinct ≤ 10 + cardinality < 0.1 |
| 5 | `free_text_notes` | Name pattern (`description`, `memo`, ...) + mean string length > 50 |
| 6 | `system_hash` | Name pattern (`record_hash`, `checksum`, ...) + cardinality > 0.99 + hex/base64 shape |

## Test plan

- [x] 45 tests in 4 files (foundation 30 + integration 6 + postflight 6 + CLI 3).
- [x] 97/97 across exclusions + autoconfig regression + pipeline + sync regression + sync streaming.
- [x] `uv run ruff check` clean.

## Spec / Plan

Local-only at:
- `docs/superpowers/specs/2026-05-21-goldencheck-autoconfig-exclusions-design.md`
- `docs/superpowers/plans/2026-05-21-goldencheck-autoconfig-exclusions.md`