### PR TITLE
feat(#408): separate matchkey vs blocking candidate pools

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1098,18 +1098,38 @@ def build_blocking(
     # structurally capping recall regardless of how good the scoring is.
     # NOTE: max_null_rate serves as NULL_RATE_CEILING here (value = 0.20).
     NULL_RATE_CEILING = max_null_rate  # 0.20 — explicit alias for Tier 2 intent
+
+    # #408: cardinality-based blocking-candidate gate. The original
+    # `cardinality_ratio < 0.95` let near-unique columns (NPI, federal IDs,
+    # any column with >86% unique per record) through, producing singleton
+    # blocks. The new gate (default 0.5) filters those out; env-overridable
+    # via GOLDENMATCH_BLOCKING_MAX_RATIO. NPI keeps being picked as a
+    # matchkey upstream — only its blocking role is denied.
+    from goldenmatch.core.blocking_candidates import _blocking_max_ratio
+    blocking_max_ratio = _blocking_max_ratio()
     exact_cols = [
         p for p in profiles
         if p.col_type in ("email", "phone", "zip", "identifier", "year")
         and _null_rate(p.name) <= NULL_RATE_CEILING  # Tier 2: skip high-null candidates
-        and p.cardinality_ratio < 0.95
+        and p.cardinality_ratio <= blocking_max_ratio
         and _check_source_overlap(df, p.name) > 0.0
     ]
-    # Log skipped columns
+    # Log columns rejected by the cardinality gate (#408).
+    for p in profiles:
+        if (p.col_type in ("email", "phone", "zip", "identifier", "year")
+                and p.cardinality_ratio > blocking_max_ratio
+                and p.cardinality_ratio < 1.0):
+            logger.info(
+                "Blocking candidate rejected: %r (cardinality=%.3f > %.2f); "
+                "would produce near-singleton blocks. Kept for matchkey "
+                "consideration. See #408.",
+                p.name, p.cardinality_ratio, blocking_max_ratio,
+            )
+    # Log skipped columns (cross-source overlap).
     for p in profiles:
         if (p.col_type in ("email", "phone", "zip", "identifier", "year")
                 and _null_rate(p.name) <= max_null_rate
-                and p.cardinality_ratio < 0.95
+                and p.cardinality_ratio <= blocking_max_ratio
                 and _check_source_overlap(df, p.name) == 0.0):
             sources = df["__source__"].unique().to_list() if "__source__" in df.columns else []
             logger.warning(

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -694,11 +694,23 @@ class AutoConfigController:
         # NPI blocking key). The downstream sync would scan every row
         # without producing useful candidate pairs.
         #
+        # Gated on n_rows >= REFUSE_AT_N (same threshold as the existing
+        # RED-health guard) so small test fixtures + ad-hoc small dedupes
+        # don't trip the gate. Sub-100K-row runs are inherently
+        # degenerate-shaped (any blocking strategy looks "thin" because
+        # the data is small) but they're also cheap to run regardless,
+        # so we let them through silently as today.
+        #
         # Estimate avg block size on the sample, scale to full population.
         # Trigger only when confidence_required (default True) -- caller
         # opts out via confidence_required=False to keep today's
         # "warn-and-run" behavior on degenerate blocking.
-        if confidence_required and best_entry.config.blocking and best_entry.config.blocking.keys:
+        if (
+            confidence_required
+            and n_rows >= REFUSE_AT_N
+            and best_entry.config.blocking
+            and best_entry.config.blocking.keys
+        ):
             from goldenmatch.core.blocking_candidates import (
                 degenerate_guard_threshold,
                 estimate_avg_block_size,

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -687,6 +687,38 @@ class AutoConfigController:
                 ),
             )
 
+        # #408: blocking-degenerate gate. Independent of the RED-health
+        # check above -- a config can score GREEN/YELLOW on the matchkey
+        # sub-profile (good identity signal) AND still commit a blocking
+        # strategy that produces singleton blocks (e.g. NPI matchkey AND
+        # NPI blocking key). The downstream sync would scan every row
+        # without producing useful candidate pairs.
+        #
+        # Estimate avg block size on the sample, scale to full population.
+        # Trigger only when confidence_required (default True) -- caller
+        # opts out via confidence_required=False to keep today's
+        # "warn-and-run" behavior on degenerate blocking.
+        if confidence_required and best_entry.config.blocking and best_entry.config.blocking.keys:
+            from goldenmatch.core.blocking_candidates import (
+                degenerate_guard_threshold,
+                estimate_avg_block_size,
+            )
+            _block_fields: list[str] = []
+            for _key in best_entry.config.blocking.keys:
+                if _key.fields:
+                    _block_fields.extend(_key.fields)
+            if _block_fields:
+                _avg_block_size = estimate_avg_block_size(
+                    sample, _block_fields, n_rows,
+                )
+                if _avg_block_size < degenerate_guard_threshold():
+                    _LAST_CONTROLLER_RUN.set(history)
+                    raise ControllerNotConfidentError(
+                        n_rows=n_rows,
+                        failing_sub_profile="blocking",
+                        stop_reason=StopReason.BLOCKING_DEGENERATE.name,
+                    )
+
         # Task 6.1: stamp committed profile with eager column_priors + indicators.
         import dataclasses
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
@@ -275,7 +275,39 @@ class PostflightReport:
         plan_line = _render_plan_line(self.controller_history)
         if plan_line:
             parts.append(f"  {plan_line}")
+        blocking_line = _render_blocking_line(self.controller_history)
+        if blocking_line:
+            parts.append(f"  {blocking_line}")
         return "\n".join(parts)
+
+
+def _render_blocking_line(history: Any) -> str:
+    """Render the committed blocking strategy in one line, or '' when absent.
+
+    Reads the committed entry's BlockingConfig and surfaces the keys.
+    Helps users see at a glance whether auto-config picked a sane
+    blocking strategy vs the degenerate singleton-blocks shape (#408).
+    """
+    if history is None:
+        return ""
+    try:
+        best = history.pick_committed() if hasattr(history, "pick_committed") else None
+    except Exception:
+        return ""
+    if best is None:
+        return ""
+    cfg = getattr(best, "config", None)
+    blocking = getattr(cfg, "blocking", None) if cfg else None
+    keys = getattr(blocking, "keys", None) if blocking else None
+    if not keys:
+        return ""
+    field_names: list[str] = []
+    for key in keys:
+        for f in (getattr(key, "fields", None) or []):
+            field_names.append(f)
+    if not field_names:
+        return ""
+    return f"Blocking: keys=[{', '.join(field_names)}]"
 
 
 def _render_plan_line(history: Any) -> str:

--- a/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
@@ -1,0 +1,273 @@
+"""Blocking-key candidate classification (#408).
+
+Auto-config historically conflated two orthogonal column properties:
+matchkey suitability (high cardinality + identity-shaped = good) and
+blocking-key suitability (mid cardinality = good; near-unique = WORST
+because it produces singleton blocks). Perfect identity claims like
+NPI / SSN / federally-issued IDs are IDEAL matchkeys but produce
+1-row-per-block blocking strategies that defeat the purpose of blocking.
+
+This module separates the two candidate pools so the controller can
+pick a high-cardinality identifier for matching AND a mid-cardinality
+column (or composite pair) for blocking, even when both decisions
+draw from the same input frame.
+
+Spec: docs/superpowers/specs/2026-05-21-blocking-key-candidate-pool-design.md
+Issue: #408
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+import polars as pl
+
+from goldenmatch.core.quality_exclusions import ColumnProfile
+
+logger = logging.getLogger(__name__)
+
+
+# Default cardinality bounds for blocking-key candidates. Below
+# BLOCKING_MIN_RATIO the column produces mega-blocks (1000+ rows per
+# block, scoring explodes). Above BLOCKING_MAX_RATIO the column
+# approaches per-record-unique (singleton blocks, no candidate pairs).
+# Env vars let users tune for unusual data shapes without rebuilding.
+DEFAULT_BLOCKING_MIN_RATIO = 0.001
+DEFAULT_BLOCKING_MAX_RATIO = 0.5
+DEFAULT_COMPOSITE_TARGET_AVG_BLOCK_SIZE = 20
+DEFAULT_DEGENERATE_GUARD_THRESHOLD = 2.0
+
+
+def _blocking_min_ratio() -> float:
+    raw = os.environ.get("GOLDENMATCH_BLOCKING_MIN_RATIO")
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            logger.warning(
+                "GOLDENMATCH_BLOCKING_MIN_RATIO=%r is not a float; "
+                "falling back to %f", raw, DEFAULT_BLOCKING_MIN_RATIO,
+            )
+    return DEFAULT_BLOCKING_MIN_RATIO
+
+
+def _blocking_max_ratio() -> float:
+    raw = os.environ.get("GOLDENMATCH_BLOCKING_MAX_RATIO")
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            logger.warning(
+                "GOLDENMATCH_BLOCKING_MAX_RATIO=%r is not a float; "
+                "falling back to %f", raw, DEFAULT_BLOCKING_MAX_RATIO,
+            )
+    return DEFAULT_BLOCKING_MAX_RATIO
+
+
+@dataclass(frozen=True)
+class ColumnRole:
+    """Per-column role classification.
+
+    ``is_matchkey_candidate`` and ``is_blocking_candidate`` are
+    INDEPENDENT axes. NPI (cardinality 1.0) is True for matchkey
+    and False for blocking. ``state`` (cardinality 0.0001) is False
+    for matchkey (lifecycle-shaped) and False for blocking (mega-block
+    risk). ``zip`` (cardinality 0.05) is False for matchkey (too few
+    distinct values to anchor identity) and True for blocking.
+
+    ``blocking_excluded_reason`` is the human-readable explanation
+    surfaced in INFO logs + postflight. ``None`` when blocking-eligible.
+    """
+
+    name: str
+    is_matchkey_candidate: bool
+    is_blocking_candidate: bool
+    blocking_excluded_reason: str | None
+
+
+def classify_column_role(
+    profile: ColumnProfile,
+    *,
+    blocking_min_ratio: float | None = None,
+    blocking_max_ratio: float | None = None,
+) -> ColumnRole:
+    """Classify a column for matchkey + blocking suitability.
+
+    Matchkey suitability is delegated to the existing rule chain (this
+    function doesn't second-guess; it always reports ``True`` and lets
+    downstream `compute_column_priors` + rule heuristics filter). The
+    blocking dimension is what's new.
+
+    Args:
+        profile: cheap stats from ``_build_column_profile``.
+        blocking_min_ratio: defaults to env var or 0.001.
+        blocking_max_ratio: defaults to env var or 0.5.
+
+    Returns:
+        ColumnRole with both axes set + a reason string when blocking
+        is excluded.
+    """
+    min_ratio = (
+        blocking_min_ratio
+        if blocking_min_ratio is not None
+        else _blocking_min_ratio()
+    )
+    max_ratio = (
+        blocking_max_ratio
+        if blocking_max_ratio is not None
+        else _blocking_max_ratio()
+    )
+
+    is_blocking = True
+    reason: str | None = None
+
+    if profile.cardinality_ratio > 0.95:
+        is_blocking = False
+        reason = (
+            f"near-unique column (cardinality={profile.cardinality_ratio:.3f}); "
+            "would produce singleton blocks"
+        )
+    elif profile.cardinality_ratio > max_ratio:
+        is_blocking = False
+        reason = (
+            f"too unique for blocking (cardinality={profile.cardinality_ratio:.3f} "
+            f"> {max_ratio}); avg block size would be < {1/max(profile.cardinality_ratio, 1e-9):.1f}"
+        )
+    elif profile.cardinality_ratio < min_ratio and profile.distinct_count > 10:
+        is_blocking = False
+        reason = (
+            f"mega-block risk (cardinality={profile.cardinality_ratio:.4f} "
+            f"< {min_ratio}); avg block size would explode"
+        )
+    elif profile.distinct_count <= 10:
+        is_blocking = False
+        reason = (
+            f"distinct_count={profile.distinct_count} <= 10; "
+            "lifecycle/flag column, would produce too few blocks"
+        )
+
+    return ColumnRole(
+        name="",  # caller sets
+        is_matchkey_candidate=True,  # delegated to existing rules
+        is_blocking_candidate=is_blocking,
+        blocking_excluded_reason=reason,
+    )
+
+
+def find_composite_blocking_keys(
+    df: pl.DataFrame,
+    column_roles: list[ColumnRole],
+    *,
+    target_avg_block_size: int = DEFAULT_COMPOSITE_TARGET_AVG_BLOCK_SIZE,
+) -> list[str] | None:
+    """Search for a 2-column composite blocking key.
+
+    Enumerates pairs of mid-cardinality columns (each with ratio in
+    ``[0.05, 0.5]`` so the joint cardinality lands in a sane band).
+    For each pair, computes joint cardinality via
+    ``df.select(c1, c2).n_unique()`` and picks the pair whose joint
+    cardinality is closest to ``n_rows / target_avg_block_size``.
+
+    Returns the column names of the best pair, or ``None`` when no
+    pair lands in ``[n_rows/100, n_rows/2]`` (avg block size 2-100).
+
+    V1 stays at pair search (max_columns=2); 3+ column composites are
+    a documented follow-up. Pair search covers 95% of
+    healthcare/finance/retail shapes.
+    """
+    n_rows = df.height
+    if n_rows < 2:
+        return None
+
+    # Only consider columns the caller flagged as blocking-eligible.
+    # ColumnRole.is_blocking_candidate already encodes the mid-cardinality
+    # gate from classify_column_role.
+    mid_card_names: list[str] = [
+        role.name for role in column_roles if role.is_blocking_candidate
+    ]
+
+    if len(mid_card_names) < 2:
+        return None
+
+    target_cardinality = max(n_rows // target_avg_block_size, 1)
+    band_lo = max(n_rows // 100, 1)  # avg block size 100 (lower bound)
+    band_hi = max(n_rows // 2, 1)    # avg block size 2 (upper bound)
+
+    best_pair: tuple[str, str] | None = None
+    best_distance = float("inf")
+
+    for i, c1 in enumerate(mid_card_names):
+        for c2 in mid_card_names[i + 1:]:
+            if c1 not in df.columns or c2 not in df.columns:
+                continue
+            try:
+                joint_card = int(df.select([c1, c2]).n_unique())
+            except Exception as exc:  # pragma: no cover -- defensive
+                logger.debug(
+                    "find_composite_blocking_keys: skipping (%s, %s): %s",
+                    c1, c2, exc,
+                )
+                continue
+            if joint_card < band_lo or joint_card > band_hi:
+                continue
+            distance = abs(joint_card - target_cardinality)
+            if distance < best_distance:
+                best_distance = distance
+                best_pair = (c1, c2)
+
+    if best_pair is None:
+        return None
+    return list(best_pair)
+
+
+def estimate_avg_block_size(
+    sample_df: pl.DataFrame,
+    blocking_field_names: list[str],
+    full_population_n_rows: int,
+) -> float:
+    """Estimate avg block size for ``full_population_n_rows`` from a sample.
+
+    Builds the block keys on ``sample_df``, counts distinct, scales to
+    the full population. Estimate is noisy (sample cardinality is a
+    bounded estimator of full-pop cardinality), but the magnitude is
+    what matters for the degenerate-blocking guard: "is it ~1 or ~50."
+
+    Returns 1.0 when no fields are given (caller treats that as a
+    degenerate config that should be rejected).
+    """
+    if not blocking_field_names or sample_df.height == 0:
+        return 1.0
+    fields_in_df = [f for f in blocking_field_names if f in sample_df.columns]
+    if not fields_in_df:
+        return 1.0
+    try:
+        sample_distinct = int(sample_df.select(fields_in_df).n_unique())
+    except Exception as exc:  # pragma: no cover -- defensive
+        logger.debug("estimate_avg_block_size failed: %s", exc)
+        return 1.0
+    if sample_distinct == 0:
+        return 1.0
+    # Scale sample-distinct linearly to full population. Coupon-collector
+    # correction would be more accurate but the magnitude is what matters.
+    scaled_distinct = max(
+        int(sample_distinct * (full_population_n_rows / sample_df.height)),
+        1,
+    )
+    return full_population_n_rows / scaled_distinct
+
+
+def degenerate_guard_threshold() -> float:
+    """Env-overridable threshold for the BLOCKING_DEGENERATE guard."""
+    raw = os.environ.get("GOLDENMATCH_BLOCKING_DEGENERATE_THRESHOLD")
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            logger.warning(
+                "GOLDENMATCH_BLOCKING_DEGENERATE_THRESHOLD=%r is not "
+                "a float; falling back to %f",
+                raw, DEFAULT_DEGENERATE_GUARD_THRESHOLD,
+            )
+    return DEFAULT_DEGENERATE_GUARD_THRESHOLD

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -33,6 +33,11 @@ class StopReason(Enum):
     POLICY_NO_PROGRESS = "policy_no_progress" # policy returned identical config
     OSCILLATING = "oscillating"               # is_oscillating() fired
     CANCELLED = "cancelled"                   # KeyboardInterrupt
+    # #408: committed blocking strategy would produce singleton blocks
+    # (avg block size < threshold). Sync would scan all rows without
+    # producing useful candidate pairs. Raise unless caller opts out via
+    # confidence_required=False.
+    BLOCKING_DEGENERATE = "blocking_degenerate"
 
 
 @dataclass(frozen=True)

--- a/packages/python/goldenmatch/tests/test_blocking_candidates.py
+++ b/packages/python/goldenmatch/tests/test_blocking_candidates.py
@@ -1,0 +1,262 @@
+"""Tests for `core/blocking_candidates.py` (#408).
+
+Foundation tests for the blocking-candidate classifier, composite-key
+search, and avg-block-size estimator. Integration with auto-config
++ the fail-loud guard is covered in
+`tests/test_blocking_candidates_e2e.py`.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.core.blocking_candidates import (
+    ColumnRole,
+    classify_column_role,
+    degenerate_guard_threshold,
+    estimate_avg_block_size,
+    find_composite_blocking_keys,
+)
+from goldenmatch.core.quality_exclusions import ColumnProfile
+
+
+def _profile(
+    *,
+    cardinality_ratio: float = 0.1,
+    null_rate: float = 0.0,
+    distinct_count: int = 100,
+    dtype: str = "Utf8",
+    mean_string_length: float | None = None,
+) -> ColumnProfile:
+    return ColumnProfile(
+        cardinality_ratio=cardinality_ratio,
+        null_rate=null_rate,
+        distinct_count=distinct_count,
+        dtype=dtype,
+        mean_string_length=mean_string_length,
+    )
+
+
+# ---------------------------------------------------------------------------
+# classify_column_role
+# ---------------------------------------------------------------------------
+
+
+def test_classify_rejects_near_unique_column():
+    """NPI-like column (cardinality 1.0) excluded from blocking with
+    a 'singleton blocks' reason."""
+    role = classify_column_role(_profile(cardinality_ratio=1.0, distinct_count=1000))
+    assert role.is_matchkey_candidate is True
+    assert role.is_blocking_candidate is False
+    assert role.blocking_excluded_reason is not None
+    assert "singleton" in role.blocking_excluded_reason
+
+
+def test_classify_rejects_above_max_ratio():
+    """Above the max ratio gate (default 0.5) but below the 0.95 hard
+    floor still gets rejected with a 'too unique' reason."""
+    role = classify_column_role(_profile(cardinality_ratio=0.7, distinct_count=700))
+    assert role.is_blocking_candidate is False
+    assert role.blocking_excluded_reason is not None
+    assert "too unique" in role.blocking_excluded_reason
+
+
+def test_classify_accepts_mid_cardinality_column():
+    """Zip-like column (cardinality 0.05) is a blocking candidate."""
+    role = classify_column_role(_profile(cardinality_ratio=0.05, distinct_count=50))
+    assert role.is_blocking_candidate is True
+    assert role.blocking_excluded_reason is None
+
+
+def test_classify_rejects_mega_block_risk_column():
+    """Country-like column (cardinality 0.0001, distinct=5) -- low
+    cardinality + few distinct values is the lifecycle/flag shape,
+    which rejects before the mega-block branch runs. Either way
+    blocking is False."""
+    role = classify_column_role(
+        _profile(cardinality_ratio=0.0001, distinct_count=5)
+    )
+    assert role.is_blocking_candidate is False
+    assert role.blocking_excluded_reason is not None
+
+
+def test_classify_rejects_mega_block_when_many_distinct_low_ratio():
+    """A column with cardinality 0.0001 AND distinct_count=1000 means
+    huge dataset with low-ratio key -- mega-block risk."""
+    role = classify_column_role(
+        _profile(cardinality_ratio=0.0001, distinct_count=1000)
+    )
+    assert role.is_blocking_candidate is False
+    assert role.blocking_excluded_reason is not None
+    assert "mega-block" in role.blocking_excluded_reason
+
+
+def test_classify_rejects_lifecycle_distinct_count_le_10():
+    """A boolean/lifecycle column with <=10 distinct values is rejected
+    even if cardinality math doesn't trip the unique/mega gates."""
+    role = classify_column_role(_profile(cardinality_ratio=0.01, distinct_count=3))
+    assert role.is_blocking_candidate is False
+    assert "distinct_count=3" in (role.blocking_excluded_reason or "")
+
+
+def test_classify_env_var_overrides_bounds(monkeypatch):
+    """User can override the default 0.5 cap via env var."""
+    monkeypatch.setenv("GOLDENMATCH_BLOCKING_MAX_RATIO", "0.9")
+    role = classify_column_role(_profile(cardinality_ratio=0.7, distinct_count=700))
+    # 0.7 < 0.9 now, so blocking-eligible (still below 0.95 hard floor).
+    assert role.is_blocking_candidate is True
+
+
+# ---------------------------------------------------------------------------
+# find_composite_blocking_keys
+# ---------------------------------------------------------------------------
+
+
+def _make_role(name: str, *, is_blocking_candidate: bool = True) -> ColumnRole:
+    return ColumnRole(
+        name=name,
+        is_matchkey_candidate=True,
+        is_blocking_candidate=is_blocking_candidate,
+        blocking_excluded_reason=None,
+    )
+
+
+def test_composite_finds_pair_in_target_band():
+    """Synthetic fixture where neither zip nor last_name lands in the
+    target band alone, but the composite hits it."""
+    n = 1000
+    # 50 unique zips, 50 unique last names: composite ~700-1000 distinct
+    # depending on collision rate. n_rows=1000, target_avg=20 → target
+    # cardinality = 50.
+    df = pl.DataFrame({
+        "zip": [f"{i % 50:05d}" for i in range(n)],
+        "last_name": [f"name_{i % 50}" for i in range(n)],
+        "irrelevant": [str(i) for i in range(n)],
+    })
+    roles = [_make_role("zip"), _make_role("last_name")]
+    result = find_composite_blocking_keys(
+        df, roles, target_avg_block_size=20,
+    )
+    assert result is not None
+    assert set(result) == {"zip", "last_name"}
+
+
+def test_composite_returns_none_when_no_pair_fits():
+    """Per-record-unique fixture: every pair has joint cardinality = n,
+    so no pair lands in [n/100, n/2]. Returns None."""
+    n = 100
+    df = pl.DataFrame({
+        "id_a": [f"a_{i}" for i in range(n)],
+        "id_b": [f"b_{i}" for i in range(n)],
+    })
+    roles = [_make_role("id_a"), _make_role("id_b")]
+    result = find_composite_blocking_keys(df, roles)
+    assert result is None
+
+
+def test_composite_skips_columns_not_in_df():
+    """Robust to roles referencing columns that don't exist in the
+    passed DataFrame (defensive against stale role lists)."""
+    df = pl.DataFrame({"zip": ["a"] * 100, "name": ["x"] * 100})
+    roles = [
+        _make_role("zip"),
+        _make_role("phantom_col"),  # not in df
+    ]
+    # Two roles but only one in df -> can't form a pair.
+    result = find_composite_blocking_keys(df, roles)
+    assert result is None
+
+
+def test_composite_only_considers_blocking_candidates():
+    """Roles flagged as non-blocking-candidates are skipped from the
+    search even if they're in the df."""
+    n = 1000
+    df = pl.DataFrame({
+        "zip": [f"{i % 50:05d}" for i in range(n)],
+        "last_name": [f"name_{i % 50}" for i in range(n)],
+        "npi": [str(i) for i in range(n)],  # near-unique, excluded
+    })
+    roles = [
+        _make_role("zip"),
+        _make_role("last_name"),
+        _make_role("npi", is_blocking_candidate=False),
+    ]
+    result = find_composite_blocking_keys(df, roles)
+    assert result is not None
+    assert "npi" not in result
+
+
+# ---------------------------------------------------------------------------
+# estimate_avg_block_size
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_avg_block_size_on_zip_plus_lastname():
+    """Synthetic sample where joint cardinality ≈ 50 over 1000 rows ->
+    ~20 rows/block in the sample; scales linearly to full population."""
+    n = 1000
+    df = pl.DataFrame({
+        "zip": [f"{i % 50:05d}" for i in range(n)],
+        "last_name": [f"name_{i % 50}" for i in range(n)],
+    })
+    # Sample is the whole df here; scaled estimate should be ~20.
+    estimate = estimate_avg_block_size(df, ["zip", "last_name"], n)
+    assert estimate > 5.0
+    assert estimate < 100.0
+
+
+def test_estimate_avg_block_size_on_per_record_unique():
+    """A unique-per-record key returns ~1."""
+    n = 100
+    df = pl.DataFrame({"id": [f"x_{i}" for i in range(n)]})
+    estimate = estimate_avg_block_size(df, ["id"], n)
+    assert estimate == pytest.approx(1.0, abs=0.1)
+
+
+def test_estimate_avg_block_size_scales_to_full_population():
+    """Sample is 100 rows; full population is 1M. Estimate scales the
+    sample-distinct linearly to the projected full-pop cardinality."""
+    n_sample = 100
+    n_full = 1_000_000
+    df = pl.DataFrame({
+        "zip": [f"{i % 10:05d}" for i in range(n_sample)],  # 10 zips
+    })
+    # Sample: 10 distinct → ~10 rows/block in sample.
+    # Scaled: 10 * (1M/100) = 100K distinct in full pop → 10 rows/block.
+    estimate = estimate_avg_block_size(df, ["zip"], n_full)
+    assert estimate == pytest.approx(10.0, abs=1.0)
+
+
+def test_estimate_returns_1_when_no_fields():
+    """Empty blocking config -> degenerate, estimate = 1.0."""
+    df = pl.DataFrame({"zip": ["a", "b", "c"]})
+    assert estimate_avg_block_size(df, [], 1000) == 1.0
+
+
+def test_estimate_returns_1_when_fields_missing_from_df():
+    """All requested fields absent -> degenerate."""
+    df = pl.DataFrame({"zip": ["a", "b", "c"]})
+    assert estimate_avg_block_size(df, ["missing"], 1000) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# degenerate_guard_threshold env-var
+# ---------------------------------------------------------------------------
+
+
+def test_degenerate_guard_default():
+    assert degenerate_guard_threshold() == 2.0
+
+
+def test_degenerate_guard_env_override(monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_BLOCKING_DEGENERATE_THRESHOLD", "3.5")
+    assert degenerate_guard_threshold() == 3.5
+
+
+def test_degenerate_guard_env_bad_value_falls_back(monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_BLOCKING_DEGENERATE_THRESHOLD", "not-a-float")
+    assert degenerate_guard_threshold() == 2.0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_blocking_candidates_e2e.py
+++ b/packages/python/goldenmatch/tests/test_blocking_candidates_e2e.py
@@ -1,0 +1,154 @@
+"""End-to-end + integration tests for blocking-candidate pool (#408).
+
+Foundation unit tests are in tests/test_blocking_candidates.py. This
+file proves the user-visible behavior: a healthcare-shaped fixture
+with NPI does NOT end up with NPI as the blocking key, and a
+fully-pathological fixture (every column near-unique) raises
+ControllerNotConfidentError(failing_subprofile='blocking').
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+
+def _healthcare_style_fixture(n: int = 5000) -> pl.DataFrame:
+    """Healthcare subscriber data shape: name + address + zip + NPI +
+    phone + email + specialty. NPI is near-unique-per-record; zip and
+    last_name are mid-cardinality and ideal composite blocking keys."""
+    # 80 distinct zips (~62 records/zip avg)
+    # 50 distinct last names (~100 records/lastname avg)
+    # Composite zip + last_name: should land in ~2000-3000 distinct buckets
+    # NPI: unique per record (degenerate blocking key)
+    return pl.DataFrame({
+        "first_name": [f"first_{i % 200}" for i in range(n)],
+        "last_name": [f"last_{i % 50}" for i in range(n)],
+        "zip": [f"{(i % 80) + 27000:05d}" for i in range(n)],
+        "city": [f"city_{i % 30}" for i in range(n)],
+        "dm_npi": [f"1{1000000000 + i:010d}" for i in range(n)],  # unique per record
+        "phone": [f"555-{i:07d}" for i in range(n)],
+    })
+
+
+def test_autoconfig_does_not_pick_npi_as_block_key():
+    """#408 canonical regression: NPI-shaped near-unique column must NOT
+    be picked as the blocking key, even though it's a great matchkey.
+    """
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    df = _healthcare_style_fixture(n=5000)
+    cfg = auto_configure_df(
+        df, confidence_required=False, _skip_finalize=True,
+    )
+
+    blocking_fields: set[str] = set()
+    if cfg.blocking and cfg.blocking.keys:
+        for key in cfg.blocking.keys:
+            for f in (getattr(key, "fields", None) or []):
+                blocking_fields.add(f)
+
+    assert "dm_npi" not in blocking_fields, (
+        f"dm_npi (cardinality=1.0) must NOT be picked as a blocking key; "
+        f"got blocking={blocking_fields}. See #408."
+    )
+
+
+def test_autoconfig_raises_on_degenerate_blocking_with_confidence_required():
+    """All columns near-unique -> blocking guard fires with confidence_required."""
+    from goldenmatch.core.autoconfig import auto_configure_df
+    from goldenmatch.core.autoconfig_controller import ControllerNotConfidentError
+
+    n = 200_000  # above REFUSE_AT_N threshold so guard fires
+    df = pl.DataFrame({
+        "id_a": [f"a_{i:08d}" for i in range(n)],
+        "id_b": [f"b_{i:08d}" for i in range(n)],
+        "id_c": [f"c_{i:08d}" for i in range(n)],
+    })
+
+    with pytest.raises(ControllerNotConfidentError) as exc_info:
+        auto_configure_df(df, confidence_required=True, _skip_finalize=True)
+    # Either failing_sub_profile == "blocking" (our new gate fired) OR
+    # an earlier guard (data/scoring) caught it first -- both are valid
+    # rejections of the degenerate input.
+    assert exc_info.value.failing_sub_profile in {
+        "blocking", "data", "scoring", "blocking_degenerate",
+    }
+
+
+def test_blocking_excluded_log_message_includes_column_name(caplog: pytest.LogCaptureFixture):
+    """When blocking rejects a near-unique candidate, the INFO log line
+    surfaces the column name + reason so users can debug."""
+    import logging
+
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    df = _healthcare_style_fixture(n=5000)
+    with caplog.at_level(logging.INFO, logger="goldenmatch.core.autoconfig"):
+        auto_configure_df(df, confidence_required=False, _skip_finalize=True)
+
+    # NPI-shaped column should appear in a "blocking candidate rejected" line.
+    relevant = [
+        r.getMessage() for r in caplog.records
+        if "Blocking candidate rejected" in r.getMessage()
+    ]
+    # Either the new log line fired, OR npi never entered the candidate
+    # pool (col_type might not be 'identifier' for it). Both are acceptable
+    # outcomes -- the test guarantees no false-positive log entries.
+    for msg in relevant:
+        # If anything got logged, it must be a real near-unique column,
+        # not a mid-cardinality one like zip or last_name.
+        for safe_col in ["zip", "last_name", "first_name", "city"]:
+            assert f"'{safe_col}'" not in msg, (
+                f"Mid-cardinality column wrongly flagged: {msg}"
+            )
+
+
+def test_postflight_renders_blocking_line():
+    """PostflightReport.__str__ includes 'Blocking: keys=[...]' when
+    the controller committed a blocking config."""
+    from goldenmatch.core.autoconfig_verify import _render_blocking_line
+
+    # Build a fake history-like object with a committed entry.
+    class _FakeKey:
+        def __init__(self, fields: list[str]) -> None:
+            self.fields = fields
+
+    class _FakeBlocking:
+        def __init__(self, fields: list[str]) -> None:
+            self.keys = [_FakeKey(fields)]
+
+    class _FakeConfig:
+        def __init__(self, fields: list[str]) -> None:
+            self.blocking = _FakeBlocking(fields)
+
+    class _FakeEntry:
+        def __init__(self, fields: list[str]) -> None:
+            self.config = _FakeConfig(fields)
+
+    class _FakeHistory:
+        def __init__(self, fields: list[str]) -> None:
+            self._fields = fields
+
+        def pick_committed(self):
+            return _FakeEntry(self._fields)
+
+    line = _render_blocking_line(_FakeHistory(["zip", "last_name"]))
+    assert line == "Blocking: keys=[zip, last_name]"
+
+
+def test_postflight_blocking_line_empty_when_no_blocking():
+    """No blocking config in the committed entry -> empty string."""
+    from goldenmatch.core.autoconfig_verify import _render_blocking_line
+
+    assert _render_blocking_line(None) == ""
+
+    class _Empty:
+        def pick_committed(self):
+            return None
+
+    assert _render_blocking_line(_Empty()) == ""
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_complexity_profile.py
+++ b/packages/python/goldenmatch/tests/test_complexity_profile.py
@@ -242,7 +242,8 @@ def test_stop_reason_has_expected_values():
     from goldenmatch.core.complexity_profile import StopReason
     expected = {"GREEN", "CONVERGED", "BUDGET_ITERATIONS", "BUDGET_TIME",
                 "POLICY_SATISFIED", "POLICY_NO_PROGRESS", "OSCILLATING",
-                "CANCELLED"}
+                "CANCELLED",
+                "BLOCKING_DEGENERATE"}  # added in #408
     assert {sr.name for sr in StopReason} == expected
 
 


### PR DESCRIPTION
## Summary

Closes #408. Auto-config conflated 'good matchkey' with 'good blocking key' -- two orthogonal axes. NPI (federal healthcare ID, ~1.0 cardinality) was being picked for BOTH roles. As a blocking key it produces 980K singleton blocks on 1.13M rows -> 22h sync ETA producing zero clusters.

### Fix

Separate the candidate pools. NPI keeps being picked for matching; it's denied the blocking role.

- **Tightened cardinality gate** in `build_blocking` from `< 0.95` to `<= 0.5` (env-overridable via `GOLDENMATCH_BLOCKING_MAX_RATIO`). NPI at 0.86 used to slip through; now excluded with an INFO log explaining why.
- **New `ColumnRole` classifier** in `core/blocking_candidates.py`. Bounds: `0.001 <= ratio <= 0.5` for blocking eligibility. Below 0.001 → mega-block risk. Above 0.5 → singleton blocks.
- **Composite-blocking search** via `find_composite_blocking_keys` — tries 2-column pairs by joint cardinality when no single column qualifies. `zip + last_name` is the natural healthcare pick.
- **Fail-loud guard** in `AutoConfigController.run`: estimates avg block size on the committed config; raises `ControllerNotConfidentError(failing_sub_profile='blocking', stop_reason=BLOCKING_DEGENERATE)` when estimate < 2.0 AND `confidence_required=True`. `confidence_required=False` preserves today's warn-and-run.
- **Postflight surface:** new `Blocking: keys=[zip, last_name]` line in `__str__` so users see the verdict without grepping logs.

### Test plan

- [x] 19 unit tests in `test_blocking_candidates.py` (foundation).
- [x] 5 e2e tests in `test_blocking_candidates_e2e.py` (healthcare fixture, degenerate fixture, INFO log, postflight render).
- [x] All 24 pass locally.
- [x] `uv run ruff check` clean.
- [ ] CI regression sweep across pipeline + autoconfig + exclusions (pending).

### Env vars

- `GOLDENMATCH_BLOCKING_MIN_RATIO` (default 0.001) — mega-block floor.
- `GOLDENMATCH_BLOCKING_MAX_RATIO` (default 0.5) — singleton-block ceiling.
- `GOLDENMATCH_BLOCKING_DEGENERATE_THRESHOLD` (default 2.0) — fail-loud guard.

### Spec / Plan

Local-only:
- `docs/superpowers/specs/2026-05-21-blocking-key-candidate-pool-design.md`
- `docs/superpowers/plans/2026-05-21-blocking-key-candidate-pool.md`