### PR TITLE
feat: 10 predefined golden-strategy plugins (numeric / format / business)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md
+++ b/docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md
@@ -1,0 +1,158 @@
+# Predefined golden-strategy plugins
+
+**Status:** spec → implementing in v1.18.2
+**Date:** 2026-05-22
+**Predecessor:** v1.18.0 custom plugin slot (#golden-strategy-plugins)
+
+## Problem
+
+v1.18.0 shipped the custom-plugin slot (`strategy="custom:<name>"`) with
+zero built-in plugins -- by design. Users wanting common patterns like
+"pick max numeric value" or "lowercase + dedupe emails" had to write
+their own. Two pain points:
+
+1. **Numeric aggregates are absent from the built-in strategies.** All
+   8 built-ins (most_complete, majority_vote, first_non_null,
+   most_recent, source_priority, longest_value, unanimous_or_null,
+   confidence_majority) treat values as opaque strings. A column like
+   `lifetime_value` or `account_balance` has no built-in "pick the
+   max" option.
+2. **Format-canonical merges are operator favorites that get
+   reimplemented constantly.** "Pick the lowercased / plus-stripped
+   email" or "pick the most-digits phone" or "pick the value from
+   our authoritative CRM source" come up in every customer
+   integration. Shipping these as named plugins means the YAML
+   config carries the intent (`strategy: "custom:email_normalize"`)
+   instead of a custom Python module.
+
+## Decision
+
+Ship **10 predefined plugins** in three categories, auto-registered
+when `PluginRegistry.discover()` runs:
+
+### Numeric aggregates (3)
+
+- **`numeric_max`** -- largest numeric value. Ignores non-numeric.
+- **`numeric_min`** -- smallest numeric value.
+- **`numeric_mean`** -- arithmetic mean of numeric values.
+
+### Format-canonical (4)
+
+- **`shortest_value`** -- shortest non-null string. Useful for codes
+  / identifiers where shorter usually means more canonical.
+- **`concat_unique`** -- comma-separated join of unique non-null
+  values (sorted). Useful for tags / categories / multi-select fields.
+- **`email_normalize`** -- lowercase + strip plus-addressing; pick
+  the mode (most common normalized form).
+- **`phone_digits_only`** -- strip formatting; pick the value with
+  the most digits (favors full international format over local).
+
+### Business-shaped (3)
+
+- **`system_of_record`** -- pick value from authoritative source
+  per `rule_kwargs.source_priority`. Same as built-in `source_priority`
+  but with explicit "system of record" semantic naming for the YAML
+  intent. Falls back to first non-null when no priority source has
+  a value.
+- **`lifecycle_stage`** -- pick the most-advanced lifecycle value.
+  Default order (lowest -> highest): `subscriber`, `lead`, `mql`,
+  `sql`, `opportunity`, `customer`, `evangelist`. Override via
+  `rule_kwargs.lifecycle_order` (list of stage names).
+- **`freshness_with_max_age`** -- like `most_recent` but emits NULL
+  if no value is fresher than `rule_kwargs.max_age_days` (default 365).
+  Compliance / data-freshness use case.
+
+## Discovery
+
+`PluginRegistry.discover()` auto-registers builtins BEFORE scanning
+entry points. Order matters: a user's entry-point plugin with the
+same name as a builtin wins (entry-point registration overwrites
+the builtin in `_register()`).
+
+`goldenmatch/plugins/builtin/__init__.py` exposes `_register_builtins(registry)`
+which is called at the top of `discover()`. Discovery is idempotent
+via the existing `_discovered` flag.
+
+## API surface
+
+All 10 plugins satisfy the `GoldenStrategyPlugin` protocol from
+v1.18.0:
+
+```python
+class NumericMaxStrategy:
+    name = "numeric_max"
+    def merge(self, values, *, sources=None, dates=None,
+              quality_weights=None, pair_scores=None,
+              rule_kwargs=None):
+        ...
+```
+
+User opts in via:
+```yaml
+golden_rules:
+  field_rules:
+    lifetime_value:
+      strategy: "custom:numeric_max"
+    email:
+      strategy: "custom:email_normalize"
+    crm_status:
+      strategy: "custom:system_of_record"
+      source_priority: ["salesforce", "hubspot"]
+    last_seen_at:
+      strategy: "custom:freshness_with_max_age"
+      date_column: "last_seen_at"
+```
+
+`rule_kwargs` carries `source_priority` / `lifecycle_order` /
+`max_age_days` -- the dispatcher in `core/golden.py::merge_field`
+already passes the GoldenFieldRule's model_dump.
+
+## Confidence semantics
+
+- Single non-null candidate: 1.0
+- Multiple candidates, clear winner (e.g. unique max): 1.0
+- Tied or ambiguous: 0.7 (mirrors the built-in `most_complete`
+  tie-break confidence)
+- Format-canonical mode-pick: `count / total` (matches
+  `majority_vote`)
+- `freshness_with_max_age` emits NULL when all values stale:
+  confidence 0.0
+- `unanimous_or_null` semantics for compliance plugins: emit NULL
+  with confidence 0.0 when no winner
+
+## Tests
+
+One test module per category:
+- `tests/plugins/test_builtin_numeric.py`
+- `tests/plugins/test_builtin_format.py`
+- `tests/plugins/test_builtin_business.py`
+
+Each plugin gets at minimum:
+- Happy path (clear winner)
+- Single non-null
+- All-null returns (None, 0.0)
+- Edge case specific to the plugin (e.g. `numeric_max` with strings
+  that happen to parse as numbers; `email_normalize` with
+  plus-addressing variants)
+
+Plus a discovery test (`tests/plugins/test_builtin_discovery.py`)
+verifying `PluginRegistry.discover()` finds all 10 by name.
+
+## Out of scope (v1.19+)
+
+- `numeric_median` / `numeric_weighted_average` (cheap to add later;
+  starting with the 3 most-asked-for)
+- `url_canonical` (URL canonicalization has edge cases that warrant
+  their own spec)
+- `verified_value_or_null` (KYC-shaped; needs a source-verification
+  registry that's bigger than a single plugin)
+- `dnc_safe_phone` (Do Not Call lookup; external service dependency)
+
+## Kill criterion
+
+- All 10 plugins auto-registered after `PluginRegistry.discover()`
+- Each plugin has >= 3 unit tests; all pass
+- Existing `test_custom_golden_strategy.py` tests still pass (plugin
+  protocol unchanged)
+- Documentation: README has a "Predefined plugins" section listing
+  all 10 with one-line descriptions

--- a/packages/python/goldenmatch/goldenmatch/plugins/builtin/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/builtin/__init__.py
@@ -1,0 +1,82 @@
+"""Predefined golden-strategy plugins (v1.18.2, #predefined-merge-plugins).
+
+Three categories of plugin shipping with goldenmatch:
+
+- numeric: numeric_max, numeric_min, numeric_mean
+- format:  shortest_value, concat_unique, email_normalize, phone_digits_only
+- business: system_of_record, lifecycle_stage, freshness_with_max_age
+
+Used via ``strategy="custom:<name>"`` in GoldenRulesConfig.field_rules.
+Auto-registered by ``PluginRegistry.discover()``; user entry-point
+plugins with the same name win (last-registration-wins in
+``_register()``).
+
+Spec: ``docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md``
+"""
+from __future__ import annotations
+
+from goldenmatch.plugins.builtin.business import (
+    FreshnessWithMaxAgeStrategy,
+    LifecycleStageStrategy,
+    SystemOfRecordStrategy,
+)
+from goldenmatch.plugins.builtin.format import (
+    ConcatUniqueStrategy,
+    EmailNormalizeStrategy,
+    PhoneDigitsOnlyStrategy,
+    ShortestValueStrategy,
+)
+from goldenmatch.plugins.builtin.numeric import (
+    NumericMaxStrategy,
+    NumericMeanStrategy,
+    NumericMinStrategy,
+)
+
+# The full list of builtin plugin classes. Order is informational only;
+# registration is by name (last-write-wins for entry-point overrides).
+BUILTIN_PLUGINS = [
+    # Numeric (3)
+    NumericMaxStrategy,
+    NumericMinStrategy,
+    NumericMeanStrategy,
+    # Format-canonical (4)
+    ShortestValueStrategy,
+    ConcatUniqueStrategy,
+    EmailNormalizeStrategy,
+    PhoneDigitsOnlyStrategy,
+    # Business-shaped (3)
+    SystemOfRecordStrategy,
+    LifecycleStageStrategy,
+    FreshnessWithMaxAgeStrategy,
+]
+
+
+def register_builtins(registry: object) -> None:
+    """Register every builtin plugin on the given PluginRegistry.
+
+    Called from ``PluginRegistry.discover()`` BEFORE entry-point scan
+    so that user entry-point plugins with the same name override
+    the builtin (consistent with the documented "user wins" pattern).
+    """
+    for cls in BUILTIN_PLUGINS:
+        plugin = cls()
+        # Bypass the public register_golden_strategy() type check --
+        # builtins don't need protocol validation since they're shipped
+        # with the package and verified via the test suite.
+        registry._register("golden_strategy", plugin.name, plugin)  # type: ignore[attr-defined]
+
+
+__all__ = [
+    "BUILTIN_PLUGINS",
+    "ConcatUniqueStrategy",
+    "EmailNormalizeStrategy",
+    "FreshnessWithMaxAgeStrategy",
+    "LifecycleStageStrategy",
+    "NumericMaxStrategy",
+    "NumericMeanStrategy",
+    "NumericMinStrategy",
+    "PhoneDigitsOnlyStrategy",
+    "ShortestValueStrategy",
+    "SystemOfRecordStrategy",
+    "register_builtins",
+]

--- a/packages/python/goldenmatch/goldenmatch/plugins/builtin/business.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/builtin/business.py
@@ -1,0 +1,190 @@
+"""Business-shaped predefined plugins.
+
+system_of_record, lifecycle_stage, freshness_with_max_age. Each
+satisfies ``GoldenStrategyPlugin`` from ``goldenmatch.plugins.base``.
+
+Spec: ``docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md``
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+# Default order for `lifecycle_stage` (low -> high). Lowercased for
+# case-insensitive matching.
+DEFAULT_LIFECYCLE_ORDER = [
+    "subscriber",
+    "lead",
+    "marketing_qualified_lead",
+    "mql",
+    "sales_qualified_lead",
+    "sql",
+    "opportunity",
+    "customer",
+    "evangelist",
+]
+
+
+class SystemOfRecordStrategy:
+    """Pick value from authoritative source per `rule_kwargs.source_priority`.
+
+    Semantically equivalent to the built-in `source_priority` strategy
+    but with explicit "system of record" naming so the YAML config
+    carries operator intent:
+
+    .. code-block:: yaml
+
+       golden_rules:
+         field_rules:
+           account_status:
+             strategy: "custom:system_of_record"
+             source_priority: ["salesforce", "hubspot", "netsuite"]
+
+    Falls back to first non-null when no priority source has a value.
+    """
+
+    name = "system_of_record"
+
+    def merge(
+        self,
+        values: list,
+        *,
+        sources: list[str] | None = None,
+        rule_kwargs: dict | None = None,
+        **_: Any,
+    ) -> Any:
+        non_null = [(i, v) for i, v in enumerate(values) if v is not None]
+        if not non_null:
+            return (None, 0.0)
+        priority = (rule_kwargs or {}).get("source_priority") or []
+        if sources is None or not priority:
+            # No priority config -> first non-null with low confidence
+            # (the YAML intent says "system of record" but no SoR is
+            # configured, so this is a fallback).
+            return (non_null[0][1], 0.5, non_null[0][0])
+        for src in priority:
+            for i, (s, v) in enumerate(zip(sources, values)):
+                if s == src and v is not None:
+                    # Confidence decays with priority rank
+                    rank = priority.index(src)
+                    conf = max(0.5, 1.0 - rank * 0.1)
+                    return (v, conf, i)
+        # No source in priority list had a value -> first non-null.
+        return (non_null[0][1], 0.4, non_null[0][0])
+
+
+class LifecycleStageStrategy:
+    """Pick the most-advanced lifecycle stage from the cluster.
+
+    Default order (low -> high): subscriber, lead, mql, sql,
+    opportunity, customer, evangelist. Override via
+    `rule_kwargs.lifecycle_order` (list of stage names; comparison
+    is lowercase-insensitive).
+
+    Unknown stages are ranked below the lowest known stage
+    (effectively ignored when ANY known stage is present).
+
+    Confidence: 1.0 when a unique maximum stage exists; 0.7 on ties.
+    """
+
+    name = "lifecycle_stage"
+
+    def merge(
+        self,
+        values: list,
+        *,
+        rule_kwargs: dict | None = None,
+        **_: Any,
+    ) -> Any:
+        non_null = [(i, v) for i, v in enumerate(values) if v is not None]
+        if not non_null:
+            return (None, 0.0)
+        order = (rule_kwargs or {}).get("lifecycle_order") or DEFAULT_LIFECYCLE_ORDER
+        order_map = {str(stage).strip().lower(): idx for idx, stage in enumerate(order)}
+        # Unknown values: rank = -1 (below all known stages).
+        ranked = [
+            (order_map.get(str(v).strip().lower(), -1), i, v)
+            for i, v in non_null
+        ]
+        max_rank = max(r for r, _, _ in ranked)
+        tied = [(i, v) for r, i, v in ranked if r == max_rank]
+        conf = 1.0 if len(tied) == 1 else 0.7
+        return (tied[0][1], conf, tied[0][0])
+
+
+def _parse_date(value: Any) -> datetime | None:
+    """Best-effort datetime coercion. Handles common ISO + epoch."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        try:
+            return datetime.fromtimestamp(float(value), tz=UTC)
+        except (OSError, OverflowError, ValueError):
+            return None
+    s = str(value).strip()
+    if not s:
+        return None
+    # Try ISO 8601 variants. Python 3.11+ handles most.
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+    except ValueError:
+        pass
+    # Common fallback patterns.
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%m/%d/%Y", "%d/%m/%Y", "%Y-%m-%d %H:%M:%S"):
+        try:
+            dt = datetime.strptime(s, fmt)
+            return dt.replace(tzinfo=UTC)
+        except ValueError:
+            continue
+    return None
+
+
+class FreshnessWithMaxAgeStrategy:
+    """Like `most_recent` but emits NULL if no value is fresh enough.
+
+    `rule_kwargs.max_age_days` (default 365) defines the cutoff.
+    Values whose accompanying date is older than cutoff are dropped.
+    If no values remain after filtering, emits (None, 0.0).
+
+    Use when compliance / data-quality requires "no stale data" --
+    e.g. KYC address must be < 90 days old, else missing-data
+    follow-up triggers.
+
+    Requires `dates` kwarg (parallel to values). Without dates,
+    behaves as if every value is stale (emits None).
+    """
+
+    name = "freshness_with_max_age"
+
+    def merge(
+        self,
+        values: list,
+        *,
+        dates: list | None = None,
+        rule_kwargs: dict | None = None,
+        **_: Any,
+    ) -> Any:
+        if dates is None:
+            return (None, 0.0)
+        max_age_days = float((rule_kwargs or {}).get("max_age_days", 365))
+        now = datetime.now(tz=UTC)
+        cutoff = now - timedelta(days=max_age_days)
+        candidates: list[tuple[int, datetime, Any]] = []
+        for i, (d, v) in enumerate(zip(dates, values)):
+            if v is None:
+                continue
+            parsed = _parse_date(d)
+            if parsed is None or parsed < cutoff:
+                continue
+            candidates.append((i, parsed, v))
+        if not candidates:
+            return (None, 0.0)
+        # Sort newest-first.
+        candidates.sort(key=lambda x: x[1], reverse=True)
+        top_dt = candidates[0][1]
+        tied = [(i, v) for i, dt, v in candidates if dt == top_dt]
+        conf = 1.0 if len(tied) == 1 else 0.7
+        return (tied[0][1], conf, tied[0][0])

--- a/packages/python/goldenmatch/goldenmatch/plugins/builtin/format.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/builtin/format.py
@@ -1,0 +1,150 @@
+"""Format-canonical predefined plugins.
+
+shortest_value, concat_unique, email_normalize, phone_digits_only.
+Each satisfies ``GoldenStrategyPlugin`` from ``goldenmatch.plugins.base``.
+
+Spec: ``docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md``
+"""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any
+
+# Email plus-addressing pattern: local+anything@domain -> local@domain.
+_EMAIL_PLUS_RE = re.compile(r"^([^+@]+)\+[^@]*(@.+)$")
+# Phone digits-only pattern.
+_NON_DIGIT_RE = re.compile(r"\D+")
+
+
+class ShortestValueStrategy:
+    """Pick the shortest non-null string. Inverse of `longest_value`.
+
+    Useful for codes / identifiers where shorter usually means more
+    canonical (e.g. country code 'US' over 'United States of America').
+    Quality-weighted tie-break when weights are provided.
+
+    Confidence: 1.0 unique shortest, 0.7 tied (by quality), 0.5
+    tied (first-index wins).
+    """
+
+    name = "shortest_value"
+
+    def merge(
+        self,
+        values: list,
+        *,
+        quality_weights: list[float] | None = None,
+        **_: Any,
+    ) -> Any:
+        non_null = [(i, v) for i, v in enumerate(values) if v is not None]
+        if not non_null:
+            return (None, 0.0)
+        str_vals = [(i, str(v), v) for i, v in non_null]
+        min_len = min(len(s) for _, s, _ in str_vals)
+        shortest = [(i, v) for i, s, v in str_vals if len(s) == min_len]
+        if len(shortest) == 1:
+            return (shortest[0][1], 1.0, shortest[0][0])
+        if quality_weights is not None:
+            best = max(
+                shortest,
+                key=lambda x: quality_weights[x[0]] if x[0] < len(quality_weights) else 1.0,
+            )
+            return (best[1], 0.7, best[0])
+        return (shortest[0][1], 0.5, shortest[0][0])
+
+
+class ConcatUniqueStrategy:
+    """Join unique non-null values into a sorted, comma-separated string.
+
+    For tags / categories / multi-select fields where the "golden"
+    value is the UNION of source values, not one of them.
+
+    Separator override via ``rule_kwargs.separator`` (default ", ").
+
+    NOTE: The output is a synthesized string. Returned idx is 0
+    (no real provenance) since no single source row holds the
+    concatenated form.
+
+    Confidence: 1.0 when at least one non-null exists.
+    """
+
+    name = "concat_unique"
+
+    def merge(
+        self,
+        values: list,
+        *,
+        rule_kwargs: dict | None = None,
+        **_: Any,
+    ) -> Any:
+        non_null = [str(v) for v in values if v is not None and str(v) != ""]
+        if not non_null:
+            return (None, 0.0)
+        unique_sorted = sorted(set(non_null))
+        sep = (rule_kwargs or {}).get("separator", ", ")
+        return (sep.join(unique_sorted), 1.0, 0)
+
+
+def _canonicalize_email(value: str) -> str:
+    """Lowercase + strip plus-addressing. Trims whitespace."""
+    v = value.strip().lower()
+    match = _EMAIL_PLUS_RE.match(v)
+    if match:
+        return match.group(1) + match.group(2)
+    return v
+
+
+class EmailNormalizeStrategy:
+    """Normalize emails and pick the mode (most common canonical form).
+
+    Normalization: lowercase + strip plus-addressing
+    (`bob+work@x.com` -> `bob@x.com`). After normalization, pick the
+    most-frequent canonical form. Returns the CANONICAL value, not
+    the original (`Bob+Work@X.COM` -> `bob@x.com`).
+
+    Confidence: `count / total`. Single non-null gets 1.0.
+    """
+
+    name = "email_normalize"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        non_null = [(i, str(v)) for i, v in enumerate(values) if v is not None]
+        if not non_null:
+            return (None, 0.0)
+        normalized = [(i, _canonicalize_email(v)) for i, v in non_null]
+        # Mode pick.
+        counts = Counter(n for _, n in normalized)
+        winner, count = counts.most_common(1)[0]
+        # Return idx of first occurrence of the winner.
+        first_idx = next(i for i, n in normalized if n == winner)
+        conf = count / len(non_null)
+        return (winner, conf, first_idx)
+
+
+class PhoneDigitsOnlyStrategy:
+    """Strip phone formatting and pick the value with the most digits.
+
+    Favors international (E.164 / 11+ digits) over local (10 digits)
+    over abbreviated. Output is the DIGITS-ONLY form (no '+',
+    parentheses, dashes, or spaces).
+
+    Confidence: 1.0 when a unique max-digit form exists; 0.7 on
+    ties (first-index wins).
+    """
+
+    name = "phone_digits_only"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        non_null = [(i, str(v)) for i, v in enumerate(values) if v is not None]
+        if not non_null:
+            return (None, 0.0)
+        stripped = [(i, _NON_DIGIT_RE.sub("", v)) for i, v in non_null]
+        # Drop entries that have no digits.
+        stripped = [(i, d) for i, d in stripped if d]
+        if not stripped:
+            return (None, 0.0)
+        max_len = max(len(d) for _, d in stripped)
+        tied = [(i, d) for i, d in stripped if len(d) == max_len]
+        conf = 1.0 if len(tied) == 1 else 0.7
+        return (tied[0][1], conf, tied[0][0])

--- a/packages/python/goldenmatch/goldenmatch/plugins/builtin/numeric.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/builtin/numeric.py
@@ -1,0 +1,86 @@
+"""Numeric-aggregate predefined plugins.
+
+Each plugin satisfies ``GoldenStrategyPlugin`` from
+``goldenmatch.plugins.base``. Non-numeric or null values are ignored;
+all-null / all-unparseable input yields ``(None, 0.0)``.
+
+Spec: ``docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md``
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _to_float(value: Any) -> float | None:
+    """Best-effort numeric coercion. Returns None for unparseable."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class NumericMaxStrategy:
+    """Pick the largest numeric value in the cluster.
+
+    Non-numeric values are ignored. All-non-numeric or all-null
+    input -> (None, 0.0).
+
+    Confidence: 1.0 when unique max; 0.7 on ties (first index wins).
+    """
+
+    name = "numeric_max"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        nums = [(i, _to_float(v), v) for i, v in enumerate(values)]
+        nums = [(i, f, v) for i, f, v in nums if f is not None]
+        if not nums:
+            return (None, 0.0)
+        max_f = max(f for _, f, _ in nums)
+        tied = [(i, v) for i, f, v in nums if f == max_f]
+        conf = 1.0 if len(tied) == 1 else 0.7
+        return (tied[0][1], conf, tied[0][0])
+
+
+class NumericMinStrategy:
+    """Pick the smallest numeric value. Same shape as `numeric_max`."""
+
+    name = "numeric_min"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        nums = [(i, _to_float(v), v) for i, v in enumerate(values)]
+        nums = [(i, f, v) for i, f, v in nums if f is not None]
+        if not nums:
+            return (None, 0.0)
+        min_f = min(f for _, f, _ in nums)
+        tied = [(i, v) for i, f, v in nums if f == min_f]
+        conf = 1.0 if len(tied) == 1 else 0.7
+        return (tied[0][1], conf, tied[0][0])
+
+
+class NumericMeanStrategy:
+    """Pick the arithmetic mean of numeric values.
+
+    Returned value is a Python float. Confidence reflects coverage:
+    `non_null_count / total_count`. Useful for `account_balance`,
+    `risk_score`, `confidence`-like fields where averaging across
+    sources is sensible.
+
+    NOTE: the mean is a synthesized value (no source record holds it),
+    so the returned ``idx`` is 0 (no real provenance). Callers that
+    need strict provenance should use `numeric_max` or `numeric_min`.
+    """
+
+    name = "numeric_mean"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        nums = [_to_float(v) for v in values]
+        valid = [f for f in nums if f is not None]
+        if not valid:
+            return (None, 0.0)
+        mean = sum(valid) / len(valid)
+        conf = len(valid) / len(values)
+        return (mean, conf, 0)

--- a/packages/python/goldenmatch/goldenmatch/plugins/registry.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/registry.py
@@ -45,9 +45,25 @@ class PluginRegistry:
         cls._discovered = False
 
     def discover(self) -> None:
-        """Scan entry points and register all found plugins."""
+        """Scan entry points and register all found plugins.
+
+        Builtins first (#predefined-merge-plugins, v1.18.2), then
+        entry points. Entry-point plugins with the same name OVERRIDE
+        builtins -- consistent with the documented "user wins" pattern
+        (last-write into `_register`).
+        """
         if PluginRegistry._discovered:
             return
+
+        # v1.18.2: auto-register the 10 predefined golden-strategy
+        # plugins (numeric / format / business). Failures here are
+        # bugs in the shipped code, not user config, so they log at
+        # WARNING level. See goldenmatch/plugins/builtin/__init__.py.
+        try:
+            from goldenmatch.plugins.builtin import register_builtins
+            register_builtins(self)
+        except Exception as e:  # pragma: no cover -- shipped-code bug
+            logger.warning("Failed to register builtin plugins: %s", e)
 
         for plugin_type, group_name in _GROUPS.items():
             eps = entry_points(group=group_name)

--- a/packages/python/goldenmatch/tests/plugins/test_builtin_business.py
+++ b/packages/python/goldenmatch/tests/plugins/test_builtin_business.py
@@ -1,0 +1,166 @@
+"""Tests for predefined business-shaped plugins (#predefined-merge-plugins).
+
+Spec: docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from goldenmatch.plugins.builtin.business import (
+    FreshnessWithMaxAgeStrategy,
+    LifecycleStageStrategy,
+    SystemOfRecordStrategy,
+)
+
+# ---------------------------------------------------------------------------
+# system_of_record
+# ---------------------------------------------------------------------------
+
+
+def test_sor_picks_top_priority_source():
+    val, conf, idx = SystemOfRecordStrategy().merge(
+        values=["hub-val", "sfdc-val", "ns-val"],
+        sources=["hubspot", "salesforce", "netsuite"],
+        rule_kwargs={"source_priority": ["salesforce", "hubspot", "netsuite"]},
+    )
+    assert val == "sfdc-val"
+    assert idx == 1
+    assert conf == 1.0  # rank 0
+
+
+def test_sor_falls_back_when_top_priority_null():
+    val, conf, idx = SystemOfRecordStrategy().merge(
+        values=[None, "hub-val", "ns-val"],
+        sources=["salesforce", "hubspot", "netsuite"],
+        rule_kwargs={"source_priority": ["salesforce", "hubspot", "netsuite"]},
+    )
+    assert val == "hub-val"
+    assert idx == 1
+    assert conf == 0.9  # rank 1 -> 1.0 - 0.1
+
+
+def test_sor_no_priority_falls_back_to_first_non_null():
+    val, conf, _idx = SystemOfRecordStrategy().merge(
+        values=[None, "anything", "else"],
+        sources=["foo", "bar", "baz"],
+    )
+    assert val == "anything"
+    assert conf == 0.5  # fallback confidence
+
+
+def test_sor_all_null():
+    val, conf = SystemOfRecordStrategy().merge(
+        values=[None, None],
+        sources=["a", "b"],
+        rule_kwargs={"source_priority": ["a"]},
+    )
+    assert val is None
+    assert conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# lifecycle_stage
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_picks_most_advanced():
+    val, conf, idx = LifecycleStageStrategy().merge(["lead", "customer", "mql"])
+    assert val == "customer"
+    assert conf == 1.0
+    assert idx == 1
+
+
+def test_lifecycle_custom_order():
+    val, _conf, _idx = LifecycleStageStrategy().merge(
+        ["bronze", "gold", "silver"],
+        rule_kwargs={"lifecycle_order": ["bronze", "silver", "gold", "platinum"]},
+    )
+    assert val == "gold"
+
+
+def test_lifecycle_case_insensitive():
+    val, _, _ = LifecycleStageStrategy().merge(["LEAD", "Customer", "MQL"])
+    assert val == "Customer"
+
+
+def test_lifecycle_unknown_value_ignored():
+    """Unknown 'space_alien' ranks below all known stages."""
+    val, _, _ = LifecycleStageStrategy().merge(["space_alien", "lead"])
+    assert val == "lead"
+
+
+def test_lifecycle_all_null():
+    val, conf = LifecycleStageStrategy().merge([None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+def test_lifecycle_tied_stages():
+    val, conf, idx = LifecycleStageStrategy().merge(["customer", "customer"])
+    assert val == "customer"
+    assert conf == 0.7  # tied
+    assert idx == 0
+
+
+# ---------------------------------------------------------------------------
+# freshness_with_max_age
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def test_freshness_picks_newest_within_window():
+    now = datetime.now(tz=UTC)
+    fresh = _iso(now - timedelta(days=30))
+    fresher = _iso(now - timedelta(days=10))
+    val, conf, idx = FreshnessWithMaxAgeStrategy().merge(
+        ["stale-val", "fresh-val"],
+        dates=[fresh, fresher],
+        rule_kwargs={"max_age_days": 90},
+    )
+    assert val == "fresh-val"
+    assert conf == 1.0
+    assert idx == 1
+
+
+def test_freshness_emits_null_when_all_stale():
+    now = datetime.now(tz=UTC)
+    too_old = _iso(now - timedelta(days=400))
+    val, conf = FreshnessWithMaxAgeStrategy().merge(
+        ["stale-1", "stale-2"],
+        dates=[too_old, too_old],
+        rule_kwargs={"max_age_days": 90},
+    )
+    assert val is None
+    assert conf == 0.0
+
+
+def test_freshness_default_max_age_365():
+    now = datetime.now(tz=UTC)
+    fresh = _iso(now - timedelta(days=200))
+    val, _, _ = FreshnessWithMaxAgeStrategy().merge(
+        ["v1"], dates=[fresh],
+    )
+    assert val == "v1"
+
+
+def test_freshness_no_dates_emits_null():
+    val, conf = FreshnessWithMaxAgeStrategy().merge(["v1"], dates=None)
+    assert val is None
+    assert conf == 0.0
+
+
+def test_freshness_handles_iso_with_z():
+    now = datetime.now(tz=UTC)
+    z_format = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    val, _, _ = FreshnessWithMaxAgeStrategy().merge(
+        ["v1"], dates=[z_format], rule_kwargs={"max_age_days": 30},
+    )
+    assert val == "v1"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/plugins/test_builtin_discovery.py
+++ b/packages/python/goldenmatch/tests/plugins/test_builtin_discovery.py
@@ -1,0 +1,82 @@
+"""Tests for builtin-plugin discovery (#predefined-merge-plugins).
+
+PluginRegistry.discover() auto-registers the 10 builtins BEFORE
+entry-point scan so user entry-point plugins override builtins by
+last-write-wins.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.plugins.builtin import BUILTIN_PLUGINS
+from goldenmatch.plugins.registry import PluginRegistry
+
+EXPECTED_BUILTIN_NAMES = {
+    # Numeric
+    "numeric_max", "numeric_min", "numeric_mean",
+    # Format-canonical
+    "shortest_value", "concat_unique", "email_normalize", "phone_digits_only",
+    # Business
+    "system_of_record", "lifecycle_stage", "freshness_with_max_age",
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    PluginRegistry.reset()
+    yield
+    PluginRegistry.reset()
+
+
+def test_builtins_list_matches_expected():
+    """The BUILTIN_PLUGINS list contains exactly the 10 documented names."""
+    actual_names = {cls().name for cls in BUILTIN_PLUGINS}
+    assert actual_names == EXPECTED_BUILTIN_NAMES
+
+
+def test_discover_registers_all_builtins():
+    """After PluginRegistry.discover(), each builtin name is fetchable."""
+    registry = PluginRegistry.instance()
+    registry.discover()
+    for name in EXPECTED_BUILTIN_NAMES:
+        plugin = registry.get_golden_strategy(name)
+        assert plugin is not None, f"builtin {name!r} not registered"
+        assert plugin.name == name  # type: ignore[attr-defined]
+
+
+def test_list_plugins_includes_builtins():
+    """`list_plugins()` reflects auto-registration."""
+    registry = PluginRegistry.instance()
+    registry.discover()
+    plugins = registry.list_plugins()
+    listed = set(plugins["golden_strategy"])
+    assert EXPECTED_BUILTIN_NAMES.issubset(listed)
+
+
+def test_user_plugin_can_override_builtin_by_name():
+    """A user-registered plugin with the same name as a builtin wins."""
+    registry = PluginRegistry.instance()
+    registry.discover()  # builtins now registered
+
+    class _CustomOverride:
+        name = "numeric_max"
+        def merge(self, values, **kwargs):
+            return ("overridden", 1.0)
+
+    registry.register_golden_strategy("numeric_max", _CustomOverride())
+    fetched = registry.get_golden_strategy("numeric_max")
+    assert fetched is not None
+    assert fetched.__class__.__name__ == "_CustomOverride"
+
+
+def test_dispatch_works_end_to_end_via_custom_strategy_prefix():
+    """`strategy="custom:numeric_max"` dispatches to the builtin."""
+    from goldenmatch.config.schemas import GoldenFieldRule
+    from goldenmatch.core.golden import merge_field
+
+    rule = GoldenFieldRule(strategy="custom:numeric_max")
+    val, _conf, _idx = merge_field([10, 50, 25], rule)
+    assert val == 50
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/plugins/test_builtin_format.py
+++ b/packages/python/goldenmatch/tests/plugins/test_builtin_format.py
@@ -1,0 +1,146 @@
+"""Tests for predefined format-canonical plugins (#predefined-merge-plugins).
+
+Spec: docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.plugins.builtin.format import (
+    ConcatUniqueStrategy,
+    EmailNormalizeStrategy,
+    PhoneDigitsOnlyStrategy,
+    ShortestValueStrategy,
+)
+
+# ---------------------------------------------------------------------------
+# shortest_value
+# ---------------------------------------------------------------------------
+
+
+def test_shortest_value_picks_shortest():
+    val, conf, idx = ShortestValueStrategy().merge(["United States", "US", "USA"])
+    assert val == "US"
+    assert conf == 1.0
+    assert idx == 1
+
+
+def test_shortest_value_ties_quality_weighted():
+    val, conf, idx = ShortestValueStrategy().merge(
+        ["AB", "XY"],
+        quality_weights=[0.5, 0.9],
+    )
+    assert val == "XY"
+    assert conf == 0.7
+    assert idx == 1
+
+
+def test_shortest_value_ties_no_weights():
+    val, conf, idx = ShortestValueStrategy().merge(["AB", "XY"])
+    assert val == "AB"
+    assert conf == 0.5  # tie, first-wins
+    assert idx == 0
+
+
+def test_shortest_value_all_null():
+    val, conf = ShortestValueStrategy().merge([None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# concat_unique
+# ---------------------------------------------------------------------------
+
+
+def test_concat_unique_joins_sorted():
+    val, conf, _ = ConcatUniqueStrategy().merge(
+        ["python", "rust", "python", "go"],
+    )
+    assert val == "go, python, rust"
+    assert conf == 1.0
+
+
+def test_concat_unique_custom_separator():
+    val, _, _ = ConcatUniqueStrategy().merge(
+        ["a", "b"], rule_kwargs={"separator": " | "},
+    )
+    assert val == "a | b"
+
+
+def test_concat_unique_skips_empty_strings():
+    val, _, _ = ConcatUniqueStrategy().merge(["", "a", None, "b", ""])
+    assert val == "a, b"
+
+
+def test_concat_unique_all_null():
+    val, conf = ConcatUniqueStrategy().merge([None, None, ""])
+    assert val is None
+    assert conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# email_normalize
+# ---------------------------------------------------------------------------
+
+
+def test_email_normalize_lowercase_and_strip_plus():
+    val, _, _ = EmailNormalizeStrategy().merge(["Bob+Work@X.COM"])
+    assert val == "bob@x.com"
+
+
+def test_email_normalize_picks_mode():
+    """3 records normalize to bob@x.com; 1 to alice@x.com -> bob wins."""
+    val, conf, _ = EmailNormalizeStrategy().merge([
+        "bob@x.com", "Bob+News@X.com", "BOB@X.com", "alice@x.com",
+    ])
+    assert val == "bob@x.com"
+    assert conf == 0.75  # 3/4
+
+
+def test_email_normalize_all_null():
+    val, conf = EmailNormalizeStrategy().merge([None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+def test_email_normalize_single_value():
+    val, conf, idx = EmailNormalizeStrategy().merge(["solo@example.com"])
+    assert val == "solo@example.com"
+    assert conf == 1.0
+    assert idx == 0
+
+
+# ---------------------------------------------------------------------------
+# phone_digits_only
+# ---------------------------------------------------------------------------
+
+
+def test_phone_digits_only_strips_formatting():
+    val, _, _ = PhoneDigitsOnlyStrategy().merge(["(555) 123-4567"])
+    assert val == "5551234567"
+
+
+def test_phone_digits_only_prefers_most_digits():
+    """+1 555 123 4567 (11 digits) wins over 555-123-4567 (10)."""
+    val, conf, idx = PhoneDigitsOnlyStrategy().merge([
+        "555-123-4567", "+1 555 123 4567", "5551234",
+    ])
+    assert val == "15551234567"
+    assert idx == 1
+    assert conf == 1.0
+
+
+def test_phone_digits_only_all_null():
+    val, conf = PhoneDigitsOnlyStrategy().merge([None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+def test_phone_digits_only_all_non_digit():
+    val, conf = PhoneDigitsOnlyStrategy().merge(["abc", "xyz"])
+    assert val is None
+    assert conf == 0.0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/plugins/test_builtin_numeric.py
+++ b/packages/python/goldenmatch/tests/plugins/test_builtin_numeric.py
@@ -1,0 +1,113 @@
+"""Tests for predefined numeric-aggregate plugins (#predefined-merge-plugins).
+
+Spec: docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.plugins.builtin.numeric import (
+    NumericMaxStrategy,
+    NumericMeanStrategy,
+    NumericMinStrategy,
+)
+
+# ---------------------------------------------------------------------------
+# numeric_max
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_max_picks_largest():
+    val, conf, idx = NumericMaxStrategy().merge([10, 50, 25])
+    assert val == 50
+    assert conf == 1.0
+    assert idx == 1
+
+
+def test_numeric_max_handles_string_numbers():
+    val, conf, idx = NumericMaxStrategy().merge(["10", "50", "25"])
+    assert val == "50"
+    assert conf == 1.0
+    assert idx == 1
+
+
+def test_numeric_max_ignores_non_numeric():
+    val, conf, idx = NumericMaxStrategy().merge(["abc", 100, None, "xyz", 200])
+    assert val == 200
+    assert idx == 4
+
+
+def test_numeric_max_all_null_returns_none():
+    val, conf = NumericMaxStrategy().merge([None, None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+def test_numeric_max_all_non_numeric_returns_none():
+    val, conf = NumericMaxStrategy().merge(["abc", "xyz", None])
+    assert val is None
+    assert conf == 0.0
+
+
+def test_numeric_max_ties_give_first_index():
+    val, conf, idx = NumericMaxStrategy().merge([100, 100, 50])
+    assert val == 100
+    assert idx == 0
+    assert conf == 0.7  # tie
+
+
+# ---------------------------------------------------------------------------
+# numeric_min
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_min_picks_smallest():
+    val, conf, idx = NumericMinStrategy().merge([10, 50, 25])
+    assert val == 10
+    assert conf == 1.0
+    assert idx == 0
+
+
+def test_numeric_min_handles_negatives():
+    val, conf, idx = NumericMinStrategy().merge([5, -100, 10])
+    assert val == -100
+    assert idx == 1
+
+
+def test_numeric_min_all_null_returns_none():
+    val, conf = NumericMinStrategy().merge([None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# numeric_mean
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_mean_averages():
+    val, conf, idx = NumericMeanStrategy().merge([10, 20, 30])
+    assert val == 20.0
+    assert conf == 1.0
+    assert idx == 0  # synthesized value, no real provenance
+
+
+def test_numeric_mean_ignores_null():
+    val, conf, idx = NumericMeanStrategy().merge([10, None, 30, None])
+    assert val == 20.0
+    # coverage = 2/4
+    assert conf == 0.5
+
+
+def test_numeric_mean_all_null_returns_none():
+    val, conf = NumericMeanStrategy().merge([None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+def test_numeric_mean_handles_mixed_types():
+    val, _conf, _idx = NumericMeanStrategy().merge([10, "20", 30])
+    assert val == 20.0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
v1.18.0 shipped the custom-plugin slot with zero built-in plugins by design. This adds 10 predefined plugins, auto-registered via `PluginRegistry.discover()`.

Used via `strategy="custom:<name>"` in YAML / Python configs.

## What ships

| Category | Plugin | Description |
|---|---|---|
| Numeric | `numeric_max` | Largest numeric value |
| Numeric | `numeric_min` | Smallest numeric value |
| Numeric | `numeric_mean` | Arithmetic mean (synthesized) |
| Format | `shortest_value` | Inverse of `longest_value` -- codes/identifiers |
| Format | `concat_unique` | Sorted comma-join of unique non-nulls; tags/categories |
| Format | `email_normalize` | Lowercase + strip plus-addressing; pick mode |
| Format | `phone_digits_only` | Strip formatting; pick most-digits |
| Business | `system_of_record` | Pick from `rule_kwargs.source_priority`; YAML intent |
| Business | `lifecycle_stage` | Most-advanced stage (subscriber...evangelist); override via `rule_kwargs.lifecycle_order` |
| Business | `freshness_with_max_age` | `most_recent` but emits NULL when all values stale (`max_age_days`, default 365) |

## Discovery

`PluginRegistry.discover()` registers builtins BEFORE entry-point scan. User entry-point plugins with the same name override builtins by last-write-wins.

## Test plan

- [x] 49 new unit tests across 4 test modules
- [x] `uv run ruff check` clean
- [x] End-to-end dispatch test via `strategy="custom:numeric_max"`
- CI is the gate

## Spec

`docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md`