### PR TITLE
fix(#417): enforce --exclude-columns pre-autoconfig + matchkey-derived blocking guard

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/cli/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/sync.py
@@ -68,24 +68,41 @@ def sync_cmd(
             row_count = connector.get_row_count(table)
             console.print(f"Connected. Table [cyan]{table}[/cyan] has [green]{row_count:,}[/green] rows.")
 
-        # Auto-configure if no config
+        # #417: parse --exclude-columns BEFORE autoconfig runs. Previously
+        # auto_configure was called first, then exclusions were merged
+        # into the resulting cfg -- but by then matchkeys + blocking had
+        # already been built from the excluded columns. The user reported
+        # `--exclude-columns dm_npi` still produced `exact_dm_npi` matchkey
+        # because the exclusion arrived too late to filter candidates.
+        from goldenmatch._exclusions_schema import (
+            merge_exclude_columns_into_config,
+            parse_csv_exclude_columns,
+        )
+        _cli_excludes = parse_csv_exclude_columns(exclude_columns)
+
+        # Auto-configure if no config. exclude_columns set via the
+        # ContextVar so the detector chain sees them as user-supplied
+        # exclusions BEFORE matchkey + blocking selection.
         if cfg is None:
-            from goldenmatch.core.autoconfig import auto_configure
-            # Read sample for profiling
-            sample = next(connector.read_table(table, chunk_size=1000))
-            import tempfile
-            with tempfile.NamedTemporaryFile(suffix=".csv", delete=False, mode="w") as f:
-                sample.write_csv(f.name)
-                cfg = auto_configure([(f.name, table)])
+            from goldenmatch.core.autoconfig import (
+                _RUNTIME_EXCLUDE_COLUMNS,
+                auto_configure,
+            )
+            _ctx_token = _RUNTIME_EXCLUDE_COLUMNS.set(_cli_excludes or None)
+            try:
+                # Read sample for profiling
+                sample = next(connector.read_table(table, chunk_size=1000))
+                import tempfile
+                with tempfile.NamedTemporaryFile(suffix=".csv", delete=False, mode="w") as f:
+                    sample.write_csv(f.name)
+                    cfg = auto_configure([(f.name, table)])
+            finally:
+                _RUNTIME_EXCLUDE_COLUMNS.reset(_ctx_token)
             if not quiet:
                 console.print("[green]Auto-configured matching rules.[/green]")
 
-        # Merge --exclude-columns into config (additive with YAML field).
-        # Done AFTER auto-configure if zero-config path ran, so detector
-        # exclusions are in place first; user CLI exclusions layer on top.
-        from goldenmatch._exclusions_schema import (
-            merge_exclude_columns_into_config,
-        )
+        # Also merge CLI excludes into the config object so the downstream
+        # sync pipeline + GoldenFlow / GoldenCheck surfaces see them.
         _resolved_excludes = merge_exclude_columns_into_config(
             cfg, exclude_columns,
         )

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -892,43 +892,41 @@ class AutoConfigController:
 
             # Keys are present -- run the estimator-based guard. (Or keys
             # absent but profile not RED -- existing trust-the-profile path.)
-            if _blocking is None or not getattr(_blocking, "keys", None):
-                # Empty keys + profile not RED -- skip the rest of the
-                # guard. Pre-existing path (trust the profile).
-                pass
-            else:
-                _block_fields: list[str] = []
+            # #417 v3: when blocking.keys is empty, the downstream
+            # streaming sync derives effective blocking from
+            # matchkeys[0].fields (the user reported this behavior
+            # producing a mega-block when matchkey is a sparse identity
+            # column like NPI). Inspect those fields here too so the
+            # guard sees the real blocking shape, not just the
+            # explicit config.blocking.keys.
+            _block_fields: list[str] = []
+            if _blocking is not None and getattr(_blocking, "keys", None):
                 for _key in _blocking.keys:
                     if _key.fields:
                         _block_fields.extend(_key.fields)
-                if _block_fields:
-                    _avg_block_size = estimate_avg_block_size(
-                        sample, _block_fields, n_rows,
-                    )
-                    _too_small = _avg_block_size < degenerate_guard_threshold()
-                    # #417: mega-block case. When every row hashes to the
-                    # same blocking key, avg_block_size == n_rows. Catch it
-                    # before the downstream sync wedges in O(n^2) scoring.
-                    _too_large = _avg_block_size > degenerate_guard_max_avg_block_size()
-                    if _too_small or _too_large:
-                        logger.warning(
-                            "BLOCKING_DEGENERATE guard fired: avg_block_size=%.1f "
-                            "(too_small=%s, too_large=%s, fields=%s). See #417.",
-                            _avg_block_size, _too_small, _too_large, _block_fields,
-                        )
-                        _LAST_CONTROLLER_RUN.set(history)
-                        raise ControllerNotConfidentError(
-                            n_rows=n_rows,
-                            failing_sub_profile="blocking",
-                            stop_reason=StopReason.BLOCKING_DEGENERATE.name,
-                        )
-                elif _profile_red:
-                    # Keys exist but every key has empty `fields` AND
-                    # profile is RED -- another degenerate shape.
+            elif _profile_red:
+                # No explicit blocking.keys; fall back to matchkeys[0]
+                # so we catch the implicit-blocking degenerate case.
+                _mks = best_entry.config.get_matchkeys() or []
+                if _mks and _mks[0].fields:
+                    _block_fields = [
+                        f.field for f in _mks[0].fields if f.field
+                    ]
+
+            if _block_fields:
+                _avg_block_size = estimate_avg_block_size(
+                    sample, _block_fields, n_rows,
+                )
+                _too_small = _avg_block_size < degenerate_guard_threshold()
+                # #417: mega-block case. When every row hashes to the
+                # same blocking key, avg_block_size == n_rows. Catch it
+                # before the downstream sync wedges in O(n^2) scoring.
+                _too_large = _avg_block_size > degenerate_guard_max_avg_block_size()
+                if _too_small or _too_large:
                     logger.warning(
-                        "BLOCKING_DEGENERATE guard fired: blocking keys present "
-                        "but every key has empty `fields` at n_rows=%d. See #417.",
-                        n_rows,
+                        "BLOCKING_DEGENERATE guard fired: avg_block_size=%.1f "
+                        "(too_small=%s, too_large=%s, fields=%s). See #417.",
+                        _avg_block_size, _too_small, _too_large, _block_fields,
                     )
                     _LAST_CONTROLLER_RUN.set(history)
                     raise ControllerNotConfidentError(
@@ -936,6 +934,20 @@ class AutoConfigController:
                         failing_sub_profile="blocking",
                         stop_reason=StopReason.BLOCKING_DEGENERATE.name,
                     )
+            elif _blocking is not None and _blocking.keys and _profile_red:
+                # Keys exist but every key has empty `fields` AND profile
+                # is RED -- another degenerate shape.
+                logger.warning(
+                    "BLOCKING_DEGENERATE guard fired: blocking keys present "
+                    "but every key has empty `fields` at n_rows=%d. See #417.",
+                    n_rows,
+                )
+                _LAST_CONTROLLER_RUN.set(history)
+                raise ControllerNotConfidentError(
+                    n_rows=n_rows,
+                    failing_sub_profile="blocking",
+                    stop_reason=StopReason.BLOCKING_DEGENERATE.name,
+                )
 
         # Task 6.1: stamp committed profile with eager column_priors + indicators.
         import dataclasses


### PR DESCRIPTION
## Summary

Closes #417 (third pass). User's retest after #420 surfaced two distinct bugs not addressed by #419/#420.

### 1. `--exclude-columns` was applied AFTER autoconfig

CLI sync.py ran `auto_configure` first, then merged `--exclude-columns` into the resulting config. By then matchkeys + blocking were already built from the to-be-excluded columns. User excluded `dm_npi` but autoconfig still picked `exact_dm_npi` as the primary matchkey.

Fix: parse CLI excludes BEFORE `auto_configure`, set `_RUNTIME_EXCLUDE_COLUMNS` ContextVar (the same mechanism `dedupe_df` / `match_df` use), reset in finally. The detector chain in `auto_configure_df` reads the ContextVar and drops columns from df before the controller selects candidates.

### 2. Guard didn't observe matchkey-derived blocking

When `config.blocking.keys` is empty, the streaming sync derives effective blocking from `matchkeys[0].fields`. The `BLOCKING_DEGENERATE` guard only checked `config.blocking.keys`, so it skipped exactly the path where the user's mega-block came from: empty `blocking.keys` + sparse-NPI matchkey -> all-NULL hashes -> one block of 1.13M rows.

Fix: when `blocking.keys` is empty AND profile is RED, fall back to inspecting `matchkeys[0].fields`. Estimator-based check then sees the real degenerate shape and raises.

## Test plan

- [x] `uv run ruff check` clean
- [ ] CI is the gate