### PR TITLE
perf(#433): cut CI wall time by ~50% on dominant tests

### DIFF
--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -132,6 +132,7 @@ goldenmatch = "goldenmatch.cli.main:app"
 testpaths = ["tests"]
 markers = [
     "benchmark: integration tests against real benchmark datasets (skipped by default; run with `pytest -m benchmark`)",
+    "keep_real_refuse_at_n: opt out of the test_controller_confidence_gate autouse REFUSE_AT_N monkeypatch (#433)",
 ]
 
 [tool.coverage.run]

--- a/packages/python/goldenmatch/tests/test_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig.py
@@ -609,6 +609,12 @@ class TestCompoundBlockingIntegration:
     """Integration test: auto_configure_df on a wide dataset with oversized single-column blocks."""
 
     def test_wide_dataset_produces_safe_config(self):
+        # #433: was 112s on CI (the dominant test). The full
+        # controller iteration adds ~100s and isn't what this test
+        # verifies -- the assertion is about blocking safety on a
+        # wide dataset, which is computed in the initial v0 config.
+        # confidence_required=False short-circuits past the
+        # iteration loop and returns v0 directly.
         random.seed(42)
         n = 10000
         models = [f"Model{random.choice('ABCDEFGHIJ')}{i}" for i in range(100)]
@@ -624,7 +630,7 @@ class TestCompoundBlockingIntegration:
         })
 
         from goldenmatch.core.autoconfig import auto_configure_df
-        config = auto_configure_df(df)
+        config = auto_configure_df(df, confidence_required=False)
 
         assert config.blocking is not None
         if config.blocking.strategy == "multi_pass":

--- a/packages/python/goldenmatch/tests/test_controller_confidence_gate.py
+++ b/packages/python/goldenmatch/tests/test_controller_confidence_gate.py
@@ -34,6 +34,33 @@ def _disable_autoconfig_memory(monkeypatch):
     monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
 
 
+# #433: gate tests previously built REFUSE_AT_N (100K) row dataframes
+# to exercise the gate. Each test ran the controller iteration loop on
+# 100K rows, costing ~30s/test * 4 tests = ~120s of CI wall time.
+#
+# The gate's behavior depends on the COMPARISON `df.height >= REFUSE_AT_N`,
+# not the absolute scale. Lowering REFUSE_AT_N to SMALL_N via monkeypatch
+# and using SMALL_N-row dataframes exercises the same code path on a
+# fraction of the data.
+#
+# The constant-guardrail test `test_refuse_at_n_constant_is_100k` opts
+# OUT of this fixture (its own monkeypatch fixture below). That keeps
+# the load-bearing 100K value pinned in source.
+SMALL_N = 500
+
+
+@pytest.fixture(autouse=True)
+def _lower_refuse_at_n_for_speed(monkeypatch, request):
+    """Lower REFUSE_AT_N to SMALL_N inside the autoconfig_controller
+    module so gate-mechanism tests don't need 100K-row fixtures.
+
+    Skipped via marker `keep_real_refuse_at_n` for the constant guardrail."""
+    if request.node.get_closest_marker("keep_real_refuse_at_n"):
+        return
+    from goldenmatch.core import autoconfig_controller as ctrl_mod
+    monkeypatch.setattr(ctrl_mod, "REFUSE_AT_N", SMALL_N)
+
+
 def _force_red_history_entry(monkeypatch, n_rows_in_df: int):
     """Replace RunHistory.pick_committed with a callable returning a
     forced-RED HistoryEntry."""
@@ -79,23 +106,27 @@ def _df(n_rows: int) -> pl.DataFrame:
     })
 
 
+@pytest.mark.keep_real_refuse_at_n
 def test_refuse_at_n_constant_is_100k():
+    # Source-of-truth guardrail: REFUSE_AT_N is the documented 100K
+    # threshold. Opts out of the autouse monkeypatch via marker so the
+    # real constant is asserted.
     assert REFUSE_AT_N == 100_000
 
 
 def test_gate_fires_on_red_at_or_above_threshold(monkeypatch):
     """df.height = REFUSE_AT_N exactly + RED -> raise."""
-    _force_red_history_entry(monkeypatch, n_rows_in_df=REFUSE_AT_N)
-    df = _df(REFUSE_AT_N)
+    _force_red_history_entry(monkeypatch, n_rows_in_df=SMALL_N)
+    df = _df(SMALL_N)
     with pytest.raises(ControllerNotConfidentError) as exc_info:
         gm.dedupe_df(df)
-    assert exc_info.value.n_rows == REFUSE_AT_N
+    assert exc_info.value.n_rows == SMALL_N
     assert exc_info.value.failing_sub_profile == "data"
 
 
 def test_gate_does_not_fire_below_threshold(monkeypatch):
     """df.height < REFUSE_AT_N + RED -> warn-and-run (current behavior)."""
-    n = REFUSE_AT_N - 1
+    n = SMALL_N - 1
     _force_red_history_entry(monkeypatch, n_rows_in_df=n)
     df = _df(n)
     result = gm.dedupe_df(df)
@@ -107,7 +138,7 @@ def test_gate_does_not_fire_on_yellow_or_green(monkeypatch):
     from goldenmatch.core.autoconfig_history import HistoryEntry, RunHistory
 
     green_profile = ComplexityProfile(
-        data=DataProfile(n_rows=REFUSE_AT_N, n_cols=3, column_types={
+        data=DataProfile(n_rows=SMALL_N, n_cols=3, column_types={
             "a": "text", "b": "text", "c": "text",
         }),
         blocking=BlockingProfile(
@@ -122,8 +153,8 @@ def test_gate_does_not_fire_on_yellow_or_green(monkeypatch):
             dip_statistic=0.05,  # avoid RED: health() returns RED when dip<0.005
         ),
         meta=ProfileMeta(
-            iteration=0, is_sample=False, sample_size=REFUSE_AT_N,
-            n_rows_full=REFUSE_AT_N, wall_clock_ms=0, seed=0,
+            iteration=0, is_sample=False, sample_size=SMALL_N,
+            n_rows_full=SMALL_N, wall_clock_ms=0, seed=0,
         ),
     )
 
@@ -137,7 +168,7 @@ def test_gate_does_not_fire_on_yellow_or_green(monkeypatch):
         )
 
     monkeypatch.setattr(RunHistory, "pick_committed", _picker)
-    df = _df(REFUSE_AT_N)
+    df = _df(SMALL_N)
     result = gm.dedupe_df(df)  # should NOT raise
     assert result is not None
 
@@ -145,7 +176,7 @@ def test_gate_does_not_fire_on_yellow_or_green(monkeypatch):
 def test_gate_short_circuits_with_confidence_required_false(monkeypatch):
     """Spec §Backward compatibility: kwarg opt-out preserves today's
     warn-and-run behavior. Un-skipped in Phase 4."""
-    _force_red_history_entry(monkeypatch, n_rows_in_df=REFUSE_AT_N)
-    df = _df(REFUSE_AT_N)
+    _force_red_history_entry(monkeypatch, n_rows_in_df=SMALL_N)
+    df = _df(SMALL_N)
     result = gm.dedupe_df(df, confidence_required=False)
     assert result is not None

--- a/packages/python/goldenmatch/tests/test_controller_confidence_gate.py
+++ b/packages/python/goldenmatch/tests/test_controller_confidence_gate.py
@@ -52,13 +52,33 @@ SMALL_N = 500
 @pytest.fixture(autouse=True)
 def _lower_refuse_at_n_for_speed(monkeypatch, request):
     """Lower REFUSE_AT_N to SMALL_N inside the autoconfig_controller
-    module so gate-mechanism tests don't need 100K-row fixtures.
+    module + tighten the iteration budget so gate-mechanism tests
+    don't need 100K-row fixtures OR multiple iteration passes.
 
-    Skipped via marker `keep_real_refuse_at_n` for the constant guardrail."""
+    Skipped via marker `keep_real_refuse_at_n` for the constant guardrail.
+
+    Without the iteration-budget cap, the smaller dataframe runs each
+    pipeline iteration so fast that the controller fits MORE iterations
+    in the wall-budget than it did on 100K -- net slower. Capping
+    max_iterations to 0 keeps the loop minimal (1 iteration via
+    `range(max_iterations + 1)`). The gate fires AFTER the loop based
+    on the mocked pick_committed, so iteration count doesn't change
+    test outcomes -- only wall time.
+    """
     if request.node.get_closest_marker("keep_real_refuse_at_n"):
         return
     from goldenmatch.core import autoconfig_controller as ctrl_mod
     monkeypatch.setattr(ctrl_mod, "REFUSE_AT_N", SMALL_N)
+    # Replace ControllerBudget.for_dataset with a min-iterations stub.
+    # `range(max_iterations + 1)` means max_iterations=0 still runs 1
+    # iteration -- enough for the mocked pick_committed to commit.
+    def _tight_for_dataset(cls, n_rows: int) -> ctrl_mod.ControllerBudget:
+        return cls(max_iterations=0, max_seconds=15.0)
+
+    monkeypatch.setattr(
+        ctrl_mod.ControllerBudget, "for_dataset",
+        classmethod(_tight_for_dataset),
+    )
 
 
 def _force_red_history_entry(monkeypatch, n_rows_in_df: int):


### PR DESCRIPTION
Three items from the #433 investigation. CI is the verifier.

## Items addressed

| Test | Before | Strategy |
|---|---|---|
| `test_wide_dataset_produces_safe_config` | 112s | pass `confidence_required=False` -- assertion lives in v0 config, no need to run full controller iteration |
| `test_gate_fires_on_red_at_or_above_threshold` | 27s | monkeypatch `REFUSE_AT_N` to 500 + use 500-row df |
| `test_gate_does_not_fire_below_threshold` | 35s | same |
| `test_gate_does_not_fire_on_yellow_or_green` | 37s | same |
| `test_gate_short_circuits_with_confidence_required_false` | 10s | same |

The constant-guardrail test `test_refuse_at_n_constant_is_100k` opts out via new `@pytest.mark.keep_real_refuse_at_n` marker (registered in pyproject) so the load-bearing 100K value stays pinned in source.

## Expected wall cut

Top-6 was ~320s of 415s. This addresses ~240s of that. Expected: 415s -> ~175s = 58% cut. Will see the real number on this PR's CI run.

Refs #433.