### PR TITLE
fix(#424): COPY-based match log + buffer pairs across blocks

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/db/metadata.py
+++ b/packages/python/goldenmatch/goldenmatch/db/metadata.py
@@ -151,23 +151,51 @@ def log_matches_batch(
     matches: list[tuple[int, int, float, str]],
     run_id: str,
 ) -> None:
-    """Batch log match decisions."""
+    """Batch log match decisions.
+
+    #424: psycopg3's ``executemany`` is NOT pipelined unless wrapped in
+    ``with conn.pipeline():`` -- the previous code's comment was wrong.
+    Each row was N round-trips at ~7ms RTT to a managed Postgres,
+    capping throughput at ~125 rows/sec on the user's 1.13M-row run.
+    Use ``cursor.copy()`` instead -- 10-100x faster for bulk loads.
+    """
     if not matches:
         return
-    # psycopg3 dropped psycopg2.extras.execute_values; the documented
-    # replacement is executemany on a parameterized INSERT. psycopg3's
-    # executemany is also pipelined (single round-trip per N rows) so
-    # the throughput is comparable to the old VALUES-batched form.
+
+    # Detect psycopg3 cursor.copy() support. PostgresConnector ships
+    # psycopg3 via the [postgres] extra; SQLite / DuckDB connectors
+    # don't have copy(). Probe for the method on a real cursor.
     cursor = connector.conn.cursor()
     try:
-        cursor.executemany(
-            "INSERT INTO gm_match_log (record_id_a, record_id_b, score, action, run_id) "
-            "VALUES (%s, %s, %s, %s, %s)",
-            [(a, b, s, action, run_id) for a, b, s, action in matches],
-        )
-        connector.conn.commit()
-    except Exception:
-        connector.conn.rollback()
-        raise
+        if hasattr(cursor, "copy"):
+            # psycopg3 COPY path. ~10-100x faster than executemany at the
+            # observed batch sizes. The COPY ... FROM STDIN BINARY form
+            # would be faster still but text is simpler + robust.
+            copy_stmt = (
+                "COPY gm_match_log "
+                "(record_id_a, record_id_b, score, action, run_id) "
+                "FROM STDIN"
+            )
+            try:
+                with cursor.copy(copy_stmt) as copy:
+                    for a, b, s, action in matches:
+                        copy.write_row((a, b, s, action, run_id))
+                connector.conn.commit()
+            except Exception:
+                connector.conn.rollback()
+                raise
+        else:
+            # Fallback for non-psycopg3 connectors (SQLite test paths etc).
+            try:
+                cursor.executemany(
+                    "INSERT INTO gm_match_log "
+                    "(record_id_a, record_id_b, score, action, run_id) "
+                    "VALUES (%s, %s, %s, %s, %s)",
+                    [(a, b, s, action, run_id) for a, b, s, action in matches],
+                )
+                connector.conn.commit()
+            except Exception:
+                connector.conn.rollback()
+                raise
     finally:
         cursor.close()

--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -872,6 +872,37 @@ def _full_scan_streaming(
     # Match-log batching: collect all pairs from a worker, log when
     # the worker returns, so a long run is still visible in
     # gm_matches as blocks complete (mirrors the serial behavior).
+    # #424: buffer pairs across blocks before flushing to gm_match_log.
+    # The per-block log_matches_batch call has connection / commit
+    # overhead; flushing in larger batches amortizes that. Default 10K
+    # pairs per flush, env-overridable.
+    _flush_threshold_env = _os.environ.get("GOLDENMATCH_MATCH_LOG_FLUSH_PAIRS")
+    if _flush_threshold_env:
+        try:
+            flush_threshold = max(int(_flush_threshold_env), 1)
+        except ValueError:
+            flush_threshold = 10_000
+    else:
+        flush_threshold = 10_000
+
+    # Skip-audit env var (#424): for nightly-cron workloads that only
+    # consume gm_clusters / gm_golden_records, opt out of per-pair
+    # logging entirely.
+    _skip_match_log = _os.environ.get("GOLDENMATCH_SKIP_MATCH_LOG") == "1"
+    if _skip_match_log:
+        logger.info(
+            "Streaming pipeline: GOLDENMATCH_SKIP_MATCH_LOG=1; "
+            "skipping gm_match_log writes (#424)",
+        )
+
+    _match_log_buffer: list[tuple[int, int, float, str]] = []
+
+    def _flush_match_log() -> None:
+        if dry_run or _skip_match_log or not _match_log_buffer:
+            return
+        log_matches_batch(connector, _match_log_buffer, run_id)
+        _match_log_buffer.clear()
+
     if max_workers <= 1 or len(work_items) <= 2:
         # Serial fallback path -- same as pre-#422.
         for args in work_items:
@@ -885,12 +916,12 @@ def _full_scan_streaming(
                 staging_dir, block_key, config, _empty_serial,
             )
             all_pairs.extend(pairs)
-            if pairs and not dry_run:
-                log_matches_batch(
-                    connector,
-                    [(int(a), int(b), float(s), "merged") for a, b, s in pairs],
-                    run_id,
+            if pairs:
+                _match_log_buffer.extend(
+                    (int(a), int(b), float(s), "merged") for a, b, s in pairs
                 )
+                if len(_match_log_buffer) >= flush_threshold:
+                    _flush_match_log()
     else:
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             for i, block_key, block_n, pairs in pool.map(_score_one, work_items):
@@ -899,12 +930,15 @@ def _full_scan_streaming(
                     i + 1, block_index.height, block_key, block_n, len(pairs),
                 )
                 all_pairs.extend(pairs)
-                if pairs and not dry_run:
-                    log_matches_batch(
-                        connector,
-                        [(int(a), int(b), float(s), "merged") for a, b, s in pairs],
-                        run_id,
+                if pairs:
+                    _match_log_buffer.extend(
+                        (int(a), int(b), float(s), "merged") for a, b, s in pairs
                     )
+                    if len(_match_log_buffer) >= flush_threshold:
+                        _flush_match_log()
+
+    # Final flush of any remaining buffered pairs.
+    _flush_match_log()
 
     # Final cross-block dedup: canonical (min, max) tuple set. Replaces
     # the per-block matched_pairs lookup that was dropped above.

--- a/packages/python/goldenmatch/tests/test_sync_streaming.py
+++ b/packages/python/goldenmatch/tests/test_sync_streaming.py
@@ -342,9 +342,18 @@ def test_full_scan_streaming_returns_expected_dict_shape(tmp_path, monkeypatch):
 
 
 def test_full_scan_streaming_writes_incrementally(tmp_path, monkeypatch):
-    """Step 3: match log writes fire per-block, not once at the end.
-    Lets a long sync show progress as blocks finish."""
+    """Step 3: match log writes fire as blocks complete, not all at the
+    end. Lets a long sync show progress as blocks finish.
+
+    #424: post-#424, writes batch via GOLDENMATCH_MATCH_LOG_FLUSH_PAIRS
+    (default 10K) so the COPY-based path amortizes commit overhead.
+    Set the env to 1 here to verify the per-block incremental contract
+    still works when buffering is disabled.
+    """
     from goldenmatch.db.sync import _full_scan_streaming
+
+    monkeypatch.setenv("GOLDENMATCH_MATCH_LOG_FLUSH_PAIRS", "1")
+    monkeypatch.setenv("GOLDENMATCH_STREAMING_BLOCK_WORKERS", "1")
 
     # Three distinct blocks of 3 rows each -- 3 calls to log_matches_batch
     # if streaming writes correctly.
@@ -373,11 +382,12 @@ def test_full_scan_streaming_writes_incrementally(tmp_path, monkeypatch):
         total_rows=9,
     )
 
-    # At least 3 calls (one per block with multi-member matches). Could
-    # be exactly 3 or fewer if a block emits zero pairs; just assert
-    # that more than one batch fired -- proves incremental writes.
+    # At least 2 calls -- proves incremental writes when flush threshold
+    # is set low. Could be exactly 3 or fewer if a block emits zero
+    # pairs.
     assert len(fake_conn.match_log_calls) >= 2, (
-        "streaming sync must write match log incrementally per block; "
+        "streaming sync must write match log incrementally per block "
+        "(with GOLDENMATCH_MATCH_LOG_FLUSH_PAIRS=1); "
         f"got {len(fake_conn.match_log_calls)} call(s)"
     )
 


### PR DESCRIPTION
## Summary

Closes #424. User correctly diagnosed that the previous `executemany`-based implementation isn't pipelined in psycopg3 without an explicit `with conn.pipeline():` context. At ~7ms RTT to managed Postgres, that ceilinged throughput at ~125 rows/sec.

### Three fixes, in order of impact

1. **`cursor.copy()` for psycopg3** in `log_matches_batch`. Detects `.copy()` attribute on the cursor; falls back to `executemany` for SQLite / DuckDB test paths. ~10-100× improvement on bulk loads.
2. **Buffer pairs across blocks** in `_full_scan_streaming`. Default 10K pairs per flush; env override `GOLDENMATCH_MATCH_LOG_FLUSH_PAIRS=<N>`. Final flush at end of streaming loop.
3. **`GOLDENMATCH_SKIP_MATCH_LOG=1` opt-out** for nightly-cron pipelines that only consume `gm_clusters` / `gm_golden_records`. INFO log line surfaces when set.

## Expected impact

User's repro: 1.13M-row Supabase table. Previous: 125 rows/sec sustained, ~5hr extrapolated for ~3M pairs. With COPY + 10K-pair buffering: target >10K rows/sec → <5 min for the same workload.

## Test plan

- [x] `uv run ruff check` clean
- CI is the gate
- Fallback path preserved for SQLite / DuckDB; existing test coverage carries forward