### PR TITLE
feat: 12 more predefined plugins (round 2)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md
+++ b/docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md
@@ -138,15 +138,43 @@ Each plugin gets at minimum:
 Plus a discovery test (`tests/plugins/test_builtin_discovery.py`)
 verifying `PluginRegistry.discover()` finds all 10 by name.
 
+## Round 2 (#predefined-plugins-round-2)
+
+12 additional plugins shipped after the initial round:
+
+**Numeric (3 more):**
+- `numeric_median` -- outlier-resilient
+- `numeric_sum` -- aggregate amounts/balances
+- `numeric_weighted_average` -- uses `quality_weights`
+
+**Format (3 more):**
+- `url_canonical` -- lowercase scheme+host, http->https, trim trailing /
+- `whitespace_normalize` -- collapse internal ws + trim, pick mode
+- `boolean_normalize` -- yes/no/Y/N/1/0/true/false/on/off -> Python bool
+
+**Business (3 more):**
+- `enum_canonical` -- alias_map config maps variants to canonical
+- `regex_validated` -- only accept values matching `rule_kwargs.pattern`;
+  configurable fallback (`first_non_null` or `null`)
+- `weighted_by_recency` -- exponential decay on dates; `half_life_days`
+  config (default 30). Soft "newer-but-not-only-newest" picker.
+
+**Aggregation / telemetry (new category, 3):**
+- `count_distinct` -- count of distinct non-null values; synthesized
+- `count_non_null` -- count of non-null values; synthesized
+- `agreement_rate` -- 0.0-1.0 fraction of records agreeing on mode
+
+Total shipped: 10 (round 1) + 12 (round 2) = **22 plugins**.
+
 ## Out of scope (v1.19+)
 
-- `numeric_median` / `numeric_weighted_average` (cheap to add later;
-  starting with the 3 most-asked-for)
-- `url_canonical` (URL canonicalization has edge cases that warrant
-  their own spec)
 - `verified_value_or_null` (KYC-shaped; needs a source-verification
   registry that's bigger than a single plugin)
 - `dnc_safe_phone` (Do Not Call lookup; external service dependency)
+- `address_usps_format` (USPS canonicalization is large; warrants
+  its own spec + library dep)
+- `unicode_normalize` (NFKC + diacritic strip; useful for i18n
+  matching but format-specific)
 
 ## Kill criterion
 

--- a/packages/python/goldenmatch/goldenmatch/plugins/builtin/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/builtin/__init__.py
@@ -15,39 +15,66 @@ Spec: ``docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md``
 """
 from __future__ import annotations
 
+from goldenmatch.plugins.builtin.aggregation import (
+    AgreementRateStrategy,
+    CountDistinctStrategy,
+    CountNonNullStrategy,
+)
 from goldenmatch.plugins.builtin.business import (
+    EnumCanonicalStrategy,
     FreshnessWithMaxAgeStrategy,
     LifecycleStageStrategy,
+    RegexValidatedStrategy,
     SystemOfRecordStrategy,
+    WeightedByRecencyStrategy,
 )
 from goldenmatch.plugins.builtin.format import (
+    BooleanNormalizeStrategy,
     ConcatUniqueStrategy,
     EmailNormalizeStrategy,
     PhoneDigitsOnlyStrategy,
     ShortestValueStrategy,
+    UrlCanonicalStrategy,
+    WhitespaceNormalizeStrategy,
 )
 from goldenmatch.plugins.builtin.numeric import (
     NumericMaxStrategy,
     NumericMeanStrategy,
+    NumericMedianStrategy,
     NumericMinStrategy,
+    NumericSumStrategy,
+    NumericWeightedAverageStrategy,
 )
 
 # The full list of builtin plugin classes. Order is informational only;
 # registration is by name (last-write-wins for entry-point overrides).
 BUILTIN_PLUGINS = [
-    # Numeric (3)
+    # Numeric (6)
     NumericMaxStrategy,
     NumericMinStrategy,
     NumericMeanStrategy,
-    # Format-canonical (4)
+    NumericMedianStrategy,
+    NumericSumStrategy,
+    NumericWeightedAverageStrategy,
+    # Format-canonical (7)
     ShortestValueStrategy,
     ConcatUniqueStrategy,
     EmailNormalizeStrategy,
     PhoneDigitsOnlyStrategy,
-    # Business-shaped (3)
+    UrlCanonicalStrategy,
+    WhitespaceNormalizeStrategy,
+    BooleanNormalizeStrategy,
+    # Business-shaped (6)
     SystemOfRecordStrategy,
     LifecycleStageStrategy,
     FreshnessWithMaxAgeStrategy,
+    EnumCanonicalStrategy,
+    RegexValidatedStrategy,
+    WeightedByRecencyStrategy,
+    # Aggregation / telemetry (3)
+    CountDistinctStrategy,
+    CountNonNullStrategy,
+    AgreementRateStrategy,
 ]
 
 
@@ -68,15 +95,27 @@ def register_builtins(registry: object) -> None:
 
 __all__ = [
     "BUILTIN_PLUGINS",
+    "AgreementRateStrategy",
+    "BooleanNormalizeStrategy",
     "ConcatUniqueStrategy",
+    "CountDistinctStrategy",
+    "CountNonNullStrategy",
     "EmailNormalizeStrategy",
+    "EnumCanonicalStrategy",
     "FreshnessWithMaxAgeStrategy",
     "LifecycleStageStrategy",
     "NumericMaxStrategy",
     "NumericMeanStrategy",
+    "NumericMedianStrategy",
     "NumericMinStrategy",
+    "NumericSumStrategy",
+    "NumericWeightedAverageStrategy",
     "PhoneDigitsOnlyStrategy",
+    "RegexValidatedStrategy",
     "ShortestValueStrategy",
     "SystemOfRecordStrategy",
+    "UrlCanonicalStrategy",
+    "WeightedByRecencyStrategy",
+    "WhitespaceNormalizeStrategy",
     "register_builtins",
 ]

--- a/packages/python/goldenmatch/goldenmatch/plugins/builtin/aggregation.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/builtin/aggregation.py
@@ -1,0 +1,92 @@
+"""Aggregation / telemetry predefined plugins.
+
+These return SYNTHESIZED scalar metrics about the cluster (not picks
+from the cluster's members). Useful for golden-record fields that
+should carry merge metadata -- e.g. `n_sources_agreeing` for a
+quality column, or `confidence_score` derived from agreement_rate.
+
+count_distinct, count_non_null, agreement_rate.
+
+Each satisfies ``GoldenStrategyPlugin`` from
+``goldenmatch.plugins.base``.
+
+Spec: ``docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md``
+"""
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+
+class CountDistinctStrategy:
+    """Number of distinct non-null values in the cluster.
+
+    Useful for audit columns like `n_distinct_addresses`,
+    `n_distinct_emails` that surface how much variance the source
+    systems had for this field. Higher = more disagreement.
+
+    Returned value is a Python int. Synthesized -> idx=0.
+    Confidence: 1.0 when at least one non-null value exists;
+    0.0 when all-null (and value is None).
+    """
+
+    name = "count_distinct"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        non_null = [v for v in values if v is not None]
+        if not non_null:
+            return (None, 0.0)
+        return (len(set(non_null)), 1.0, 0)
+
+
+class CountNonNullStrategy:
+    """Number of non-null values in the cluster.
+
+    Used to surface coverage -- "how many of the merged sources
+    contributed a value to this field?". Synthesized scalar.
+
+    Returned value is a Python int. idx=0.
+    Confidence: 1.0 always (the count is exact). When ALL values are
+    null, returns (0, 1.0) NOT (None, 0.0) -- the count itself is
+    well-defined data even when there were no contributions.
+    """
+
+    name = "count_non_null"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        count = sum(1 for v in values if v is not None)
+        return (count, 1.0, 0)
+
+
+class AgreementRateStrategy:
+    """Fraction of non-null values that agree with the modal value.
+
+    Returns a float in [0.0, 1.0]. 1.0 = full agreement; lower =
+    more disagreement. Mode-based (not pairwise).
+
+    Calculation::
+
+       non_null = [v for v in values if v is not None]
+       mode_count = max(Counter(non_null).values())
+       rate = mode_count / len(non_null)
+
+    Useful for audit columns like `field_agreement_score` -- low
+    values surface fields that need steward review.
+
+    Returned value is a Python float. Synthesized -> idx=0.
+    Confidence: `len(non_null) / len(values)` -- coverage of the
+    measurement (a 1.0 agreement rate on a single non-null sample
+    is less robust than 1.0 on 10 samples).
+    """
+
+    name = "agreement_rate"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        non_null = [v for v in values if v is not None]
+        if not non_null:
+            return (None, 0.0)
+        counts = Counter(non_null)
+        _winner, mode_count = counts.most_common(1)[0]
+        rate = mode_count / len(non_null)
+        conf = len(non_null) / len(values)
+        return (rate, conf, 0)

--- a/packages/python/goldenmatch/goldenmatch/plugins/builtin/business.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/builtin/business.py
@@ -7,6 +7,8 @@ Spec: ``docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md``
 """
 from __future__ import annotations
 
+import math
+import re
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -186,5 +188,165 @@ class FreshnessWithMaxAgeStrategy:
         candidates.sort(key=lambda x: x[1], reverse=True)
         top_dt = candidates[0][1]
         tied = [(i, v) for i, dt, v in candidates if dt == top_dt]
+        conf = 1.0 if len(tied) == 1 else 0.7
+        return (tied[0][1], conf, tied[0][0])
+
+
+class EnumCanonicalStrategy:
+    """Map known aliases to a canonical enum value, then pick the mode.
+
+    `rule_kwargs.alias_map` maps any alias (case-insensitive,
+    trimmed) -> canonical value. For example::
+
+       alias_map:
+         "USA": "US"
+         "United States": "US"
+         "U.S.": "US"
+         "U.S.A.": "US"
+
+    Lookup is case-insensitive on KEYS but the VALUE is returned
+    verbatim (preserves intentional casing of the canonical form).
+
+    Values not in the alias_map pass through unchanged (no
+    modification). Then the strategy picks the mode of the resulting
+    set.
+
+    Confidence: `count(winning_value) / count(non_null)`.
+    """
+
+    name = "enum_canonical"
+
+    def merge(
+        self,
+        values: list,
+        *,
+        rule_kwargs: dict | None = None,
+        **_: Any,
+    ) -> Any:
+        from collections import Counter
+
+        non_null = [(i, v) for i, v in enumerate(values) if v is not None]
+        if not non_null:
+            return (None, 0.0)
+        raw_map: dict = (rule_kwargs or {}).get("alias_map") or {}
+        # Build a case-insensitive lookup -- key.lower() -> canonical.
+        alias_map = {str(k).strip().lower(): canonical for k, canonical in raw_map.items()}
+
+        def _canonicalize(v: Any) -> Any:
+            key = str(v).strip().lower()
+            return alias_map.get(key, v)
+
+        normalized = [(i, _canonicalize(v)) for i, v in non_null]
+        counts = Counter(c for _, c in normalized)
+        winner, count = counts.most_common(1)[0]
+        first_idx = next(i for i, c in normalized if c == winner)
+        conf = count / len(non_null)
+        return (winner, conf, first_idx)
+
+
+class RegexValidatedStrategy:
+    """Only accept values matching ``rule_kwargs.pattern``.
+
+    Useful when source data is dirty and you want to filter at the
+    consolidation step (e.g. only accept email-shaped values into the
+    `email` field, only accept SSN-shaped values into `ssn`).
+
+    Behavior:
+    - Filter values to only those matching the regex (`re.fullmatch`).
+    - If at least one matches: pick the most-common one (mode).
+    - If none match: fall back per ``rule_kwargs.fallback``:
+        - "first_non_null" (default): pick the first non-null
+          unmatched value with low confidence (0.3)
+        - "null": emit (None, 0.0)
+
+    Missing ``rule_kwargs.pattern`` -> behaves like `first_non_null`.
+    """
+
+    name = "regex_validated"
+
+    def merge(
+        self,
+        values: list,
+        *,
+        rule_kwargs: dict | None = None,
+        **_: Any,
+    ) -> Any:
+        from collections import Counter
+
+        non_null = [(i, v) for i, v in enumerate(values) if v is not None]
+        if not non_null:
+            return (None, 0.0)
+        pattern = (rule_kwargs or {}).get("pattern")
+        fallback = (rule_kwargs or {}).get("fallback", "first_non_null")
+        if not pattern:
+            # No pattern configured -> first non-null.
+            return (non_null[0][1], 0.5, non_null[0][0])
+        try:
+            compiled = re.compile(pattern)
+        except re.error:
+            return (non_null[0][1], 0.3, non_null[0][0])
+        matched = [(i, v) for i, v in non_null if compiled.fullmatch(str(v))]
+        if matched:
+            counts = Counter(v for _, v in matched)
+            winner, count = counts.most_common(1)[0]
+            first_idx = next(i for i, v in matched if v == winner)
+            conf = count / len(matched)
+            return (winner, conf, first_idx)
+        # No matches.
+        if fallback == "null":
+            return (None, 0.0)
+        return (non_null[0][1], 0.3, non_null[0][0])
+
+
+class WeightedByRecencyStrategy:
+    """Pick the value with the highest exponential-decayed recency weight.
+
+    Each value's weight = exp(-age_days / half_life_days). The value
+    with the maximum weight is returned. When multiple values share
+    the same date, the first-index wins.
+
+    `rule_kwargs.half_life_days` (default 30) controls decay rate:
+    after `half_life_days` days, weight halves. A value 6 months
+    older has weight ~0.001 of a fresh value (effectively ignored).
+
+    Requires `dates` kwarg. Values without dates are dropped.
+    Confidence: 1.0 when unique winner; 0.7 on date ties.
+
+    Compare to `most_recent` (sharp cutoff at newest) and
+    `freshness_with_max_age` (binary in/out). This strategy is a soft
+    "newer-but-not-only-newest" picker.
+    """
+
+    name = "weighted_by_recency"
+
+    def merge(
+        self,
+        values: list,
+        *,
+        dates: list | None = None,
+        rule_kwargs: dict | None = None,
+        **_: Any,
+    ) -> Any:
+        if dates is None:
+            return (None, 0.0)
+        half_life_days = float((rule_kwargs or {}).get("half_life_days", 30))
+        if half_life_days <= 0:
+            half_life_days = 30.0
+        now = datetime.now(tz=UTC)
+        scored: list[tuple[int, datetime, float, Any]] = []
+        for i, (d, v) in enumerate(zip(dates, values)):
+            if v is None:
+                continue
+            parsed = _parse_date(d)
+            if parsed is None:
+                continue
+            age_days = (now - parsed).total_seconds() / 86400.0
+            weight = math.exp(-age_days / half_life_days)
+            scored.append((i, parsed, weight, v))
+        if not scored:
+            return (None, 0.0)
+        scored.sort(key=lambda x: x[2], reverse=True)
+        top_weight = scored[0][2]
+        tied = [(i, v) for i, _, w, v in scored if w == top_weight]
         conf = 1.0 if len(tied) == 1 else 0.7
         return (tied[0][1], conf, tied[0][0])

--- a/packages/python/goldenmatch/goldenmatch/plugins/builtin/format.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/builtin/format.py
@@ -15,6 +15,13 @@ from typing import Any
 _EMAIL_PLUS_RE = re.compile(r"^([^+@]+)\+[^@]*(@.+)$")
 # Phone digits-only pattern.
 _NON_DIGIT_RE = re.compile(r"\D+")
+# URL scheme + host extraction (lowercase scheme + host, preserve path).
+_URL_RE = re.compile(r"^(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*://)(?P<host>[^/?#]+)(?P<rest>.*)$")
+# Internal whitespace pattern -- one-or-more whitespace chars.
+_WHITESPACE_RE = re.compile(r"\s+")
+# Canonical boolean truthy / falsy tokens, lowercased.
+_BOOL_TRUTHY = frozenset({"true", "t", "yes", "y", "1", "on"})
+_BOOL_FALSY = frozenset({"false", "f", "no", "n", "0", "off"})
 
 
 class ShortestValueStrategy:
@@ -148,3 +155,133 @@ class PhoneDigitsOnlyStrategy:
         tied = [(i, d) for i, d in stripped if len(d) == max_len]
         conf = 1.0 if len(tied) == 1 else 0.7
         return (tied[0][1], conf, tied[0][0])
+
+
+def _canonicalize_url(value: str) -> str:
+    """Lowercase scheme + host; trim trailing slash on the path portion.
+
+    Preserves case-sensitive path/query/fragment beyond the host. URL
+    canonicalization full-spec is complex; this is the operator-
+    common subset (scheme normalization + host case + trailing slash).
+    """
+    v = value.strip()
+    match = _URL_RE.match(v)
+    if not match:
+        return v
+    scheme = match.group("scheme").lower()
+    # http -> https upgrade as a canonical normalization for matching
+    # the same logical resource. Comment out this line if you want
+    # strict scheme preservation.
+    if scheme == "http://":
+        scheme = "https://"
+    host = match.group("host").lower()
+    rest = match.group("rest")
+    # Trim ONE trailing slash from path (preserve query/fragment).
+    if rest == "/":
+        rest = ""
+    elif rest.endswith("/") and "?" not in rest and "#" not in rest:
+        rest = rest[:-1]
+    return scheme + host + rest
+
+
+class UrlCanonicalStrategy:
+    """Canonicalize URLs and pick the mode (most common canonical form).
+
+    Normalization (operator-common subset):
+    - lowercase scheme + host
+    - upgrade http -> https
+    - trim trailing slash from path
+
+    Picks the most-frequent canonical form. Returns the CANONICAL value.
+
+    Confidence: `count / total` for the mode pick.
+    """
+
+    name = "url_canonical"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        non_null = [(i, str(v)) for i, v in enumerate(values) if v is not None]
+        if not non_null:
+            return (None, 0.0)
+        normalized = [(i, _canonicalize_url(v)) for i, v in non_null]
+        counts = Counter(n for _, n in normalized)
+        winner, count = counts.most_common(1)[0]
+        first_idx = next(i for i, n in normalized if n == winner)
+        conf = count / len(non_null)
+        return (winner, conf, first_idx)
+
+
+class WhitespaceNormalizeStrategy:
+    """Collapse internal whitespace runs to a single space + trim.
+
+    "  Acme   Corp \\t\\nInc  " -> "Acme Corp Inc". Then pick the mode
+    of the normalized values (most-common cleaned form).
+
+    Returns the CANONICAL (whitespace-normalized) value, not the
+    original. Useful when source systems vary in trailing/internal
+    whitespace -- the dedupe is by content, not formatting.
+
+    Confidence: `count / total` for the mode pick.
+    """
+
+    name = "whitespace_normalize"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        non_null = [(i, str(v)) for i, v in enumerate(values) if v is not None]
+        if not non_null:
+            return (None, 0.0)
+        normalized = [
+            (i, _WHITESPACE_RE.sub(" ", v).strip())
+            for i, v in non_null
+        ]
+        # Drop entries that normalize to empty string.
+        normalized = [(i, v) for i, v in normalized if v]
+        if not normalized:
+            return (None, 0.0)
+        counts = Counter(n for _, n in normalized)
+        winner, count = counts.most_common(1)[0]
+        first_idx = next(i for i, n in normalized if n == winner)
+        conf = count / len(non_null)
+        return (winner, conf, first_idx)
+
+
+class BooleanNormalizeStrategy:
+    """Coerce yes/no/Y/N/1/0/true/false/on/off variants to canonical bool.
+
+    Truthy tokens (case-insensitive, trimmed): true, t, yes, y, 1, on
+    Falsy tokens: false, f, no, n, 0, off
+
+    Unknown tokens are ignored. If non-null values map to multiple
+    booleans, picks the majority. Ties prefer True (canonical
+    "value is present" semantics over "value is absent").
+
+    Returns Python `True` / `False` (not the original string).
+    Confidence: `count(winning_bool) / count(parseable_values)`.
+    """
+
+    name = "boolean_normalize"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        parsed: list[tuple[int, bool]] = []
+        for i, v in enumerate(values):
+            if v is None:
+                continue
+            if isinstance(v, bool):
+                parsed.append((i, v))
+                continue
+            token = str(v).strip().lower()
+            if token in _BOOL_TRUTHY:
+                parsed.append((i, True))
+            elif token in _BOOL_FALSY:
+                parsed.append((i, False))
+        if not parsed:
+            return (None, 0.0)
+        truthy = sum(1 for _, b in parsed if b)
+        falsy = len(parsed) - truthy
+        # Tie-break to True.
+        winner = True if truthy >= falsy else False
+        win_count = truthy if winner else falsy
+        # Idx of first occurrence of the winning bool.
+        first_idx = next(i for i, b in parsed if b == winner)
+        conf = win_count / len(parsed)
+        return (winner, conf, first_idx)

--- a/packages/python/goldenmatch/goldenmatch/plugins/builtin/numeric.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/builtin/numeric.py
@@ -84,3 +84,104 @@ class NumericMeanStrategy:
         mean = sum(valid) / len(valid)
         conf = len(valid) / len(values)
         return (mean, conf, 0)
+
+
+class NumericMedianStrategy:
+    """Pick the median numeric value -- resilient to outliers vs mean.
+
+    For even counts, returns the lower-of-two-middles (no synthesized
+    interpolation) so the returned value preserves a real source row's
+    index. For odd counts, the unique middle value is returned with
+    its real idx.
+
+    Non-numeric values ignored. All-non-numeric -> (None, 0.0).
+    Confidence: `non_null_count / total_count`.
+    """
+
+    name = "numeric_median"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        candidates = [(i, _to_float(v), v) for i, v in enumerate(values)]
+        candidates = [(i, f, v) for i, f, v in candidates if f is not None]
+        if not candidates:
+            return (None, 0.0)
+        sorted_by_value = sorted(candidates, key=lambda x: x[1])
+        n = len(sorted_by_value)
+        # For even count, pick the lower middle (index n//2 - 1) so
+        # the returned value preserves a real source's idx.
+        mid_idx = (n - 1) // 2
+        i, _f, v = sorted_by_value[mid_idx]
+        conf = len(candidates) / len(values)
+        return (v, conf, i)
+
+
+class NumericSumStrategy:
+    """Sum of numeric values. Useful for aggregating amounts / balances
+    across sources where the golden record should reflect a total.
+
+    Returned idx is 0 (synthesized value, no real provenance).
+    Confidence: 1.0 when at least one non-null exists; 0.0 otherwise.
+    """
+
+    name = "numeric_sum"
+
+    def merge(self, values: list, **_: Any) -> Any:
+        nums = [_to_float(v) for v in values]
+        valid = [f for f in nums if f is not None]
+        if not valid:
+            return (None, 0.0)
+        total = sum(valid)
+        return (total, 1.0, 0)
+
+
+class NumericWeightedAverageStrategy:
+    """Quality-weighted average of numeric values.
+
+    Uses ``quality_weights`` (from the dispatcher; same length as
+    ``values``) when available. Falls back to uniform-weighted
+    average when weights are absent. Non-numeric values are excluded
+    along with their weights.
+
+    Confidence: `sum(non_null_weights) / sum(all_weights)` -- captures
+    how much of the input's total weight was usable. Falls back to
+    `non_null_count / len(values)` when no weights provided.
+
+    Synthesized value; idx=0.
+    """
+
+    name = "numeric_weighted_average"
+
+    def merge(
+        self,
+        values: list,
+        *,
+        quality_weights: list[float] | None = None,
+        **_: Any,
+    ) -> Any:
+        pairs: list[tuple[float, float]] = []
+        for i, v in enumerate(values):
+            f = _to_float(v)
+            if f is None:
+                continue
+            w = (
+                float(quality_weights[i])
+                if quality_weights is not None and i < len(quality_weights)
+                else 1.0
+            )
+            if w <= 0:
+                continue
+            pairs.append((f, w))
+        if not pairs:
+            return (None, 0.0)
+        total_weight = sum(w for _, w in pairs)
+        if total_weight == 0:
+            return (None, 0.0)
+        avg = sum(f * w for f, w in pairs) / total_weight
+        if quality_weights is not None:
+            all_weight = sum(
+                max(float(w), 0.0) for w in quality_weights[: len(values)]
+            )
+            conf = total_weight / all_weight if all_weight > 0 else 1.0
+        else:
+            conf = len(pairs) / len(values)
+        return (avg, conf, 0)

--- a/packages/python/goldenmatch/tests/plugins/test_builtin_discovery.py
+++ b/packages/python/goldenmatch/tests/plugins/test_builtin_discovery.py
@@ -11,12 +11,17 @@ from goldenmatch.plugins.builtin import BUILTIN_PLUGINS
 from goldenmatch.plugins.registry import PluginRegistry
 
 EXPECTED_BUILTIN_NAMES = {
-    # Numeric
+    # Numeric (6)
     "numeric_max", "numeric_min", "numeric_mean",
-    # Format-canonical
+    "numeric_median", "numeric_sum", "numeric_weighted_average",
+    # Format-canonical (7)
     "shortest_value", "concat_unique", "email_normalize", "phone_digits_only",
-    # Business
+    "url_canonical", "whitespace_normalize", "boolean_normalize",
+    # Business (6)
     "system_of_record", "lifecycle_stage", "freshness_with_max_age",
+    "enum_canonical", "regex_validated", "weighted_by_recency",
+    # Aggregation / telemetry (3)
+    "count_distinct", "count_non_null", "agreement_rate",
 }
 
 

--- a/packages/python/goldenmatch/tests/plugins/test_builtin_round2.py
+++ b/packages/python/goldenmatch/tests/plugins/test_builtin_round2.py
@@ -1,0 +1,415 @@
+"""Tests for the round-2 predefined plugins (#predefined-plugins-round-2).
+
+Covers the 12 plugins added in round 2:
+- Numeric: numeric_median, numeric_sum, numeric_weighted_average
+- Format: url_canonical, whitespace_normalize, boolean_normalize
+- Business: enum_canonical, regex_validated, weighted_by_recency
+- Aggregation: count_distinct, count_non_null, agreement_rate
+
+Spec: docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from goldenmatch.plugins.builtin.aggregation import (
+    AgreementRateStrategy,
+    CountDistinctStrategy,
+    CountNonNullStrategy,
+)
+from goldenmatch.plugins.builtin.business import (
+    EnumCanonicalStrategy,
+    RegexValidatedStrategy,
+    WeightedByRecencyStrategy,
+)
+from goldenmatch.plugins.builtin.format import (
+    BooleanNormalizeStrategy,
+    UrlCanonicalStrategy,
+    WhitespaceNormalizeStrategy,
+)
+from goldenmatch.plugins.builtin.numeric import (
+    NumericMedianStrategy,
+    NumericSumStrategy,
+    NumericWeightedAverageStrategy,
+)
+
+# ---------------------------------------------------------------------------
+# numeric_median
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_median_odd_count_picks_middle():
+    val, _conf, idx = NumericMedianStrategy().merge([10, 30, 20])
+    assert val == 20
+    assert idx == 2  # the original row containing the median value
+
+
+def test_numeric_median_even_count_picks_lower_middle():
+    """For even count, picks lower-of-two-middles to preserve a real idx."""
+    val, _conf, _idx = NumericMedianStrategy().merge([10, 20, 30, 40])
+    assert val == 20  # lower middle, not 25 (interpolated)
+
+
+def test_numeric_median_resilient_to_outlier():
+    val, _conf, _idx = NumericMedianStrategy().merge([5, 6, 7, 8, 1000])
+    assert val == 7  # mean would be 205.2
+
+
+def test_numeric_median_all_null():
+    val, conf = NumericMedianStrategy().merge([None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# numeric_sum
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_sum_aggregates():
+    val, conf, idx = NumericSumStrategy().merge([10, 20, 30])
+    assert val == 60
+    assert conf == 1.0
+    assert idx == 0
+
+
+def test_numeric_sum_skips_null():
+    val, _, _ = NumericSumStrategy().merge([10, None, 30])
+    assert val == 40
+
+
+def test_numeric_sum_all_null():
+    val, conf = NumericSumStrategy().merge([None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# numeric_weighted_average
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_avg_uses_weights():
+    val, _conf, _idx = NumericWeightedAverageStrategy().merge(
+        [10.0, 100.0],
+        quality_weights=[0.9, 0.1],
+    )
+    # 10*0.9 + 100*0.1 = 19.0; /1.0 = 19.0
+    assert val == pytest.approx(19.0)
+
+
+def test_weighted_avg_falls_back_to_uniform_without_weights():
+    val, _conf, _idx = NumericWeightedAverageStrategy().merge([10, 20, 30])
+    assert val == pytest.approx(20.0)
+
+
+def test_weighted_avg_all_null():
+    val, conf = NumericWeightedAverageStrategy().merge(
+        [None, None], quality_weights=[1.0, 1.0],
+    )
+    assert val is None
+    assert conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# url_canonical
+# ---------------------------------------------------------------------------
+
+
+def test_url_canonical_lowercases_host_and_upgrades_http():
+    val, _conf, _idx = UrlCanonicalStrategy().merge(["http://EXAMPLE.com/path"])
+    assert val == "https://example.com/path"
+
+
+def test_url_canonical_trims_trailing_slash():
+    val, _, _ = UrlCanonicalStrategy().merge(["https://example.com/"])
+    assert val == "https://example.com"
+
+
+def test_url_canonical_picks_mode():
+    val, conf, _ = UrlCanonicalStrategy().merge([
+        "https://example.com",
+        "HTTPS://Example.COM/",
+        "http://example.com",
+        "https://other.com",
+    ])
+    assert val == "https://example.com"
+    assert conf == 0.75  # 3 of 4 normalize the same
+
+
+def test_url_canonical_all_null():
+    val, conf = UrlCanonicalStrategy().merge([None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# whitespace_normalize
+# ---------------------------------------------------------------------------
+
+
+def test_whitespace_collapses_internal_runs():
+    val, _, _ = WhitespaceNormalizeStrategy().merge(["Acme    Corp"])
+    assert val == "Acme Corp"
+
+
+def test_whitespace_trims_and_normalizes_tabs():
+    val, _, _ = WhitespaceNormalizeStrategy().merge(["  Acme\t\tCorp\n  "])
+    assert val == "Acme Corp"
+
+
+def test_whitespace_picks_mode():
+    val, _conf, _idx = WhitespaceNormalizeStrategy().merge([
+        "Acme Corp",
+        "Acme    Corp ",
+        "Other Corp",
+    ])
+    assert val == "Acme Corp"
+
+
+def test_whitespace_all_null_or_empty():
+    val, conf = WhitespaceNormalizeStrategy().merge([None, "   ", "\t\n"])
+    assert val is None
+    assert conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# boolean_normalize
+# ---------------------------------------------------------------------------
+
+
+def test_boolean_normalize_truthy():
+    val, _, _ = BooleanNormalizeStrategy().merge(["yes"])
+    assert val is True
+
+
+def test_boolean_normalize_falsy():
+    val, _, _ = BooleanNormalizeStrategy().merge(["NO"])
+    assert val is False
+
+
+def test_boolean_normalize_majority_vote():
+    val, _conf, _ = BooleanNormalizeStrategy().merge(["Y", "1", "yes", "no"])
+    assert val is True
+    # 3 truthy vs 1 falsy -> conf 0.75
+
+
+def test_boolean_normalize_tie_prefers_true():
+    val, _, _ = BooleanNormalizeStrategy().merge(["yes", "no"])
+    assert val is True
+
+
+def test_boolean_normalize_unknown_tokens_ignored():
+    val, _, _ = BooleanNormalizeStrategy().merge(["maybe", "true"])
+    assert val is True
+
+
+def test_boolean_normalize_all_unknown():
+    val, conf = BooleanNormalizeStrategy().merge(["maybe", "perhaps"])
+    assert val is None
+    assert conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# enum_canonical
+# ---------------------------------------------------------------------------
+
+
+def test_enum_canonical_maps_aliases():
+    val, conf, _ = EnumCanonicalStrategy().merge(
+        ["USA", "United States", "U.S."],
+        rule_kwargs={
+            "alias_map": {
+                "USA": "US",
+                "United States": "US",
+                "U.S.": "US",
+            },
+        },
+    )
+    assert val == "US"
+    assert conf == 1.0  # all 3 normalize to same
+
+
+def test_enum_canonical_passes_unknown_through():
+    val, _, _ = EnumCanonicalStrategy().merge(
+        ["Canada", "Canada", "Mexico"],
+        rule_kwargs={"alias_map": {"USA": "US"}},
+    )
+    assert val == "Canada"  # mode of unmapped values
+
+
+def test_enum_canonical_case_insensitive_keys():
+    val, _, _ = EnumCanonicalStrategy().merge(
+        ["usa", "USA", "Usa"],
+        rule_kwargs={"alias_map": {"USA": "US"}},
+    )
+    assert val == "US"
+
+
+def test_enum_canonical_no_alias_map():
+    val, _, _ = EnumCanonicalStrategy().merge(
+        ["a", "b", "a"],
+    )
+    assert val == "a"
+
+
+# ---------------------------------------------------------------------------
+# regex_validated
+# ---------------------------------------------------------------------------
+
+
+def test_regex_validated_filters_matching():
+    val, _conf, _ = RegexValidatedStrategy().merge(
+        ["not-an-email", "bob@example.com", "alice@example.com"],
+        rule_kwargs={"pattern": r"[^@\s]+@[^@\s]+\.[^@\s]+"},
+    )
+    assert val in {"bob@example.com", "alice@example.com"}
+
+
+def test_regex_validated_no_match_falls_back():
+    val, conf, _ = RegexValidatedStrategy().merge(
+        ["junk1", "junk2"],
+        rule_kwargs={"pattern": r"[0-9]{4}"},
+    )
+    assert val == "junk1"
+    assert conf == 0.3  # fallback confidence
+
+
+def test_regex_validated_no_match_null_fallback():
+    val, conf = RegexValidatedStrategy().merge(
+        ["junk1", "junk2"],
+        rule_kwargs={"pattern": r"[0-9]{4}", "fallback": "null"},
+    )
+    assert val is None
+    assert conf == 0.0
+
+
+def test_regex_validated_no_pattern_first_non_null():
+    val, conf, _ = RegexValidatedStrategy().merge(["a", "b"])
+    assert val == "a"
+    assert conf == 0.5
+
+
+def test_regex_validated_invalid_pattern_falls_back():
+    val, _, _ = RegexValidatedStrategy().merge(
+        ["a", "b"], rule_kwargs={"pattern": "["},
+    )
+    assert val == "a"
+
+
+# ---------------------------------------------------------------------------
+# weighted_by_recency
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_by_recency_prefers_newer():
+    now = datetime.now(tz=UTC)
+    old = (now - timedelta(days=365)).isoformat()
+    new = (now - timedelta(days=1)).isoformat()
+    val, _, idx = WeightedByRecencyStrategy().merge(
+        ["old-val", "new-val"],
+        dates=[old, new],
+        rule_kwargs={"half_life_days": 30},
+    )
+    assert val == "new-val"
+    assert idx == 1
+
+
+def test_weighted_by_recency_no_dates():
+    val, conf = WeightedByRecencyStrategy().merge(["a", "b"], dates=None)
+    assert val is None
+    assert conf == 0.0
+
+
+def test_weighted_by_recency_skips_missing_dates():
+    now = datetime.now(tz=UTC)
+    fresh = (now - timedelta(days=1)).isoformat()
+    val, _, _ = WeightedByRecencyStrategy().merge(
+        ["a", "b", "c"],
+        dates=[None, fresh, None],
+    )
+    assert val == "b"
+
+
+def test_weighted_by_recency_negative_half_life_uses_default():
+    """Bad half_life config falls back to the 30-day default."""
+    now = datetime.now(tz=UTC)
+    fresh = (now - timedelta(days=1)).isoformat()
+    val, _, _ = WeightedByRecencyStrategy().merge(
+        ["a"], dates=[fresh], rule_kwargs={"half_life_days": -5},
+    )
+    assert val == "a"
+
+
+# ---------------------------------------------------------------------------
+# count_distinct
+# ---------------------------------------------------------------------------
+
+
+def test_count_distinct_basic():
+    val, conf, _ = CountDistinctStrategy().merge(["a", "b", "a", "c"])
+    assert val == 3
+    assert conf == 1.0
+
+
+def test_count_distinct_ignores_null():
+    val, _, _ = CountDistinctStrategy().merge(["a", None, "a", "b"])
+    assert val == 2
+
+
+def test_count_distinct_all_null():
+    val, conf = CountDistinctStrategy().merge([None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# count_non_null
+# ---------------------------------------------------------------------------
+
+
+def test_count_non_null_basic():
+    val, conf, _ = CountNonNullStrategy().merge(["a", None, "b", None])
+    assert val == 2
+    assert conf == 1.0
+
+
+def test_count_non_null_all_null_returns_zero_not_none():
+    """Count of zero is well-defined data; don't conflate with None."""
+    val, conf, _ = CountNonNullStrategy().merge([None, None])
+    assert val == 0
+    assert conf == 1.0
+
+
+# ---------------------------------------------------------------------------
+# agreement_rate
+# ---------------------------------------------------------------------------
+
+
+def test_agreement_rate_full_agreement():
+    val, _, _ = AgreementRateStrategy().merge(["a", "a", "a"])
+    assert val == pytest.approx(1.0)
+
+
+def test_agreement_rate_split():
+    val, _, _ = AgreementRateStrategy().merge(["a", "a", "b", "b"])
+    assert val == pytest.approx(0.5)
+
+
+def test_agreement_rate_coverage_in_confidence():
+    """Confidence reflects coverage: 1.0 rate on 1 sample is less robust
+    than 1.0 rate on 10 samples. Confidence = non_null / total."""
+    val, conf, _ = AgreementRateStrategy().merge(["a", None, None])
+    assert val == pytest.approx(1.0)
+    assert conf == pytest.approx(1 / 3)
+
+
+def test_agreement_rate_all_null():
+    val, conf = AgreementRateStrategy().merge([None, None])
+    assert val is None
+    assert conf == 0.0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Adds 12 plugins across 4 buckets to bring the total from 10 -> 22.

## What ships

| Bucket | Plugin | Description |
|---|---|---|
| Numeric | `numeric_median` | Outlier-resilient |
| Numeric | `numeric_sum` | Aggregate amounts |
| Numeric | `numeric_weighted_average` | Uses `quality_weights` |
| Format | `url_canonical` | Lowercase host, http→https, trim / |
| Format | `whitespace_normalize` | Collapse internal ws + trim |
| Format | `boolean_normalize` | yes/no/Y/N/1/0/true/false → bool |
| Business | `enum_canonical` | `alias_map` config |
| Business | `regex_validated` | `pattern` filter; configurable fallback |
| Business | `weighted_by_recency` | Exponential decay; `half_life_days` |
| Aggregation | `count_distinct` | Distinct non-null count |
| Aggregation | `count_non_null` | Non-null count (returns 0, not None) |
| Aggregation | `agreement_rate` | 0-1 mode-agreement rate |

## Test plan

- [x] 40+ new tests in `tests/plugins/test_builtin_round2.py`
- [x] Discovery test updated for 22 builtins (was 10)
- [x] `uv run ruff check` clean
- CI is the gate

## Spec

`docs/superpowers/specs/2026-05-22-predefined-merge-plugins-design.md` updated with round-2 section.