### PR TITLE
fix(#130): enable WAL mode in MemoryStore + un-skip concurrent-write test

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/memory/store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/store.py
@@ -120,8 +120,16 @@ class MemoryStore:
             os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
             self._conn = sqlite3.connect(path)
             self._conn.row_factory = sqlite3.Row
+            # #130: enable WAL mode for concurrent-write reliability.
+            # Default journal_mode=delete intermittently raises "database
+            # is locked" when two MemoryStore instances write to the same
+            # file. WAL allows one writer + multiple readers concurrently
+            # and is the right default for shared SQLite memory stores.
+            # `PRAGMA journal_mode=WAL` is per-database, persisted in the
+            # file header, and a no-op on subsequent opens.
+            self._conn.execute("PRAGMA journal_mode=WAL")
             self._conn.executescript(_SCHEMA)
-            log.debug("MemoryStore opened: %s", path)
+            log.debug("MemoryStore opened: %s (journal_mode=WAL)", path)
         else:
             raise NotImplementedError(f"Backend '{backend}' not yet implemented")
 

--- a/packages/python/goldenmatch/tests/test_memory_store.py
+++ b/packages/python/goldenmatch/tests/test_memory_store.py
@@ -241,16 +241,10 @@ class TestCorrectionSourceEnum:
         assert sources_seen == {s.value for s in CorrectionSource}
 
 
-@pytest.mark.skip(
-    reason="WAL mode required for reliable concurrent writes from two "
-    "MemoryStore instances on the same SQLite file. Default journaling "
-    "intermittently raises 'database is locked'. Tracked as a follow-up; "
-    "test exists to surface the limitation rather than enforce it."
-)
 def test_concurrent_memory_store_writes_dont_lock(tmp_path):
     """Two MemoryStore instances pointing at the same DB; each writes one
-    correction; both are visible to a third reader. Skipped by default --
-    flips green only when WAL mode is enabled (TODO)."""
+    correction; both are visible to a third reader. #130: now enforced
+    after MemoryStore defaults journal_mode=WAL on every open."""
     db = str(tmp_path / "concurrent.db")
     s1 = MemoryStore(backend="sqlite", path=db)
     s2 = MemoryStore(backend="sqlite", path=db)


### PR DESCRIPTION
Closes #130. MemoryStore defaults `journal_mode=WAL` on SQLite open. Test `test_concurrent_memory_store_writes_dont_lock` un-skipped. 24/24 pass locally.