### PR TITLE
feat: unified column exclusions for GoldenFlow + GoldenMatch

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -319,6 +319,7 @@ def dedupe_df(
     backend: str | None = None,
     source_name: str = "dataframe",
     confidence_required: bool = True,
+    exclude_columns: list[str] | None = None,
 ) -> DedupeResult:
     """Deduplicate a Polars DataFrame directly (no file I/O).
 
@@ -349,52 +350,90 @@ def dedupe_df(
         configs.
     """
     import goldenmatch._api as _self_api
+    from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
     from goldenmatch.core.pipeline import run_dedupe_df
 
-    _used_controller = False
-    if isinstance(config, str):
-        config = load_config(config)
-    elif config is None:
-        if exact or fuzzy:
-            config = _build_config(exact, fuzzy, blocking, threshold, llm_scorer, backend)
-        else:
-            # Zero-config: call auto_configure_df *before* the pipeline so the
-            # pipeline never re-invokes auto-config. This eliminates the
-            # double-pipeline-run introduced by Task 5.1 (the controller loop
-            # itself calls dedupe_df on samples; if the pipeline also ran
-            # auto_configure_df we'd recurse). Task 5.2 fix.
-            # Access via module attribute so tests can patch goldenmatch._api.auto_configure_df.
-            _auto_config_provider = _detect_llm_provider() if llm_scorer else None
-            from goldenmatch.core.bench import stage as _bench_stage
-            with _bench_stage("auto_configure"):
-                config = _self_api.auto_configure_df(
-                    df,
-                    llm_provider=_auto_config_provider,
-                    llm_auto=llm_auto,
-                    _skip_finalize=True,
-                    confidence_required=confidence_required,
-                )
-            _used_controller = True
+    # Bind the kwarg-supplied exclude_columns to the runtime ContextVar
+    # BEFORE any pipeline step that reads it (auto_configure_df,
+    # GoldenFlow transforms). The pipeline downstream + the auto-config
+    # exclusion resolver both read this var. config.exclude_columns is
+    # OR'd in by the resolver itself; here we only propagate the kwarg
+    # so it's visible even when the user passes a hand-written config.
+    _kwarg_token = None
+    if exclude_columns:
+        _kwarg_token = _RUNTIME_EXCLUDE_COLUMNS.set(list(exclude_columns))
 
-    # All branches above bind config to GoldenMatchConfig (load_config returns
-    # GoldenMatchConfig; _build_config returns GoldenMatchConfig;
-    # auto_configure_df returns GoldenMatchConfig). The Optional in the type
-    # signature is the public input contract, not a runtime state here.
-    assert config is not None, "dedupe_df: config resolution above must bind config"
+    try:
+        _used_controller = False
+        if isinstance(config, str):
+            config = load_config(config)
+        elif config is None:
+            if exact or fuzzy:
+                config = _build_config(exact, fuzzy, blocking, threshold, llm_scorer, backend)
+            else:
+                # Zero-config: call auto_configure_df *before* the pipeline so the
+                # pipeline never re-invokes auto-config. This eliminates the
+                # double-pipeline-run introduced by Task 5.1 (the controller loop
+                # itself calls dedupe_df on samples; if the pipeline also ran
+                # auto_configure_df we'd recurse). Task 5.2 fix.
+                # Access via module attribute so tests can patch goldenmatch._api.auto_configure_df.
+                _auto_config_provider = _detect_llm_provider() if llm_scorer else None
+                from goldenmatch.core.bench import stage as _bench_stage
+                with _bench_stage("auto_configure"):
+                    config = _self_api.auto_configure_df(
+                        df,
+                        llm_provider=_auto_config_provider,
+                        llm_auto=llm_auto,
+                        _skip_finalize=True,
+                        confidence_required=confidence_required,
+                    )
+                _used_controller = True
 
-    # Apply overrides uniformly regardless of config source
-    if backend:
-        config.backend = backend
-    if llm_scorer:
-        from goldenmatch.config.schemas import LLMScorerConfig
-        config.llm_scorer = LLMScorerConfig(enabled=True)
-    if llm_auto:
-        config.llm_auto = llm_auto
+        # All branches above bind config to GoldenMatchConfig (load_config returns
+        # GoldenMatchConfig; _build_config returns GoldenMatchConfig;
+        # auto_configure_df returns GoldenMatchConfig). The Optional in the type
+        # signature is the public input contract, not a runtime state here.
+        assert config is not None, "dedupe_df: config resolution above must bind config"
 
-    result = run_dedupe_df(
-        df, config, source_name=source_name,
-        auto_config=False,
-    )
+        # Apply overrides uniformly regardless of config source
+        if backend:
+            config.backend = backend
+        if llm_scorer:
+            from goldenmatch.config.schemas import LLMScorerConfig
+            config.llm_scorer = LLMScorerConfig(enabled=True)
+        if llm_auto:
+            config.llm_auto = llm_auto
+
+        # Merge kwarg-supplied exclude_columns into config.exclude_columns
+        # so downstream pipeline steps that read off config (rather than
+        # the ContextVar) see them too. Idempotent + order-preserving.
+        if exclude_columns:
+            merged = list(dict.fromkeys(
+                list(getattr(config, "exclude_columns", None) or [])
+                + list(exclude_columns)
+            ))
+            try:
+                config.exclude_columns = merged
+            except Exception:
+                # Defensive: if the config object can't accept the field
+                # (e.g. user passed a non-Pydantic shim), the ContextVar
+                # still carries the kwarg list so behavior is preserved.
+                pass
+
+        # If the user passed a hand-written config with exclude_columns
+        # set, propagate to the ContextVar too so GoldenFlow + the
+        # auto-config exclusion resolver see it on every call path.
+        cfg_excl = getattr(config, "exclude_columns", None) or []
+        if cfg_excl and _kwarg_token is None:
+            _kwarg_token = _RUNTIME_EXCLUDE_COLUMNS.set(list(cfg_excl))
+
+        result = run_dedupe_df(
+            df, config, source_name=source_name,
+            auto_config=False,
+        )
+    finally:
+        if _kwarg_token is not None:
+            _RUNTIME_EXCLUDE_COLUMNS.reset(_kwarg_token)
 
     _mem = result.get("memory_stats")
     pf = _attach_memory_to_postflight(result.get("postflight_report"), _mem)
@@ -449,6 +488,7 @@ def match_df(
     threshold: float | None = None,
     backend: str | None = None,
     confidence_required: bool = True,
+    exclude_columns: list[str] | None = None,
 ) -> MatchResult:
     """Match a target DataFrame against a reference DataFrame (no file I/O).
 
@@ -477,33 +517,63 @@ def match_df(
         configs.
     """
     import goldenmatch._api as _self_api
+    from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
     from goldenmatch.core.pipeline import run_match_df
 
-    _used_controller = False
-    if isinstance(config, str):
-        config = load_config(config)
-    elif config is None:
-        if exact or fuzzy:
-            config = _build_config(exact, fuzzy, blocking, threshold, backend=backend)
-        else:
-            # Zero-config: call auto_configure_df *before* the pipeline so the
-            # pipeline never re-invokes auto-config. Eliminates double-pipeline-run
-            # (Task 5.2 fix — mirrors dedupe_df zero-config refactor).
-            # Pass reference= so auto-config sees both column sets and emits
-            # matchkeys/blocking that apply uniformly across the join.
-            # Access via module attribute so tests can patch goldenmatch._api.auto_configure_df.
-            config = _self_api.auto_configure_df(
-                target, reference=reference, _skip_finalize=True,
-                confidence_required=confidence_required,
-            )
-            _used_controller = True
+    # Same exclude_columns plumbing as dedupe_df -- ContextVar before any
+    # pipeline step so auto-config + GoldenFlow transforms both see it.
+    _kwarg_token = None
+    if exclude_columns:
+        _kwarg_token = _RUNTIME_EXCLUDE_COLUMNS.set(list(exclude_columns))
 
-    assert config is not None, "match_df: config resolution above must bind config"
+    try:
+        _used_controller = False
+        if isinstance(config, str):
+            config = load_config(config)
+        elif config is None:
+            if exact or fuzzy:
+                config = _build_config(exact, fuzzy, blocking, threshold, backend=backend)
+            else:
+                # Zero-config: call auto_configure_df *before* the pipeline so the
+                # pipeline never re-invokes auto-config. Eliminates double-pipeline-run
+                # (Task 5.2 fix — mirrors dedupe_df zero-config refactor).
+                # Pass reference= so auto-config sees both column sets and emits
+                # matchkeys/blocking that apply uniformly across the join.
+                # Access via module attribute so tests can patch goldenmatch._api.auto_configure_df.
+                config = _self_api.auto_configure_df(
+                    target, reference=reference, _skip_finalize=True,
+                    confidence_required=confidence_required,
+                )
+                _used_controller = True
 
-    if backend:
-        config.backend = backend
+        assert config is not None, "match_df: config resolution above must bind config"
 
-    result = run_match_df(target, reference, config, auto_config=False)
+        if backend:
+            config.backend = backend
+
+        # Merge kwarg-supplied exclude_columns into config.exclude_columns
+        # so downstream pipeline steps see them via config too.
+        if exclude_columns:
+            merged = list(dict.fromkeys(
+                list(getattr(config, "exclude_columns", None) or [])
+                + list(exclude_columns)
+            ))
+            try:
+                config.exclude_columns = merged
+            except Exception:
+                pass
+
+        # If user passed a hand-written config with exclude_columns set,
+        # propagate to ContextVar so GoldenFlow + the auto-config exclusion
+        # resolver see it on every call path.
+        cfg_excl = getattr(config, "exclude_columns", None) or []
+        if cfg_excl and _kwarg_token is None:
+            _kwarg_token = _RUNTIME_EXCLUDE_COLUMNS.set(list(cfg_excl))
+
+        result = run_match_df(target, reference, config, auto_config=False)
+    finally:
+        if _kwarg_token is not None:
+            _RUNTIME_EXCLUDE_COLUMNS.reset(_kwarg_token)
 
     _mem = result.get("memory_stats")
     pf = _attach_memory_to_postflight(result.get("postflight_report"), _mem)

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -657,6 +657,22 @@ class GoldenMatchConfig(BaseModel):
     backend: str | None = None  # None (default Polars), "ray", "duckdb"
     memory: MemoryConfig | None = None
     identity: IdentityConfig | None = None
+    exclude_columns: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Column names to skip across the suite. GoldenMatch "
+            "auto-config never picks these for matchkeys/blocking. "
+            "GoldenFlow transforms skip them entirely (column passes "
+            "through unchanged). Layered ADDITIVELY with GoldenCheck "
+            "detector-derived exclusions (#404) -- the user list is "
+            "OR'd with auto-detection, not a replacement. "
+            "`QualityConfig.autoconfig_force_include` still wins on "
+            "conflict (rescue beats every opt-out path). Column still "
+            "appears in golden record output -- exclusion is about "
+            "matching + transforming, not output. See spec "
+            "docs/superpowers/specs/2026-05-21-unified-column-exclusions-design.md."
+        ),
+    )
     prepared_record_store: bool = Field(
         default=False,
         description=(

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1410,32 +1410,85 @@ _LAST_AUTOCONFIG_EXCLUSIONS: ContextVar = ContextVar(
     "_LAST_AUTOCONFIG_EXCLUSIONS", default=None,
 )
 
-def _resolve_quality_config_for_exclusions():
-    """Read auto-config force-exclude / force-include overrides.
+# ContextVar set by dedupe_df / match_df with the kwarg-supplied
+# exclude_columns list (#unified-exclusions). Layered ADDITIVELY with
+# config.exclude_columns and detector-derived exclusions inside
+# auto_configure_df. Cleared after each call via context-bound semantics
+# (callers do `.set(...)` then rely on the ContextVar value living only
+# for the duration of their own frame).
+_RUNTIME_EXCLUDE_COLUMNS: ContextVar = ContextVar(
+    "_RUNTIME_EXCLUDE_COLUMNS", default=None,
+)
 
-    V1 reads from env vars (comma-separated column names):
-      GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE=col1,col2,col3
-      GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE=col1,col2,col3
 
-    The QualityConfig.autoconfig_force_{exclude,include} fields are
-    defined on the schema (#404) for future API plumbing, but threading
-    them through dedupe_df / match_df is a public API change deferred
-    to V2. For V1, env vars cover ad-hoc rescue + force-exclude cases.
+def _env_force_exclude() -> list[str]:
+    raw = os.environ.get("GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE", "")
+    return [c.strip() for c in raw.split(",") if c.strip()]
 
-    Returns a shim object with the same attribute shape as
-    QualityConfig (so detect_autoconfig_exclusions can read either
-    interchangeably), or None when both env vars are empty.
+
+def _env_force_include() -> list[str]:
+    raw = os.environ.get("GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE", "")
+    return [c.strip() for c in raw.split(",") if c.strip()]
+
+
+def _resolve_effective_exclusion_overrides(
+    config=None,
+) -> tuple[list[str], list[str]]:
+    """Combine every exclusion source into (force_exclude, force_include).
+
+    Sources, layered additively for force_exclude:
+      1. ``config.exclude_columns`` -- new top-level field (this PR).
+      2. ``_RUNTIME_EXCLUDE_COLUMNS`` ContextVar -- kwarg from
+         ``dedupe_df`` / ``match_df``.
+      3. ``config.quality.autoconfig_force_exclude`` -- #404 sub-field.
+      4. ``GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE`` env var -- #404 V1 path.
+
+    Sources for force_include (RESCUE -- beats every opt-out path):
+      a. ``config.quality.autoconfig_force_include`` -- #404 sub-field.
+      b. ``GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE`` env var -- #404 V1 path.
+
+    Order in the final set is irrelevant (it's a union); ordering here
+    just makes the log line predictable.
     """
-    fe = os.environ.get("GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE", "")
-    fi = os.environ.get("GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE", "")
-    fe_list = [c.strip() for c in fe.split(",") if c.strip()]
-    fi_list = [c.strip() for c in fi.split(",") if c.strip()]
-    if not fe_list and not fi_list:
+    fe: list[str] = []
+    fi: list[str] = []
+    if config is not None:
+        # New top-level field.
+        cfg_excl = getattr(config, "exclude_columns", None) or []
+        fe.extend(cfg_excl)
+        # Legacy #404 sub-field on QualityConfig (still supported).
+        qc = getattr(config, "quality", None)
+        if qc is not None:
+            fe.extend(getattr(qc, "autoconfig_force_exclude", None) or [])
+            fi.extend(getattr(qc, "autoconfig_force_include", None) or [])
+    runtime_excl = _RUNTIME_EXCLUDE_COLUMNS.get()
+    if runtime_excl:
+        fe.extend(runtime_excl)
+    fe.extend(_env_force_exclude())
+    fi.extend(_env_force_include())
+    # De-dupe while preserving first-occurrence order for log readability.
+    fe = list(dict.fromkeys(fe))
+    fi = list(dict.fromkeys(fi))
+    return fe, fi
+
+
+def _resolve_quality_config_for_exclusions():
+    """DEPRECATED: kept for backward-compat. New code should call
+    ``_resolve_effective_exclusion_overrides`` which combines every
+    exclusion source (top-level config field, kwarg ContextVar,
+    QualityConfig sub-fields, env vars).
+
+    Returns a shim object only when env vars set something -- preserves
+    the pre-unification behavior of "None means no override at all".
+    """
+    fe = _env_force_exclude()
+    fi = _env_force_include()
+    if not fe and not fi:
         return None
 
     class _ShimQualityConfig:
-        autoconfig_force_exclude = fe_list
-        autoconfig_force_include = fi_list
+        autoconfig_force_exclude = fe
+        autoconfig_force_include = fi
 
     return _ShimQualityConfig()
 
@@ -1557,20 +1610,16 @@ def auto_configure_df(
         from goldenmatch.core.quality_exclusions import (
             detect_autoconfig_exclusions,
         )
-        # Pull force-include/exclude overrides from the user's
-        # QualityConfig if present.
-        force_exclude_list: list[str] = []
-        force_include_list: list[str] = []
-        # The controller takes config from v0_kwargs; user-supplied
-        # quality config isn't threaded here yet. Read from a module-
-        # level place if needed in the future; for now the caller
-        # must drive overrides via _LAST_QUALITY_CONFIG (set by the
-        # public _api.dedupe_df dispatch). Falls back to empty lists
-        # when no quality config is present.
-        _qc = _resolve_quality_config_for_exclusions()
-        if _qc is not None:
-            force_exclude_list = list(_qc.autoconfig_force_exclude or [])
-            force_include_list = list(_qc.autoconfig_force_include or [])
+        # Combine every exclusion source: top-level config.exclude_columns
+        # (this PR), dedupe_df / match_df kwarg via _RUNTIME_EXCLUDE_COLUMNS
+        # ContextVar, QualityConfig.autoconfig_force_{exclude,include}
+        # (#404 sub-field), env vars. force_include rescues from every
+        # opt-out path. auto_configure_df has no input config -- only
+        # the ContextVar + env vars are visible here; the dedupe_df
+        # shim writes both before calling us.
+        force_exclude_list, force_include_list = (
+            _resolve_effective_exclusion_overrides(config=None)
+        )
         # Internal bookkeeping columns are invisible to detectors.
         skip = {"__row_id__", "__source__"}
         for col in df.columns:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1432,7 +1432,7 @@ def _env_force_include() -> list[str]:
 
 
 def _resolve_effective_exclusion_overrides(
-    config=None,
+    config: Any | None = None,
 ) -> tuple[list[str], list[str]]:
     """Combine every exclusion source into (force_exclude, force_include).
 
@@ -1472,25 +1472,6 @@ def _resolve_effective_exclusion_overrides(
     return fe, fi
 
 
-def _resolve_quality_config_for_exclusions():
-    """DEPRECATED: kept for backward-compat. New code should call
-    ``_resolve_effective_exclusion_overrides`` which combines every
-    exclusion source (top-level config field, kwarg ContextVar,
-    QualityConfig sub-fields, env vars).
-
-    Returns a shim object only when env vars set something -- preserves
-    the pre-unification behavior of "None means no override at all".
-    """
-    fe = _env_force_exclude()
-    fi = _env_force_include()
-    if not fe and not fi:
-        return None
-
-    class _ShimQualityConfig:
-        autoconfig_force_exclude = fe
-        autoconfig_force_include = fi
-
-    return _ShimQualityConfig()
 
 # Tier 4: cross-run memory.  Set GOLDENMATCH_AUTOCONFIG_MEMORY=0 (or "false"
 # or "disabled") to opt out (useful in CI or when disk I/O should be minimal).

--- a/packages/python/goldenmatch/goldenmatch/core/transform.py
+++ b/packages/python/goldenmatch/goldenmatch/core/transform.py
@@ -61,13 +61,48 @@ def run_transform(
     if not enabled or mode == "disabled":
         return df, []
 
+    # Unified column exclusions (see spec
+    # docs/superpowers/specs/2026-05-21-unified-column-exclusions-design.md):
+    # honor the runtime ContextVar populated by dedupe_df / match_df. Excluded
+    # columns are STRIPPED before _do_transform sees them and re-attached
+    # unchanged after, so a record_hash column with exclude_columns=
+    # ['record_hash'] passes through verbatim even when GoldenFlow has a
+    # lowercase/strip rule for it. Column order is preserved.
+    excluded_set: set[str] = set()
+    try:
+        from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
+        runtime_excl = _RUNTIME_EXCLUDE_COLUMNS.get()
+        if runtime_excl:
+            excluded_set = {c for c in runtime_excl if c in df.columns}
+    except Exception:
+        # ContextVar lookup is best-effort; pipeline never blocks on it.
+        excluded_set = set()
+
+    original_columns = df.columns
+    preserved_df: pl.DataFrame | None = None
+    if excluded_set:
+        preserved_df = df.select(list(excluded_set))
+        df = df.drop(list(excluded_set))
+        if preserved_df.width > 0:
+            logger.debug(
+                "GoldenFlow: %d column(s) skipped via exclude_columns: %s",
+                len(excluded_set), sorted(excluded_set),
+            )
+
     try:
         result = _do_transform(df)
     except Exception:
         logger.warning("GoldenFlow: transform failed, skipping", exc_info=True)
         if strict:
             raise
+        # Restore preserved columns to the input df before returning.
+        if preserved_df is not None and preserved_df.width > 0:
+            df = df.hstack(preserved_df).select(original_columns)
         return df, []
+
+    # Re-attach preserved columns and restore the original column order.
+    if preserved_df is not None and preserved_df.width > 0:
+        result.df = result.df.hstack(preserved_df).select(original_columns)
 
     # Convert manifest to autofix-compatible format
     fixes = []

--- a/packages/python/goldenmatch/tests/test_unified_exclude_columns.py
+++ b/packages/python/goldenmatch/tests/test_unified_exclude_columns.py
@@ -1,0 +1,291 @@
+"""Tests for unified column exclusions across GoldenFlow + GoldenMatch.
+
+Spec: docs/superpowers/specs/2026-05-21-unified-column-exclusions-design.md
+Plan: docs/superpowers/plans/2026-05-21-unified-column-exclusions.md
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import polars as pl
+import pytest
+
+
+def _person_df_with_hash(n: int = 50) -> pl.DataFrame:
+    """Person-shaped data with a record_hash + audit timestamp column.
+
+    Auto-config + sentinel detectors would still pick name/last_name
+    for matching; this fixture is for testing exclusion semantics, not
+    detector logic.
+    """
+    return pl.DataFrame({
+        "first_name": [f"name_{i}" for i in range(n)],
+        "last_name": [f"smith_{i % 5}" for i in range(n)],
+        "city": (["NYC", "LA", "SF", "Boston", "Seattle"] * (n // 5 + 1))[:n],
+        # Will collide with auto-config detectors AND with explicit
+        # exclude semantics, depending on which test exercises which.
+        "record_hash": [f"{i:032x}" for i in range(n)],
+        "created_at": [
+            datetime.datetime(2026, 1, 1) + datetime.timedelta(seconds=i)
+            for i in range(n)
+        ],
+    })
+
+
+# ---------------------------------------------------------------------------
+# Step 1: GoldenMatchConfig.exclude_columns field
+# ---------------------------------------------------------------------------
+
+
+def test_config_exclude_columns_field_defaults_empty():
+    """New field defaults to empty list -- backward-compat with every
+    existing config."""
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    cfg = GoldenMatchConfig()
+    assert cfg.exclude_columns == []
+
+
+def test_config_exclude_columns_round_trips_yaml(tmp_path):
+    """YAML round-trip: dump a config with exclude_columns set, reload,
+    assert it survives."""
+    import yaml
+    from goldenmatch.config.loader import load_config
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    cfg = GoldenMatchConfig(exclude_columns=["created_at", "external_id"])
+    yaml_path = tmp_path / "test.yml"
+    yaml_path.write_text(yaml.safe_dump(cfg.model_dump(exclude_none=True)))
+
+    reloaded = load_config(str(yaml_path))
+    assert reloaded.exclude_columns == ["created_at", "external_id"]
+
+
+# ---------------------------------------------------------------------------
+# Step 2: ContextVar + resolver combines every exclusion source
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_combines_config_field_kwarg_context_and_env(monkeypatch):
+    """`_resolve_effective_exclusion_overrides` ORs together: config.exclude_columns,
+    _RUNTIME_EXCLUDE_COLUMNS, QualityConfig.autoconfig_force_exclude,
+    and the env var. force_include from any source rescues."""
+    from goldenmatch.config.schemas import GoldenMatchConfig, QualityConfig
+    from goldenmatch.core.autoconfig import (
+        _RUNTIME_EXCLUDE_COLUMNS,
+        _resolve_effective_exclusion_overrides,
+    )
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE", "env_col")
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE", "rescued")
+
+    cfg = GoldenMatchConfig(
+        exclude_columns=["config_col"],
+        quality=QualityConfig(
+            autoconfig_force_exclude=["sub_col"],
+            autoconfig_force_include=["another_rescue"],
+        ),
+    )
+    token = _RUNTIME_EXCLUDE_COLUMNS.set(["runtime_col"])
+    try:
+        fe, fi = _resolve_effective_exclusion_overrides(config=cfg)
+    finally:
+        _RUNTIME_EXCLUDE_COLUMNS.reset(token)
+
+    assert set(fe) == {"config_col", "runtime_col", "sub_col", "env_col"}
+    assert set(fi) == {"another_rescue", "rescued"}
+
+
+def test_resolver_no_config_falls_back_to_env_and_context(monkeypatch):
+    """auto_configure_df calls the resolver with config=None. Resolver
+    should still surface the kwarg ContextVar + env vars."""
+    from goldenmatch.core.autoconfig import (
+        _RUNTIME_EXCLUDE_COLUMNS,
+        _resolve_effective_exclusion_overrides,
+    )
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE", "env_col")
+    monkeypatch.delenv("GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE", raising=False)
+
+    token = _RUNTIME_EXCLUDE_COLUMNS.set(["runtime_col"])
+    try:
+        fe, fi = _resolve_effective_exclusion_overrides(config=None)
+    finally:
+        _RUNTIME_EXCLUDE_COLUMNS.reset(token)
+
+    assert set(fe) == {"runtime_col", "env_col"}
+    assert fi == []
+
+
+# ---------------------------------------------------------------------------
+# Step 3: dedupe_df / match_df kwarg
+# ---------------------------------------------------------------------------
+
+
+def test_dedupe_df_exclude_columns_kwarg_drops_from_matchkeys():
+    """`dedupe_df(df, exclude_columns=[...])` -> committed config never
+    references those columns in matchkeys or blocking."""
+    import goldenmatch
+
+    df = _person_df_with_hash(n=80)
+    # Pass record_hash explicitly even though the system_hash detector
+    # would also catch it -- this proves the kwarg works on its own.
+    result = goldenmatch.dedupe_df(
+        df, exclude_columns=["record_hash"], confidence_required=False,
+    )
+    cfg = result.config
+
+    # Walk matchkeys + blocking and assert record_hash is absent.
+    matchkey_cols: set[str] = set()
+    for mk in (cfg.get_matchkeys() or []):
+        for f in (getattr(mk, "fields", None) or []):
+            if getattr(f, "field", None):
+                matchkey_cols.add(f.field)
+    blocking_cols: set[str] = set()
+    if cfg.blocking and cfg.blocking.keys:
+        for key in cfg.blocking.keys:
+            for f in (getattr(key, "fields", None) or []):
+                blocking_cols.add(f)
+
+    assert "record_hash" not in matchkey_cols
+    assert "record_hash" not in blocking_cols
+
+
+def test_dedupe_df_kwarg_appears_in_postflight():
+    """Kwarg-supplied exclusions surface in
+    postflight.autoconfig_exclusions with the user_force_exclude tag."""
+    import goldenmatch
+
+    df = _person_df_with_hash(n=60)
+    result = goldenmatch.dedupe_df(
+        df, exclude_columns=["record_hash"], confidence_required=False,
+    )
+    pf = result.postflight_report
+    assert pf is not None
+    assert pf.autoconfig_exclusions
+    matched = [ec for ec in pf.autoconfig_exclusions if ec.column == "record_hash"]
+    assert matched, (
+        f"record_hash must show up in postflight; got "
+        f"{[ec.column for ec in pf.autoconfig_exclusions]}"
+    )
+
+
+def test_dedupe_df_kwarg_layered_with_config_field():
+    """Both `config.exclude_columns` and the kwarg populated -> union."""
+    import goldenmatch
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    df = _person_df_with_hash(n=80)
+    cfg = GoldenMatchConfig(exclude_columns=["created_at"])
+    result = goldenmatch.dedupe_df(
+        df, config=cfg, exclude_columns=["record_hash"],
+        confidence_required=False,
+    )
+    # The merged config field carries both.
+    assert set(result.config.exclude_columns) >= {"created_at", "record_hash"}
+
+
+def test_force_include_beats_exclude_columns(monkeypatch):
+    """`GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE=record_hash` rescues even
+    when the user explicitly excluded it via the kwarg. Matches the
+    'opt-in beats every opt-out' invariant from #404."""
+    import goldenmatch
+
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE", "record_hash")
+
+    df = _person_df_with_hash(n=60)
+    result = goldenmatch.dedupe_df(
+        df, exclude_columns=["record_hash"], confidence_required=False,
+    )
+    pf = result.postflight_report
+    if pf is not None and pf.autoconfig_exclusions:
+        excluded_cols = {ec.column for ec in pf.autoconfig_exclusions}
+        assert "record_hash" not in excluded_cols, (
+            "force_include must beat exclude_columns kwarg; got "
+            f"{excluded_cols}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 4: GoldenFlow honors the exclusion set
+# ---------------------------------------------------------------------------
+
+
+def test_run_transform_skips_excluded_columns_via_context_var():
+    """`_RUNTIME_EXCLUDE_COLUMNS` propagates into GoldenFlow: a column
+    in the exclusion set passes through unchanged even when the
+    underlying transform engine would touch it."""
+    from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
+    from goldenmatch.core.transform import run_transform
+
+    df = pl.DataFrame({
+        "name": ["Alice", "Bob"],
+        "record_hash": ["ABC123def456", "XYZ789abc012"],
+    })
+    original_hashes = df["record_hash"].to_list()
+
+    token = _RUNTIME_EXCLUDE_COLUMNS.set(["record_hash"])
+    try:
+        out, _fixes = run_transform(df, config=None)
+    finally:
+        _RUNTIME_EXCLUDE_COLUMNS.reset(token)
+
+    assert out["record_hash"].to_list() == original_hashes, (
+        "record_hash must survive GoldenFlow when in the exclusion set; "
+        f"got {out['record_hash'].to_list()}"
+    )
+    # Column order preserved.
+    assert out.columns == df.columns
+
+
+def test_run_transform_without_excluded_columns_unchanged():
+    """When no exclusion is set, GoldenFlow behaves as before. Smoke
+    test against backward-compat."""
+    from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
+    from goldenmatch.core.transform import run_transform
+
+    df = pl.DataFrame({"name": ["Alice", "Bob"]})
+
+    # Reset to None to clear any leakage from earlier tests on the same worker.
+    token = _RUNTIME_EXCLUDE_COLUMNS.set(None)
+    try:
+        out, _fixes = run_transform(df, config=None)
+    finally:
+        _RUNTIME_EXCLUDE_COLUMNS.reset(token)
+
+    assert out.columns == df.columns
+    assert out.height == df.height
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full dedupe_df run with exclude_columns + hand-written config
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_hand_written_config_exclude_columns_propagates_to_transform():
+    """User passes a hand-written config with exclude_columns set --
+    GoldenFlow inside the pipeline must still skip those columns."""
+    import goldenmatch
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    df = pl.DataFrame({
+        "first_name": ["Alice", "Bob"] * 10,
+        "last_name": ["Smith", "Jones"] * 10,
+        "record_hash": [f"HASH_{i:030d}" for i in range(20)],
+    })
+    original_hashes = df["record_hash"].to_list()
+
+    cfg = GoldenMatchConfig(exclude_columns=["record_hash"])
+    result = goldenmatch.dedupe_df(df, config=cfg, confidence_required=False)
+
+    # The golden output is downstream of GoldenFlow -- assert hashes
+    # survived. The actual columns present depend on the pipeline's
+    # output shape, but record_hash must be byte-identical where present.
+    if result.dupes is not None and "record_hash" in result.dupes.columns:
+        assert set(result.dupes["record_hash"].to_list()) <= set(original_hashes)
+    if result.unique is not None and "record_hash" in result.unique.columns:
+        assert set(result.unique["record_hash"].to_list()) <= set(original_hashes)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

One API to say "skip these columns" across the whole suite. Layered additively with #404's GoldenCheck detector exclusions; nothing removed, everything OR-merged.

### Three new surfaces

```yaml
# YAML
exclude_columns: [created_at, external_id, record_hash]
```

```python
# Python kwarg (no YAML required)
dedupe_df(df, exclude_columns=['record_hash'])
match_df(target, ref, exclude_columns=['external_id'])
```

Existing env vars (`GOLDENMATCH_AUTOCONFIG_FORCE_{EXCLUDE,INCLUDE}`) and `QualityConfig.autoconfig_force_{exclude,include}` sub-fields all still work; the new field is layered on top.

### Semantics

- **Additive opt-out:** every exclusion source is OR'd into the effective set.
- **Opt-in wins:** `force_include` from any source rescues a column from every opt-out path. Matches #404's invariant.
- **GoldenFlow:** excluded columns get stripped before `_do_transform` sees them and re-attached unchanged after. `record_hash` survives byte-identical even when GoldenFlow has a lowercase/strip rule for it.
- **GoldenMatch:** excluded columns never appear in matchkeys or blocking. Still appear in the golden record output (exclusion is about matching + transforming, not output shape).

### Test plan

- [x] 11 new tests in `test_unified_exclude_columns.py` (config field default, YAML round-trip, resolver combination, kwarg drops from matchkeys + blocking, kwarg in postflight, config + kwarg layered, force_include beats kwarg, GoldenFlow honors ContextVar, GoldenFlow no-op without exclusions, e2e hand-written config).
- [x] 127 passed across exclusions + autoconfig + pipeline + sync regression.
- [x] `uv run ruff check` clean.

### Spec / Plan

Local-only:
- `docs/superpowers/specs/2026-05-21-unified-column-exclusions-design.md`
- `docs/superpowers/plans/2026-05-21-unified-column-exclusions.md`