### PR TITLE
feat: Wave A v1.13 autoconfig (#131 stratified sampling + #127 oscillation guard) + ADR practice

### DIFF
--- a/docs/adr/0000-adopt-adr-practice.md
+++ b/docs/adr/0000-adopt-adr-practice.md
@@ -1,0 +1,36 @@
+# ADR-0000: Adopt ADR practice
+
+**Status:** Accepted
+**Date:** 2026-05-21
+
+## Context
+
+`docs/superpowers/specs/` and `docs/superpowers/plans/` capture HOW features get built. But the WHY behind load-bearing decisions — why this default, why this algorithm, why this rejected — is scattered across PR descriptions, commit messages, CLAUDE.md notes, and inline comments. Future contributors keep asking "why isn't this X?" and re-proposing rejected alternatives because the rationale isn't surfaced in one place.
+
+Recent examples surfaced in this session:
+- "Why does auto-config refuse on RED config at 100K rows by default?" → answer scattered across PR #271-#276 + a controller-budget spec.
+- "Why is the streaming-sync threshold 500K and not 5M?" → answer in PR #402's commit body.
+- "Why doesn't the unified `exclude_columns` rescue work through env vars when the YAML field is set?" → answer in PR #406's body.
+
+## Decision
+
+Adopt the Michael Nygard ADR format. One small markdown file per load-bearing decision in `docs/adr/`, numbered sequentially. Index in `docs/adr/README.md`.
+
+ADRs complement specs/plans:
+- **Specs** = how to build (design + implementation).
+- **Plans** = sequencing (steps + PR shape + tests).
+- **ADRs** = why a load-bearing choice was made + what alternatives were rejected.
+
+## Consequences
+
+Positive:
+- Future "why is this X?" questions resolve in one place.
+- Rejected alternatives stay rejected — future contributors see the rationale before re-proposing.
+- New contributors get the architectural shape from `docs/adr/` instead of archaeology.
+
+Negative:
+- Process overhead: one more thing to write when shipping a load-bearing change.
+- Risk of ADR sprawl if every minor decision gets one. Mitigation: README's "when to write an ADR" criteria.
+
+Neutral:
+- ADRs are not gospel. Decisions get superseded. ADRs are append-only with status changes; old ADRs stay linked from their successors.

--- a/docs/adr/0001-confidence-required-default.md
+++ b/docs/adr/0001-confidence-required-default.md
@@ -1,0 +1,33 @@
+# ADR-0001: `confidence_required=True` as the default safety gate
+
+**Status:** Accepted
+**Date:** 2026-05-21 (decision originally landed 2026-05-16, PR #271-#276)
+
+## Context
+
+Auto-config can commit a RED-health profile when the controller exhausts its iteration budget on adversarial data. Pre-2026-05-16, the controller would silently commit that RED config and the downstream pipeline would run a 22-26 minute degenerate dedupe producing meaningless output. Users had no way to know auto-config had given up; they'd see a successful exit code and useless `gm_clusters` data.
+
+PR #271-#276 added `ControllerNotConfidentError` — when the controller commits a RED config on a large input (`n_rows ≥ REFUSE_AT_N = 100_000`), it raises instead of running. The open question was the **default**: should auto-config raise loudly, or warn and run?
+
+## Decision
+
+`confidence_required=True` is the default on `auto_configure_df` / `dedupe_df` / `match_df`. RED config + `n_rows ≥ 100_000` + `confidence_required=True` → raise `ControllerNotConfidentError`. The caller has to opt into the silent low-precision path via explicit `confidence_required=False`.
+
+Rejected alternatives:
+- **`confidence_required=False` default + WARN log.** Users miss the warning and ship bad data. The asymmetry is wrong: a noisy raise costs the user 1 minute to find docs; a silent low-precision run costs them an unknown amount of trust in their downstream consumers.
+- **Per-sub-profile flags** (`refuse_on_blocking_red=True`, `refuse_on_scoring_red=True`). More API surface for marginal expressiveness. The single boolean covers 95% of cases; the failing-sub-profile is surfaced on the exception for diagnosis.
+
+## Consequences
+
+Positive:
+- Bad output never silently ships. Users see the error message + docs link immediately.
+- Programs that integrate goldenmatch can catch the exception and route to an explicit-config branch.
+
+Negative:
+- Backward-incompatible for users who had pipelines depending on the old "warn and run" behavior. Mitigation: the env-var rollback path + explicit `confidence_required=False` kwarg on every entry point.
+- Test fixtures < `REFUSE_AT_N` (100K rows) pass through without the gate, which means small-N test cases of degenerate behavior don't trip it. Documented as intentional; the gate is for production-scale calls.
+
+Cross-references:
+- Spec: `docs/superpowers/specs/2026-05-16-controller-budget-vs-blocking-discovery-design.md`
+- PRs: #271, #272, #273, #274, #275, #276
+- Related ADR-0003 (matchkey/blocking pool split) — that split's `BLOCKING_DEGENERATE` guard composes with this one.

--- a/docs/adr/0002-unified-exclude-columns.md
+++ b/docs/adr/0002-unified-exclude-columns.md
@@ -1,0 +1,44 @@
+# ADR-0002: Unified `exclude_columns` API surface across the suite
+
+**Status:** Accepted
+**Date:** 2026-05-21 (PRs #405, #406, #407)
+
+## Context
+
+GoldenCheck, GoldenFlow, and GoldenMatch each had their own (or no) notion of "skip this column." GoldenCheck has `Finding` objects with rule-specific severities. GoldenFlow's `apply_transforms` touched every column it had a rule for. GoldenMatch's auto-config picked matchkeys from every column it profiled.
+
+Three problems:
+1. A `record_hash` column legitimately needed to be matched on (PPRL bloom-filter use case) but NOT transformed by GoldenFlow. No way to express that.
+2. Auto-config detector exclusions (#404 — audit, sentinel, foreign-id, etc.) needed to be paired with a user-override mechanism. Env vars covered ad-hoc cases; the YAML config had nowhere to put a user list.
+3. Different surfaces (CLI / REST / MCP / A2A / Python) had to surface the same parameter consistently.
+
+## Decision
+
+Single `GoldenMatchConfig.exclude_columns: list[str]` field — the canonical source of truth. Layered ADDITIVELY with detector-derived exclusions (#404) and env-var overrides (#404 V1 path). `QualityConfig.autoconfig_force_include` wins on conflict (rescue beats every opt-out path).
+
+Three surface layers:
+- **YAML** (`exclude_columns: [created_at, external_id]`).
+- **Python kwarg** (`dedupe_df(df, exclude_columns=[...])`).
+- **CLI flag** (`--exclude-columns col1,col2,col3`).
+
+REST / MCP / A2A surfaces share one `EXCLUDE_COLUMNS_SCHEMA` JSON Schema fragment (in `goldenmatch/_exclusions_schema.py`) so the parameter shape stays in lockstep across servers. Parity test diff-checks them byte-equal.
+
+Rejected alternatives:
+- **Per-tool exclusions** (`flow_exclude` / `match_exclude`). Premature; the single "skip across the suite" sledgehammer covers 95% of real cases. Per-tool granularity is a V2 if a user files for it.
+- **Pattern/glob exclusions** (`exclude_columns: ["audit_*"]`). Defer; concrete column lists work today.
+- **Replace detector exclusions with user list only.** No — detectors catch what users don't realize is bad (sentinel-polluted phone columns, foreign IDs disguised as identity claims). Layered is the right composition.
+
+## Consequences
+
+Positive:
+- One mental model: "want to skip a column? `exclude_columns`." Works the same way across every entry point.
+- GoldenFlow's strip-and-reattach pattern (column passes through unchanged) preserves the column in golden record output without applying transforms.
+- MCP / A2A schemas can't drift — parity test enforces.
+
+Negative:
+- The runtime ContextVar (`_RUNTIME_EXCLUDE_COLUMNS`) is process-wide within a pytest worker. Tests that set it must reset it (autouse fixture in `tests/conftest.py`). Caught a real cross-test leak in CI; documented as a goldenmatch-specific gotcha.
+- The "additive layering" means there's no clean way to express "ignore detectors entirely, use ONLY my list." That's documented in #404's spec as an explicit non-goal — if a user filed for it, we'd add a `disable_autoconfig_exclusions: bool` flag.
+
+Cross-references:
+- Specs: `docs/superpowers/specs/2026-05-21-unified-column-exclusions-design.md` + `2026-05-21-exclude-columns-surfaces-design.md`
+- PRs: #404 (issue), #405 (detectors), #406 (API + YAML), #407 (CLI / REST / MCP / A2A surfaces)

--- a/docs/adr/0003-matchkey-vs-blocking-pools.md
+++ b/docs/adr/0003-matchkey-vs-blocking-pools.md
@@ -1,0 +1,45 @@
+# ADR-0003: Matchkey suitability vs blocking suitability as orthogonal axes
+
+**Status:** Accepted
+**Date:** 2026-05-21 (PRs #409, #411, #414)
+
+## Context
+
+Pre-#408, auto-config picked the highest-identity-score column for BOTH the matchkey role AND the blocking-key role. On healthcare data with `dm_npi` (federal NPI — every record has a unique NPI), this produced:
+- `matchkey: exact_dm_npi` — correct.
+- `blocking: [dm_npi]` — catastrophic. 980,531 blocks for 1.13M rows; each block has 1-3 records compared only to themselves; sync ETA 22-60 hours producing zero useful clusters.
+
+The user's diagnosis (#408): "autoconfig conflates 'good identity claim' with 'good blocking key.' They're orthogonal axes. A perfect identity claim like NPI is the worst-possible blocking key (1 row per block by definition)."
+
+## Decision
+
+Treat matchkey suitability and blocking suitability as independent column properties. A column may qualify for one, the other, both, or neither.
+
+- **Matchkey candidate**: high cardinality + identity-shaped values. Existing rule chain (`compute_column_priors`, etc.) handles this unchanged.
+- **Blocking candidate**: mid-cardinality (`0.001 ≤ ratio ≤ 0.5` by default, env-overridable). Below 0.001 → mega-block risk. Above 0.5 → singleton blocks.
+
+When no single column qualifies for blocking, search 2-column composites via joint cardinality. When that also fails, raise `ControllerNotConfidentError(failing_sub_profile="blocking")`.
+
+Cardinality is computed via **Chao1 sample-size correction** (ADR-0004) because auto-config profiles a sample, not the full frame.
+
+Rejected alternatives:
+- **Pick best for matchkey, force fall-through for blocking.** Tried first; the fallthrough silently committed `first_string` with `substring:0:5` → mega-block at full scale. Composite search and the fail-loud guard came in via #411.
+- **LLM-suggest blocking when single-column fails.** Heavier; cardinality-bounded heuristic works without an LLM call.
+- **Postgres-only `pg_stats.n_distinct` shortcut.** Tempting (exact, free) but doesn't generalize across connectors. Chao1 works universally.
+
+## Consequences
+
+Positive:
+- NPI keeps being picked as the matchkey it should be; the blocking role is denied without affecting matching.
+- Composite blocking auto-fallback on `zip + last_name` (or similar) lands without YAML config.
+- `BLOCKING_DEGENERATE` failing sub-profile in `ControllerNotConfidentError` is now part of the user-facing error vocabulary, distinct from data / scoring / cluster failures.
+
+Negative:
+- The cardinality bounds (`0.001 ≤ ratio ≤ 0.5`) are tunable defaults. Users with edge cases (e.g. legitimate per-record blocking) need the env var (`GOLDENMATCH_BLOCKING_MAX_RATIO`) or the `confidence_required=False` opt-out.
+- Sample-vs-full bias was a real shipping bug in #411 (caught by user as #410 v2). Tests passing the full df directly to `auto_configure_df` masked the gap. ADR-0004 fixed the underlying issue; this ADR notes the lesson: **test fixtures should sometimes be sub-sampled to surface controller-path behavior**.
+
+Cross-references:
+- Specs: `docs/superpowers/specs/2026-05-21-blocking-key-candidate-pool-design.md` + `2026-05-21-blocking-pool-followup-design.md`
+- PRs: #408 (issue), #409 (gate), #410 (follow-up issue), #411 (Chao1 + composite), #414 (true n_rows threading)
+- ADR-0004: Chao1 correction
+- ADR-0001: `confidence_required` gate (composes with `BLOCKING_DEGENERATE`)

--- a/docs/adr/0004-chao1-sample-correction.md
+++ b/docs/adr/0004-chao1-sample-correction.md
@@ -1,0 +1,45 @@
+# ADR-0004: Chao1 sample-size correction for autoconfig cardinality
+
+**Status:** Accepted
+**Date:** 2026-05-21 (PR #411, #414)
+
+## Context
+
+Auto-config profiles a 5K controller sample. The blocking-candidate gate (ADR-0003) checks `cardinality_ratio` against bounds (0.001–0.5). On real data, `zip` at full N=1.13M has ratio ~0.004 (5K distinct), but at sample N=1000 it shows ratio 0.6-0.8 (600-800 distinct) because the sample is too small to repeat any zip code many times. The gate would reject `zip` on sample data even though it's an obvious blocking candidate at full scale.
+
+Three projection options considered:
+
+| Option | Formula | Math character | Trade-off |
+|---|---|---|---|
+| **Linear** | `sample_distinct × full_n / sample_n` | overestimates | rejects more |
+| **Postgres `pg_stats.n_distinct`** | (exact, from catalog) | accurate | Postgres-only |
+| **Chao1 sqrt** | `sample_distinct × √(full_n / sample_n)` | sublinear, underestimates ~30% | passes more |
+
+## Decision
+
+Use the **Chao1 sqrt scaler** for projecting sample cardinality to full population. Universal across connectors; underestimates by ~30% on heavy-tail distributions, which is the **safe direction** for our gate (smaller projected ratio → more permissive on real columns → more likely to keep a useful blocking candidate).
+
+Implementation: `scale_cardinality_ratio_to_full_population(sample_distinct, sample_n_rows, full_n_rows)` in `core/blocking_candidates.py`. Same scaler reused by `estimate_avg_block_size` for the `BLOCKING_DEGENERATE` fail-loud guard.
+
+Env override: `GOLDENMATCH_BLOCKING_CARDINALITY_SCALER=observed` reverts to linear scaling (pre-#411 behavior) for users who want exact reproducibility against a prior version.
+
+Rejected alternatives:
+- **Linear scaling.** Overestimates distinct count on heavy-tail data; would incorrectly reject `zip` and similar mid-cardinality columns that ARE good blocking candidates.
+- **Postgres-specific `pg_stats.n_distinct`.** Works only for the postgres connector; the same problem exists for CSV / parquet / DuckDB. Universal Chao1 is the right default, with a Postgres optimization as a deferred follow-up.
+- **Coupon-collector exact correction.** Overkill — magnitude is what matters for the gate (is it ~0.05 or ~0.8), not 3-decimal precision.
+
+## Consequences
+
+Positive:
+- Mid-cardinality columns survive the gate even on small samples.
+- Same scaler composes into the `BLOCKING_DEGENERATE` guard (one formula, two consumers).
+- Postgres `pg_stats.n_distinct` shortcut is still possible as a future optimization without changing the API.
+
+Negative:
+- Chao1 **underestimates** uniqueness for per-record-unique columns sampled small. A column with 1000 distinct in a 1000-row sample projects to ratio ~0.03 at full N=1.13M, which **passes** the gate. The downstream `BLOCKING_DEGENERATE` guard catches this false-pass at the controller level (ADR-0001's machinery). Documented explicitly in the spec + test.
+- The `sample_n ≥ full_n` short-circuit (returns observed ratio) requires the controller to actually pass the true full count. Initial #411 shipped without the controller threading the true `n_rows` to v0 — sample size leaked in as `total_rows`. #414 fixed that by adding `n_rows_full` kwarg to `_legacy_auto_configure_v0` and threading from the controller. Tests now pin the contract.
+
+Cross-references:
+- Specs: `docs/superpowers/specs/2026-05-21-blocking-pool-followup-design.md`
+- PRs: #411 (Chao1 wiring), #414 (controller threading fix)
+- ADR-0003: matchkey vs blocking pools

--- a/docs/adr/0005-streaming-block-sync.md
+++ b/docs/adr/0005-streaming-block-sync.md
@@ -1,0 +1,39 @@
+# ADR-0005: Streaming-block sync as the >500K-row path
+
+**Status:** Accepted
+**Date:** 2026-05-21 (PRs #400, #402)
+
+## Context
+
+Pre-#386, `run_sync`'s full-scan path collected the entire input into memory before dispatching to `dedupe_df`. On an 8 GB sandbox, a 1.13M-row table × 60 cols × ~50 bytes/cell ≈ 5-8 GB collected, leaving no headroom for `dedupe_df`'s allocations. SIGKILL (exit 137) at the dispatch boundary; no clusters written.
+
+#386 added streaming-block sync (`_full_scan_streaming` in `db/sync.py`): walk the staging parquet one block at a time, score the block, write `gm_match_log` incrementally, drop the block frame, repeat. Peak RSS bounded by the largest individual block's scoring footprint, not the dataset total. #400 wired it behind a threshold-gated router.
+
+The remaining question (#401): what's the threshold?
+
+## Decision
+
+Default `GOLDENMATCH_SYNC_STREAMING_THRESHOLD = 500_000` rows. Above this, route to streaming-block. Below, use the legacy single-collect path (faster per-row, fits comfortably in 16 GB).
+
+Reasoning: 500K × 60 cols × ~50 bytes/cell ≈ 1.5 GB collected. Leaves room for `dedupe_df`'s allocations (~3-5 GB peak) on an 8 GB sandbox. The pre-#402 default of 5M was tuned for 16 GB+ hosts and failed open on 8 GB sandboxes.
+
+Rejected alternatives:
+- **Always stream.** Streaming is ~20-30% slower per row than the legacy single-collect on small frames (the per-block orchestration overhead doesn't pay off below ~500K rows). Default-on would tax every small-N user.
+- **Auto-detect host memory + size threshold to it.** Tempting but the user often runs goldenmatch in containers / sandboxes where free memory misrepresents available capacity. Explicit threshold + env override is simpler and predictable.
+- **Always single-collect, fix dedupe_df to accept a LazyFrame.** Bigger refactor; `dedupe_df`'s internal pipeline materializes anyway for matchkey computation. Wouldn't help.
+
+## Consequences
+
+Positive:
+- 1.13M-row syncs now complete on 8 GB sandboxes (the original #401 scenario).
+- The narrow scoring kernel (`_score_partition_with_config` in `core/pipeline.py`) is shared between streaming-block sync and distributed scoring (`distributed/scoring.py::_score_partition`). One kernel, two code paths.
+- Backend-selection log line at the routing point makes the chosen path observable without grepping.
+
+Negative:
+- Small-frame syncs (<500K) don't get the bounded-RSS guarantee. Users on memory-constrained hosts with <500K data either tolerate it (still fits) or lower `GOLDENMATCH_SYNC_STREAMING_THRESHOLD` explicitly.
+- The 500K default is a magic number tuned for 8 GB sandboxes. Users on 32 GB+ hosts may prefer the legacy path's speed even up to 5M. Documented; env-overridable.
+- V1 streaming-block sync is non-resumable. A 50M-row sync that fails partway requires re-running from scratch. Resumable state is a documented V2 follow-up; the spec calls this out.
+
+Cross-references:
+- Spec: `docs/superpowers/specs/2026-05-21-streaming-block-sync-design.md`
+- PRs: #386 (issue), #400 (implementation), #401 (followup issue), #402 (threshold change)

--- a/docs/adr/0006-telemetry-gated-rule-deprecation.md
+++ b/docs/adr/0006-telemetry-gated-rule-deprecation.md
@@ -1,0 +1,47 @@
+# ADR-0006: Telemetry-gated rule deprecation
+
+**Status:** Accepted
+**Date:** 2026-05-21 (pattern established for #124's deletion process)
+
+## Context
+
+`rule_demote_clustered_identity` (v1.11) was designed for one specific failure mode (T3 adversarial collision) that Path Y (v1.12) ended up solving differently. Phase 7 diagnostic showed the rule never fires in real workloads — earlier rules exhaust iteration budget first.
+
+Synthetic tests for the rule pass because they invoke it directly. But "never fires in production" is hard to prove without observation.
+
+The naive deletion path is: drop the rule + its 5-file collateral chain, run benchmarks, ship. The risk: a production workload somewhere DOES fire it, the deletion silently degrades that workload's matching, and the regression doesn't surface until much later.
+
+## Decision
+
+For autoconfig rules that are candidates for deletion, ship in two waves:
+
+**Wave 1 — Telemetry.** Add an INFO log at the rule's fire path, gated by an opt-in env var (`GOLDENMATCH_TELEMETRY_<RULE_NAME>=1`). Production users opt in; we collect firing counts via grep over a 1-2 week observation window.
+
+**Wave 2 — Deletion.** When telemetry confirms zero firings in production, delete the rule + every piece of collateral (helpers, indicators, dataclasses, test files, `DEFAULT_RULES` count assertions). Runs the full benchmark suite as the regression gate.
+
+The deletion gate is:
+- Zero firings in the telemetry window.
+- DQbench composite ≥ v1.12 floor.
+- No benchmark F1 regression.
+
+Rejected alternatives:
+- **Direct deletion.** Documented above as the risk path.
+- **Feature flag the rule, default off.** Adds permanent code paths that aren't deleted. Worse outcome than the two-wave approach.
+- **Mark deprecated + leave running.** Doesn't actually remove the maintenance surface or the iteration-budget cost. The point is to remove dead code, not annotate it.
+
+## Consequences
+
+Positive:
+- Removes the "did anyone use this?" uncertainty before deletion.
+- The pattern generalizes — any future rule deprecation follows the same two-wave shape.
+- Forces honest scoping: if telemetry shows non-zero firings, the deletion case has to be re-argued.
+
+Negative:
+- 1-2 week delay between Wave 1 and Wave 2. Requires patience.
+- The telemetry log is one more env var users have to know about. Documented in CLAUDE.md / spec.
+- If the env var isn't set anywhere in production (no opt-in), the observation window produces no signal. Mitigation: include the env var in the "release notes / migration guide" that prompts users to opt in.
+
+Cross-references:
+- Spec: `docs/superpowers/specs/2026-05-21-demote-rule-deletion-design.md`
+- Issue: #124
+- Roadmap: `docs/superpowers/specs/2026-05-21-v1-13-autoconfig-roadmap.md` Wave B (telemetry) → Wave C (deletion)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,73 @@
+# Architecture Decision Records (ADRs)
+
+Captures load-bearing architectural decisions in goldenmatch. Each ADR is a small markdown file in this directory, numbered sequentially.
+
+## Why
+
+The codebase has accumulated many decisions whose rationale is documented in PR descriptions, commit messages, or scattered through `docs/superpowers/specs/`. ADRs surface the **decisions themselves** — what choice was made, what alternatives were considered, what the consequences are — so future contributors can quickly understand "why is the system this way?" without archaeology.
+
+ADRs complement specs:
+- **Specs** describe HOW to build something (design + implementation plan).
+- **ADRs** describe WHY a load-bearing choice was made (and what was rejected).
+
+A spec is for the implementer. An ADR is for the next person who asks "why isn't this X instead?"
+
+## Format
+
+Standard [Michael Nygard format](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/locales/en/templates/decision-record-template-by-michael-nygard/index.md):
+
+```markdown
+# ADR-NNNN: Title
+
+**Status:** Proposed | Accepted | Deprecated | Superseded by ADR-XXXX
+**Date:** YYYY-MM-DD
+
+## Context
+What forced this decision? What's the situation?
+
+## Decision
+What was decided?
+
+## Consequences
+What follows from this — both positive and negative?
+```
+
+Keep each ADR short (≤ 1 page). Long debate goes in linked specs.
+
+## Status conventions
+
+- **Proposed** — under discussion; not yet implemented.
+- **Accepted** — decided + implemented. Most ADRs.
+- **Deprecated** — the decision is no longer in effect but kept for history.
+- **Superseded by ADR-NNNN** — replaced by a later decision. Don't delete; link forward.
+
+## When to write an ADR
+
+Write one when:
+- A load-bearing default changes (threshold, algorithm, API shape).
+- A rejected alternative needs to stay rejected (or future contributors will keep proposing it).
+- A non-obvious tradeoff was made (chose X over Y for non-obvious reason Z).
+- A pattern is established that should be followed elsewhere.
+
+Skip ADRs for:
+- Bug fixes (those are commit messages).
+- Routine refactors that preserve behavior.
+- Decisions captured fully in a single spec or PR.
+
+## Cross-references
+
+- Specs: `docs/superpowers/specs/`
+- Plans: `docs/superpowers/plans/`
+- Roadmaps: see specs marked as `Status: roadmap` (e.g. `2026-05-21-v1-13-autoconfig-roadmap.md`).
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| 0000 | Adopt ADR practice | Accepted |
+| 0001 | `confidence_required=True` as the default safety gate | Accepted |
+| 0002 | Unified `exclude_columns` API surface across the suite | Accepted |
+| 0003 | Matchkey suitability vs blocking suitability as orthogonal axes | Accepted |
+| 0004 | Chao1 sample-size correction for autoconfig cardinality | Accepted |
+| 0005 | Streaming-block sync as the >500K-row path | Accepted |
+| 0006 | Telemetry-gated rule deprecation | Accepted |

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -174,10 +174,14 @@ _STRAT_NAME_PREFERENCE = (
 def _pick_stratification_key(df: pl.DataFrame) -> str | None:
     """Pick the most-informative mid-cardinality column for stratification.
 
-    Picks columns with 10–500 distinct values; prefers blocking-shaped
-    names (zip, state, etc) as tiebreak. Returns None when no column
-    qualifies — caller falls back to uniform random.
+    Picks columns with 10–500 distinct values AND ratio < 0.5 (so
+    strata aren't singletons). Prefers blocking-shaped names (zip,
+    state, etc) as tiebreak. Returns None when no column qualifies —
+    caller falls back to uniform random.
     """
+    n_rows = df.height
+    if n_rows <= 0:
+        return None
     candidates: list[tuple[str, int, int]] = []  # (name, distinct, preference_rank)
     for col in df.columns:
         if col.startswith("__"):  # skip internal bookkeeping
@@ -187,6 +191,12 @@ def _pick_stratification_key(df: pl.DataFrame) -> str | None:
         except Exception:  # pragma: no cover -- defensive
             continue
         if not (_STRAT_MIN_DISTINCT <= n_distinct <= _STRAT_MAX_DISTINCT):
+            continue
+        # Skip columns where most rows are unique. partition_by on a
+        # near-unique column produces N singleton strata; the inner loop's
+        # `alloc >= stratum.height` branch returns all of them, defeating
+        # the sample cap.
+        if n_distinct / n_rows > 0.5:
             continue
         # Lower preference_rank = better match. -1 = name matched preferences.
         rank = -1 if any(p in col.lower() for p in _STRAT_NAME_PREFERENCE) else 0

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -153,6 +153,91 @@ def _call_policy_propose(
     return policy.propose(profile, current, history)
 
 
+# #131: stratified-sampling helpers. Mid-cardinality column picker +
+# Polars-native stratified sampler. Both module-level so tests can
+# unit-test them without spinning up a full AutoConfigController.
+
+# Stratification-key cardinality band. Below MIN, too few distinct
+# values to stratify usefully; above MAX, too many strata (every
+# stratum gets ~1 row, no signal).
+_STRAT_MIN_DISTINCT = 10
+_STRAT_MAX_DISTINCT = 500
+
+# Column-name regex preference: blocking-shaped columns make better
+# strat keys than arbitrary mid-card columns. Used as a tiebreak.
+_STRAT_NAME_PREFERENCE = (
+    "zip", "postal", "state", "region", "country", "city",
+    "phone_area", "area_code",
+)
+
+
+def _pick_stratification_key(df: pl.DataFrame) -> str | None:
+    """Pick the most-informative mid-cardinality column for stratification.
+
+    Picks columns with 10–500 distinct values; prefers blocking-shaped
+    names (zip, state, etc) as tiebreak. Returns None when no column
+    qualifies — caller falls back to uniform random.
+    """
+    candidates: list[tuple[str, int, int]] = []  # (name, distinct, preference_rank)
+    for col in df.columns:
+        if col.startswith("__"):  # skip internal bookkeeping
+            continue
+        try:
+            n_distinct = int(df[col].n_unique())
+        except Exception:  # pragma: no cover -- defensive
+            continue
+        if not (_STRAT_MIN_DISTINCT <= n_distinct <= _STRAT_MAX_DISTINCT):
+            continue
+        # Lower preference_rank = better match. -1 = name matched preferences.
+        rank = -1 if any(p in col.lower() for p in _STRAT_NAME_PREFERENCE) else 0
+        candidates.append((col, n_distinct, rank))
+    if not candidates:
+        return None
+    # Sort: preference-rank ASC (preferred names first), then by
+    # distinct count DESC (more strata = finer stratification, up to cap).
+    candidates.sort(key=lambda x: (x[2], -x[1]))
+    return candidates[0][0]
+
+
+def _stratified_sample(
+    df: pl.DataFrame,
+    strat_key: str,
+    target_n: int,
+    *,
+    min_per_stratum: int = 10,
+    seed: int = 0,
+) -> pl.DataFrame:
+    """Sample ``target_n`` rows stratified by ``strat_key``.
+
+    Allocates rows proportionally to stratum size, with a minimum
+    floor (``min_per_stratum``) so rare strata get representation
+    even when proportional allocation would round them to 0. If the
+    sum of floors exceeds target_n (very many small strata), each
+    stratum gets ``target_n // n_strata`` rows.
+    """
+    strata = df.partition_by(strat_key, as_dict=False)
+    n_strata = len(strata)
+    if n_strata == 0:
+        return df.sample(n=min(target_n, df.height), seed=seed, shuffle=True)
+    # Proportional allocation with floor.
+    total = df.height
+    allocations: list[int] = []
+    for stratum in strata:
+        proportional = max(int(stratum.height * target_n / total), min_per_stratum)
+        allocations.append(min(proportional, stratum.height))
+    # If the floor blew the budget, fall back to even allocation.
+    if sum(allocations) > target_n * 1.5:
+        per_stratum = max(target_n // n_strata, 1)
+        allocations = [min(per_stratum, s.height) for s in strata]
+    samples = []
+    for stratum, alloc in zip(strata, allocations):
+        if alloc >= stratum.height:
+            samples.append(stratum)
+        elif alloc > 0:
+            samples.append(stratum.sample(n=alloc, seed=seed, shuffle=True))
+    return pl.concat(samples) if samples else df.head(target_n)
+
+
 class ConfigValidationError(Exception):
     """Raised when input data is unworkable for ER (empty, all-null, etc.)."""
 
@@ -1031,6 +1116,20 @@ class AutoConfigController:
             return df
         seed = self._seed_for(df)
         n = min(self.budget.sample_size_default, df.height)
+
+        # #131: stratified sampling. When a mid-cardinality column is
+        # available (typically zip, state, or similar blocking-shaped
+        # column), stratify by it so rare values get representation.
+        # Random sampling under-represents the long-tail on heavy-tailed
+        # distributions, skewing the controller's cardinality estimates.
+        if os.environ.get("GOLDENMATCH_AUTOCONFIG_SAMPLE_STRATEGY", "").lower() != "random":
+            strat_key = _pick_stratification_key(df)
+            if strat_key is not None:
+                return _stratified_sample(
+                    df, strat_key, n,
+                    min_per_stratum=10, seed=seed,
+                )
+
         # Polars sample with shuffle=False keeps row order; we want diverse coverage so shuffle=True.
         return df.sample(n=n, seed=seed, shuffle=True)
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_policy.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_policy.py
@@ -49,6 +49,13 @@ class HeuristicRefitPolicy:
       - None = satisfied → controller breaks loop with POLICY_SATISFIED
       - A new config that == current is also treated as satisfied (bug guard)
       - A previously-seen config is allowed; oscillation handled by controller
+
+    #127: per-rule fire-history guard. If a rule fires with the same
+    ``(rule_name, rationale)`` as the immediately-previous call, the
+    policy skips it and advances to the next rule. Prevents
+    iteration-budget exhaustion on rules that oscillate (e.g.
+    ``rule_blocking_too_coarse`` flipping between ``last_name`` and
+    ``email`` indefinitely).
     """
 
     def __init__(self, rules: list[Rule] | None = None) -> None:
@@ -56,6 +63,10 @@ class HeuristicRefitPolicy:
             from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
             rules = DEFAULT_RULES
         self._rules: list[Rule] = rules
+        # #127: track the most recent (rule_name, rationale) that fired
+        # so the next propose call can skip identical fires. None until
+        # the first non-None outcome.
+        self._last_fire: tuple[str, str] | None = None
 
     def propose(
         self,
@@ -75,6 +86,17 @@ class HeuristicRefitPolicy:
                 # Bug guard: rule "decided to do nothing" without saying so.
                 # Logged at WARN by the controller (not here — keep policy pure).
                 return None
+            # #127: oscillation guard. If this rule fired with the same
+            # rationale on the immediately-previous call, skip it.
+            key = (decision.rule_name, decision.rationale)
+            if self._last_fire is not None and key == self._last_fire:
+                _osc_logger = __import__("logging").getLogger(__name__)
+                _osc_logger.info(
+                    "Oscillation guard: skipping %s (same rationale as prev): %r. See #127.",
+                    decision.rule_name, decision.rationale,
+                )
+                continue  # advance to next rule
+            self._last_fire = key
             # Attach decision to the latest history entry, if any
             if history.entries:
                 history.entries[-1].decision = decision

--- a/packages/python/goldenmatch/tests/test_oscillation_guard.py
+++ b/packages/python/goldenmatch/tests/test_oscillation_guard.py
@@ -1,0 +1,158 @@
+"""Tests for iteration-oscillation guard (#127).
+
+Spec: docs/superpowers/specs/2026-05-21-oscillation-guard-design.md
+"""
+
+from __future__ import annotations
+
+import pytest
+from goldenmatch.config.schemas import GoldenMatchConfig
+from goldenmatch.core.autoconfig_history import PolicyDecision, RunHistory
+from goldenmatch.core.autoconfig_policy import HeuristicRefitPolicy
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ComplexityProfile,
+    DataProfile,
+    ScoringProfile,
+)
+
+
+def _red_profile_with_oversized_block() -> ComplexityProfile:
+    """Build a RED ComplexityProfile that would normally provoke a
+    blocking-too-coarse rule."""
+    return ComplexityProfile(
+        data=DataProfile(n_rows=100_000, n_cols=5),
+        blocking=BlockingProfile(
+            n_blocks=2,
+            total_comparisons=5_000_000_000,
+            reduction_ratio=0.001,
+            block_sizes_p99=50_000,
+            block_sizes_max=50_000,
+            oversized_block_count=2,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=0,
+            candidates_compared=1,
+            dip_statistic=0.01,
+            mass_above_threshold=0.01,
+            mass_in_borderline=0.0,
+        ),
+    )
+
+
+def test_oscillation_guard_skips_repeat_rule_same_rationale():
+    """A rule firing with identical (rule_name, rationale) on
+    consecutive propose calls is skipped on the second call.
+
+    Uses a synthetic single-rule policy where the rule always returns
+    the same decision tuple. Without the guard, propose returns the
+    same config forever; with the guard, the second call falls through
+    to return None (no other rules to try).
+    """
+    fire_count = {"n": 0}
+
+    def _always_fire_same(profile, current, history):
+        fire_count["n"] += 1
+        # Distinguishing new_config so the bug-guard ("new_config == current"
+        # → return None) doesn't preempt the oscillation guard under test.
+        new_cfg = GoldenMatchConfig(backend=f"alt_{fire_count['n']}")
+        decision = PolicyDecision(
+            rule_name="rule_oscillates",
+            rationale="same_rationale_always",
+            config_diff={"x": 1},
+        )
+        return new_cfg, decision
+
+    policy = HeuristicRefitPolicy(rules=[_always_fire_same])
+    history = RunHistory()
+    profile = _red_profile_with_oversized_block()
+    current = GoldenMatchConfig()
+
+    # First call: rule fires.
+    result1 = policy.propose(profile, current=current, history=history)
+    assert result1 is not None
+    assert fire_count["n"] == 1
+
+    # Second call: rule fires again, same (name, rationale), so guard skips.
+    # No other rules → policy returns None.
+    result2 = policy.propose(profile, current=current, history=history)
+    assert result2 is None, "guard should have skipped the duplicate fire"
+
+
+def test_oscillation_guard_allows_repeat_rule_with_different_rationale():
+    """Same rule, different rationale → both fires allowed. Pins that
+    the guard keys on rationale, not just rule_name."""
+    call_count = {"n": 0}
+
+    def _vary_rationale(profile, current, history):
+        call_count["n"] += 1
+        return GoldenMatchConfig(backend=f"alt_{call_count['n']}"), PolicyDecision(
+            rule_name="rule_varies",
+            rationale=f"different_rationale_{call_count['n']}",  # different each call
+            config_diff={},
+        )
+
+    policy = HeuristicRefitPolicy(rules=[_vary_rationale])
+    history = RunHistory()
+    profile = _red_profile_with_oversized_block()
+    current = GoldenMatchConfig()
+
+    result1 = policy.propose(profile, current=current, history=history)
+    result2 = policy.propose(profile, current=current, history=history)
+
+    assert result1 is not None
+    assert result2 is not None, "different rationale should bypass the guard"
+
+
+def test_oscillation_guard_falls_through_to_next_rule_when_first_blocked():
+    """When rule A is guard-blocked, the policy advances to rule B."""
+    def _rule_a_fires_same(profile, current, history):
+        return GoldenMatchConfig(backend="a"), PolicyDecision(
+            rule_name="rule_a",
+            rationale="repeating",
+            config_diff={},
+        )
+
+    def _rule_b_fires_once(profile, current, history):
+        return GoldenMatchConfig(backend="b"), PolicyDecision(
+            rule_name="rule_b",
+            rationale="ran_at_least_once",
+            config_diff={},
+        )
+
+    policy = HeuristicRefitPolicy(rules=[_rule_a_fires_same, _rule_b_fires_once])
+    history = RunHistory()
+    profile = _red_profile_with_oversized_block()
+    current = GoldenMatchConfig()
+
+    # First call: rule_a fires.
+    policy.propose(profile, current=current, history=history)
+    # Second call: rule_a guard-blocked → rule_b fires.
+    result2 = policy.propose(profile, current=current, history=history)
+    assert result2 is not None
+    # Verify rule_b was the one that fired by checking the attached decision.
+    if history.entries:
+        decision = history.entries[-1].decision
+        if decision is not None:
+            assert decision.rule_name == "rule_b"
+
+
+def test_oscillation_guard_first_call_never_blocks():
+    """No prior fire → first call always proceeds."""
+    def _rule(profile, current, history):
+        return GoldenMatchConfig(backend="x"), PolicyDecision(
+            rule_name="any_rule",
+            rationale="any_rationale",
+            config_diff={},
+        )
+
+    policy = HeuristicRefitPolicy(rules=[_rule])
+    history = RunHistory()
+    profile = _red_profile_with_oversized_block()
+
+    result = policy.propose(profile, current=GoldenMatchConfig(), history=history)
+    assert result is not None
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_stratified_sampling.py
+++ b/packages/python/goldenmatch/tests/test_stratified_sampling.py
@@ -1,0 +1,118 @@
+"""Tests for stratified autoconfig sampling (#131).
+
+Spec: docs/superpowers/specs/2026-05-21-stratified-sampling-design.md
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.core.autoconfig_controller import (
+    _pick_stratification_key,
+    _stratified_sample,
+)
+
+
+def test_pick_stratification_key_picks_mid_cardinality():
+    """50-distinct column wins over 5000-distinct + 3-distinct."""
+    df = pl.DataFrame({
+        "high_card": [f"id_{i}" for i in range(5000)],
+        "mid_card": [f"zip_{i % 50}" for i in range(5000)],  # 50 distinct
+        "low_card": ["A", "B", "C"] * 1666 + ["A", "B"],  # 3 distinct
+    })
+    assert _pick_stratification_key(df) == "mid_card"
+
+
+def test_pick_stratification_key_prefers_blocking_named_columns():
+    """Among mid-cardinality candidates, prefer blocking-shaped names."""
+    df = pl.DataFrame({
+        "random_attr": [f"x_{i % 30}" for i in range(1000)],  # 30 distinct
+        "zip_code": [f"{i % 50:05d}" for i in range(1000)],   # 50 distinct, named
+    })
+    # zip_code has more distinct, BUT name preference is the tiebreak.
+    # Algorithm: sort by (preference_rank ASC, -distinct ASC). zip_code
+    # is rank=-1 (preferred), random_attr is rank=0. zip_code wins.
+    assert _pick_stratification_key(df) == "zip_code"
+
+
+def test_pick_stratification_key_returns_none_when_no_mid_card_columns():
+    """Per-record-unique + binary-only columns → None."""
+    df = pl.DataFrame({
+        "id": [f"u_{i}" for i in range(1000)],          # 1000 distinct
+        "is_active": [True, False] * 500,                 # 2 distinct
+    })
+    assert _pick_stratification_key(df) is None
+
+
+def test_pick_stratification_key_skips_internal_columns():
+    """__row_id__ / __source__ etc. never picked as strat keys."""
+    df = pl.DataFrame({
+        "__row_id__": list(range(1000)),
+        "__source__": [f"src_{i % 50}" for i in range(1000)],  # mid-card but internal
+        "real_zip": [f"{i % 100:05d}" for i in range(1000)],
+    })
+    result = _pick_stratification_key(df)
+    assert result == "real_zip"
+
+
+# ---------------------------------------------------------------------------
+# _stratified_sample
+# ---------------------------------------------------------------------------
+
+
+def test_stratified_sample_represents_rare_strata():
+    """Rare stratum (1% of data) gets the min_per_stratum floor."""
+    # 990 rows in stratum 'A', 10 rows in stratum 'B' (1% rare).
+    df = pl.DataFrame({
+        "zip": (["A"] * 990) + (["B"] * 10),
+        "id": list(range(1000)),
+    })
+    # Target 100 rows; with min_per_stratum=10, rare stratum gets at least 10.
+    sample = _stratified_sample(df, "zip", target_n=100, min_per_stratum=10, seed=42)
+    b_count = sample.filter(pl.col("zip") == "B").height
+    assert b_count >= 10, (
+        f"rare stratum 'B' got {b_count} rows; min_per_stratum=10 violated"
+    )
+
+
+def test_stratified_sample_random_only_under_represents_rare():
+    """Sanity check: random sampling under-represents rare 1% stratum."""
+    df = pl.DataFrame({
+        "zip": (["A"] * 990) + (["B"] * 10),
+        "id": list(range(1000)),
+    })
+    # Random sample of 100: B gets ~1 row in expectation (vs 10 with strat).
+    random_sample = df.sample(n=100, seed=42, shuffle=True)
+    strat_sample = _stratified_sample(df, "zip", 100, min_per_stratum=10, seed=42)
+    b_random = random_sample.filter(pl.col("zip") == "B").height
+    b_strat = strat_sample.filter(pl.col("zip") == "B").height
+    assert b_strat >= b_random, (
+        f"stratified ({b_strat}) should match-or-beat random ({b_random})"
+    )
+
+
+def test_stratified_sample_respects_stratum_size_when_smaller_than_floor():
+    """If a stratum has 5 rows and min_per_stratum=10, sample takes all 5."""
+    df = pl.DataFrame({
+        "zip": (["A"] * 100) + (["B"] * 5),
+        "id": list(range(105)),
+    })
+    sample = _stratified_sample(df, "zip", target_n=50, min_per_stratum=10, seed=42)
+    b_count = sample.filter(pl.col("zip") == "B").height
+    # Can't sample more than the stratum has.
+    assert b_count == 5
+
+
+def test_stratified_sample_returns_concat_of_per_stratum():
+    """Output is a Polars DataFrame with same columns as input."""
+    df = pl.DataFrame({
+        "zip": [f"z{i % 5}" for i in range(100)],
+        "name": [f"n_{i}" for i in range(100)],
+    })
+    sample = _stratified_sample(df, "zip", target_n=30, seed=42)
+    assert set(sample.columns) == {"zip", "name"}
+    assert sample.height > 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Wave A of the v1.13 autoconfig roadmap (`docs/superpowers/specs/2026-05-21-v1-13-autoconfig-roadmap.md`). Plus: adopts the ADR practice with 7 foundational ADRs capturing recent load-bearing decisions.

### ADRs

`docs/adr/` initialized — see `README.md`. ADR-0000 through ADR-0006 capture: confidence_required gate, unified exclude_columns, matchkey/blocking pool split, Chao1 correction, streaming-block sync, telemetry-gated deprecation. Complements specs (HOW) + plans (sequencing) by surfacing WHY load-bearing choices were made.

### #131 — stratified sampling

`_sample_one` picks a mid-cardinality column (preferring zip/state/etc) and stratifies by it. `min_per_stratum=10` floor protects rare strata. Falls back to random when no qualifying column. Env-rollback via `GOLDENMATCH_AUTOCONFIG_SAMPLE_STRATEGY=random`.

### #127 — oscillation guard

`HeuristicRefitPolicy` tracks the last `(rule_name, rationale)` fired. Identical fire next call → guard skips, policy advances. Different rationale bypasses. First call never blocks.

## Test plan

- [x] 12 new unit tests across `test_stratified_sampling.py` + `test_oscillation_guard.py`.
- [x] 77 passed across Wave A + adjacent regression (blocking + autoconfig + NE).
- [x] `uv run ruff check` clean.

Closes #131. Closes #127.