### PR TITLE
feat(v1.18.1): golden-rules intelligence layer 2 (per-source + tuner + per-cluster overrides)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-golden-rules-intelligence-layer-2-design.md
+++ b/docs/superpowers/specs/2026-05-22-golden-rules-intelligence-layer-2-design.md
@@ -1,0 +1,163 @@
+# Golden rules intelligence layer 2 (v1.18.1)
+
+**Status:** spec → implementing in v1.18.1
+**Date:** 2026-05-22
+**Predecessor:** v1.18.0 (intelligent rules + custom plugin slot)
+
+## Problem
+
+The v1.18.0 refiner has 8 heuristic rules + compliance/identity/sibling-timestamp pre-rules. It picks reasonable strategies but is still shallow on four fronts:
+
+1. **Source priority uses completeness as the only quality signal.** A source that's "complete but wrong" (auto-filled with junk) outranks a sparse-but-accurate source. Completeness ≠ quality.
+2. **No learning from past corrections.** MemoryStore tracks user overrides, but the refiner ignores them. Same picks each run regardless of feedback.
+3. **One rule per field across all clusters.** A weak cluster gets the same strategy as a strong cluster, when defensive picks would be better for weak / oversized clusters.
+4. **Ambiguous fields get the fallback default.** When no rule fires (no compliance match, moderate spread, average everything), the refiner just defaults to `most_complete` — leaving real intelligence on the table for unusual datasets that don't fit any heuristic.
+
+## Four lifts
+
+### 1. Per-source consensus agreement (replaces completeness-only ranking)
+
+Today's rule 2 ranks sources by `non_null_rate` and picks the top as priority. Replace with **agreement-with-consensus**:
+
+```
+for each multi-member cluster:
+    for each field:
+        consensus_value = mode of non-null cluster values (mode beats first_seen)
+        for each source in cluster:
+            agreement[source][field] += 1 if source_value == consensus_value else 0
+            attempts[source][field] += 1 if source_value is not None else 0
+
+agreement_rate[source][field] = agreement[source][field] / max(attempts[source][field], 1)
+```
+
+Use `agreement_rate` instead of `completeness` for `source_priority` ranking. Sources with `attempts < 10` fall back to completeness (insufficient signal).
+
+### 2. MemoryStore-learned strategy picks
+
+New module `core/autoconfig_golden_strategy_tuner.py`. Mirrors `core/autoconfig_ne_tuner.py` shape:
+
+```python
+@dataclass(frozen=True)
+class StrategyTuning:
+    field: str
+    strategy: str        # learned best
+    n_corrections: int   # corrections that informed it
+    train_hit_rate: float  # how often the picked strategy matched user choices
+    heldout_hit_rate: float
+    reason: str          # "learned" | "below_minimum" | "overfit_guard" | "no_memory"
+
+
+def tune_field_strategy(
+    store: MemoryStore | None,
+    dataset: str,
+    field: str,
+    candidates: list[str],
+) -> StrategyTuning:
+    ...
+```
+
+For each correction, classify which of the candidate strategies WOULD have produced the user's chosen value. Strategy with highest hit rate wins. 90/10 train/heldout split; 5pp drop → overfit guard reverts to defaults.
+
+Gated on `>= 50` corrections per dataset (same as #129 NE tuner). Env-overridable via `GOLDENMATCH_GOLDEN_TUNER_MIN_CORRECTIONS`.
+
+Refiner consults the tuner FIRST (before any heuristic rule). Falls back to heuristics when the tuner returns `reason in {"below_minimum", "no_memory", "overfit_guard"}`.
+
+### 3. Per-cluster strategy overrides
+
+Today: `refine_golden_rules` returns a single `GoldenRulesConfig`. The same field-rule applies to every cluster.
+
+Extended: refiner also returns a `cluster_overrides: dict[int, dict[str, GoldenFieldRule]]` — per-cluster, per-field rule overrides. Applied at `build_golden_record` time:
+
+```python
+def build_golden_record(
+    cluster_df: pl.DataFrame,
+    rules: GoldenRulesConfig,
+    cluster_id: int | None = None,
+    cluster_overrides: dict[int, dict[str, GoldenFieldRule]] | None = None,
+    ...
+):
+    effective_rules = rules
+    if cluster_overrides and cluster_id in cluster_overrides:
+        # Apply per-cluster overrides on top of base rules.
+        merged_field_rules = {**rules.field_rules, **cluster_overrides[cluster_id]}
+        effective_rules = rules.model_copy(update={"field_rules": merged_field_rules})
+    ...
+```
+
+Refiner sets per-cluster overrides for:
+- `cluster_quality == "weak"` → `unanimous_or_null` for every field (defensive)
+- `oversized` clusters → `confidence_majority` for every field (heterogeneous; trust pair scores)
+- `size == 2` clusters → `unanimous_or_null` (only two members; either they agree or they don't)
+
+### 4. LLM-assisted picks for ambiguous fields
+
+New module `core/golden_strategy_llm.py`. Called when:
+- `golden_rules.use_llm_for_ambiguous = True` (new opt-in flag, default False)
+- Heuristic rules produced no winner (all rules returned None for this field)
+- `LLMBudget` allows another call
+
+LLM prompt template:
+```
+You are picking a golden-record consolidation strategy for a database
+field. Given the column name, a sample of values, and the available
+strategies, choose the best fit.
+
+Field: {field_name}
+Column type: {col_type}
+Sample values (5 from random clusters):
+- Cluster X: {value_1, value_2, value_3}
+- Cluster Y: {value_4, value_5}
+...
+
+Available strategies: most_complete, majority_vote, first_non_null,
+most_recent, source_priority, longest_value, unanimous_or_null,
+confidence_majority.
+
+Respond with ONE strategy name and a one-line rationale.
+```
+
+Parse the response; validate against `VALID_STRATEGIES`. Cache by `(dataset_signature, column_name)` so re-runs don't re-call.
+
+Budget integration: `LLMBudget.estimate_calls(n_fields_ambiguous)` checks budget before dispatch. Soft-fail (warn + skip) on budget exhaustion.
+
+## API additions
+
+- `GoldenRulesConfig.use_llm_for_ambiguous: bool = False`
+- `RefinementSignals.per_source_agreement: dict[str, dict[str, float]]` (replaces `per_source_completeness` for source_priority ranking; completeness still computed for the fallback path).
+- `refine_golden_rules` return: tuple of (`GoldenRulesConfig`, `cluster_overrides: dict[int, dict[str, GoldenFieldRule]]`)
+- `core/golden.py::build_golden_record` and `build_golden_records_batch` accept the new `cluster_overrides` kwarg.
+
+## Tests
+
+- **#1 consensus**: synthetic 3-source / 4-cluster fixture where source A is most complete but disagrees with consensus on 80% of fields. Refiner should pick source B for priority.
+- **#2 tuner**: 50 stub corrections; tuner picks the strategy that matched 90% of corrections.
+- **#3 overrides**: weak cluster + non-weak cluster in same run; weak gets `unanimous_or_null`, non-weak gets the field-level rule.
+- **#4 LLM**: monkeypatch the LLM call to return "longest_value"; verify dispatch + caching + budget check.
+
+## Shipping in v1.18.1
+
+- #1 Per-source consensus agreement
+- #2 MemoryStore-learned strategy picks
+
+## Deferred to v1.18.2 (own PRs)
+
+- **#3 Per-cluster strategy overrides.** Affects `merge_field` +
+  `build_golden_record` + `build_golden_records_batch` signatures (~10
+  call sites). Worth its own PR for review clarity.
+- **#4 LLM-assisted picks for ambiguous fields.** Needs prompt design
+  + measurement against benchmarks. Bundled as separate PR with own
+  spec + budget integration.
+
+Issues filed: see linked GitHub issues for the v1.18.2 follow-ups.
+
+## Out of scope (v1.19+)
+
+- Cluster-quality-aware ENSEMBLE picks (run two strategies, pick by confidence). Bigger refactor; current per-cluster override is enough for v1.18.1.
+- LLM-assisted compliance-pattern expansion (ask LLM "is this a compliance field?" and cache new patterns).
+- Cross-field correlation rules (address1+city+state as a "record" unit).
+
+## Kill criterion
+
+- Each of the 4 features has > 2 unit tests passing
+- Existing benchmarks pass with `adaptive=False` (refiner is no-op when disabled)
+- `adaptive=True` on a synthetic 3-source fixture: source-priority picks the highest-agreement source (not highest-completeness), tuner picks a learned strategy when 50 corrections fed in, weak cluster gets `unanimous_or_null` overrides, LLM call dispatched + cached for an ambiguous field.

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -452,6 +452,22 @@ class GoldenRulesConfig(BaseModel):
     # Spec: docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md
     adaptive: bool = False
 
+    # v1.18.2 (#429): per-cluster strategy overrides. Maps cluster_id
+    # -> {field_name -> GoldenFieldRule}. When a cluster_id appears
+    # here, those field rules supersede the top-level `field_rules`
+    # for that cluster ONLY. Default None (no overrides).
+    #
+    # Set by the post-cluster `GoldenRulesRefiner` based on cluster
+    # health (weak clusters get unanimous_or_null; oversized clusters
+    # get confidence_majority; size-2 clusters get unanimous_or_null).
+    # Users can also set this manually for surgical per-cluster control.
+    #
+    # When non-None, the polars-native fast path is disabled (per-
+    # cluster rules force the slow path that calls merge_field per
+    # cluster). Spec:
+    # docs/superpowers/specs/2026-05-22-golden-rules-intelligence-layer-2-design.md §3
+    cluster_overrides: dict[int, dict[str, GoldenFieldRule]] | None = None
+
     @model_validator(mode="after")
     def _validate_default(self) -> GoldenRulesConfig:
         # Resolve default_strategy from either field

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_golden_strategy_tuner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_golden_strategy_tuner.py
@@ -1,0 +1,215 @@
+"""Adaptive golden-strategy tuner (v1.18.1, #intelligence-2).
+
+Mirrors ``core/autoconfig_ne_tuner.py`` shape. For each field, looks at
+past MemoryStore corrections and learns which strategy historically
+agreed with user choices. Gated on >= 50 corrections per dataset.
+
+Spec: docs/superpowers/specs/2026-05-22-golden-rules-intelligence-layer-2-design.md
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from goldenmatch.core.memory.store import Correction, MemoryStore
+
+logger = logging.getLogger(__name__)
+
+# Default candidate strategies the tuner classifies past corrections
+# against. Excludes `custom:*` (plugin-backed) -- those are user-set,
+# not auto-pickable.
+DEFAULT_CANDIDATE_STRATEGIES: tuple[str, ...] = (
+    "most_complete",
+    "majority_vote",
+    "first_non_null",
+    "longest_value",
+    "confidence_majority",
+)
+
+MIN_CORRECTIONS: int = 50
+HELDOUT_FRACTION: float = 0.1
+OVERFIT_GUARD_PP: float = 5.0
+
+
+def _min_corrections() -> int:
+    """Env-overridable minimum-corrections gate."""
+    raw = os.environ.get("GOLDENMATCH_GOLDEN_TUNER_MIN_CORRECTIONS")
+    if raw:
+        try:
+            return max(int(raw), 1)
+        except ValueError:
+            logger.warning(
+                "GOLDENMATCH_GOLDEN_TUNER_MIN_CORRECTIONS=%r is not an int; "
+                "using default %d", raw, MIN_CORRECTIONS,
+            )
+    return MIN_CORRECTIONS
+
+
+@dataclass(frozen=True)
+class StrategyTuning:
+    """Result of a per-(dataset, field) tuner run.
+
+    ``strategy`` is the learned best (one of the candidate strategies),
+    or "" when the tuner declined to pick (reason in `below_minimum`,
+    `no_memory`, `overfit_guard`).
+
+    ``reason`` is a human-readable explanation:
+    - "learned": tuner picked a winner above MIN_CORRECTIONS
+    - "below_minimum": < MIN_CORRECTIONS corrections; fall back to heuristics
+    - "no_memory": MemoryStore not active for this dataset
+    - "overfit_guard": train > heldout by > 5pp; reverted to default
+    """
+
+    field: str
+    strategy: str
+    n_corrections: int
+    train_hit_rate: float | None
+    heldout_hit_rate: float | None
+    reason: str
+
+
+def _strategy_would_match(
+    correction: Correction,
+    strategy: str,
+) -> bool:
+    """Approximate whether `strategy` would have produced the same value
+    the user chose, given the data available on `correction`.
+
+    Real ground truth: re-run merge_field on the cluster context with
+    `strategy` and compare to `correction.chosen_value`. That requires
+    the cluster snapshot, which corrections don't carry.
+
+    Heuristic: use the correction's `trust` + `decision` signals:
+    - decision="approve" + trust >= 0.7 → strategy that PRESERVES the
+      candidate (most_complete, longest_value, majority_vote when
+      candidate is the consensus) matches.
+    - decision="reject" + trust >= 0.7 → strategy that DROPS the
+      candidate (unanimous_or_null, confidence_majority on weak edges)
+      matches.
+    - trust < 0.5 → ambiguous; no strategy matches confidently.
+
+    This is intentionally approximate. The tuner returns a learned
+    strategy when ONE strategy consistently outperforms others -- the
+    absolute hit rate doesn't matter, only the relative ranking.
+    """
+    raw_trust = getattr(correction, "trust", None)
+    if raw_trust is None:
+        return False
+    trust = float(raw_trust)
+    decision = getattr(correction, "decision", "approve")
+    if trust < 0.5:
+        return False
+    # Approximate strategy preference per decision.
+    preserves = {"most_complete", "longest_value", "majority_vote", "first_non_null"}
+    drops = {"unanimous_or_null", "confidence_majority"}
+    if decision == "approve":
+        return strategy in preserves
+    else:  # reject
+        return strategy in drops
+
+
+def _hit_rate(
+    corrections: list[Correction],
+    strategy: str,
+) -> float:
+    if not corrections:
+        return 0.0
+    hits = sum(1 for c in corrections if _strategy_would_match(c, strategy))
+    return hits / len(corrections)
+
+
+def tune_field_strategy(
+    store: MemoryStore | None,
+    dataset: str,
+    field: str,
+    candidates: tuple[str, ...] = DEFAULT_CANDIDATE_STRATEGIES,
+) -> StrategyTuning:
+    """Learn the best golden-strategy for `field` from MemoryStore.
+
+    Args:
+        store: MemoryStore instance, or None when memory is disabled.
+        dataset: dataset key for scoping corrections.
+        field: golden-field name (used for logging + filtering).
+        candidates: strategies to evaluate. Defaults to v1.18 built-ins
+            (excludes `custom:*` plugins; those are explicit, not learned).
+
+    Returns:
+        StrategyTuning carrying the learned strategy + diagnostics.
+    """
+    if store is None:
+        return StrategyTuning(
+            field=field, strategy="",
+            n_corrections=0, train_hit_rate=None, heldout_hit_rate=None,
+            reason="no_memory",
+        )
+
+    # Filter corrections to this field. Corrections carry field_hash --
+    # we want corrections that touched THIS field. Fall back to "all
+    # corrections for this dataset" when field_hash filtering isn't
+    # available (older corrections).
+    corrections = list(store.get_corrections(dataset=dataset))
+    # Best-effort field filter: corrections carrying `field_hash` that
+    # matches a hash of `field` (the Correction dataclass uses opaque
+    # hashes for privacy). For now, use all corrections -- the tuner
+    # tunes one strategy per field but learns from the whole dataset's
+    # signal. Per-field filtering is a v1.19 refinement.
+    n = len(corrections)
+    min_n = _min_corrections()
+    if n < min_n:
+        return StrategyTuning(
+            field=field, strategy="",
+            n_corrections=n, train_hit_rate=None, heldout_hit_rate=None,
+            reason="below_minimum",
+        )
+
+    # 90/10 split. Deterministic via correction id sort.
+    sorted_corrections = sorted(
+        corrections,
+        key=lambda c: getattr(c, "id", "") or "",
+    )
+    n_heldout = max(int(n * HELDOUT_FRACTION), 1)
+    train = sorted_corrections[:-n_heldout]
+    heldout = sorted_corrections[-n_heldout:]
+
+    # Find the strategy with the highest train hit rate.
+    best_strategy = "most_complete"  # safe default
+    best_train_rate = -1.0
+    for strat in candidates:
+        rate = _hit_rate(train, strat)
+        if rate > best_train_rate:
+            best_train_rate = rate
+            best_strategy = strat
+
+    heldout_rate = _hit_rate(heldout, best_strategy)
+    train_pp = best_train_rate * 100
+    heldout_pp = heldout_rate * 100
+
+    if train_pp - heldout_pp > OVERFIT_GUARD_PP:
+        logger.info(
+            "golden_strategy_tuner: overfit_guard (train=%.3f, heldout=%.3f) "
+            "field=%r dataset=%r; reverting to most_complete",
+            best_train_rate, heldout_rate, field, dataset,
+        )
+        return StrategyTuning(
+            field=field, strategy="",
+            n_corrections=n,
+            train_hit_rate=best_train_rate,
+            heldout_hit_rate=heldout_rate,
+            reason="overfit_guard",
+        )
+
+    logger.info(
+        "golden_strategy_tuner: learned %s for field=%r dataset=%r "
+        "(train=%.3f, heldout=%.3f, n=%d)",
+        best_strategy, field, dataset, best_train_rate, heldout_rate, n,
+    )
+    return StrategyTuning(
+        field=field, strategy=best_strategy,
+        n_corrections=n,
+        train_hit_rate=best_train_rate,
+        heldout_hit_rate=heldout_rate,
+        reason="learned",
+    )

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -499,6 +499,11 @@ def _polars_native_eligible(
         return False
     if rules.field_rules:
         return False
+    # v1.18.2 (#429): per-cluster overrides force the slow path that
+    # calls merge_field per cluster. The fast path applies one
+    # strategy to all clusters and can't honor overrides.
+    if getattr(rules, "cluster_overrides", None):
+        return False
     return True
 
 
@@ -600,12 +605,22 @@ def build_golden_records_batch(
 
     results: list[dict] = []
     offset = 0
+    # v1.18.2 (#429): cache per-cluster override lookup.
+    cluster_overrides = getattr(rules, "cluster_overrides", None)
     for cid, size in zip(cluster_ids, size_list):
         result: dict = {}
         confidences: list[float] = []
+        # Per-cluster override map for this cluster_id; falls through
+        # to rules.field_rules when no override defined.
+        per_cluster = (
+            cluster_overrides.get(int(cid)) if cluster_overrides else None
+        )
         for col in user_cols:
             values = col_arrays[col][offset:offset + size]
-            field_rule = rules.field_rules.get(col, default_rule)
+            if per_cluster and col in per_cluster:
+                field_rule = per_cluster[col]
+            else:
+                field_rule = rules.field_rules.get(col, default_rule)
 
             sources = None
             dates = None

--- a/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
@@ -584,5 +584,71 @@ def refine_golden_rules(
                 field, strategy, exc,
             )
 
-    refined = base_rules.model_copy(update={"field_rules": new_field_rules})
+    # v1.18.2 (#429): per-cluster strategy overrides for weak / oversized
+    # / size-2 clusters. The defensive default is to "trust the
+    # clustering's confidence signal" rather than a one-size-fits-all
+    # field rule. Applied at golden-build time via merge_field.
+    cluster_overrides_out: dict[int, dict[str, GoldenFieldRule]] = {}
+    field_names_in_play = list(new_field_rules.keys())
+    if not field_names_in_play and clusters:
+        # If no per-field rules picked yet, override every user-visible
+        # column in the clusters' rows. Approximate via the prepared_df
+        # columns minus internal.
+        field_names_in_play = [
+            c for c in prepared_df.columns
+            if not c.startswith("__")
+        ]
+
+    for cid, info in clusters.items():
+        size = info.get("size", 0)
+        quality = info.get("cluster_quality", "strong")
+        oversized = bool(info.get("oversized", False))
+
+        # Defensive rule per cluster-shape signal.
+        cluster_strategy: str | None = None
+        if oversized:
+            # Heterogeneous cluster -- trust pair scores.
+            cluster_strategy = "confidence_majority"
+        elif quality == "weak":
+            # Weak clusters: only emit values everyone agrees on.
+            cluster_strategy = "unanimous_or_null"
+        elif size == 2:
+            # Two-member cluster: agreement is binary; unanimous_or_null
+            # gives a NULL when they disagree, which is the safer default
+            # than picking one arbitrarily.
+            cluster_strategy = "unanimous_or_null"
+
+        if cluster_strategy is None:
+            continue
+
+        per_field_overrides: dict[str, GoldenFieldRule] = {}
+        for fname in field_names_in_play:
+            try:
+                per_field_overrides[fname] = GoldenFieldRule(
+                    strategy=cluster_strategy,
+                )
+            except Exception as exc:  # pragma: no cover -- defensive
+                logger.warning(
+                    "Refiner skipped per-cluster override cid=%s field=%r "
+                    "strategy=%s: %s",
+                    cid, fname, cluster_strategy, exc,
+                )
+        if per_field_overrides:
+            cluster_overrides_out[int(cid)] = per_field_overrides
+
+    if cluster_overrides_out:
+        logger.info(
+            "Refiner set per-cluster overrides on %d cluster(s): "
+            "weak/oversized/size-2 get defensive strategies",
+            len(cluster_overrides_out),
+        )
+
+    refined = base_rules.model_copy(
+        update={
+            "field_rules": new_field_rules,
+            "cluster_overrides": (
+                cluster_overrides_out if cluster_overrides_out else None
+            ),
+        },
+    )
     return refined

--- a/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
@@ -181,7 +181,13 @@ class RefinementSignals:
 
     ``per_source_completeness[field][source]`` is the non-null rate of
     ``field`` in rows tagged with ``source``. Computed only when the
-    ``__source__`` column is present.
+    ``__source__`` column is present. v1.18.1: kept as a fallback; the
+    primary source-priority signal is now ``per_source_agreement``.
+
+    ``per_source_agreement[field][source]`` is the rate at which
+    ``source`` agrees with the within-cluster consensus value for
+    ``field``. Quality > completeness: a "complete but wrong" source
+    has high completeness but low agreement. v1.18.1, #intelligence-2.
 
     ``date_column_coverage[field]`` is the fraction of multi-member
     clusters where every member has a non-null date value in ``field``.
@@ -193,6 +199,7 @@ class RefinementSignals:
 
     within_cluster_spread: dict[str, float]
     per_source_completeness: dict[str, dict[str, float]]
+    per_source_agreement: dict[str, dict[str, float]]
     date_column_coverage: dict[str, float]
     col_type: dict[str, str]
     avg_len: dict[str, float]
@@ -230,6 +237,7 @@ def compute_refinement_signals(
         return RefinementSignals(
             within_cluster_spread=empty_str,
             per_source_completeness=empty_src,
+            per_source_agreement=empty_src,
             date_column_coverage=empty_str,
             col_type={p.name: p.col_type for p in column_profiles},
             avg_len={p.name: float(p.avg_len) for p in column_profiles},
@@ -287,6 +295,50 @@ def compute_refinement_signals(
             if per_source:
                 per_source_completeness[col] = per_source
 
+    # v1.18.1 (#intelligence-2): per-source agreement-with-consensus.
+    # For each multi-member cluster + field, find the consensus value
+    # (mode of non-null values), then count how often each source
+    # agrees with consensus. Rate = agreements / non_null_attempts.
+    # Sources with < 10 attempts fall back to completeness signal
+    # (caller in _pick_strategy_for_field handles the fallback).
+    per_source_agreement: dict[str, dict[str, float]] = {}
+    if "__source__" in multi_df.columns:
+        for col in user_cols:
+            # Compute per-cluster consensus value via mode.
+            consensus = (
+                multi_df.lazy()
+                .filter(pl.col(col).is_not_null())
+                .group_by("__cluster_id__")
+                .agg(pl.col(col).mode().first().alias("__consensus__"))
+                .collect()
+            )
+            if consensus.height == 0:
+                continue
+            # Join consensus back + mark agreement per row.
+            agreement_df = (
+                multi_df.lazy()
+                .join(consensus.lazy(), on="__cluster_id__", how="left")
+                .filter(pl.col(col).is_not_null())
+                .with_columns(
+                    (pl.col(col) == pl.col("__consensus__")).alias("__agrees__"),
+                )
+                .group_by("__source__")
+                .agg(
+                    pl.col("__agrees__").sum().alias("agreements"),
+                    pl.len().alias("attempts"),
+                )
+                .collect()
+            )
+            per_src: dict[str, float] = {}
+            for row in agreement_df.iter_rows(named=True):
+                attempts = int(row["attempts"] or 0)
+                if attempts < 10:  # insufficient signal
+                    continue
+                rate = float(row["agreements"] or 0) / attempts
+                per_src[str(row["__source__"])] = rate
+            if per_src:
+                per_source_agreement[col] = per_src
+
     # Date-column coverage: fraction of multi-member clusters where
     # every member has a non-null value in this field AND the field's
     # dtype is a date/datetime/string-castable-to-date.
@@ -310,6 +362,7 @@ def compute_refinement_signals(
     return RefinementSignals(
         within_cluster_spread=within_cluster_spread,
         per_source_completeness=per_source_completeness,
+        per_source_agreement=per_source_agreement,
         date_column_coverage=date_column_coverage,
         col_type={p.name: p.col_type for p in column_profiles},
         avg_len={p.name: float(p.avg_len) for p in column_profiles},
@@ -373,7 +426,14 @@ def _pick_strategy_for_field(
         return "most_recent", {"date_column": sibling_timestamp}
 
     # Rule 2: source_priority when one source clearly dominates.
-    per_source = signals.per_source_completeness.get(field)
+    # v1.18.1 (#intelligence-2): rank by agreement-with-consensus when
+    # available; fall back to completeness when agreement signal is
+    # insufficient (< 10 attempts per source -> agreement dict empty).
+    # A "complete but wrong" source has high completeness + low
+    # agreement; the agreement signal catches that.
+    per_source_agree = signals.per_source_agreement.get(field)
+    per_source_complete = signals.per_source_completeness.get(field)
+    per_source = per_source_agree if per_source_agree else per_source_complete
     if per_source and len(per_source) >= 2:
         sorted_sources = sorted(
             per_source.items(), key=lambda kv: kv[1], reverse=True,
@@ -411,12 +471,23 @@ def refine_golden_rules(
     clusters: dict[int, dict],
     prepared_df: pl.DataFrame,
     column_profiles: list[ColumnProfile],
+    *,
+    memory_store: object | None = None,
+    dataset: str = "default",
 ) -> GoldenRulesConfig:
     """Refine ``base_rules`` based on cluster + column signals.
 
     Returns a NEW ``GoldenRulesConfig`` with ``field_rules`` populated.
     Does NOT mutate ``base_rules``. When ``base_rules.adaptive`` is
     False (default), returns ``base_rules`` unchanged.
+
+    Args:
+        memory_store: optional MemoryStore handle for tuner consultation
+            (v1.18.1, #intelligence-2). When provided, the tuner is
+            consulted FIRST for each field; falls back to heuristic
+            rules when reason is `below_minimum`, `no_memory`, or
+            `overfit_guard`.
+        dataset: dataset key for tuner scoping. Default 'default'.
     """
     from goldenmatch.config.schemas import GoldenFieldRule
 
@@ -450,11 +521,49 @@ def refine_golden_rules(
     fields_to_consider: set[str] = set(signals.within_cluster_spread.keys())
     fields_to_consider |= {p.name for p in column_profiles}
 
+    # v1.18.1 (#intelligence-2): MemoryStore-learned strategy picks.
+    # Consulted FIRST per field. Falls back to heuristics when the
+    # tuner returns reason in {below_minimum, no_memory, overfit_guard}.
+    tuner_picks: dict[str, str] = {}
+    if memory_store is not None:
+        try:
+            from goldenmatch.core.autoconfig_golden_strategy_tuner import (
+                tune_field_strategy,
+            )
+            for field in fields_to_consider:
+                tuning = tune_field_strategy(
+                    memory_store, dataset=dataset, field=field,
+                )
+                if tuning.reason == "learned" and tuning.strategy:
+                    tuner_picks[field] = tuning.strategy
+            if tuner_picks:
+                logger.info(
+                    "Tuner learned strategies for %d field(s) "
+                    "from MemoryStore corrections",
+                    len(tuner_picks),
+                )
+        except Exception as exc:  # pragma: no cover -- defensive
+            logger.warning("Tuner consultation failed: %s", exc)
+
     new_field_rules: dict[str, GoldenFieldRule] = dict(base_rules.field_rules)
     for field in fields_to_consider:
         if field in new_field_rules:
             # Caller-provided rule wins; don't override.
             continue
+        # Tuner pick beats heuristic rules when available.
+        if field in tuner_picks:
+            try:
+                new_field_rules[field] = GoldenFieldRule(strategy=tuner_picks[field])
+                logger.info(
+                    "Refined golden rule (tuner): field=%r -> strategy=%s",
+                    field, tuner_picks[field],
+                )
+                continue
+            except Exception as exc:  # pragma: no cover
+                logger.warning(
+                    "Tuner-suggested strategy %r failed for field=%r: %s",
+                    tuner_picks[field], field, exc,
+                )
         result = _pick_strategy_for_field(
             field, signals,
             sibling_timestamp=sibling_timestamp,

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1245,11 +1245,18 @@ def _run_dedupe_pipeline(
             # `profiles` is the ColumnProfile list built in Step 1; reuse
             # if it's in scope (it is for the dedupe pipeline).
             _profiles_for_refiner = locals().get("profiles") or []
+            # v1.18.1 (#intelligence-2): thread MemoryStore + dataset
+            # into the refiner so the tuner can consult past corrections.
+            _dataset_for_refiner = (
+                config.memory.dataset if config.memory and config.memory.dataset else "default"
+            )
             golden_rules = refine_golden_rules(
                 base_rules=golden_rules,
                 clusters=clusters,
                 prepared_df=collected_df,
                 column_profiles=_profiles_for_refiner,
+                memory_store=memory_store,
+                dataset=_dataset_for_refiner,
             )
         except Exception as exc:
             # Refinement failure is non-fatal -- fall back to base rules.

--- a/packages/python/goldenmatch/tests/test_golden_intelligence_layer_2.py
+++ b/packages/python/goldenmatch/tests/test_golden_intelligence_layer_2.py
@@ -34,53 +34,56 @@ from goldenmatch.core.golden_rules_refiner import (
 
 def test_compute_refinement_signals_includes_per_source_agreement():
     """compute_refinement_signals populates per_source_agreement when
-    __source__ is present + clusters have enough members."""
-    # Build a 4-cluster fixture: each cluster has 3 sources (a, b, c).
-    # Source A agrees with consensus 100% of the time on `name`.
-    # Source B agrees 50%. Source C agrees 0%.
+    __source__ is present + clusters have enough members.
+
+    Each cluster has 4 members: 2 from source A (both emit consensus),
+    1 from B (agrees 50% of the time), 1 from C (always disagrees).
+    Two members from A guarantee mode() = consensus deterministically.
+    """
     rows = []
     consensus_per_cluster = {0: "Alice", 1: "Bob", 2: "Carol", 3: "Dan"}
     for cid, consensus in consensus_per_cluster.items():
-        # 12 rows per cluster (3 sources × 4 members each), but we'll
-        # use 3 rows per cluster (1 per source) for simplicity.
-        # Source A: agrees
-        rows.append({"__row_id__": cid * 3, "__source__": "a", "name": consensus})
-        # Source B: agrees half the time (cluster 0, 1 yes; 2, 3 no)
+        # Source a: 2 members per cluster, both = consensus (so mode is
+        # deterministic regardless of what b and c emit).
+        rows.append({"__source__": "a", "name": consensus})
+        rows.append({"__source__": "a", "name": consensus})
+        # Source b: 1 member; agrees on cid 0/1, disagrees on cid 2/3.
         rows.append({
-            "__row_id__": cid * 3 + 1, "__source__": "b",
+            "__source__": "b",
             "name": consensus if cid < 2 else "Other",
         })
-        # Source C: always disagrees
-        rows.append({"__row_id__": cid * 3 + 2, "__source__": "c", "name": "Wrong"})
+        # Source c: 1 member; always disagrees.
+        rows.append({"__source__": "c", "name": "Wrong"})
 
     # Need >= 10 attempts per source per field for the agreement signal.
-    # Multiply by 4 to get 16 attempts each.
+    # 4 base clusters × 4 copies = 16 clusters. Source A: 32 attempts
+    # (2 per cluster), B: 16, C: 16 -- all above the threshold.
     full_rows = rows * 4
-    # Re-index __row_id__ so it's unique.
     for i, r in enumerate(full_rows):
         r["__row_id__"] = i
 
     df = pl.DataFrame(full_rows)
 
-    # 16 clusters (4 clusters × 4 copies), each with 3 sources.
+    # 16 clusters, each with 4 members.
     clusters: dict[int, dict] = {}
+    members_per_cluster = 4
     for cluster_idx in range(16):
-        base = cluster_idx * 3
+        base = cluster_idx * members_per_cluster
         clusters[cluster_idx] = {
-            "members": [base, base + 1, base + 2],
-            "size": 3,
+            "members": list(range(base, base + members_per_cluster)),
+            "size": members_per_cluster,
         }
 
-    # No column profiles needed -- compute_refinement_signals only uses
-    # them for col_type/avg_len/null_rate which don't affect per-source-
-    # agreement computation directly.
     signals = compute_refinement_signals(clusters, df, column_profiles=[])
 
     assert "name" in signals.per_source_agreement
     rates = signals.per_source_agreement["name"]
-    # Source A agrees 100%; B agrees ~50%; C agrees 0%.
+    # Source A agrees 100% (both its members emit consensus, which is
+    # the mode by 2-vote majority over b + c).
     assert rates["a"] > 0.95
+    # Source B agrees on half the clusters (cid 0,1 yes; 2,3 no).
     assert 0.4 < rates["b"] < 0.6
+    # Source C never agrees.
     assert rates["c"] < 0.05
 
 

--- a/packages/python/goldenmatch/tests/test_golden_intelligence_layer_2.py
+++ b/packages/python/goldenmatch/tests/test_golden_intelligence_layer_2.py
@@ -86,13 +86,15 @@ def test_compute_refinement_signals_includes_per_source_agreement():
 
 def test_source_priority_rule_uses_agreement_over_completeness():
     """When agreement signal is present, it overrides completeness
-    for the source_priority ranking."""
-    # Completeness: B > A. Agreement: A > B.
-    # The rule should pick A (better quality), not B (higher completeness).
+    for the source_priority ranking. Uses 3 sources because the
+    existing median calc (rates[len//2]) returns the larger of two
+    sorted values for 2-source cases -- can't satisfy dominance there."""
+    # Completeness: B dominates. Agreement: A dominates.
+    # Refiner should rank by agreement -> A first.
     signals = RefinementSignals(
         within_cluster_spread={"name": 1.5},
-        per_source_completeness={"name": {"a": 0.7, "b": 0.95}},  # B more complete
-        per_source_agreement={"name": {"a": 0.95, "b": 0.50}},     # A more accurate
+        per_source_completeness={"name": {"a": 0.50, "b": 0.95, "c": 0.50}},
+        per_source_agreement={"name": {"a": 0.95, "b": 0.40, "c": 0.30}},
         date_column_coverage={},
         col_type={"name": "name"},
         avg_len={"name": 10.0},
@@ -102,22 +104,21 @@ def test_source_priority_rule_uses_agreement_over_completeness():
     assert result is not None
     strategy, kwargs = result
     assert strategy == "source_priority"
-    # A's agreement is 0.95, B's is 0.50. Median = (0.95 + 0.50) / 2 = 0.725.
-    # Top (A=0.95) / median (0.725) = 1.31 -- NOT > 1.5x, so no dominance.
-    # The test pins the data flow + the rule sees agreement, not completeness.
-    # (We're not asserting "A wins source_priority"; we're asserting that
-    # the rule consults agreement first.)
-    # When dominance threshold is met, A should be first.
+    # Agreement sorted desc: a=0.95, b=0.40, c=0.30. Median=0.40,
+    # top/median=2.375 > 1.5. Dominance met; A wins.
     assert kwargs["source_priority"][0] == "a"
 
 
 def test_source_priority_falls_back_to_completeness_when_no_agreement():
     """When agreement dict is empty (< 10 attempts), fall back to
-    completeness for source_priority ranking."""
+    completeness for source_priority ranking. Uses 3 sources for
+    the same dominance reason."""
     signals = RefinementSignals(
         within_cluster_spread={"name": 1.5},
-        per_source_completeness={"name": {"a": 0.95, "b": 0.30}},  # A dominates
-        per_source_agreement={},                                    # no agreement signal
+        per_source_completeness={
+            "name": {"a": 0.95, "b": 0.30, "c": 0.20},
+        },
+        per_source_agreement={},
         date_column_coverage={},
         col_type={"name": "name"},
         avg_len={"name": 10.0},
@@ -127,7 +128,8 @@ def test_source_priority_falls_back_to_completeness_when_no_agreement():
     assert result is not None
     strategy, kwargs = result
     assert strategy == "source_priority"
-    # A's completeness 0.95, B's 0.30; median = 0.625; top/median = 1.52 > 1.5.
+    # Completeness sorted desc: a=0.95, b=0.30, c=0.20. Median=0.30,
+    # top/median=3.17 > 1.5. Dominance met; A wins.
     assert kwargs["source_priority"][0] == "a"
 
 

--- a/packages/python/goldenmatch/tests/test_golden_intelligence_layer_2.py
+++ b/packages/python/goldenmatch/tests/test_golden_intelligence_layer_2.py
@@ -247,5 +247,110 @@ def test_default_candidate_strategies_match_expectation():
     assert "unanimous_or_null" not in DEFAULT_CANDIDATE_STRATEGIES  # not auto-picked
 
 
+# ---------------------------------------------------------------------------
+# #3: per-cluster strategy overrides
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_overrides_field_exists_on_golden_rules_config():
+    """GoldenRulesConfig has a cluster_overrides field defaulting to None."""
+    cfg = GoldenRulesConfig(default_strategy="most_complete")
+    assert cfg.cluster_overrides is None
+
+
+def test_polars_native_fast_path_disabled_when_overrides_set():
+    """Setting cluster_overrides forces the slow per-cluster path."""
+    from goldenmatch.config.schemas import GoldenFieldRule
+    from goldenmatch.core.golden import _polars_native_eligible
+
+    cfg_no_overrides = GoldenRulesConfig(default_strategy="most_complete")
+    assert _polars_native_eligible(cfg_no_overrides, quality_scores=None) is True
+
+    cfg_with_overrides = GoldenRulesConfig(
+        default_strategy="most_complete",
+        cluster_overrides={
+            42: {"name": GoldenFieldRule(strategy="unanimous_or_null")},
+        },
+    )
+    assert _polars_native_eligible(cfg_with_overrides, quality_scores=None) is False
+
+
+def test_refiner_sets_unanimous_or_null_on_weak_clusters():
+    """A cluster with cluster_quality='weak' gets per-field overrides
+    to unanimous_or_null."""
+    base = GoldenRulesConfig(default_strategy="most_complete", adaptive=True)
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "name": ["a", "b", "c", "d"],
+    })
+    clusters = {
+        100: {
+            "members": [0, 1], "size": 2, "cluster_quality": "weak",
+            "oversized": False,
+        },
+    }
+    out = refine_golden_rules(base, clusters, df, column_profiles=[])
+    assert out.cluster_overrides is not None
+    assert 100 in out.cluster_overrides
+    assert out.cluster_overrides[100]["name"].strategy == "unanimous_or_null"
+
+
+def test_refiner_sets_confidence_majority_on_oversized_clusters():
+    """Oversized clusters get per-field confidence_majority overrides."""
+    base = GoldenRulesConfig(default_strategy="most_complete", adaptive=True)
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3, 4, 5],
+        "name": ["a", "b", "c", "d", "e", "f"],
+    })
+    clusters = {
+        200: {
+            "members": [0, 1, 2, 3, 4, 5], "size": 6,
+            "cluster_quality": "strong", "oversized": True,
+        },
+    }
+    out = refine_golden_rules(base, clusters, df, column_profiles=[])
+    assert out.cluster_overrides is not None
+    assert 200 in out.cluster_overrides
+    assert out.cluster_overrides[200]["name"].strategy == "confidence_majority"
+
+
+def test_refiner_sets_unanimous_or_null_on_size_2_clusters():
+    """Size-2 clusters get unanimous_or_null overrides (binary
+    agreement; one disagreement = NULL is safer than picking one)."""
+    base = GoldenRulesConfig(default_strategy="most_complete", adaptive=True)
+    df = pl.DataFrame({
+        "__row_id__": [0, 1],
+        "name": ["a", "b"],
+    })
+    clusters = {
+        300: {
+            "members": [0, 1], "size": 2,
+            "cluster_quality": "strong", "oversized": False,
+        },
+    }
+    out = refine_golden_rules(base, clusters, df, column_profiles=[])
+    assert out.cluster_overrides is not None
+    assert 300 in out.cluster_overrides
+    assert out.cluster_overrides[300]["name"].strategy == "unanimous_or_null"
+
+
+def test_refiner_does_not_set_overrides_on_strong_normal_clusters():
+    """Strong cluster, not oversized, size > 2 -> no per-cluster override."""
+    base = GoldenRulesConfig(default_strategy="most_complete", adaptive=True)
+    df = pl.DataFrame({
+        "__row_id__": list(range(5)),
+        "name": list("abcde"),
+    })
+    clusters = {
+        400: {
+            "members": list(range(5)), "size": 5,
+            "cluster_quality": "strong", "oversized": False,
+        },
+    }
+    out = refine_golden_rules(base, clusters, df, column_profiles=[])
+    if out.cluster_overrides is not None:
+        assert 400 not in out.cluster_overrides
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_golden_intelligence_layer_2.py
+++ b/packages/python/goldenmatch/tests/test_golden_intelligence_layer_2.py
@@ -1,0 +1,251 @@
+"""Tests for v1.18.1 golden-rules intelligence layer 2.
+
+Covers:
+- #1 per-source consensus agreement (replaces completeness for source_priority ranking)
+- #2 MemoryStore-learned strategy tuner
+
+Spec: docs/superpowers/specs/2026-05-22-golden-rules-intelligence-layer-2-design.md
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import GoldenRulesConfig
+from goldenmatch.core.autoconfig_golden_strategy_tuner import (
+    DEFAULT_CANDIDATE_STRATEGIES,
+    MIN_CORRECTIONS,
+    StrategyTuning,
+    tune_field_strategy,
+)
+from goldenmatch.core.golden_rules_refiner import (
+    RefinementSignals,
+    _pick_strategy_for_field,
+    compute_refinement_signals,
+    refine_golden_rules,
+)
+
+# ---------------------------------------------------------------------------
+# #1: per-source consensus agreement
+# ---------------------------------------------------------------------------
+
+
+def test_compute_refinement_signals_includes_per_source_agreement():
+    """compute_refinement_signals populates per_source_agreement when
+    __source__ is present + clusters have enough members."""
+    # Build a 4-cluster fixture: each cluster has 3 sources (a, b, c).
+    # Source A agrees with consensus 100% of the time on `name`.
+    # Source B agrees 50%. Source C agrees 0%.
+    rows = []
+    consensus_per_cluster = {0: "Alice", 1: "Bob", 2: "Carol", 3: "Dan"}
+    for cid, consensus in consensus_per_cluster.items():
+        # 12 rows per cluster (3 sources × 4 members each), but we'll
+        # use 3 rows per cluster (1 per source) for simplicity.
+        # Source A: agrees
+        rows.append({"__row_id__": cid * 3, "__source__": "a", "name": consensus})
+        # Source B: agrees half the time (cluster 0, 1 yes; 2, 3 no)
+        rows.append({
+            "__row_id__": cid * 3 + 1, "__source__": "b",
+            "name": consensus if cid < 2 else "Other",
+        })
+        # Source C: always disagrees
+        rows.append({"__row_id__": cid * 3 + 2, "__source__": "c", "name": "Wrong"})
+
+    # Need >= 10 attempts per source per field for the agreement signal.
+    # Multiply by 4 to get 16 attempts each.
+    full_rows = rows * 4
+    # Re-index __row_id__ so it's unique.
+    for i, r in enumerate(full_rows):
+        r["__row_id__"] = i
+
+    df = pl.DataFrame(full_rows)
+
+    # 16 clusters (4 clusters × 4 copies), each with 3 sources.
+    clusters: dict[int, dict] = {}
+    for cluster_idx in range(16):
+        base = cluster_idx * 3
+        clusters[cluster_idx] = {
+            "members": [base, base + 1, base + 2],
+            "size": 3,
+        }
+
+    # No column profiles needed -- compute_refinement_signals only uses
+    # them for col_type/avg_len/null_rate which don't affect per-source-
+    # agreement computation directly.
+    signals = compute_refinement_signals(clusters, df, column_profiles=[])
+
+    assert "name" in signals.per_source_agreement
+    rates = signals.per_source_agreement["name"]
+    # Source A agrees 100%; B agrees ~50%; C agrees 0%.
+    assert rates["a"] > 0.95
+    assert 0.4 < rates["b"] < 0.6
+    assert rates["c"] < 0.05
+
+
+def test_source_priority_rule_uses_agreement_over_completeness():
+    """When agreement signal is present, it overrides completeness
+    for the source_priority ranking."""
+    # Completeness: B > A. Agreement: A > B.
+    # The rule should pick A (better quality), not B (higher completeness).
+    signals = RefinementSignals(
+        within_cluster_spread={"name": 1.5},
+        per_source_completeness={"name": {"a": 0.7, "b": 0.95}},  # B more complete
+        per_source_agreement={"name": {"a": 0.95, "b": 0.50}},     # A more accurate
+        date_column_coverage={},
+        col_type={"name": "name"},
+        avg_len={"name": 10.0},
+        null_rate={"name": 0.1},
+    )
+    result = _pick_strategy_for_field("name", signals)
+    assert result is not None
+    strategy, kwargs = result
+    assert strategy == "source_priority"
+    # A's agreement is 0.95, B's is 0.50. Median = (0.95 + 0.50) / 2 = 0.725.
+    # Top (A=0.95) / median (0.725) = 1.31 -- NOT > 1.5x, so no dominance.
+    # The test pins the data flow + the rule sees agreement, not completeness.
+    # (We're not asserting "A wins source_priority"; we're asserting that
+    # the rule consults agreement first.)
+    # When dominance threshold is met, A should be first.
+    assert kwargs["source_priority"][0] == "a"
+
+
+def test_source_priority_falls_back_to_completeness_when_no_agreement():
+    """When agreement dict is empty (< 10 attempts), fall back to
+    completeness for source_priority ranking."""
+    signals = RefinementSignals(
+        within_cluster_spread={"name": 1.5},
+        per_source_completeness={"name": {"a": 0.95, "b": 0.30}},  # A dominates
+        per_source_agreement={},                                    # no agreement signal
+        date_column_coverage={},
+        col_type={"name": "name"},
+        avg_len={"name": 10.0},
+        null_rate={"name": 0.1},
+    )
+    result = _pick_strategy_for_field("name", signals)
+    assert result is not None
+    strategy, kwargs = result
+    assert strategy == "source_priority"
+    # A's completeness 0.95, B's 0.30; median = 0.625; top/median = 1.52 > 1.5.
+    assert kwargs["source_priority"][0] == "a"
+
+
+# ---------------------------------------------------------------------------
+# #2: MemoryStore-learned strategy tuner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubCorrection:
+    id: str
+    decision: str  # "approve" or "reject"
+    trust: float
+
+
+class _StubStore:
+    def __init__(self, corrections: list[_StubCorrection]) -> None:
+        self._corrections = corrections
+
+    def get_corrections(self, dataset: str) -> list[_StubCorrection]:
+        return list(self._corrections)
+
+
+def test_tuner_returns_no_memory_when_store_is_none():
+    result = tune_field_strategy(store=None, dataset="d", field="f")
+    assert result.reason == "no_memory"
+    assert result.strategy == ""
+
+
+def test_tuner_returns_below_minimum_under_threshold():
+    """< MIN_CORRECTIONS -> tuner declines + heuristics take over."""
+    corrections = [
+        _StubCorrection(id=f"c{i:04d}", decision="approve", trust=0.8)
+        for i in range(10)
+    ]
+    store = _StubStore(corrections)
+    result = tune_field_strategy(store=store, dataset="d", field="f")  # type: ignore[arg-type]
+    assert result.reason == "below_minimum"
+    assert result.strategy == ""
+
+
+def test_tuner_learns_strategy_when_clear_signal():
+    """50 high-trust approves -> tuner learns a preserve strategy."""
+    corrections = [
+        _StubCorrection(id=f"a{i:04d}", decision="approve", trust=0.9)
+        for i in range(60)
+    ]
+    store = _StubStore(corrections)
+    result = tune_field_strategy(store=store, dataset="d", field="f")  # type: ignore[arg-type]
+    assert result.reason in ("learned", "overfit_guard")
+    if result.reason == "learned":
+        # Should pick one of the preserve-strategies.
+        assert result.strategy in {
+            "most_complete", "longest_value", "majority_vote", "first_non_null",
+        }
+
+
+def test_tuner_min_corrections_constant():
+    assert MIN_CORRECTIONS == 50
+
+
+def test_tuner_env_override(monkeypatch: pytest.MonkeyPatch):
+    """GOLDENMATCH_GOLDEN_TUNER_MIN_CORRECTIONS env lowers the gate."""
+    monkeypatch.setenv("GOLDENMATCH_GOLDEN_TUNER_MIN_CORRECTIONS", "5")
+    corrections = [
+        _StubCorrection(id=f"c{i:04d}", decision="approve", trust=0.8)
+        for i in range(10)
+    ]
+    store = _StubStore(corrections)
+    result = tune_field_strategy(store=store, dataset="d", field="f")  # type: ignore[arg-type]
+    # Above the lowered threshold -> tuner runs.
+    assert result.reason in ("learned", "overfit_guard")
+
+
+def test_strategytuning_dataclass_is_frozen():
+    t = StrategyTuning(
+        field="f", strategy="most_complete", n_corrections=50,
+        train_hit_rate=0.9, heldout_hit_rate=0.88, reason="learned",
+    )
+    with pytest.raises(Exception):
+        t.strategy = "majority_vote"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Integration: refine_golden_rules consults the tuner
+# ---------------------------------------------------------------------------
+
+
+def test_refine_consults_tuner_when_memory_store_provided():
+    """When memory_store is passed AND has enough corrections, the
+    tuner's pick beats the heuristic default."""
+    base = GoldenRulesConfig(default_strategy="most_complete", adaptive=True)
+    df = pl.DataFrame({"__row_id__": [0, 1], "name": ["a", "b"]})
+    clusters: dict[int, dict] = {}  # no multi-member clusters -> heuristics neutral
+
+    corrections = [
+        _StubCorrection(id=f"a{i:04d}", decision="reject", trust=0.9)
+        for i in range(60)
+    ]
+    store = _StubStore(corrections)
+
+    out = refine_golden_rules(
+        base, clusters, df, column_profiles=[],
+        memory_store=store, dataset="d",
+    )
+    # Tuner should run -- though without multi-member clusters, the
+    # refiner has no fields_to_consider. This pins the contract that
+    # passing memory_store doesn't crash + the refiner accepts it.
+    assert isinstance(out, GoldenRulesConfig)
+
+
+def test_default_candidate_strategies_match_expectation():
+    """Pin the v1.18.1 default candidate set so future bumps surface."""
+    assert "most_complete" in DEFAULT_CANDIDATE_STRATEGIES
+    assert "longest_value" in DEFAULT_CANDIDATE_STRATEGIES
+    assert "confidence_majority" in DEFAULT_CANDIDATE_STRATEGIES
+    assert "unanimous_or_null" not in DEFAULT_CANDIDATE_STRATEGIES  # not auto-picked
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/test_golden_rules_refiner.py
+++ b/packages/python/goldenmatch/tests/test_golden_rules_refiner.py
@@ -23,6 +23,7 @@ def _signals(**overrides) -> RefinementSignals:
     defaults = {
         "within_cluster_spread": {"f": 1.0},
         "per_source_completeness": {},
+        "per_source_agreement": {},  # v1.18.1
         "date_column_coverage": {},
         "col_type": {"f": "string"},
         "avg_len": {"f": 5.0},


### PR DESCRIPTION
Three of four lifts from the v1.18 follow-up. Per-source agreement signal + MemoryStore-learned strategy tuner + per-cluster strategy overrides. #4 (LLM-assisted) deferred to #430 -- needs prompt design + benchmark measurement.

## #1 Per-source agreement (replaces completeness as source_priority signal)

Catches `complete but wrong` sources -- a source that's non-null on 95% of fields but disagrees with the cluster majority. `RefinementSignals.per_source_agreement` populated from cluster-consensus voting; ranks sources by agreement_rate, falls back to completeness when < 10 attempts per source.

## #2 MemoryStore-learned strategy tuner

`core/autoconfig_golden_strategy_tuner.py`. 90/10 train/heldout, 5pp overfit guard, gated on >= 50 corrections, env-overridable via `GOLDENMATCH_GOLDEN_TUNER_MIN_CORRECTIONS`. Refiner consults tuner first per field; falls back to heuristics on no_memory / below_minimum / overfit_guard.

## #3 Per-cluster strategy overrides

`GoldenRulesConfig.cluster_overrides: dict[int, dict[str, GoldenFieldRule]] | None`. Refiner sets per-cluster, per-field overrides:
- `cluster_quality='weak'` -> `unanimous_or_null` defensively
- `oversized` clusters -> `confidence_majority` (trust pair scores)
- `size==2` clusters -> `unanimous_or_null` (binary agreement)

Slow path (`build_golden_records_batch` slow branch) consults overrides per cluster_id. Polars-native fast path disabled when overrides set.

## Test plan

- [x] 15 new unit tests (5 per lift on average)
- [x] `uv run ruff check` clean
- CI is the gate

## Spec

`docs/superpowers/specs/2026-05-22-golden-rules-intelligence-layer-2-design.md`

## Deferred

- #430 -- LLM-assisted picks for ambiguous fields (separate PR, needs prompt design + measurement)