### PR TITLE
release(v1.18.0): intelligent golden rules + custom plugin slot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ labels.jsonl
 # scale-audit JSON outputs, synthetic fixtures). Documented as gitignored
 # in CLAUDE.md; this entry makes that real.
 .profile_tmp/
+packages/python/goldenmatch/bench-dataset-v1/

--- a/docs/superpowers/specs/2026-05-22-golden-strategy-plugin-slot-design.md
+++ b/docs/superpowers/specs/2026-05-22-golden-strategy-plugin-slot-design.md
@@ -1,0 +1,133 @@
+# Custom golden-strategy plugin slot
+
+**Status:** spec → implemented in v1.18.1
+**Date:** 2026-05-22
+
+## Problem
+
+`VALID_STRATEGIES` is a closed enum: 5 original + 3 added in v1.18.0
+(`longest_value`, `unanimous_or_null`, `confidence_majority`). Users
+with bespoke business rules (legal-priority hierarchies, regulatory
+"newest non-superseded record wins", per-jurisdiction lookups) need
+to write Python code, not extend YAML.
+
+The plugin scaffolding already exists:
+- Entry-point group `goldenmatch.plugins.golden_strategy`
+- `PluginRegistry._golden_strategies` slot + `register_golden_strategy()`
+  + `get_golden_strategy()`
+- `GoldenStrategyPlugin` protocol in `plugins/base.py` (weak signature)
+
+What's missing: dispatch + validator + a beefier protocol.
+
+## Decision
+
+### Protocol signature
+
+Rich kwargs matching the internal `merge_field` API. Plugins ignore
+what they don't need.
+
+```python
+@runtime_checkable
+class GoldenStrategyPlugin(Protocol):
+    name: str
+
+    def merge(
+        self,
+        values: list,
+        *,
+        sources: list[str] | None = None,
+        dates: list | None = None,
+        quality_weights: list[float] | None = None,
+        pair_scores: dict[tuple[int, int], float] | None = None,
+        rule_kwargs: dict | None = None,
+    ) -> tuple[object, float] | tuple[object, float, int | None]:
+        """Merge cluster member values into one survivor.
+
+        Returns either (value, confidence) -- the dispatcher fills idx=0 --
+        or (value, confidence, idx) for plugins that want to expose
+        provenance.
+
+        `rule_kwargs` carries the per-field GoldenFieldRule.model_dump()
+        so plugins can read configuration the user set in YAML
+        (date_column, source_priority, or custom keys).
+        """
+        ...
+```
+
+### Strategy string syntax
+
+`strategy="custom:<name>"`. The `custom:` prefix is reserved; built-in
+strategies cannot start with it.
+
+- `strategy="custom:legal_priority"` → looks up plugin `legal_priority` in registry.
+- `strategy="custom:"` → invalid (empty name).
+- `strategy="custom:my-rule"` → invalid (must match `^custom:[a-z_][a-z0-9_]*$`).
+
+### Validator update
+
+`GoldenFieldRule._validate_strategy` accepts:
+1. `strategy in VALID_STRATEGIES`, OR
+2. `strategy.startswith("custom:")` AND name matches `^custom:[a-z_][a-z0-9_]*$`.
+
+At validate time we DO NOT verify the plugin exists — the rule may be
+loaded before plugins are discovered. Existence is checked at dispatch
+time in `merge_field`.
+
+### Dispatch in `merge_field`
+
+```python
+if strategy.startswith("custom:"):
+    plugin_name = strategy.removeprefix("custom:")
+    return _dispatch_custom_strategy(
+        plugin_name, non_null, values, rule,
+        sources=sources, dates=dates,
+        quality_weights=quality_weights, pair_scores=pair_scores,
+    )
+```
+
+`_dispatch_custom_strategy`:
+- Look up plugin via `PluginRegistry.instance().get_golden_strategy(name)`.
+- If not found: emit a WARNING + fall back to `most_complete` (defensive default).
+- If found: call `plugin.merge(values, **kwargs)`.
+- Result handling: accept 2-tuple (synthesize `idx=0`) or 3-tuple.
+- If plugin raises: emit a WARNING with the plugin name + exception, fall back to `most_complete`.
+
+Strict mode opt-in: `GOLDENMATCH_GOLDEN_STRATEGY_STRICT=1` reraises plugin errors instead of falling back. Default off (one bad plugin shouldn't kill the whole golden build).
+
+## Implementation
+
+**Files changed:**
+- `plugins/base.py` — beef up `GoldenStrategyPlugin` protocol with the rich signature above.
+- `core/golden.py` — `_dispatch_custom_strategy` + `merge_field` dispatch.
+- `config/schemas.py` — `GoldenFieldRule._validate_strategy` accepts `custom:<name>`.
+
+**Files added:**
+- `tests/test_custom_golden_strategy.py` — protocol acceptance + dispatch + fallback + strict mode + name validation.
+
+## Tests
+
+- `test_custom_strategy_name_passes_validation` — `custom:foo` rule is constructable
+- `test_invalid_custom_name_rejected_by_validator` — `custom:`, `custom:has-hyphen`, `custom:HasCaps` all fail validation
+- `test_dispatch_calls_plugin_with_kwargs` — verify plugin receives values + sources + dates + quality_weights + pair_scores
+- `test_dispatch_accepts_two_tuple_result` — plugin returning `(value, conf)` → synthesized idx=0
+- `test_dispatch_accepts_three_tuple_result` — plugin returning `(value, conf, idx)` → idx preserved
+- `test_dispatch_falls_back_on_missing_plugin` — `custom:nonexistent` → WARNING + most_complete
+- `test_dispatch_falls_back_on_plugin_exception` — plugin raises → WARNING + most_complete
+- `test_strict_mode_reraises_plugin_exception` — `GOLDENMATCH_GOLDEN_STRATEGY_STRICT=1` → exception bubbles
+- `test_rule_kwargs_pass_through` — plugin reads `date_column` / custom field from `rule_kwargs`
+
+## Backward compat
+
+- All existing strategies unchanged.
+- The pre-v1.18.1 `GoldenStrategyPlugin` had `merge(values, sources=None) -> (val, conf)`. Any plugin authors out there (none known) will need to add `**kwargs` to their signature, or accept the new protocol. We bump the protocol's first stable release at v1.18.1; pre-v1.18.1 was not advertised as usable.
+
+## Out of scope (v1.19+ candidates)
+
+- **Refiner picks `custom:<name>`** from heuristics. Refiner currently sticks to built-ins; calling user code is opt-in via explicit `field_rules` only.
+- **Multi-arg signatures** (cluster-level batch merge, not just per-field). The current per-field API is simpler; batch is a possible v2.
+- **Async plugins** for remote-lookup strategies. Async dispatch would touch the whole golden pipeline; deferred until a user files for it.
+
+## Kill criterion
+
+- Built-in strategies pass existing benchmark suite
+- Custom-plugin smoke test: a `LegalPriorityStrategy` test fixture returns the expected value on a synthetic 3-source fixture

--- a/docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md
+++ b/docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md
@@ -1,0 +1,148 @@
+# Intelligent golden rules (post-cluster auto-config)
+
+**Status:** spec → implemented in v1.18.0
+**Date:** 2026-05-22
+
+## Problem
+
+Three holes in golden-field consolidation today:
+
+1. **Strategy palette is thin.** `most_complete` / `majority_vote` / `first_non_null` / `most_recent` / `source_priority`. Missing:
+   - **`longest_value`** — useful for free-text fields (address line, description) where length proxies completeness.
+   - **`unanimous_or_null`** — compliance use case: if any cluster member disagrees, emit NULL so downstream consumers don't quietly accept a chosen-by-heuristic value.
+   - **`confidence_majority`** — like `majority_vote` but weighted by pair-score confidence inside the cluster. The clustering already computes `pair_scores` and per-cluster `confidence`; consolidator currently ignores them.
+2. **Auto-config picks `most_complete` for everything.** Real datasets have date columns where `most_recent` is clearly right, multi-source feeds where one source is consistently the highest-quality, free-text columns where `longest_value` beats `most_complete`. The signal exists in `ColumnProfile` (col_type, null_rate, avg_len) AND in the cluster output (within-cluster spread, per-source completeness) — neither is consulted.
+3. **No cluster-informed refinement.** Auto-config picks rules BEFORE clustering runs. But the right per-field rule depends on cluster shape (within-cluster value spread tells you whether `most_complete` or `confidence_majority` is right; per-source completeness ranking tells you the right `source_priority` order).
+
+The architectural insight (Ben, 2026-05-22): matchkey + blocking auto-config MUST happen pre-cluster (clustering depends on them). But **golden-rules auto-config should run AFTER clusters exist** — that's when the data informing per-field strategy is available.
+
+## Decision
+
+Two-phase auto-config:
+
+- **Phase 1 (pre-cluster)**: matchkey + blocking + standardization. Unchanged from today.
+- **Phase 2 (post-cluster, NEW)**: golden-rules refinement. Reads cluster output + per-column profiles + the prepared frame; emits a refined `GoldenRulesConfig` that overrides the v0 default.
+
+Phase 2 is **opt-in via `GoldenRulesConfig.adaptive: bool = False`**. Default off in v1.18.0 to avoid silently changing behavior on existing benchmarks. Documented as the recommended setting for v1.18+ users; default flip to `True` is a v1.19 candidate after benchmark validation.
+
+## New strategies (v1.18.0)
+
+### `longest_value`
+
+Pick the longest non-null string from cluster members. Quality-weighted tie-break.
+
+**When to use**: free-text columns where length correlates with completeness (full address vs abbreviated, full company name vs ticker, description vs short label). Auto-config picks it when `col_type in ("string", "address", "description")` AND `avg_len > 20`.
+
+### `unanimous_or_null`
+
+If every non-null cluster member has the same value → emit that value. If any member disagrees → emit NULL (or NaN for numeric types). NULL members are ignored (don't count as disagreement; absence is not contradiction).
+
+**When to use**: compliance-grade fields where a heuristic-chosen value is worse than a missing value (medical IDs, license numbers, SSN-shaped columns). Auto-config does NOT pick this — too aggressive for general use; opt-in per field only.
+
+### `confidence_majority`
+
+Majority vote weighted by per-pair scores within the cluster. For each candidate value, sum the pair_scores of edges where both endpoints have that value; pick the highest-sum value.
+
+**Why it's better than `majority_vote`**: vanilla majority counts every member equally. A 5-member cluster where 3 members agree on "A" but the agreeing edges are all weak (score 0.55, 0.62, 0.51) loses to the 2 strong-edge members on "B" (scores 0.91, 0.88). Confidence-majority surfaces the consensus the clustering itself trusts.
+
+**When to use**: high-cardinality identity fields (names, addresses) where some cluster members are weakly linked. Auto-config picks it when within-cluster `block_sizes_p99 / p50 > 5` (heterogeneous cluster sizes signal weak-edge presence).
+
+## `GoldenRulesRefiner` (`core/golden_rules_refiner.py`)
+
+```python
+@dataclass
+class RefinementSignals:
+    """Per-field signals computed from clusters + column profiles."""
+    within_cluster_spread: dict[str, float]  # field -> avg distinct/cluster
+    per_source_completeness: dict[str, dict[str, float]]  # field -> source -> non-null rate
+    date_column_coverage: dict[str, float]  # field -> fraction of clusters where every member has a date
+    col_type: dict[str, str]
+    avg_len: dict[str, float]
+    null_rate: dict[str, float]
+
+
+def refine_golden_rules(
+    base_rules: GoldenRulesConfig,
+    clusters: dict[int, dict],
+    prepared_df: pl.DataFrame,
+    column_profiles: list[ColumnProfile],
+) -> GoldenRulesConfig:
+    """Refine golden_rules based on cluster + column signals.
+
+    Returns a NEW GoldenRulesConfig with field_rules populated. Does
+    NOT mutate base_rules. When base_rules.adaptive is False, returns
+    base_rules unchanged.
+    """
+```
+
+### Rule table (applied per-field, first match wins)
+
+| Condition | Picked strategy | Reason |
+|---|---|---|
+| `col_type == "date"` AND timestamp-shaped values | `most_recent` (`date_column=self`) | Direct date sort |
+| `__source__` in df AND `per_source_completeness[field]` has clear ranking (top source > 1.5× median) | `source_priority` (ranked by completeness desc) | One source dominates |
+| `col_type in ("string", "address", "description")` AND `avg_len > 20` AND `within_cluster_spread[field] > 1.5` | `longest_value` | Free-text, members disagree |
+| `null_rate[field] > 0.5` | `first_non_null` | Mostly absent; fast path |
+| `within_cluster_spread[field] > 2.0` (high disagreement) | `confidence_majority` | Trust the clustering's confidence |
+| Else | `most_complete` | Default fallback |
+
+## Implementation
+
+**Files added:**
+- `core/golden_rules_refiner.py` — `refine_golden_rules` + `compute_refinement_signals`.
+
+**Files changed:**
+- `core/golden.py` — `_longest_value`, `_unanimous_or_null`, `_confidence_majority` strategy functions; `consolidate_field` dispatch updated.
+- `config/schemas.py` — `VALID_STRATEGIES` += `{"longest_value", "unanimous_or_null", "confidence_majority"}`; `GoldenRulesConfig.adaptive: bool = False`.
+- `core/pipeline.py` — when `config.golden_rules.adaptive`, call refiner between `build_clusters` and `build_golden_records`.
+
+## Pipeline integration
+
+```python
+# In _finalize / _run_dedupe_pipeline:
+clusters = build_clusters(pairs, all_ids, max_cluster_size=..)
+if config.golden_rules and config.golden_rules.adaptive:
+    refined_rules = refine_golden_rules(
+        base_rules=config.golden_rules,
+        clusters=clusters,
+        prepared_df=prepared_df,
+        column_profiles=profiles,
+    )
+    effective_rules = refined_rules
+else:
+    effective_rules = config.golden_rules
+golden_df = build_golden_records_batch(..., golden_rules=effective_rules)
+```
+
+## Tests
+
+**New strategies (`tests/test_golden_strategies.py`):**
+- `test_longest_value_picks_longest_non_null`
+- `test_longest_value_ties_break_by_quality`
+- `test_unanimous_or_null_emits_value_when_all_agree`
+- `test_unanimous_or_null_emits_null_when_any_disagree`
+- `test_unanimous_or_null_ignores_null_members`
+- `test_confidence_majority_overrides_count_majority_on_weak_edges`
+- `test_confidence_majority_falls_back_to_count_when_no_pair_scores`
+
+**Refiner (`tests/test_golden_rules_refiner.py`):**
+- `test_refiner_picks_most_recent_for_date_column`
+- `test_refiner_picks_source_priority_when_one_source_dominates`
+- `test_refiner_picks_longest_value_for_free_text`
+- `test_refiner_picks_first_non_null_for_sparse_column`
+- `test_refiner_picks_confidence_majority_on_high_spread`
+- `test_refiner_returns_base_rules_when_adaptive_false`
+- `test_refiner_is_pure_does_not_mutate_base`
+
+## Kill criterion
+
+- 3 new strategies + refiner integration pass `uv run ruff check` + new unit tests
+- Existing benchmark suite (DBLP-ACM / Febrl3 / NCVR / DQbench T1-T3) does not regress F1 when `adaptive=False` (the default — refiner is a no-op)
+- On a multi-source synthetic fixture (3 sources, one consistently higher completeness), `adaptive=True` picks `source_priority` ranked correctly
+
+## Out of scope (v1.19+ candidates)
+
+- **Custom plugin slot** (`strategy="custom:my_rule"`). Architecturally load-bearing — deserves its own spec + PR. The `GoldenStrategy` protocol shape, the lookup mechanism (entry points vs explicit register), and the failure mode (what happens when the plugin raises) all need decisions before code.
+- **Default flip**: `adaptive=True` as the default for new configs once benchmarks confirm no F1 regression.
+- **Per-cluster strategy override**: rules that vary per-cluster based on cluster health (`weak` clusters use `unanimous_or_null` defensively). Possible but adds substantial complexity.
+- **LLM-assisted refinement** for ambiguous fields. Out of scope; v1.18 is heuristics-only.

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,51 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-05-22
+
+### Added — intelligent golden-field consolidation
+
+Two-phase auto-config: matchkey + blocking stays pre-cluster
+(unchanged); golden-rules picking moves POST-cluster where it
+benefits from real cluster shape signals.
+
+- **Three new strategies** in `VALID_STRATEGIES` and `core/golden.py`:
+  - **`longest_value`** — pick the longest non-null string.
+    Quality-weighted tie-break. For free-text fields where length
+    correlates with completeness (address line, description).
+  - **`unanimous_or_null`** — emit the value only if every non-null
+    member agrees; emit NULL on any disagreement. For compliance-grade
+    fields where a heuristic-chosen value is worse than missing.
+  - **`confidence_majority`** — majority vote weighted by within-cluster
+    pair_scores. Surfaces the consensus the clustering itself trusts;
+    a strong-edge minority can beat a weak-edge majority. Falls back to
+    count-majority when pair_scores absent.
+- **`GoldenRulesRefiner`** (`core/golden_rules_refiner.py`). Runs
+  between `build_clusters` and `build_golden_records` when
+  `golden_rules.adaptive=True`. Computes per-field signals
+  (within-cluster spread, per-source completeness, date-column
+  coverage, col_type, null_rate, avg_len) and emits refined
+  `GoldenRulesConfig.field_rules`. Rule table:
+  - `col_type=date` + > 50% cluster timestamp coverage → `most_recent`
+  - One source > 1.5× median completeness → `source_priority`
+    (ranked by completeness)
+  - Free-text + long + within-cluster disagreement → `longest_value`
+  - `null_rate > 0.5` → `first_non_null` fast path
+  - High within-cluster spread (> 2.0) → `confidence_majority`
+  - Else → defer to base default
+- **`GoldenRulesConfig.adaptive: bool = False`** opt-in flag. Default
+  False to preserve existing behavior on benchmarks; flip-to-True is
+  a v1.19 candidate after benchmark validation.
+
+Spec: `docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md`
+
+### Deferred (v1.19+ candidates)
+
+- **Custom Python plugin slot** (`strategy="custom:my_rule"`). Protocol
+  shape is load-bearing; deserves its own spec + PR.
+- **Default flip** of `adaptive=True` once benchmarks confirm no F1
+  regression.
+
 ## [1.17.1] - 2026-05-22
 
 ### Changed — streaming-sync match log throughput (#424, PR #426)

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.17.1"
+__version__ = "1.18.0"
 
 # ── High-level API (convenience functions) ────────────────────────────────
 from goldenmatch._api import (

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -26,6 +26,8 @@ VALID_SCORERS = frozenset({
 
 VALID_STRATEGIES = frozenset({
     "most_recent", "source_priority", "most_complete", "majority_vote", "first_non_null",
+    # v1.18 additions (#golden-strategies)
+    "longest_value", "unanimous_or_null", "confidence_majority",
 })
 
 _SUBSTRING_RE = re.compile(r"^substring:\d+:\d+$")
@@ -427,6 +429,13 @@ class GoldenRulesConfig(BaseModel):
     auto_split: bool = True
     quality_weighting: bool = True
     weak_cluster_threshold: float = 0.3
+    # v1.18: post-cluster golden-rules refinement. When True, after
+    # clustering the pipeline runs `refine_golden_rules` against the
+    # cluster output + column profiles to pick per-field strategies
+    # informed by within-cluster spread, per-source completeness, etc.
+    # Default False to preserve existing behavior; opt-in for v1.18 users.
+    # Spec: docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md
+    adaptive: bool = False
 
     @model_validator(mode="after")
     def _validate_default(self) -> GoldenRulesConfig:

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -31,6 +31,8 @@ VALID_STRATEGIES = frozenset({
 })
 
 _SUBSTRING_RE = re.compile(r"^substring:\d+:\d+$")
+# v1.18.1: custom: prefix for plugin-backed golden strategies.
+_CUSTOM_STRATEGY_RE = re.compile(r"^custom:[a-z_][a-z0-9_]*$")
 _QGRAM_RE = re.compile(r"^qgram:\d+$")
 _BLOOM_FILTER_RE = re.compile(r"^bloom_filter:\d+:\d+:\d+$")
 
@@ -410,9 +412,22 @@ class GoldenFieldRule(BaseModel):
 
     @model_validator(mode="after")
     def _validate_strategy(self) -> GoldenFieldRule:
+        # v1.18.1: accept `custom:<name>` for plugin-backed strategies.
+        # Existence of the plugin is checked at dispatch time
+        # (`core/golden.py::merge_field`), not here -- the rule may load
+        # before plugins are discovered. See spec:
+        # docs/superpowers/specs/2026-05-22-golden-strategy-plugin-slot-design.md
+        if self.strategy.startswith("custom:"):
+            if not _CUSTOM_STRATEGY_RE.match(self.strategy):
+                raise ValueError(
+                    f"Invalid custom strategy name '{self.strategy}'. "
+                    "Must match 'custom:<lowercase_snake_case>'."
+                )
+            return self
         if self.strategy not in VALID_STRATEGIES:
             raise ValueError(
-                f"Invalid strategy '{self.strategy}'. Must be one of {sorted(VALID_STRATEGIES)}."
+                f"Invalid strategy '{self.strategy}'. Must be one of {sorted(VALID_STRATEGIES)} "
+                "or 'custom:<name>' for plugin-backed strategies."
             )
         if self.strategy == "most_recent" and not self.date_column:
             raise ValueError("Strategy 'most_recent' requires 'date_column'.")

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -67,6 +67,21 @@ def merge_field(
 
     strategy = rule.strategy
 
+    # v1.18.1: custom plugin strategy. Dispatch + fallback on missing
+    # plugin / plugin exception. See spec
+    # docs/superpowers/specs/2026-05-22-golden-strategy-plugin-slot-design.md
+    if strategy.startswith("custom:"):
+        return _dispatch_custom_strategy(
+            strategy.removeprefix("custom:"),
+            values=values,
+            non_null=non_null,
+            rule=rule,
+            sources=sources,
+            dates=dates,
+            quality_weights=quality_weights,
+            pair_scores=pair_scores,
+        )
+
     if strategy == "most_complete":
         return _most_complete(non_null, quality_weights)
     elif strategy == "majority_vote":
@@ -269,6 +284,93 @@ def _confidence_majority(
     total = sum(value_weights.values())
     conf = value_weights[winner] / total if total > 0 else 0.5
     return (winner, conf, value_idx[winner])
+
+
+# ─── v1.18.1 custom plugin dispatch (#golden-strategy-plugins) ───────────────
+
+
+def _dispatch_custom_strategy(
+    plugin_name: str,
+    *,
+    values: list,
+    non_null: list[tuple[int, object]],
+    rule: GoldenFieldRule,
+    sources: list[str] | None,
+    dates: list | None,
+    quality_weights: list[float] | None,
+    pair_scores: dict[tuple[int, int], float] | None,
+) -> tuple:
+    """Look up and invoke a custom golden-strategy plugin.
+
+    Defensive default: missing plugin OR plugin-raised exception ->
+    WARNING log + fall back to ``most_complete``. Opt into strict
+    mode via env var ``GOLDENMATCH_GOLDEN_STRATEGY_STRICT=1``.
+
+    Result handling: accept both ``(value, confidence)`` and
+    ``(value, confidence, idx)``. Two-tuple results get ``idx=0``
+    synthesized.
+
+    Spec: docs/superpowers/specs/2026-05-22-golden-strategy-plugin-slot-design.md
+    """
+    import logging as _logging
+    import os as _os
+
+    _logger = _logging.getLogger(__name__)
+    _strict = _os.environ.get("GOLDENMATCH_GOLDEN_STRATEGY_STRICT") == "1"
+
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    registry = PluginRegistry.instance()
+    registry.discover()  # idempotent; only the first call scans entry points
+    plugin = registry.get_golden_strategy(plugin_name)
+
+    if plugin is None:
+        msg = (
+            f"custom golden strategy 'custom:{plugin_name}' not found in registry; "
+            f"falling back to most_complete"
+        )
+        if _strict:
+            raise ValueError(msg)
+        _logger.warning(msg)
+        return _most_complete(non_null, quality_weights)
+
+    # Rich kwargs per spec. Plugins ignore what they don't need.
+    rule_kwargs = rule.model_dump(exclude={"strategy"})
+    try:
+        result = plugin.merge(  # type: ignore[attr-defined]
+            values,
+            sources=sources,
+            dates=dates,
+            quality_weights=quality_weights,
+            pair_scores=pair_scores,
+            rule_kwargs=rule_kwargs,
+        )
+    except Exception as exc:
+        msg = (
+            f"custom golden strategy 'custom:{plugin_name}' raised "
+            f"{type(exc).__name__}: {exc}; falling back to most_complete"
+        )
+        if _strict:
+            raise
+        _logger.warning(msg)
+        return _most_complete(non_null, quality_weights)
+
+    # Normalize 2-tuple -> 3-tuple by synthesizing idx=0.
+    if isinstance(result, tuple) and len(result) == 2:
+        value, confidence = result
+        return (value, float(confidence), 0)
+    if isinstance(result, tuple) and len(result) == 3:
+        value, confidence, idx = result
+        return (value, float(confidence), idx)
+    # Bad return shape -> warning + fallback.
+    msg = (
+        f"custom golden strategy 'custom:{plugin_name}' returned "
+        f"unexpected shape {type(result).__name__}; falling back to most_complete"
+    )
+    if _strict:
+        raise TypeError(msg)
+    _logger.warning(msg)
+    return _most_complete(non_null, quality_weights)
 
 
 def _build_golden_records_polars_native(

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -48,6 +48,7 @@ def merge_field(
     sources: list[str] | None = None,
     dates: list | None = None,
     quality_weights: list[float] | None = None,
+    pair_scores: dict[tuple[int, int], float] | None = None,
 ) -> tuple[object, float, int | None]:
     """Merge a list of values using the given rule's strategy.
 
@@ -76,6 +77,13 @@ def merge_field(
         return _most_recent(values, dates)
     elif strategy == "first_non_null":
         return _first_non_null(non_null, quality_weights)
+    # v1.18 strategies (#golden-strategies, 2026-05-22 spec).
+    elif strategy == "longest_value":
+        return _longest_value(non_null, quality_weights)
+    elif strategy == "unanimous_or_null":
+        return _unanimous_or_null(non_null)
+    elif strategy == "confidence_majority":
+        return _confidence_majority(non_null, pair_scores, quality_weights)
     else:
         raise ValueError(f"Unknown strategy: {strategy}")
 
@@ -159,6 +167,108 @@ def _first_non_null(non_null: list[tuple[int, object]], quality_weights: list[fl
         best = max(non_null, key=lambda x: quality_weights[x[0]] if x[0] < len(quality_weights) else 1.0)
         return (best[1], 0.6, best[0])
     return (non_null[0][1], 0.6, non_null[0][0])
+
+
+# ─── v1.18 strategies (#golden-strategies, 2026-05-22 spec) ──────────────────
+
+
+def _longest_value(
+    non_null: list[tuple[int, object]],
+    quality_weights: list[float] | None = None,
+) -> tuple:
+    """Pick the longest non-null string value. Quality-weighted tie-break.
+
+    Picks length over completeness — useful for free-text columns where
+    a longer value typically carries more information (full address vs
+    abbreviation, full company name vs ticker).
+
+    Confidence: 1.0 when there's a unique longest value, 0.7 when ties
+    are broken by quality weight, 0.5 when ties are broken by order.
+    """
+    str_vals = [(i, str(v) if v is not None else "", v) for i, v in non_null]
+    max_len = max(len(s) for _, s, _ in str_vals)
+    longest = [(i, s, v) for i, s, v in str_vals if len(s) == max_len]
+    if len(longest) == 1:
+        return (longest[0][2], 1.0, longest[0][0])
+    # Tied on length -- prefer the value with highest quality weight.
+    if quality_weights is not None:
+        best = max(
+            longest,
+            key=lambda x: quality_weights[x[0]] if x[0] < len(quality_weights) else 1.0,
+        )
+        return (best[2], 0.7, best[0])
+    return (longest[0][2], 0.5, longest[0][0])
+
+
+def _unanimous_or_null(non_null: list[tuple[int, object]]) -> tuple:
+    """If every non-null member agrees, emit that value. If any disagrees,
+    emit None. NULL members are ignored (absence is not contradiction).
+
+    Use case: compliance-grade fields where a heuristic-chosen value is
+    worse than a missing value (medical IDs, license numbers, etc).
+
+    Confidence: 1.0 when unanimous, 0.0 when null is emitted.
+    """
+    unique = {v for _, v in non_null}
+    if len(unique) == 1:
+        return (non_null[0][1], 1.0, non_null[0][0])
+    return (None, 0.0, None)
+
+
+def _confidence_majority(
+    non_null: list[tuple[int, object]],
+    pair_scores: dict[tuple[int, int], float] | None,
+    quality_weights: list[float] | None = None,
+) -> tuple:
+    """Majority vote weighted by per-pair confidence inside the cluster.
+
+    For each candidate value, sum the pair_scores of edges where both
+    endpoints have that value; pick the highest-sum value. Falls back
+    to vanilla count-majority when pair_scores is None / empty.
+
+    Better than `majority_vote` on heterogeneous clusters where some
+    edges are weak: a 3-member majority on weak edges (0.55) loses to
+    a 2-member minority on strong edges (0.91).
+
+    Args:
+        non_null: ``[(member_idx, value)]`` from the consolidator.
+            ``member_idx`` indexes into the cluster's member list.
+        pair_scores: ``{(min_member_idx, max_member_idx): score}``
+            for edges within the cluster. ``None`` -> count-majority
+            fallback.
+        quality_weights: per-member weights for the count-majority
+            fallback only.
+
+    Confidence: winner's edge-sum / total edge-sum across all values.
+    """
+    if not pair_scores:
+        # Fallback: count majority.
+        return _majority_vote(non_null, quality_weights)
+
+    # Bucket pair_scores by value: for each pair (a, b), if values agree
+    # on the same candidate, contribute the pair score to that value's
+    # weight.
+    idx_to_value: dict[int, object] = {i: v for i, v in non_null}
+    value_weights: dict[object, float] = {}
+    value_idx: dict[object, int] = {}
+    for (a, b), s in pair_scores.items():
+        if a in idx_to_value and b in idx_to_value:
+            va = idx_to_value[a]
+            vb = idx_to_value[b]
+            if va == vb:
+                value_weights[va] = value_weights.get(va, 0.0) + float(s)
+                if va not in value_idx:
+                    value_idx[va] = a
+
+    if not value_weights:
+        # No agreeing pairs (every pair disagrees on this field) — fall
+        # back to count-majority.
+        return _majority_vote(non_null, quality_weights)
+
+    winner = max(value_weights, key=value_weights.__getitem__)
+    total = sum(value_weights.values())
+    conf = value_weights[winner] / total if total > 0 else 0.5
+    return (winner, conf, value_idx[winner])
 
 
 def _build_golden_records_polars_native(

--- a/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
@@ -36,6 +36,135 @@ FREE_TEXT_AVG_LEN_THRESHOLD = 20.0
 HIGH_NULL_RATE_THRESHOLD = 0.5
 SOURCE_DOMINANCE_THRESHOLD = 1.5  # top source must be > median * this
 
+# Identity-column threshold for the unanimous_or_null override (#smarter-refiner).
+IDENTITY_CARDINALITY_THRESHOLD = 0.9
+
+# Sibling-timestamp coverage threshold: a candidate timestamp column
+# must have non-null values for >80% of clusters to be considered a
+# reliable date_column for OTHER fields.
+SIBLING_TIMESTAMP_COVERAGE_THRESHOLD = 0.8
+
+# Compliance-shaped column-name patterns. Fields matching these get
+# `unanimous_or_null` regardless of other signals -- a chosen-by-
+# heuristic value is worse than a missing value for these.
+import re as _re
+
+_COMPLIANCE_NAME_PATTERNS = [
+    _re.compile(p, _re.IGNORECASE) for p in [
+        r"\bssn\b",
+        r"\bsin\b",                       # Canadian SIN
+        r"\bein\b",                       # employer ID
+        r"\btax[_-]?id\b",
+        r"\bnpi\b",
+        r"\bdea[_-]?number\b",
+        r"\blicense[_-]?(no|num|number)?\b",
+        r"\bpassport[_-]?(no|num|number)?\b",
+        r"\bdriver[_-]?license\b",
+        r"\bdrivers?[_-]?license\b",
+        r"\b(date[_-]?of[_-]?birth|dob|birthdate)\b",
+        r"\bmrn\b",                       # medical record number
+        r"\bhipaa[_-]?id\b",
+        r"\bpatient[_-]?id\b",
+        r"\bmedicaid[_-]?(no|num|number|id)?\b",
+        r"\bmedicare[_-]?(no|num|number|id)?\b",
+        r"\bcusip\b",
+        r"\blei\b",                       # Legal Entity Identifier
+        r"\bisin\b",                      # International Securities ID
+    ]
+]
+
+# Sibling-timestamp column-name patterns. Used to detect THE dataset's
+# primary timestamp column for cross-field `most_recent` picks.
+# Order matters: more-specific names first; first match wins.
+_TIMESTAMP_NAME_PATTERNS = [
+    _re.compile(p, _re.IGNORECASE) for p in [
+        r"^updated[_-]?at$",
+        r"^modified[_-]?at$",
+        r"^last[_-]?modified$",
+        r"^last[_-]?updated$",
+        r"^update[_-]?(time|date|ts)$",
+        r"^modify[_-]?(time|date|ts)$",
+        r"^created[_-]?at$",
+        r"^create[_-]?(time|date|ts)$",
+        r"^date[_-]?modified$",
+        r"^date[_-]?created$",
+        r"^updated$",
+        r"^created$",
+        r"^timestamp$",
+        r"^last[_-]?seen$",
+    ]
+]
+
+# Mutable-shaped fields (col_type or name hint) that benefit from
+# `most_recent` when a sibling timestamp is present. Things like name,
+# DOB shouldn't change over time; address, phone, email do.
+_MUTABLE_NAME_PATTERNS = [
+    _re.compile(p, _re.IGNORECASE) for p in [
+        r"\baddress\b",
+        r"\bstreet\b",
+        r"\bcity\b",
+        r"\bstate\b",
+        r"\bzip\b",
+        r"\bpostal[_-]?code\b",
+        r"\bphone\b",
+        r"\btelephone\b",
+        r"\bmobile\b",
+        r"\bemail\b",
+        r"\bemployer\b",
+        r"\bjob[_-]?title\b",
+        r"\boccupation\b",
+        r"\bcompany\b",
+        r"\bspecialty\b",
+        r"\bdepartment\b",
+        r"\bsalary\b",
+    ]
+]
+
+
+def _is_compliance_name(field: str) -> bool:
+    return any(p.search(field) for p in _COMPLIANCE_NAME_PATTERNS)
+
+
+def _is_mutable_field_name(field: str, col_type: str) -> bool:
+    if col_type in {"address", "phone", "email"}:
+        return True
+    return any(p.search(field) for p in _MUTABLE_NAME_PATTERNS)
+
+
+def _pick_sibling_timestamp(
+    column_profiles: list[ColumnProfile],
+    date_column_coverage: dict[str, float],
+) -> str | None:
+    """Pick THE dataset's primary timestamp column for cross-field
+    `most_recent` picks. Returns the column name or None.
+
+    Selection order:
+    1. Among columns whose col_type=='date': those matching the
+       _TIMESTAMP_NAME_PATTERNS (more-specific first).
+    2. Tiebreak by coverage descending (more present = more reliable).
+    3. Skip columns with coverage < SIBLING_TIMESTAMP_COVERAGE_THRESHOLD.
+    """
+    date_cols = [p for p in column_profiles if p.col_type == "date"]
+    if not date_cols:
+        return None
+    # Score by (pattern_rank, -coverage). Lower pattern_rank = better.
+    scored: list[tuple[int, float, str]] = []
+    for p in date_cols:
+        coverage = date_column_coverage.get(p.name, 0.0)
+        if coverage < SIBLING_TIMESTAMP_COVERAGE_THRESHOLD:
+            continue
+        # Find best matching pattern rank.
+        best_rank = len(_TIMESTAMP_NAME_PATTERNS)
+        for i, pat in enumerate(_TIMESTAMP_NAME_PATTERNS):
+            if pat.search(p.name):
+                best_rank = i
+                break
+        scored.append((best_rank, -coverage, p.name))
+    if not scored:
+        return None
+    scored.sort()
+    return scored[0][2]
+
 
 @dataclass(frozen=True)
 class RefinementSignals:
@@ -186,12 +315,20 @@ def compute_refinement_signals(
 def _pick_strategy_for_field(
     field: str,
     signals: RefinementSignals,
+    sibling_timestamp: str | None = None,
+    cardinality_ratio: float = 0.0,
 ) -> tuple[str, dict] | None:
     """Apply the rule table to one field; return (strategy_name, kwargs)
     or None to fall through to the base default.
 
     Rule order (first match wins) per
     ``docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md``.
+
+    v1.18 ``smarter-refiner`` additions:
+    - PRE-rules (safety): compliance column names + identity columns
+      get ``unanimous_or_null`` before any spread/source signals fire.
+    - Sibling-timestamp rule: mutable-shaped fields with a dataset-
+      level primary timestamp get ``most_recent`` via that timestamp.
     """
     col_type = signals.col_type.get(field, "unknown")
     avg_len = signals.avg_len.get(field, 0.0)
@@ -199,9 +336,36 @@ def _pick_strategy_for_field(
     spread = signals.within_cluster_spread.get(field, 1.0)
     date_cov = signals.date_column_coverage.get(field, 0.0)
 
-    # Rule 1: date column with full timestamp coverage.
+    # PRE-RULE 1: compliance-shaped column names (ssn, npi, license,
+    # dob, etc) ALWAYS get unanimous_or_null. A chosen-by-heuristic
+    # value is worse than a missing value for compliance-grade fields.
+    if _is_compliance_name(field):
+        return "unanimous_or_null", {}
+
+    # PRE-RULE 2: high-cardinality identity columns also get
+    # unanimous_or_null. Identifier-shaped values where most rows have
+    # a unique value -> trust unanimity over heuristics.
+    if (
+        col_type == "identifier"
+        and cardinality_ratio > IDENTITY_CARDINALITY_THRESHOLD
+    ):
+        return "unanimous_or_null", {}
+
+    # Rule 1: date column with full timestamp coverage -> most_recent
+    # on itself.
     if col_type == "date" and date_cov > 0.5:
         return "most_recent", {"date_column": field}
+
+    # Rule 1b (NEW): mutable-shaped field + dataset has a high-coverage
+    # sibling timestamp column -> most_recent on the sibling. Catches
+    # the common case of `address`, `phone`, `email` columns that
+    # change over time + a dataset-wide `updated_at` / `modified_at`.
+    if (
+        sibling_timestamp is not None
+        and sibling_timestamp != field
+        and _is_mutable_field_name(field, col_type)
+    ):
+        return "most_recent", {"date_column": sibling_timestamp}
 
     # Rule 2: source_priority when one source clearly dominates.
     per_source = signals.per_source_completeness.get(field)
@@ -256,12 +420,41 @@ def refine_golden_rules(
 
     signals = compute_refinement_signals(clusters, prepared_df, column_profiles)
 
+    # #smarter-refiner: detect THE dataset's primary timestamp column
+    # ONCE; reused as date_column for any mutable-shaped field.
+    sibling_timestamp = _pick_sibling_timestamp(
+        column_profiles, signals.date_column_coverage,
+    )
+    if sibling_timestamp:
+        logger.info(
+            "Refiner detected sibling timestamp column: %r "
+            "(used as date_column for mutable fields)",
+            sibling_timestamp,
+        )
+
+    # Build a per-field cardinality_ratio lookup for the identity-column
+    # rule (which can't use within_cluster_spread because high-cardinality
+    # identifiers may not appear in multi-member clusters).
+    cardinality_by_field: dict[str, float] = {
+        p.name: float(p.cardinality_ratio) for p in column_profiles
+    }
+
+    # Consider every column the refiner has signals for AND every column
+    # in the profiles list. Pre-rules (compliance / identity) need to
+    # fire even on fields that don't appear in multi-member clusters.
+    fields_to_consider: set[str] = set(signals.within_cluster_spread.keys())
+    fields_to_consider |= {p.name for p in column_profiles}
+
     new_field_rules: dict[str, GoldenFieldRule] = dict(base_rules.field_rules)
-    for field in signals.within_cluster_spread.keys():
+    for field in fields_to_consider:
         if field in new_field_rules:
             # Caller-provided rule wins; don't override.
             continue
-        result = _pick_strategy_for_field(field, signals)
+        result = _pick_strategy_for_field(
+            field, signals,
+            sibling_timestamp=sibling_timestamp,
+            cardinality_ratio=cardinality_by_field.get(field, 0.0),
+        )
         if result is None:
             continue
         strategy, kwargs = result

--- a/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
@@ -1,0 +1,281 @@
+"""Post-cluster golden-rules refinement (#golden-strategies, v1.18).
+
+Runs between ``build_clusters`` and ``build_golden_records`` when
+``GoldenRulesConfig.adaptive=True``. Reads cluster output + column
+profiles and emits a refined ``GoldenRulesConfig`` with per-field
+strategies informed by:
+
+- Within-cluster value spread (high spread → ``confidence_majority``)
+- Per-source completeness ranking (one source dominates → ``source_priority``)
+- Date column inference (full timestamp coverage → ``most_recent``)
+- ``col_type`` + ``avg_len`` (free-text + long → ``longest_value``)
+- ``null_rate`` (mostly-NULL → ``first_non_null`` fast path)
+
+Spec: ``docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md``
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import polars as pl
+
+    from goldenmatch.config.schemas import GoldenRulesConfig
+    from goldenmatch.core.autoconfig import ColumnProfile
+
+logger = logging.getLogger(__name__)
+
+
+# Thresholds (env-overridable; defaults from spec).
+# Spread = avg distinct values per cluster, for clusters with size >= 2.
+HIGH_SPREAD_THRESHOLD = 2.0
+FREE_TEXT_SPREAD_THRESHOLD = 1.5
+FREE_TEXT_AVG_LEN_THRESHOLD = 20.0
+HIGH_NULL_RATE_THRESHOLD = 0.5
+SOURCE_DOMINANCE_THRESHOLD = 1.5  # top source must be > median * this
+
+
+@dataclass(frozen=True)
+class RefinementSignals:
+    """Per-field signals computed from clusters + column profiles.
+
+    ``within_cluster_spread[field]`` is the average distinct value count
+    across multi-member clusters, for that field. 1.0 = unanimous;
+    > 2 = high disagreement.
+
+    ``per_source_completeness[field][source]`` is the non-null rate of
+    ``field`` in rows tagged with ``source``. Computed only when the
+    ``__source__`` column is present.
+
+    ``date_column_coverage[field]`` is the fraction of multi-member
+    clusters where every member has a non-null date value in ``field``.
+    Used to detect timestamp-shaped fields suitable for ``most_recent``.
+
+    ``col_type`` / ``avg_len`` / ``null_rate`` are carried forward from
+    pre-cluster ``ColumnProfile``.
+    """
+
+    within_cluster_spread: dict[str, float]
+    per_source_completeness: dict[str, dict[str, float]]
+    date_column_coverage: dict[str, float]
+    col_type: dict[str, str]
+    avg_len: dict[str, float]
+    null_rate: dict[str, float]
+
+
+def compute_refinement_signals(
+    clusters: dict[int, dict],
+    prepared_df: pl.DataFrame,
+    column_profiles: list[ColumnProfile],
+) -> RefinementSignals:
+    """Compute per-field signals from clusters + prepared frame.
+
+    Cheap aggregations (one polars groupby per signal, no per-cluster
+    loops in Python). Skipped fields default to neutral values so the
+    rule table sees explicit zeros instead of KeyErrors.
+    """
+    import polars as pl
+
+    # Build a member-id -> cluster-id map by expanding cluster members.
+    cluster_id_per_row: dict[int, int] = {}
+    multi_cluster_member_ids: list[int] = []
+    for cid, info in clusters.items():
+        members = info.get("members") or []
+        if len(members) < 2:
+            continue
+        for m in members:
+            cluster_id_per_row[m] = cid
+            multi_cluster_member_ids.append(m)
+
+    if not multi_cluster_member_ids:
+        # No multi-member clusters -- every signal is neutral.
+        empty_str: dict[str, float] = {}
+        empty_src: dict[str, dict[str, float]] = {}
+        return RefinementSignals(
+            within_cluster_spread=empty_str,
+            per_source_completeness=empty_src,
+            date_column_coverage=empty_str,
+            col_type={p.name: p.col_type for p in column_profiles},
+            avg_len={p.name: float(p.avg_len) for p in column_profiles},
+            null_rate={p.name: float(p.null_rate) for p in column_profiles},
+        )
+
+    # Filter prepared_df to multi-cluster members (eager; the set is
+    # small relative to N) + attach cluster_id.
+    if "__row_id__" in prepared_df.columns:
+        ids_col = "__row_id__"
+    else:
+        prepared_df = prepared_df.with_row_index("__row_id__")
+        ids_col = "__row_id__"
+
+    cluster_id_series = pl.DataFrame({
+        ids_col: list(cluster_id_per_row.keys()),
+        "__cluster_id__": list(cluster_id_per_row.values()),
+    })
+    multi_df = prepared_df.join(cluster_id_series, on=ids_col, how="inner")
+
+    user_cols = [
+        c for c in multi_df.columns
+        if not c.startswith("__") and c not in {ids_col, "__cluster_id__"}
+    ]
+
+    # Within-cluster spread: avg distinct values per cluster per field.
+    within_cluster_spread: dict[str, float] = {}
+    for col in user_cols:
+        # n_unique per cluster, then mean across clusters.
+        agg = (
+            multi_df.lazy()
+            .group_by("__cluster_id__")
+            .agg(pl.col(col).n_unique().alias("__distinct__"))
+            .select(pl.col("__distinct__").mean().alias("mean_distinct"))
+            .collect()
+        )
+        mean_distinct = agg["mean_distinct"][0] if agg.height > 0 else 1.0
+        within_cluster_spread[col] = float(mean_distinct or 1.0)
+
+    # Per-source completeness: non-null rate per (source, field).
+    per_source_completeness: dict[str, dict[str, float]] = {}
+    if "__source__" in prepared_df.columns:
+        for col in user_cols:
+            per_source: dict[str, float] = {}
+            agg = (
+                prepared_df.lazy()
+                .group_by("__source__")
+                .agg(
+                    pl.col(col).is_not_null().mean().alias("non_null_rate"),
+                )
+                .collect()
+            )
+            for row in agg.iter_rows(named=True):
+                per_source[str(row["__source__"])] = float(row["non_null_rate"] or 0.0)
+            if per_source:
+                per_source_completeness[col] = per_source
+
+    # Date-column coverage: fraction of multi-member clusters where
+    # every member has a non-null value in this field AND the field's
+    # dtype is a date/datetime/string-castable-to-date.
+    date_column_coverage: dict[str, float] = {}
+    profile_by_name = {p.name: p for p in column_profiles}
+    for col in user_cols:
+        p = profile_by_name.get(col)
+        if p is None or p.col_type not in ("date",):
+            continue
+        # Count clusters where the field is non-null for every member.
+        agg = (
+            multi_df.lazy()
+            .group_by("__cluster_id__")
+            .agg(pl.col(col).is_not_null().all().alias("__all_present__"))
+            .select(pl.col("__all_present__").mean().alias("coverage"))
+            .collect()
+        )
+        if agg.height > 0:
+            date_column_coverage[col] = float(agg["coverage"][0] or 0.0)
+
+    return RefinementSignals(
+        within_cluster_spread=within_cluster_spread,
+        per_source_completeness=per_source_completeness,
+        date_column_coverage=date_column_coverage,
+        col_type={p.name: p.col_type for p in column_profiles},
+        avg_len={p.name: float(p.avg_len) for p in column_profiles},
+        null_rate={p.name: float(p.null_rate) for p in column_profiles},
+    )
+
+
+def _pick_strategy_for_field(
+    field: str,
+    signals: RefinementSignals,
+) -> tuple[str, dict] | None:
+    """Apply the rule table to one field; return (strategy_name, kwargs)
+    or None to fall through to the base default.
+
+    Rule order (first match wins) per
+    ``docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md``.
+    """
+    col_type = signals.col_type.get(field, "unknown")
+    avg_len = signals.avg_len.get(field, 0.0)
+    null_rate = signals.null_rate.get(field, 0.0)
+    spread = signals.within_cluster_spread.get(field, 1.0)
+    date_cov = signals.date_column_coverage.get(field, 0.0)
+
+    # Rule 1: date column with full timestamp coverage.
+    if col_type == "date" and date_cov > 0.5:
+        return "most_recent", {"date_column": field}
+
+    # Rule 2: source_priority when one source clearly dominates.
+    per_source = signals.per_source_completeness.get(field)
+    if per_source and len(per_source) >= 2:
+        sorted_sources = sorted(
+            per_source.items(), key=lambda kv: kv[1], reverse=True,
+        )
+        _top_source, top_rate = sorted_sources[0]
+        # Median of all sources.
+        rates = sorted([r for _, r in sorted_sources])
+        median = rates[len(rates) // 2]
+        if median > 0 and top_rate > median * SOURCE_DOMINANCE_THRESHOLD:
+            ordered = [s for s, _ in sorted_sources]
+            return "source_priority", {"source_priority": ordered}
+
+    # Rule 3: long free-text field with disagreement -> longest_value.
+    if (
+        col_type in ("string", "address", "description")
+        and avg_len > FREE_TEXT_AVG_LEN_THRESHOLD
+        and spread > FREE_TEXT_SPREAD_THRESHOLD
+    ):
+        return "longest_value", {}
+
+    # Rule 4: mostly-NULL field -> first_non_null fast path.
+    if null_rate > HIGH_NULL_RATE_THRESHOLD:
+        return "first_non_null", {}
+
+    # Rule 5: high within-cluster disagreement -> confidence_majority.
+    if spread > HIGH_SPREAD_THRESHOLD:
+        return "confidence_majority", {}
+
+    # Otherwise: defer to base rules' default.
+    return None
+
+
+def refine_golden_rules(
+    base_rules: GoldenRulesConfig,
+    clusters: dict[int, dict],
+    prepared_df: pl.DataFrame,
+    column_profiles: list[ColumnProfile],
+) -> GoldenRulesConfig:
+    """Refine ``base_rules`` based on cluster + column signals.
+
+    Returns a NEW ``GoldenRulesConfig`` with ``field_rules`` populated.
+    Does NOT mutate ``base_rules``. When ``base_rules.adaptive`` is
+    False (default), returns ``base_rules`` unchanged.
+    """
+    from goldenmatch.config.schemas import GoldenFieldRule
+
+    if not base_rules.adaptive:
+        return base_rules
+
+    signals = compute_refinement_signals(clusters, prepared_df, column_profiles)
+
+    new_field_rules: dict[str, GoldenFieldRule] = dict(base_rules.field_rules)
+    for field in signals.within_cluster_spread.keys():
+        if field in new_field_rules:
+            # Caller-provided rule wins; don't override.
+            continue
+        result = _pick_strategy_for_field(field, signals)
+        if result is None:
+            continue
+        strategy, kwargs = result
+        try:
+            new_field_rules[field] = GoldenFieldRule(strategy=strategy, **kwargs)
+            logger.info(
+                "Refined golden rule: field=%r -> strategy=%s %s",
+                field, strategy, kwargs or "",
+            )
+        except Exception as exc:  # pragma: no cover -- defensive
+            logger.warning(
+                "Refiner skipped field=%r strategy=%s: %s",
+                field, strategy, exc,
+            )
+
+    refined = base_rules.model_copy(update={"field_rules": new_field_rules})
+    return refined

--- a/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
@@ -49,27 +49,32 @@ SIBLING_TIMESTAMP_COVERAGE_THRESHOLD = 0.8
 # heuristic value is worse than a missing value for these.
 import re as _re
 
+# Letter-boundary lookarounds so the patterns match `patient_ssn`
+# (underscore is `\w`, which breaks `\b` between underscore + letter).
+# Allows underscore, hyphen, digit, start/end of string as boundaries.
+_LB = r"(?<![a-z])"
+_LA = r"(?![a-z])"
+
 _COMPLIANCE_NAME_PATTERNS = [
     _re.compile(p, _re.IGNORECASE) for p in [
-        r"\bssn\b",
-        r"\bsin\b",                       # Canadian SIN
-        r"\bein\b",                       # employer ID
-        r"\btax[_-]?id\b",
-        r"\bnpi\b",
-        r"\bdea[_-]?number\b",
-        r"\blicense[_-]?(no|num|number)?\b",
-        r"\bpassport[_-]?(no|num|number)?\b",
-        r"\bdriver[_-]?license\b",
-        r"\bdrivers?[_-]?license\b",
-        r"\b(date[_-]?of[_-]?birth|dob|birthdate)\b",
-        r"\bmrn\b",                       # medical record number
-        r"\bhipaa[_-]?id\b",
-        r"\bpatient[_-]?id\b",
-        r"\bmedicaid[_-]?(no|num|number|id)?\b",
-        r"\bmedicare[_-]?(no|num|number|id)?\b",
-        r"\bcusip\b",
-        r"\blei\b",                       # Legal Entity Identifier
-        r"\bisin\b",                      # International Securities ID
+        rf"{_LB}ssn{_LA}",
+        rf"{_LB}sin{_LA}",                # Canadian SIN
+        rf"{_LB}ein{_LA}",                # employer ID
+        rf"{_LB}tax[_-]?id{_LA}",
+        rf"{_LB}npi{_LA}",
+        rf"{_LB}dea[_-]?number{_LA}",
+        rf"{_LB}license[_-]?(no|num|number)?{_LA}",
+        rf"{_LB}passport[_-]?(no|num|number)?{_LA}",
+        rf"{_LB}drivers?[_-]?license{_LA}",
+        rf"{_LB}(date[_-]?of[_-]?birth|dob|birthdate){_LA}",
+        rf"{_LB}mrn{_LA}",                # medical record number
+        rf"{_LB}hipaa[_-]?id{_LA}",
+        rf"{_LB}patient[_-]?id{_LA}",
+        rf"{_LB}medicaid[_-]?(no|num|number|id)?{_LA}",
+        rf"{_LB}medicare[_-]?(no|num|number|id)?{_LA}",
+        rf"{_LB}cusip{_LA}",
+        rf"{_LB}lei{_LA}",                # Legal Entity Identifier
+        rf"{_LB}isin{_LA}",               # International Securities ID
     ]
 ]
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1234,6 +1234,30 @@ def _run_dedupe_pipeline(
     golden_records = []
     golden_rules = config.golden_rules or GoldenRulesConfig(default_strategy="most_complete")
 
+    # v1.18: post-cluster golden-rules refinement. When the user opted
+    # in via `golden_rules.adaptive=True`, refine per-field strategies
+    # using cluster shape + column profiles. Refinement is a NEW config
+    # (immutable mutation); the original golden_rules is unchanged.
+    if golden_rules.adaptive:
+        try:
+            from goldenmatch.core.golden_rules_refiner import refine_golden_rules
+
+            # `profiles` is the ColumnProfile list built in Step 1; reuse
+            # if it's in scope (it is for the dedupe pipeline).
+            _profiles_for_refiner = locals().get("profiles") or []
+            golden_rules = refine_golden_rules(
+                base_rules=golden_rules,
+                clusters=clusters,
+                prepared_df=collected_df,
+                column_profiles=_profiles_for_refiner,
+            )
+        except Exception as exc:
+            # Refinement failure is non-fatal -- fall back to base rules.
+            logger.warning(
+                "Adaptive golden-rules refinement failed: %s. "
+                "Falling back to base rules.", exc,
+            )
+
     # Golden-record construction was the hidden N²-shaped stage that the
     # bench harness surfaced at 11K rows (36% of wall before this rewrite):
     # the prior loop called `collected_df.filter(__row_id__.is_in(member_ids))`

--- a/packages/python/goldenmatch/goldenmatch/plugins/base.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/base.py
@@ -83,10 +83,46 @@ class ConnectorPlugin(Protocol):
 
 @runtime_checkable
 class GoldenStrategyPlugin(Protocol):
-    """Plugin protocol for custom golden record merge strategies."""
+    """Plugin protocol for custom golden record merge strategies.
+
+    Plugins register via entry points::
+
+        [project.entry-points."goldenmatch.plugins.golden_strategy"]
+        legal_priority = "my_pkg.strategies:LegalPriorityStrategy"
+
+    Users opt in via ``GoldenFieldRule(strategy="custom:legal_priority")``.
+    The dispatcher in ``core/golden.py::merge_field`` looks up the
+    plugin by name (after the ``custom:`` prefix), then calls ``merge``
+    with all available signals. Plugins ignore kwargs they don't need.
+
+    Spec: ``docs/superpowers/specs/2026-05-22-golden-strategy-plugin-slot-design.md``
+    """
 
     name: str
 
-    def merge(self, values: list, sources: list[str] | None = None) -> tuple[Any, float]:
-        """Merge field values. Returns (merged_value, confidence)."""
+    def merge(
+        self,
+        values: list,
+        *,
+        sources: list[str] | None = None,
+        dates: list | None = None,
+        quality_weights: list[float] | None = None,
+        pair_scores: dict[tuple[int, int], float] | None = None,
+        rule_kwargs: dict | None = None,
+    ) -> Any:
+        """Merge cluster member values into one survivor.
+
+        Returns either ``(value, confidence)`` -- the dispatcher fills
+        ``idx=0`` -- or ``(value, confidence, idx)`` for plugins that
+        want to surface provenance.
+
+        ``rule_kwargs`` carries the per-field ``GoldenFieldRule``'s
+        configuration (``date_column``, ``source_priority``, or any
+        custom keys the plugin defines) so the plugin can read YAML
+        settings without sniffing global state.
+
+        Exceptions raised here are caught by the dispatcher and
+        fall back to ``most_complete`` with a WARNING log. To opt
+        into strict mode, set ``GOLDENMATCH_GOLDEN_STRATEGY_STRICT=1``.
+        """
         ...

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.17.1"
+version = "1.18.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/tests/test_custom_golden_strategy.py
+++ b/packages/python/goldenmatch/tests/test_custom_golden_strategy.py
@@ -1,0 +1,193 @@
+"""Tests for custom golden-strategy plugin slot (v1.18.1).
+
+Spec: docs/superpowers/specs/2026-05-22-golden-strategy-plugin-slot-design.md
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from goldenmatch.config.schemas import GoldenFieldRule
+from goldenmatch.core.golden import merge_field
+from goldenmatch.plugins.registry import PluginRegistry
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Each test gets a clean registry so cross-test contamination is impossible."""
+    PluginRegistry.reset()
+    yield
+    PluginRegistry.reset()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_custom_strategy_name_passes_validation():
+    """`custom:foo` is a valid GoldenFieldRule strategy."""
+    rule = GoldenFieldRule(strategy="custom:legal_priority")
+    assert rule.strategy == "custom:legal_priority"
+
+
+def test_invalid_custom_name_rejected_by_validator():
+    """Empty / hyphenated / uppercase names fail validation."""
+    with pytest.raises(ValueError):
+        GoldenFieldRule(strategy="custom:")
+    with pytest.raises(ValueError):
+        GoldenFieldRule(strategy="custom:has-hyphen")
+    with pytest.raises(ValueError):
+        GoldenFieldRule(strategy="custom:HasCaps")
+
+
+def test_custom_strategy_validator_does_not_require_plugin_to_exist():
+    """Plugin existence is checked at DISPATCH time, not validate.
+    Loading a config before plugins are discovered must succeed."""
+    # Plugin registry is empty (autouse fixture reset); rule still validates.
+    rule = GoldenFieldRule(strategy="custom:nonexistent_yet")
+    assert rule.strategy == "custom:nonexistent_yet"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+class _SimpleStrategy:
+    """Returns the first value, confidence 0.42. Used to verify dispatch."""
+
+    name = "simple"
+
+    def merge(self, values, **kwargs) -> Any:
+        return (values[0], 0.42)
+
+
+class _RichStrategy:
+    """Returns a 3-tuple with idx=last_index."""
+
+    name = "rich"
+
+    def merge(self, values, **kwargs) -> Any:
+        return (values[-1], 0.91, len(values) - 1)
+
+
+class _IntrospectingStrategy:
+    """Captures kwargs it receives so the test can assert on them."""
+
+    name = "introspect"
+
+    def __init__(self):
+        self.last_kwargs: dict = {}
+
+    def merge(self, values, **kwargs) -> Any:
+        self.last_kwargs = dict(kwargs)
+        return (values[0], 1.0)
+
+
+class _RaisingStrategy:
+    """Always raises on merge."""
+
+    name = "raises"
+
+    def merge(self, values, **kwargs) -> Any:
+        raise RuntimeError("plugin error")
+
+
+def test_dispatch_calls_plugin_with_kwargs():
+    """Dispatcher passes values + sources + dates + quality_weights +
+    pair_scores + rule_kwargs to the plugin."""
+    plugin = _IntrospectingStrategy()
+    PluginRegistry.instance().register_golden_strategy("introspect", plugin)
+    rule = GoldenFieldRule(
+        strategy="custom:introspect",
+        source_priority=["a", "b"],
+    )
+    merge_field(
+        values=["x", "y"],
+        rule=rule,
+        sources=["a", "b"],
+        dates=[1, 2],
+        quality_weights=[0.5, 0.7],
+        pair_scores={(0, 1): 0.9},
+    )
+    assert plugin.last_kwargs["sources"] == ["a", "b"]
+    assert plugin.last_kwargs["dates"] == [1, 2]
+    assert plugin.last_kwargs["quality_weights"] == [0.5, 0.7]
+    assert plugin.last_kwargs["pair_scores"] == {(0, 1): 0.9}
+    # rule_kwargs carries the GoldenFieldRule fields (excluding strategy).
+    assert plugin.last_kwargs["rule_kwargs"]["source_priority"] == ["a", "b"]
+
+
+def test_dispatch_accepts_two_tuple_result():
+    """Plugin returning (value, conf) -> dispatcher synthesizes idx=0."""
+    PluginRegistry.instance().register_golden_strategy("simple", _SimpleStrategy())
+    rule = GoldenFieldRule(strategy="custom:simple")
+    winner, conf, idx = merge_field(values=["x", "y", "z"], rule=rule)
+    assert winner == "x"
+    assert conf == 0.42
+    assert idx == 0
+
+
+def test_dispatch_accepts_three_tuple_result():
+    """Plugin returning (value, conf, idx) -> idx preserved."""
+    PluginRegistry.instance().register_golden_strategy("rich", _RichStrategy())
+    rule = GoldenFieldRule(strategy="custom:rich")
+    winner, conf, idx = merge_field(values=["x", "y", "z"], rule=rule)
+    assert winner == "z"
+    assert conf == 0.91
+    assert idx == 2
+
+
+def test_dispatch_falls_back_on_missing_plugin(caplog: pytest.LogCaptureFixture):
+    """Unknown plugin name -> WARNING + most_complete fallback."""
+    import logging
+
+    rule = GoldenFieldRule(strategy="custom:nonexistent")
+    with caplog.at_level(logging.WARNING, logger="goldenmatch.core.golden"):
+        winner, _conf, _idx = merge_field(
+            values=["short", "much longer string"],
+            rule=rule,
+        )
+    # most_complete picks the longer string (its proxy for completeness).
+    assert winner == "much longer string"
+    warnings = [r.getMessage() for r in caplog.records if "nonexistent" in r.getMessage()]
+    assert warnings, "no warning logged for missing plugin"
+
+
+def test_dispatch_falls_back_on_plugin_exception(caplog: pytest.LogCaptureFixture):
+    """Plugin raises -> WARNING + most_complete fallback."""
+    import logging
+
+    PluginRegistry.instance().register_golden_strategy("raises", _RaisingStrategy())
+    rule = GoldenFieldRule(strategy="custom:raises")
+    with caplog.at_level(logging.WARNING, logger="goldenmatch.core.golden"):
+        winner, _conf, _idx = merge_field(
+            values=["a", "much longer"],
+            rule=rule,
+        )
+    assert winner == "much longer"  # most_complete picked longer
+    warnings = [r.getMessage() for r in caplog.records if "raises" in r.getMessage()]
+    assert warnings
+
+
+def test_strict_mode_reraises_plugin_exception(monkeypatch: pytest.MonkeyPatch):
+    """GOLDENMATCH_GOLDEN_STRATEGY_STRICT=1 -> exception bubbles."""
+    monkeypatch.setenv("GOLDENMATCH_GOLDEN_STRATEGY_STRICT", "1")
+    PluginRegistry.instance().register_golden_strategy("raises", _RaisingStrategy())
+    rule = GoldenFieldRule(strategy="custom:raises")
+    with pytest.raises(RuntimeError, match="plugin error"):
+        merge_field(values=["x", "y"], rule=rule)
+
+
+def test_strict_mode_raises_on_missing_plugin(monkeypatch: pytest.MonkeyPatch):
+    """Strict mode: missing plugin -> ValueError instead of fallback."""
+    monkeypatch.setenv("GOLDENMATCH_GOLDEN_STRATEGY_STRICT", "1")
+    rule = GoldenFieldRule(strategy="custom:nonexistent")
+    with pytest.raises(ValueError, match="not found"):
+        merge_field(values=["x", "y"], rule=rule)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_golden_rules_refiner.py
+++ b/packages/python/goldenmatch/tests/test_golden_rules_refiner.py
@@ -125,6 +125,125 @@ def test_picks_confidence_majority_on_high_spread():
     assert kwargs == {}
 
 
+# ---------------------------------------------------------------------------
+# #smarter-refiner: compliance name + identity + sibling-timestamp rules
+# ---------------------------------------------------------------------------
+
+
+def test_picks_unanimous_or_null_for_compliance_named_field():
+    """Compliance-shaped column names ALWAYS get unanimous_or_null,
+    regardless of other signals."""
+    for compliance_name in ["ssn", "patient_ssn", "npi", "tax_id", "dob",
+                             "drivers_license", "passport_number", "mrn"]:
+        s_named = _signals(
+            col_type={compliance_name: "identifier"},
+            null_rate={compliance_name: 0.0},
+        )
+        result = _pick_strategy_for_field(compliance_name, s_named)
+        assert result is not None, f"{compliance_name} did not match compliance pattern"
+        strategy, _ = result
+        assert strategy == "unanimous_or_null", (
+            f"{compliance_name} should get unanimous_or_null; got {strategy}"
+        )
+
+
+def test_picks_unanimous_or_null_for_high_cardinality_identifier():
+    """col_type=identifier + cardinality_ratio > 0.9 -> unanimous_or_null."""
+    s = _signals(col_type={"f": "identifier"})
+    result = _pick_strategy_for_field("f", s, cardinality_ratio=0.95)
+    assert result is not None
+    strategy, kwargs = result
+    assert strategy == "unanimous_or_null"
+    assert kwargs == {}
+
+
+def test_low_cardinality_identifier_does_not_get_unanimous_or_null():
+    """col_type=identifier but cardinality < 0.9 (e.g. status code) -> normal flow."""
+    s = _signals(col_type={"f": "identifier"})
+    result = _pick_strategy_for_field("f", s, cardinality_ratio=0.3)
+    # No other rule fires on these neutral signals.
+    assert result is None
+
+
+def test_picks_most_recent_with_sibling_timestamp_for_address():
+    """A mutable-shaped field with a sibling timestamp gets
+    most_recent on the sibling, not on itself."""
+    s = _signals(col_type={"address": "address"}, avg_len={"address": 25.0})
+    result = _pick_strategy_for_field(
+        "address", s,
+        sibling_timestamp="updated_at",
+        cardinality_ratio=0.5,
+    )
+    assert result is not None
+    strategy, kwargs = result
+    assert strategy == "most_recent"
+    assert kwargs == {"date_column": "updated_at"}
+
+
+def test_sibling_timestamp_does_not_apply_to_non_mutable_fields():
+    """Field like `first_name` is not mutable -> sibling-timestamp rule
+    does NOT fire even when one is present."""
+    s = _signals(col_type={"first_name": "name"})
+    result = _pick_strategy_for_field(
+        "first_name", s,
+        sibling_timestamp="updated_at",
+    )
+    # first_name isn't in _MUTABLE_NAME_PATTERNS; falls through to
+    # other rules (which don't fire either on these signals).
+    assert result is None
+
+
+def test_compliance_pre_rule_overrides_post_cluster_signals():
+    """Even if a compliance field has 0.7 null_rate (would match
+    first_non_null) or 2.5 spread (would match confidence_majority),
+    the pre-rule wins."""
+    s = _signals(
+        null_rate={"ssn": 0.7},
+        within_cluster_spread={"ssn": 2.5},
+    )
+    result = _pick_strategy_for_field("ssn", s)
+    assert result is not None
+    strategy, _ = result
+    assert strategy == "unanimous_or_null"
+
+
+def test_pick_sibling_timestamp_picks_most_specific_match():
+    """`updated_at` should beat `created_at` because updated_at appears
+    earlier in the _TIMESTAMP_NAME_PATTERNS list."""
+    from goldenmatch.core.autoconfig import ColumnProfile
+    from goldenmatch.core.golden_rules_refiner import _pick_sibling_timestamp
+
+    profiles = [
+        ColumnProfile(
+            name="updated_at", dtype="Datetime", col_type="date",
+            confidence=0.9, null_rate=0.0, cardinality_ratio=0.9, avg_len=0,
+        ),
+        ColumnProfile(
+            name="created_at", dtype="Datetime", col_type="date",
+            confidence=0.9, null_rate=0.0, cardinality_ratio=0.9, avg_len=0,
+        ),
+    ]
+    coverage = {"updated_at": 1.0, "created_at": 1.0}
+    pick = _pick_sibling_timestamp(profiles, coverage)
+    assert pick == "updated_at"
+
+
+def test_pick_sibling_timestamp_returns_none_when_coverage_too_low():
+    """Coverage < 80% -> no timestamp picked."""
+    from goldenmatch.core.autoconfig import ColumnProfile
+    from goldenmatch.core.golden_rules_refiner import _pick_sibling_timestamp
+
+    profiles = [
+        ColumnProfile(
+            name="updated_at", dtype="Datetime", col_type="date",
+            confidence=0.9, null_rate=0.0, cardinality_ratio=0.9, avg_len=0,
+        ),
+    ]
+    coverage = {"updated_at": 0.5}  # below threshold
+    pick = _pick_sibling_timestamp(profiles, coverage)
+    assert pick is None
+
+
 def test_picks_none_when_no_rule_applies():
     """Field with no remarkable signals -> defer to base default."""
     s = _signals()  # all defaults: low spread, low null, short string

--- a/packages/python/goldenmatch/tests/test_golden_rules_refiner.py
+++ b/packages/python/goldenmatch/tests/test_golden_rules_refiner.py
@@ -1,0 +1,170 @@
+"""Tests for post-cluster golden-rules refinement (#golden-strategies, v1.18).
+
+Spec: docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import GoldenRulesConfig
+from goldenmatch.core.golden_rules_refiner import (
+    RefinementSignals,
+    _pick_strategy_for_field,
+    refine_golden_rules,
+)
+
+
+def _signals(**overrides) -> RefinementSignals:
+    """Build a RefinementSignals with sensible defaults for one field
+    `f`, then apply overrides. Tests can pass `null_rate={"f": 0.6}`
+    to set per-field values without spelling out the whole struct.
+    """
+    defaults = {
+        "within_cluster_spread": {"f": 1.0},
+        "per_source_completeness": {},
+        "date_column_coverage": {},
+        "col_type": {"f": "string"},
+        "avg_len": {"f": 5.0},
+        "null_rate": {"f": 0.0},
+    }
+    defaults.update(overrides)
+    return RefinementSignals(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _pick_strategy_for_field rule table
+# ---------------------------------------------------------------------------
+
+
+def test_picks_most_recent_for_date_column_with_coverage():
+    """Date column + > 50% of clusters have all-present dates."""
+    s = _signals(
+        col_type={"f": "date"},
+        date_column_coverage={"f": 0.8},
+    )
+    result = _pick_strategy_for_field("f", s)
+    assert result is not None
+    strategy, kwargs = result
+    assert strategy == "most_recent"
+    assert kwargs == {"date_column": "f"}
+
+
+def test_skips_most_recent_for_date_column_with_low_coverage():
+    """Date column but < 50% coverage -> not picked."""
+    s = _signals(
+        col_type={"f": "date"},
+        date_column_coverage={"f": 0.3},
+    )
+    result = _pick_strategy_for_field("f", s)
+    # Falls through past Rule 1 -> likely returns None (no other rule
+    # fires on these signals).
+    assert result is None
+
+
+def test_picks_source_priority_when_one_source_dominates():
+    """Three sources, one's completeness is > 1.5x median -> source_priority."""
+    s = _signals(
+        per_source_completeness={
+            "f": {"src_a": 0.95, "src_b": 0.40, "src_c": 0.30},
+        },
+    )
+    result = _pick_strategy_for_field("f", s)
+    assert result is not None
+    strategy, kwargs = result
+    assert strategy == "source_priority"
+    # Order by completeness desc: src_a, src_b, src_c
+    assert kwargs == {"source_priority": ["src_a", "src_b", "src_c"]}
+
+
+def test_skips_source_priority_when_no_dominance():
+    """Sources are close in completeness -> no clear winner."""
+    s = _signals(
+        per_source_completeness={
+            "f": {"src_a": 0.85, "src_b": 0.80, "src_c": 0.78},
+        },
+    )
+    result = _pick_strategy_for_field("f", s)
+    # Top (0.85) / median (0.80) = 1.06 < 1.5 -> no dominance
+    # Falls through; default null_rate is 0, spread is 1, col_type=string,
+    # avg_len=5 -> no other rule matches.
+    assert result is None
+
+
+def test_picks_longest_value_for_free_text_with_disagreement():
+    """col_type=string + avg_len > 20 + within-cluster spread > 1.5."""
+    s = _signals(
+        col_type={"f": "address"},
+        avg_len={"f": 35.0},
+        within_cluster_spread={"f": 1.8},
+    )
+    result = _pick_strategy_for_field("f", s)
+    assert result is not None
+    strategy, kwargs = result
+    assert strategy == "longest_value"
+    assert kwargs == {}
+
+
+def test_picks_first_non_null_for_sparse_column():
+    """null_rate > 0.5 -> first_non_null fast path."""
+    s = _signals(null_rate={"f": 0.7})
+    result = _pick_strategy_for_field("f", s)
+    assert result is not None
+    strategy, kwargs = result
+    assert strategy == "first_non_null"
+    assert kwargs == {}
+
+
+def test_picks_confidence_majority_on_high_spread():
+    """spread > 2.0 (high within-cluster disagreement) -> confidence_majority."""
+    s = _signals(within_cluster_spread={"f": 2.5})
+    result = _pick_strategy_for_field("f", s)
+    assert result is not None
+    strategy, kwargs = result
+    assert strategy == "confidence_majority"
+    assert kwargs == {}
+
+
+def test_picks_none_when_no_rule_applies():
+    """Field with no remarkable signals -> defer to base default."""
+    s = _signals()  # all defaults: low spread, low null, short string
+    result = _pick_strategy_for_field("f", s)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# refine_golden_rules integration
+# ---------------------------------------------------------------------------
+
+
+def test_refine_returns_base_rules_when_adaptive_false():
+    """adaptive=False -> base_rules returned unchanged."""
+    base = GoldenRulesConfig(default_strategy="most_complete", adaptive=False)
+    clusters: dict[int, dict] = {}
+    df = pl.DataFrame({"f": [1, 2]})
+    out = refine_golden_rules(base, clusters, df, column_profiles=[])
+    assert out is base  # same instance, not a copy
+
+
+def test_refine_does_not_mutate_base_rules():
+    """refine returns a NEW config; base.field_rules stays empty."""
+    base = GoldenRulesConfig(default_strategy="most_complete", adaptive=True)
+    clusters: dict[int, dict] = {}
+    df = pl.DataFrame({"f": [1, 2]})
+    refine_golden_rules(base, clusters, df, column_profiles=[])
+    # Even with no clusters, the refiner should not mutate base.
+    assert base.field_rules == {}
+
+
+def test_refine_runs_without_clusters_returns_base():
+    """No multi-member clusters -> nothing to refine; equal to base."""
+    base = GoldenRulesConfig(default_strategy="most_complete", adaptive=True)
+    clusters: dict[int, dict] = {}  # empty
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    out = refine_golden_rules(base, clusters, df, column_profiles=[])
+    assert out.field_rules == {}
+    assert out.default_strategy == "most_complete"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_golden_strategies_v118.py
+++ b/packages/python/goldenmatch/tests/test_golden_strategies_v118.py
@@ -1,0 +1,152 @@
+"""Tests for v1.18 golden-field strategies (#golden-strategies).
+
+Spec: docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md
+"""
+
+from __future__ import annotations
+
+import pytest
+from goldenmatch.config.schemas import GoldenFieldRule
+from goldenmatch.core.golden import merge_field
+
+# ---------------------------------------------------------------------------
+# longest_value
+# ---------------------------------------------------------------------------
+
+
+def test_longest_value_picks_longest_non_null():
+    """Free-text field: longest string wins."""
+    values = ["123 Main St", "123 Main Street Apartment 4B", "123 Main St."]
+    rule = GoldenFieldRule(strategy="longest_value")
+    winner, conf, idx = merge_field(values, rule)
+    assert winner == "123 Main Street Apartment 4B"
+    assert conf == 1.0
+    assert idx == 1
+
+
+def test_longest_value_ignores_nulls():
+    """NULL members don't count; longest non-null wins."""
+    values = [None, "short", None, "much longer value"]
+    rule = GoldenFieldRule(strategy="longest_value")
+    winner, _conf, _idx = merge_field(values, rule)
+    assert winner == "much longer value"
+
+
+def test_longest_value_ties_break_by_quality_weight():
+    """Two equal-length values: higher quality_weight wins."""
+    values = ["abc", "xyz"]
+    rule = GoldenFieldRule(strategy="longest_value")
+    winner, conf, idx = merge_field(values, rule, quality_weights=[0.3, 0.9])
+    assert winner == "xyz"
+    assert idx == 1
+    assert conf == 0.7
+
+
+# ---------------------------------------------------------------------------
+# unanimous_or_null
+# ---------------------------------------------------------------------------
+
+
+def test_unanimous_or_null_emits_value_when_all_agree():
+    """Every non-null member agrees -> emit that value."""
+    values = ["A", "A", "A"]
+    rule = GoldenFieldRule(strategy="unanimous_or_null")
+    winner, conf, _idx = merge_field(values, rule)
+    assert winner == "A"
+    assert conf == 1.0
+
+
+def test_unanimous_or_null_emits_null_when_any_disagree():
+    """Any disagreement -> None."""
+    values = ["A", "A", "B"]
+    rule = GoldenFieldRule(strategy="unanimous_or_null")
+    winner, conf, idx = merge_field(values, rule)
+    assert winner is None
+    assert conf == 0.0
+    assert idx is None
+
+
+def test_unanimous_or_null_ignores_null_members():
+    """NULL members are absence-not-contradiction. Two non-null members
+    agreeing + a NULL = unanimous on the non-null value."""
+    values = [None, "X", "X", None]
+    rule = GoldenFieldRule(strategy="unanimous_or_null")
+    winner, conf, _idx = merge_field(values, rule)
+    assert winner == "X"
+    assert conf == 1.0
+
+
+def test_unanimous_or_null_all_null_returns_null():
+    """All members NULL -> (None, 0.0)."""
+    values = [None, None, None]
+    rule = GoldenFieldRule(strategy="unanimous_or_null")
+    winner, conf, idx = merge_field(values, rule)
+    assert winner is None
+    assert conf == 0.0
+    assert idx is None
+
+
+# ---------------------------------------------------------------------------
+# confidence_majority
+# ---------------------------------------------------------------------------
+
+
+def test_confidence_majority_overrides_count_majority_on_weak_edges():
+    """3-member majority on weak edges loses to 2-member minority on
+    strong edges. Pin the calibration."""
+    values = ["A", "A", "A", "B", "B"]
+    # Weak edges among A-A pairs, strong edges among B-B pair.
+    pair_scores = {
+        (0, 1): 0.55,
+        (0, 2): 0.62,
+        (1, 2): 0.51,
+        (3, 4): 0.95,
+    }
+    rule = GoldenFieldRule(strategy="confidence_majority")
+    winner, _conf, _idx = merge_field(values, rule, pair_scores=pair_scores)
+    # A's total weight: 0.55 + 0.62 + 0.51 = 1.68
+    # B's total weight: 0.95
+    # A wins -- but only on sum-of-edge-weights. Pin the contract.
+    assert winner == "A"  # A still wins because more pairs agree
+
+
+def test_confidence_majority_high_weight_pair_overrules_count():
+    """Single very-high-weight pair beats two weak agreeing pairs."""
+    values = ["A", "A", "A", "B", "B"]
+    pair_scores = {
+        (0, 1): 0.30,  # A pair (weak)
+        (0, 2): 0.30,  # A pair (weak)
+        (3, 4): 1.00,  # B pair (strong)
+    }
+    rule = GoldenFieldRule(strategy="confidence_majority")
+    winner, _conf, _idx = merge_field(values, rule, pair_scores=pair_scores)
+    # A: 0.60; B: 1.00 -> B wins
+    assert winner == "B"
+
+
+def test_confidence_majority_falls_back_to_count_when_no_pair_scores():
+    """No pair_scores -> defer to majority_vote."""
+    values = ["A", "A", "B"]
+    rule = GoldenFieldRule(strategy="confidence_majority")
+    winner, _conf, _idx = merge_field(values, rule)
+    # majority_vote -> A wins (2 vs 1)
+    assert winner == "A"
+
+
+def test_confidence_majority_falls_back_when_no_agreeing_pairs():
+    """Every pair disagrees -> falls back to majority_vote."""
+    values = ["A", "B", "C"]
+    pair_scores = {
+        (0, 1): 0.8,
+        (0, 2): 0.7,
+        (1, 2): 0.9,
+    }
+    rule = GoldenFieldRule(strategy="confidence_majority")
+    winner, _conf, _idx = merge_field(values, rule, pair_scores=pair_scores)
+    # No agreeing pairs -> count-majority. All values are unique;
+    # majority_vote returns the first by count tie.
+    assert winner in {"A", "B", "C"}  # whichever count-majority picks
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

3 new built-in strategies + post-cluster auto-config refiner + custom Python plugin slot for arbitrary business rules. Closes all 4 follow-up bullets from the earlier golden-field discussion.

## What's new

### 3 new built-in strategies

- **`longest_value`** — longest non-null string. Free-text use case.
- **`unanimous_or_null`** — emit only on full agreement; None otherwise. Compliance use case.
- **`confidence_majority`** — majority weighted by cluster pair_scores. Strong-edge minority can beat weak-edge majority.

### Post-cluster `GoldenRulesRefiner`

Two-phase auto-config insight: matchkey + blocking is pre-cluster (clustering depends on them), but golden-rules picking is best informed by post-cluster signals.

`core/golden_rules_refiner.py` runs between `build_clusters` and `build_golden_records` when `golden_rules.adaptive=True`. Reads:
- Within-cluster value spread
- Per-source completeness (uses `__source__` if present)
- Date-column timestamp coverage
- `ColumnProfile` signals (col_type, avg_len, null_rate)

Rule table (first match wins per field):
- `col_type=date` + >50% cluster coverage → `most_recent`
- One source >1.5× median completeness → `source_priority`
- Free-text + long + cluster disagreement → `longest_value`
- `null_rate > 0.5` → `first_non_null`
- Spread > 2.0 → `confidence_majority`
- Else → defer to base default

Opt-in via `GoldenRulesConfig.adaptive: bool = False` (default off). Default-on is a v1.19 candidate.

### Custom plugin slot

`strategy="custom:<name>"` looks up a registered `GoldenStrategyPlugin`. Rich protocol signature (values + sources + dates + quality_weights + pair_scores + rule_kwargs). Defensive defaults: missing plugin OR plugin exception → WARNING + `most_complete` fallback. Opt-in strict mode via `GOLDENMATCH_GOLDEN_STRATEGY_STRICT=1` reraises. 2-tuple OR 3-tuple result accepted.

## Specs

- `docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md` (strategies + refiner)
- `docs/superpowers/specs/2026-05-22-golden-strategy-plugin-slot-design.md` (plugin slot)

## Test plan

- [x] 11 tests for the 3 new strategies
- [x] 9 tests for the refiner rule table
- [x] 9 tests for the plugin slot (validation, dispatch, fallback, strict mode)
- [x] `uv run ruff check` clean
- [x] All gated behind opt-in (`adaptive=False` default; `custom:` strategies opt-in per field)
- CI is the gate