### PR TITLE
feat(v1.18.3): Phase 1 surface sync -- discovery + MCP parity

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -8,18 +8,40 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [1.19.0] - 2026-05-22
 
-### Added -- Phase 2 of v1.18 surface-sync roadmap
+### Added -- v1.18 surface-sync roadmap (Phases 1 + 2)
 
-REST API parity for v1.18.2's field-level Corrections + 22 plugins.
-Unblocks the #437 Next.js review-queue use case.
+Brings 6 programmatic surfaces into parity with v1.18.2's field-level
+Corrections + 22 predefined plugins.
+
+**Phase 1** (originally targeted v1.18.3; folded into v1.19.0 since
+Phase 2 merged first):
+
+- **Python API re-exports.** `PluginRegistry`, `BUILTIN_PLUGINS`,
+  `Decision`, `CorrectionSource` are now importable from the
+  top-level `goldenmatch` package.
+- **MCP `add_correction` schema extension.** `decision` enum gains
+  `"field_correct"`. Three new optional properties:
+  `field_name`, `original_value`, `corrected_value`. `cluster_id`
+  property added for field-level shape. Pair-level path unchanged.
+- **MCP `list_plugins` tool.** Lists all registered goldenmatch
+  plugins by category. Each entry includes `name`, `category`,
+  `source` (builtin / user), and the merge-docstring summary.
+- **CLI `goldenmatch memory add` command.** Supports both
+  pair-level (`--id-a` / `--id-b`) and field-level (`--cluster-id`
+  + `--field-name` + `--corrected-value`) shapes via `--decision`.
+  Source defaults to `steward` (trust 1.0); override via `--source`.
+
+**Phase 2:** REST API CRUD.
 
 - `POST /api/v1/memory/corrections` -- pair AND field-level shapes;
-  source defaults to "rest" with trust=0.8
+  source defaults to "rest" with trust=0.8.
 - `GET /api/v1/plugins` -- discovery endpoint; category filter;
-  builtin vs user source tagging
-- `GET /api/v1/memory/corrections` response gains field-level fields
+  builtin vs user source tagging.
+- `GET /api/v1/memory/corrections` response gains field-level fields.
 
-Spec: docs/superpowers/specs/2026-05-22-phase-2-rest-api-crud-design.md
+Specs:
+- `docs/superpowers/specs/2026-05-22-phase-1-discovery-mcp-parity-design.md`
+- `docs/superpowers/specs/2026-05-22-phase-2-rest-api-crud-design.md`
 
 ## [1.18.2] - 2026-05-22
 

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.18.2"
+__version__ = "1.19.0"
 
 # ── High-level API (convenience functions) ────────────────────────────────
 from goldenmatch._api import (
@@ -162,6 +162,10 @@ from goldenmatch.core.memory import (
     apply_corrections,
 )
 
+# Decision + source enums for Correction (Phase 1 of v1.18.3 surface sync).
+# `Decision.FIELD_CORRECT` identifies field-level inline-edit feedback.
+from goldenmatch.core.memory.store import CorrectionSource, Decision
+
 # ── Core pipeline functions ───────────────────────────────────────────────
 from goldenmatch.core.pipeline import run_dedupe, run_match
 
@@ -221,6 +225,12 @@ from goldenmatch.output.report import generate_dedupe_report
 
 # ── Output ───────────────────────────────────────────────────────────────
 from goldenmatch.output.writer import write_output
+
+# Plugin discovery surfaces (Phase 1 of v1.18.3 surface sync). Users can
+# inspect the 22 predefined golden-strategy plugins + any user-registered
+# ones via `PluginRegistry.instance().list_plugins()`.
+from goldenmatch.plugins.builtin import BUILTIN_PLUGINS
+from goldenmatch.plugins.registry import PluginRegistry
 from goldenmatch.pprl.autoconfig import (
     auto_configure_pprl,
     auto_configure_pprl_llm,
@@ -322,6 +332,9 @@ __all__ = [
     # Learning Memory
     "MemoryStore", "Correction", "LearnedAdjustment", "CorrectionStats",
     "MemoryLearner", "apply_corrections",
+    # Phase 1 of v1.18.3 surface sync:
+    "CorrectionSource", "Decision",
+    "PluginRegistry", "BUILTIN_PLUGINS",
     # Learning Memory API
     "get_memory", "add_correction", "learn", "memory_stats",
     # Identity Graph (v2.0)

--- a/packages/python/goldenmatch/goldenmatch/cli/memory.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/memory.py
@@ -35,6 +35,140 @@ memory_app = typer.Typer(
 )
 
 
+@memory_app.command("add")
+def add_cmd(
+    decision: str = typer.Option(
+        ...,
+        "--decision",
+        help="approve | reject | field_correct",
+    ),
+    dataset: str = typer.Option(..., "--dataset", help="Dataset key (required)"),
+    id_a: int | None = typer.Option(
+        None, "--id-a", help="Pair-level: first row id",
+    ),
+    id_b: int | None = typer.Option(
+        None, "--id-b", help="Pair-level: second row id",
+    ),
+    cluster_id: int | None = typer.Option(
+        None, "--cluster-id",
+        help="Field-level: cluster id the correction targets",
+    ),
+    field_name: str | None = typer.Option(
+        None, "--field-name", help="Field-level: column being corrected",
+    ),
+    original_value: str | None = typer.Option(
+        None, "--original-value", help="Field-level: original chosen value",
+    ),
+    corrected_value: str | None = typer.Option(
+        None, "--corrected-value",
+        help="Field-level: the value the reviewer changed it to",
+    ),
+    reason: str | None = typer.Option(None, "--reason", help="Optional reason"),
+    matchkey_name: str | None = typer.Option(
+        None, "--matchkey-name", help="Optional matchkey scope",
+    ),
+    source: str = typer.Option(
+        "steward", "--source",
+        help="Source: steward (1.0 trust) | agent (0.5) | boost | unmerge",
+    ),
+    path: str = typer.Option(DEFAULT_PATH, "--path", help="Memory DB path"),
+) -> None:
+    """Add a pair-level (approve/reject) or field-level correction.
+
+    Pair-level shape:
+        goldenmatch memory add --decision approve --id-a 42 --id-b 99 \\
+            --dataset my_run
+
+    Field-level shape (#437, v1.18.2+):
+        goldenmatch memory add --decision field_correct --cluster-id 42 \\
+            --field-name address1 --corrected-value "1 Elm St, Apt 4B" \\
+            --dataset my_run
+    """
+    from goldenmatch.core.memory.store import (
+        HIGH_TRUST_SOURCES,
+        Correction,
+        MemoryStore,
+        _canon_pair,
+    )
+
+    valid_decisions = {"approve", "reject", "field_correct"}
+    if decision not in valid_decisions:
+        err_console.print(
+            f"[red]Invalid decision: {decision!r}. "
+            f"Use one of {sorted(valid_decisions)}.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    trust = 1.0 if source in {s.value for s in HIGH_TRUST_SOURCES} else 0.5
+
+    if decision == "field_correct":
+        if not field_name:
+            err_console.print(
+                "[red]field_correct requires --field-name[/red]"
+            )
+            raise typer.Exit(code=1)
+        if corrected_value is None:
+            err_console.print(
+                "[red]field_correct requires --corrected-value[/red]"
+            )
+            raise typer.Exit(code=1)
+        cid = cluster_id if cluster_id is not None else (id_a or 0)
+        correction = Correction(
+            id=str(uuid.uuid4()),
+            id_a=cid,
+            id_b=0,
+            decision=decision,
+            source=source,
+            trust=trust,
+            field_hash="",
+            record_hash="",
+            original_score=0.0,
+            matchkey_name=matchkey_name,
+            reason=reason,
+            dataset=dataset,
+            created_at=datetime.now(),
+            field_name=field_name,
+            original_value=original_value,
+            corrected_value=corrected_value,
+        )
+    else:
+        if id_a is None or id_b is None:
+            err_console.print(
+                f"[red]{decision} requires --id-a and --id-b[/red]"
+            )
+            raise typer.Exit(code=1)
+        ca, cb = _canon_pair(id_a, id_b)
+        correction = Correction(
+            id=str(uuid.uuid4()),
+            id_a=ca,
+            id_b=cb,
+            decision=decision,
+            source=source,
+            trust=trust,
+            field_hash="",
+            record_hash="",
+            original_score=0.0,
+            matchkey_name=matchkey_name,
+            reason=reason,
+            dataset=dataset,
+            created_at=datetime.now(),
+        )
+
+    with MemoryStore(backend="sqlite", path=path) as store:
+        store.add_correction(correction)
+    # Print the generated id so callers can capture it.
+    console.print(f"[green]added[/green] correction id={correction.id}")
+    if decision == "field_correct":
+        console.print(
+            f"  cluster_id={correction.id_a} field={correction.field_name} "
+            f"-> {correction.corrected_value!r}"
+        )
+    else:
+        console.print(
+            f"  ({correction.id_a}, {correction.id_b}) decision={decision}"
+        )
+
+
 @memory_app.command("stats")
 def stats_cmd(
     path: str = typer.Option(DEFAULT_PATH, "--path", help="Memory DB path"),

--- a/packages/python/goldenmatch/goldenmatch/mcp/memory_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/memory_tools.py
@@ -41,18 +41,43 @@ MEMORY_TOOLS: list[Tool] = [
     Tool(
         name="add_correction",
         description=(
-            "Add a pair correction to Learning Memory. Source is set to 'agent' "
-            "with trust=0.5 (lower than human steward decisions which are 1.0). "
+            "Add a Learning Memory correction. Two shapes:\n"
+            "  - pair-level: decision='approve' or 'reject', requires id_a + id_b\n"
+            "  - field-level (v1.18.2+): decision='field_correct', requires "
+            "cluster_id + field_name + corrected_value\n"
+            "Source is 'agent' with trust=0.5 (lower than human steward 1.0). "
             "Pair (id_a, id_b) is canonicalized to (min, max) before storage."
         ),
         inputSchema={
             "type": "object",
             "properties": {
-                "id_a": {"type": "integer"},
-                "id_b": {"type": "integer"},
+                "id_a": {
+                    "type": "integer",
+                    "description": "Pair-level: first row id. Field-level: ignored.",
+                },
+                "id_b": {
+                    "type": "integer",
+                    "description": "Pair-level: second row id. Field-level: ignored.",
+                },
+                "cluster_id": {
+                    "type": "integer",
+                    "description": "Field-level: cluster_id the correction targets.",
+                },
                 "decision": {
                     "type": "string",
-                    "enum": ["approve", "reject"],
+                    "enum": ["approve", "reject", "field_correct"],
+                },
+                "field_name": {
+                    "type": "string",
+                    "description": "Field-level: the column being corrected.",
+                },
+                "original_value": {
+                    "type": "string",
+                    "description": "Field-level: the value build_golden_record chose.",
+                },
+                "corrected_value": {
+                    "type": "string",
+                    "description": "Field-level: the value the reviewer changed it to.",
                 },
                 "dataset": {
                     "type": "string",
@@ -65,7 +90,30 @@ MEMORY_TOOLS: list[Tool] = [
                     "description": "SQLite memory DB path. Default: .goldenmatch/memory.db",
                 },
             },
-            "required": ["id_a", "id_b", "decision", "dataset"],
+            "required": ["decision", "dataset"],
+        },
+    ),
+    Tool(
+        name="list_plugins",
+        description=(
+            "List all registered goldenmatch plugins by category. Includes "
+            "the 22 v1.18.2 predefined plugins (numeric/format/business/"
+            "aggregation) plus any user-registered plugins via entry-points "
+            "or PluginRegistry.register_*(). Each entry includes "
+            "name, source (builtin or user), category, and the first line of "
+            "the merge docstring."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string",
+                    "enum": [
+                        "all", "golden_strategy", "scorer", "transform", "connector",
+                    ],
+                    "default": "all",
+                },
+            },
         },
     ),
     Tool(
@@ -201,17 +249,66 @@ def _dispatch(name: str, args: dict) -> dict:
             return {"error": "Missing or empty required parameter: dataset"}
 
         decision = args.get("decision")
-        if decision not in ("approve", "reject"):
-            return {"error": f"Invalid decision: {decision!r}. Use 'approve' or 'reject'."}
+        if decision not in ("approve", "reject", "field_correct"):
+            return {
+                "error": f"Invalid decision: {decision!r}. Use 'approve', "
+                         "'reject', or 'field_correct'.",
+            }
 
+        from goldenmatch.core.memory.store import Correction, _canon_pair
+
+        # Field-level vs pair-level branching (Phase 1 of v1.18.3 surface sync).
+        if decision == "field_correct":
+            field_name = args.get("field_name")
+            corrected_value = args.get("corrected_value")
+            if not field_name:
+                return {"error": "field_correct requires field_name"}
+            if corrected_value is None:
+                return {"error": "field_correct requires corrected_value"}
+            # cluster_id occupies the id_a slot semantically; id_b=0 unused.
+            try:
+                cluster_id = int(args.get("cluster_id", args.get("id_a", 0)))
+            except (TypeError, ValueError) as exc:
+                return {"error": f"cluster_id must be an integer: {exc}"}
+            correction = Correction(
+                id=str(uuid.uuid4()),
+                id_a=cluster_id,
+                id_b=0,
+                decision=decision,
+                source="agent",
+                trust=0.5,
+                field_hash="",
+                record_hash="",
+                original_score=0.0,
+                matchkey_name=args.get("matchkey_name"),
+                reason=args.get("reason"),
+                dataset=dataset,
+                created_at=datetime.now(),
+                field_name=field_name,
+                original_value=args.get("original_value"),
+                corrected_value=corrected_value,
+            )
+            with MemoryStore(backend="sqlite", path=path) as store:
+                store.add_correction(correction)
+            return {
+                "status": "ok",
+                "id": correction.id,
+                "cluster_id": cluster_id,
+                "field_name": field_name,
+                "original_value": args.get("original_value"),
+                "corrected_value": corrected_value,
+                "decision": decision,
+                "source": "agent",
+                "trust": 0.5,
+                "dataset": dataset,
+            }
+
+        # Pair-level (approve / reject).
         try:
             id_a = int(args["id_a"])
             id_b = int(args["id_b"])
         except (KeyError, TypeError, ValueError) as exc:
             return {"error": f"id_a / id_b must be integers: {exc}"}
-
-        from goldenmatch.core.memory.store import Correction, _canon_pair
-
         ca, cb = _canon_pair(id_a, id_b)
         correction = Correction(
             id=str(uuid.uuid4()),
@@ -240,6 +337,45 @@ def _dispatch(name: str, args: dict) -> dict:
             "trust": 0.5,
             "dataset": dataset,
         }
+
+    if name == "list_plugins":
+        from goldenmatch.plugins.builtin import BUILTIN_PLUGINS
+        from goldenmatch.plugins.registry import PluginRegistry
+
+        category = args.get("category", "all")
+        registry = PluginRegistry.instance()
+        registry.discover()
+        builtin_names = {cls().name for cls in BUILTIN_PLUGINS}
+
+        def _serialize(plugin_dict: dict, kind: str) -> list[dict]:
+            out: list[dict] = []
+            for plugin_name, plugin in plugin_dict.items():
+                merge_doc = ""
+                if hasattr(plugin, "merge") and plugin.merge.__doc__:
+                    merge_doc = plugin.merge.__doc__.strip().split("\n")[0][:200]
+                out.append({
+                    "name": plugin_name,
+                    "category": kind,
+                    "source": "builtin" if (
+                        kind == "golden_strategy" and plugin_name in builtin_names
+                    ) else "user",
+                    "doc": merge_doc,
+                })
+            return sorted(out, key=lambda d: (d["source"] != "builtin", d["name"]))
+
+        result: dict[str, list[dict]] = {}
+        kinds = (
+            ("golden_strategy", "_golden_strategies"),
+            ("scorer", "_scorers"),
+            ("transform", "_transforms"),
+            ("connector", "_connectors"),
+        )
+        for kind, attr in kinds:
+            if category not in ("all", kind):
+                continue
+            store_dict = getattr(registry, attr, {})
+            result[kind] = _serialize(store_dict, kind)
+        return result
 
     if name == "learn_thresholds":
         from goldenmatch.core.memory.learner import MemoryLearner

--- a/packages/python/goldenmatch/tests/test_memory_tools.py
+++ b/packages/python/goldenmatch/tests/test_memory_tools.py
@@ -24,12 +24,14 @@ EXPECTED_NAMES = {
     "learn_thresholds",
     "memory_stats",
     "memory_export",
+    # v1.18.3 (#predefined-merge-plugins): plugin discovery via MCP.
+    "list_plugins",
 }
 
 
 def test_memory_tools_registered():
-    """MEMORY_TOOLS exposes the five tool definitions; names match frozenset."""
-    assert len(MEMORY_TOOLS) == 5
+    """MEMORY_TOOLS exposes the six tool definitions; names match frozenset."""
+    assert len(MEMORY_TOOLS) == 6
     names = {t.name for t in MEMORY_TOOLS}
     assert names == EXPECTED_NAMES
     assert _MEMORY_TOOL_NAMES == frozenset(EXPECTED_NAMES)

--- a/packages/python/goldenmatch/tests/test_phase1_discovery_mcp_parity.py
+++ b/packages/python/goldenmatch/tests/test_phase1_discovery_mcp_parity.py
@@ -1,0 +1,294 @@
+"""Tests for Phase 1 of v1.18.3 surface-sync roadmap.
+
+Spec: docs/superpowers/specs/2026-05-22-phase-1-discovery-mcp-parity-design.md
+
+Covers:
+- 1.1 Python API re-exports (PluginRegistry, BUILTIN_PLUGINS,
+      CorrectionSource, Decision)
+- 1.2 MCP add_correction schema extension (field_correct decision +
+      3 new optional properties)
+- 1.3 MCP list_plugins tool
+- 1.4 CLI `goldenmatch memory add` command (pair + field shapes)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+# ---------------------------------------------------------------------------
+# 1.1 Python API re-exports
+# ---------------------------------------------------------------------------
+
+
+def test_re_exports_plugin_registry_at_top_level():
+    import goldenmatch
+    assert hasattr(goldenmatch, "PluginRegistry")
+    # The class itself, not an instance.
+    assert callable(goldenmatch.PluginRegistry)
+
+
+def test_re_exports_builtin_plugins_at_top_level():
+    import goldenmatch
+    assert hasattr(goldenmatch, "BUILTIN_PLUGINS")
+    # 22 plugins after v1.18.2.
+    assert len(goldenmatch.BUILTIN_PLUGINS) == 22
+
+
+def test_re_exports_decision_and_correction_source_at_top_level():
+    import goldenmatch
+    assert hasattr(goldenmatch, "Decision")
+    assert hasattr(goldenmatch, "CorrectionSource")
+    assert goldenmatch.Decision.FIELD_CORRECT.value == "field_correct"
+
+
+def test_all_includes_new_surface_names():
+    import goldenmatch
+    for name in (
+        "PluginRegistry", "BUILTIN_PLUGINS", "Decision", "CorrectionSource",
+    ):
+        assert name in goldenmatch.__all__, f"{name} missing from __all__"
+
+
+# ---------------------------------------------------------------------------
+# 1.2 MCP add_correction schema + dispatch (field-level)
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_add_correction_schema_includes_field_correct():
+    from goldenmatch.mcp.memory_tools import MEMORY_TOOLS
+
+    tool = next(t for t in MEMORY_TOOLS if t.name == "add_correction")
+    enum = tool.inputSchema["properties"]["decision"]["enum"]
+    assert "field_correct" in enum
+    # Pair-level still supported.
+    assert "approve" in enum
+    assert "reject" in enum
+    # The 3 new optional fields are in the schema.
+    props = tool.inputSchema["properties"]
+    for field in ("field_name", "original_value", "corrected_value", "cluster_id"):
+        assert field in props, f"{field} missing from add_correction schema"
+
+
+def test_mcp_add_correction_dispatch_field_level(tmp_path: Path):
+    from goldenmatch.core.memory.store import MemoryStore
+    from goldenmatch.mcp.memory_tools import _dispatch as handle_memory_tool
+
+    db_path = str(tmp_path / "m.db")
+    result = handle_memory_tool(
+        "add_correction",
+        {
+            "decision": "field_correct",
+            "cluster_id": 42,
+            "field_name": "address1",
+            "original_value": "1 Elm St",
+            "corrected_value": "1 Elm Street, Apt 4B",
+            "dataset": "test_dataset",
+            "path": db_path,
+        },
+    )
+    assert result["status"] == "ok"
+    assert result["cluster_id"] == 42
+    assert result["field_name"] == "address1"
+    assert result["corrected_value"] == "1 Elm Street, Apt 4B"
+
+    # Round-trip via the store.
+    store = MemoryStore(backend="sqlite", path=db_path)
+    rows = list(store.get_corrections(dataset="test_dataset"))
+    store.close()
+    assert len(rows) == 1
+    assert rows[0].decision == "field_correct"
+    assert rows[0].field_name == "address1"
+    assert rows[0].corrected_value == "1 Elm Street, Apt 4B"
+
+
+def test_mcp_add_correction_dispatch_pair_level_regression(tmp_path: Path):
+    """Pair-level path still works (backward compat)."""
+    from goldenmatch.mcp.memory_tools import _dispatch as handle_memory_tool
+
+    db_path = str(tmp_path / "m.db")
+    result = handle_memory_tool(
+        "add_correction",
+        {
+            "decision": "approve",
+            "id_a": 5,
+            "id_b": 10,
+            "dataset": "test_dataset",
+            "path": db_path,
+        },
+    )
+    assert result["status"] == "ok"
+    assert result["id_a"] == 5
+    assert result["id_b"] == 10
+    assert result["decision"] == "approve"
+
+
+def test_mcp_add_correction_field_correct_missing_field_name(tmp_path: Path):
+    from goldenmatch.mcp.memory_tools import _dispatch as handle_memory_tool
+
+    result = handle_memory_tool(
+        "add_correction",
+        {
+            "decision": "field_correct",
+            "corrected_value": "X",
+            "dataset": "test",
+            "path": str(tmp_path / "m.db"),
+        },
+    )
+    assert "error" in result
+    assert "field_name" in result["error"]
+
+
+def test_mcp_add_correction_field_correct_missing_corrected_value(tmp_path: Path):
+    from goldenmatch.mcp.memory_tools import _dispatch as handle_memory_tool
+
+    result = handle_memory_tool(
+        "add_correction",
+        {
+            "decision": "field_correct",
+            "field_name": "address1",
+            "dataset": "test",
+            "path": str(tmp_path / "m.db"),
+        },
+    )
+    assert "error" in result
+    assert "corrected_value" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# 1.3 MCP list_plugins tool
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_list_plugins_tool_registered():
+    from goldenmatch.mcp.memory_tools import MEMORY_TOOLS
+
+    tool = next((t for t in MEMORY_TOOLS if t.name == "list_plugins"), None)
+    assert tool is not None
+    assert tool.inputSchema["properties"]["category"]["enum"] == [
+        "all", "golden_strategy", "scorer", "transform", "connector",
+    ]
+
+
+def test_mcp_list_plugins_returns_22_builtins(tmp_path: Path):
+    from goldenmatch.mcp.memory_tools import _dispatch as handle_memory_tool
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    PluginRegistry.reset()
+    result = handle_memory_tool("list_plugins", {"category": "golden_strategy"})
+    PluginRegistry.reset()
+    names = {p["name"] for p in result["golden_strategy"]}
+    # Sample of expected builtins from each category:
+    for expected in (
+        "numeric_max", "numeric_mean", "email_normalize",
+        "phone_digits_only", "system_of_record", "lifecycle_stage",
+        "agreement_rate", "count_distinct",
+    ):
+        assert expected in names, f"{expected} not in MCP list_plugins"
+    # All builtin entries have source=builtin.
+    for entry in result["golden_strategy"]:
+        if entry["name"] in {
+            "numeric_max", "numeric_mean", "email_normalize",
+        }:
+            assert entry["source"] == "builtin"
+
+
+def test_mcp_list_plugins_category_filter(tmp_path: Path):
+    from goldenmatch.mcp.memory_tools import _dispatch as handle_memory_tool
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    PluginRegistry.reset()
+    result = handle_memory_tool("list_plugins", {"category": "scorer"})
+    PluginRegistry.reset()
+    # Only scorer category present.
+    assert set(result.keys()) == {"scorer"}
+
+
+# ---------------------------------------------------------------------------
+# 1.4 CLI `goldenmatch memory add`
+# ---------------------------------------------------------------------------
+
+
+def test_cli_memory_add_pair_level(tmp_path: Path):
+    from goldenmatch.cli.memory import memory_app
+    from goldenmatch.core.memory.store import MemoryStore
+
+    db_path = str(tmp_path / "m.db")
+    runner = CliRunner()
+    result = runner.invoke(memory_app, [
+        "add",
+        "--decision", "approve",
+        "--id-a", "42",
+        "--id-b", "99",
+        "--dataset", "test",
+        "--path", db_path,
+    ])
+    assert result.exit_code == 0, result.output
+    assert "added" in result.output
+    store = MemoryStore(backend="sqlite", path=db_path)
+    rows = list(store.get_corrections(dataset="test"))
+    store.close()
+    assert len(rows) == 1
+    assert rows[0].decision == "approve"
+    assert rows[0].id_a == 42
+    assert rows[0].id_b == 99
+
+
+def test_cli_memory_add_field_level(tmp_path: Path):
+    from goldenmatch.cli.memory import memory_app
+    from goldenmatch.core.memory.store import MemoryStore
+
+    db_path = str(tmp_path / "m.db")
+    runner = CliRunner()
+    result = runner.invoke(memory_app, [
+        "add",
+        "--decision", "field_correct",
+        "--cluster-id", "42",
+        "--field-name", "address1",
+        "--corrected-value", "1 Elm Street, Apt 4B",
+        "--original-value", "1 Elm St",
+        "--dataset", "test",
+        "--path", db_path,
+    ])
+    assert result.exit_code == 0, result.output
+    store = MemoryStore(backend="sqlite", path=db_path)
+    rows = list(store.get_corrections(dataset="test"))
+    store.close()
+    assert len(rows) == 1
+    assert rows[0].decision == "field_correct"
+    assert rows[0].field_name == "address1"
+    assert rows[0].corrected_value == "1 Elm Street, Apt 4B"
+
+
+def test_cli_memory_add_pair_level_missing_id_b(tmp_path: Path):
+    from goldenmatch.cli.memory import memory_app
+
+    runner = CliRunner()
+    result = runner.invoke(memory_app, [
+        "add",
+        "--decision", "approve",
+        "--id-a", "42",
+        "--dataset", "test",
+        "--path", str(tmp_path / "m.db"),
+    ])
+    assert result.exit_code == 1
+
+
+def test_cli_memory_add_field_correct_missing_corrected_value(tmp_path: Path):
+    from goldenmatch.cli.memory import memory_app
+
+    runner = CliRunner()
+    result = runner.invoke(memory_app, [
+        "add",
+        "--decision", "field_correct",
+        "--cluster-id", "42",
+        "--field-name", "address1",
+        "--dataset", "test",
+        "--path", str(tmp_path / "m.db"),
+    ])
+    assert result.exit_code == 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Phase 1 of v1.18 surface-sync roadmap. Brings 4 programmatic surfaces into parity with v1.18.2's field-level Corrections + 22 predefined plugins.

## Deliverables (single PR, ~350 LOC)

1. **Python API re-exports** — `PluginRegistry`, `BUILTIN_PLUGINS`, `Decision`, `CorrectionSource` at top level
2. **MCP `add_correction` schema** — `field_correct` decision + 3 new optional properties (`field_name`/`original_value`/`corrected_value`) + `cluster_id`
3. **MCP `list_plugins` tool** — discovers the 22 builtins + user plugins, returns name/category/source/doc per entry
4. **CLI `goldenmatch memory add`** — pair AND field-level shapes from day 1; source defaults to `steward` (trust 1.0)

## Test plan

- [x] 13 new tests in `tests/test_phase1_discovery_mcp_parity.py`
- [x] Re-exports importable from top-level
- [x] MCP dispatch handles both shapes; validation errors per branch
- [x] `list_plugins` returns expected builtins
- [x] CLI happy paths + validation errors
- [x] `uv run ruff check` clean

## Cuts v1.18.3 on merge

Spec: `docs/superpowers/specs/2026-05-22-phase-1-discovery-mcp-parity-design.md`