### PR TITLE
feat(v1.19.0): Phase 2 surface sync -- REST API CRUD

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.19.0] - 2026-05-22
+
+### Added -- Phase 2 of v1.18 surface-sync roadmap
+
+REST API parity for v1.18.2's field-level Corrections + 22 plugins.
+Unblocks the #437 Next.js review-queue use case.
+
+- `POST /api/v1/memory/corrections` -- pair AND field-level shapes;
+  source defaults to "rest" with trust=0.8
+- `GET /api/v1/plugins` -- discovery endpoint; category filter;
+  builtin vs user source tagging
+- `GET /api/v1/memory/corrections` response gains field-level fields
+
+Spec: docs/superpowers/specs/2026-05-22-phase-2-rest-api-crud-design.md
+
 ## [1.18.2] - 2026-05-22
 
 ### Added

--- a/packages/python/goldenmatch/goldenmatch/web/app.py
+++ b/packages/python/goldenmatch/goldenmatch/web/app.py
@@ -27,6 +27,7 @@ def create_app(state: AppState) -> FastAPI:
     from goldenmatch.web.routers import labels as labels_router
     from goldenmatch.web.routers import match as match_router
     from goldenmatch.web.routers import memory as memory_router
+    from goldenmatch.web.routers import plugins as plugins_router
     from goldenmatch.web.routers import preview as preview_router
     from goldenmatch.web.routers import project as project_router
     from goldenmatch.web.routers import quality as quality_router
@@ -51,6 +52,7 @@ def create_app(state: AppState) -> FastAPI:
     app.include_router(domains_router.router)
     app.include_router(match_router.router)
     app.include_router(memory_router.router)
+    app.include_router(plugins_router.router)
     app.include_router(quality_router.router)
     app.include_router(controller_router.router)
     app.include_router(identity_router.router)

--- a/packages/python/goldenmatch/goldenmatch/web/routers/memory.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/memory.py
@@ -11,10 +11,12 @@ label → mirror → browse → learn → next run picks up adjustments.
 """
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
 
 from goldenmatch._api import get_memory, learn, memory_stats
 from goldenmatch.core.memory.store import Correction
@@ -44,7 +46,120 @@ def _serialize_correction(c: Correction) -> dict[str, Any]:
         "reason": c.reason,
         "dataset": c.dataset,
         "created_at": c.created_at.isoformat() if c.created_at else None,
+        # v1.19.0 field-level Correction fields (#437)
+        "field_name": getattr(c, "field_name", None),
+        "original_value": getattr(c, "original_value", None),
+        "corrected_value": getattr(c, "corrected_value", None),
     }
+
+
+# v1.19.0 -- Phase 2: POST /corrections (#437 surface sync)
+
+
+class CorrectionCreate(BaseModel):
+    """Pair-level OR field-level correction request body.
+
+    Pair-level requires `id_a` + `id_b` + `decision in {approve, reject}`.
+    Field-level requires `cluster_id` + `field_name` + `corrected_value`
+    + `decision="field_correct"`.
+
+    `dataset` required for both. `source` defaults to 'rest' (trust 0.8).
+    """
+    decision: str = Field(..., description="approve | reject | field_correct")
+    dataset: str
+    id_a: int | None = None
+    id_b: int | None = None
+    cluster_id: int | None = None
+    field_name: str | None = None
+    original_value: str | None = None
+    corrected_value: str | None = None
+    reason: str | None = None
+    matchkey_name: str | None = None
+    source: str = Field(default="rest", description="Source tag")
+
+
+@router.post("/corrections", status_code=201)
+def create_correction(body: CorrectionCreate) -> dict[str, Any]:
+    """File a pair-level or field-level Correction into Learning Memory."""
+    from goldenmatch.core.memory.store import (
+        HIGH_TRUST_SOURCES,
+        _canon_pair,
+    )
+    from goldenmatch.core.memory.store import (
+        Correction as CorrectionDC,
+    )
+
+    if body.decision not in ("approve", "reject", "field_correct"):
+        raise HTTPException(
+            400,
+            detail=f"Invalid decision: {body.decision!r}",
+        )
+    if not body.dataset:
+        raise HTTPException(400, detail="dataset is required")
+
+    # Trust derived from source: HIGH_TRUST_SOURCES = 1.0, else 0.5.
+    # REST defaults to 0.8 -- between agent (0.5) and human steward (1.0).
+    if body.source == "rest":
+        trust = 0.8
+    elif body.source in {s.value for s in HIGH_TRUST_SOURCES}:
+        trust = 1.0
+    else:
+        trust = 0.5
+
+    if body.decision == "field_correct":
+        if not body.field_name:
+            raise HTTPException(400, detail="field_correct requires field_name")
+        if body.corrected_value is None:
+            raise HTTPException(
+                400, detail="field_correct requires corrected_value",
+            )
+        cid = body.cluster_id if body.cluster_id is not None else (body.id_a or 0)
+        correction = CorrectionDC(
+            id=str(uuid.uuid4()),
+            id_a=cid,
+            id_b=0,
+            decision=body.decision,
+            source=body.source,
+            trust=trust,
+            field_hash="",
+            record_hash="",
+            original_score=0.0,
+            matchkey_name=body.matchkey_name,
+            reason=body.reason,
+            dataset=body.dataset,
+            created_at=datetime.now(UTC),
+            field_name=body.field_name,
+            original_value=body.original_value,
+            corrected_value=body.corrected_value,
+        )
+    else:
+        if body.id_a is None or body.id_b is None:
+            raise HTTPException(
+                400, detail=f"{body.decision} requires id_a and id_b",
+            )
+        ca, cb = _canon_pair(body.id_a, body.id_b)
+        correction = CorrectionDC(
+            id=str(uuid.uuid4()),
+            id_a=ca,
+            id_b=cb,
+            decision=body.decision,
+            source=body.source,
+            trust=trust,
+            field_hash="",
+            record_hash="",
+            original_score=0.0,
+            matchkey_name=body.matchkey_name,
+            reason=body.reason,
+            dataset=body.dataset,
+            created_at=datetime.now(UTC),
+        )
+
+    store = get_memory()
+    try:
+        store.add_correction(correction)
+    finally:
+        store.close()
+    return _serialize_correction(correction)
 
 
 @router.get("/corrections")

--- a/packages/python/goldenmatch/goldenmatch/web/routers/plugins.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/plugins.py
@@ -1,0 +1,76 @@
+"""GET /api/v1/plugins (#predefined-merge-plugins surface sync, v1.19.0).
+
+Discovery endpoint exposing the 22 v1.18.2 predefined golden-strategy
+plugins plus any user-registered plugins. Each entry includes name,
+category, source (builtin / user), and the first line of the merge
+docstring.
+
+Used by UI dropdowns to populate available golden-strategy options.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Query
+
+router = APIRouter(prefix="/api/v1/plugins")
+
+
+def _build_response(category: str = "all") -> dict[str, list[dict[str, Any]]]:
+    """Helper -- module-level so the endpoint can call it AND tests can too."""
+    from goldenmatch.plugins.builtin import BUILTIN_PLUGINS
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    registry = PluginRegistry.instance()
+    registry.discover()
+    builtin_names = {cls().name for cls in BUILTIN_PLUGINS}
+
+    def _serialize(plugin_dict: dict, kind: str) -> list[dict]:
+        out: list[dict] = []
+        for plugin_name, plugin in plugin_dict.items():
+            merge_doc = ""
+            if hasattr(plugin, "merge") and plugin.merge.__doc__:
+                merge_doc = plugin.merge.__doc__.strip().split("\n")[0][:200]
+            out.append({
+                "name": plugin_name,
+                "category": kind,
+                "source": (
+                    "builtin"
+                    if (kind == "golden_strategy" and plugin_name in builtin_names)
+                    else "user"
+                ),
+                "doc": merge_doc,
+            })
+        # Builtins first, then user; alphabetical within each.
+        return sorted(out, key=lambda d: (d["source"] != "builtin", d["name"]))
+
+    result: dict[str, list[dict[str, Any]]] = {}
+    kinds = (
+        ("golden_strategy", "_golden_strategies"),
+        ("scorer", "_scorers"),
+        ("transform", "_transforms"),
+        ("connector", "_connectors"),
+    )
+    for kind, attr in kinds:
+        if category not in ("all", kind):
+            continue
+        store_dict = getattr(registry, attr, {})
+        result[kind] = _serialize(store_dict, kind)
+    return result
+
+
+@router.get("")
+def list_plugins(
+    category: str = Query(
+        "all",
+        description="Filter to one category, or 'all'",
+        pattern="^(all|golden_strategy|scorer|transform|connector)$",
+    ),
+) -> dict[str, list[dict[str, Any]]]:
+    """List all registered goldenmatch plugins by category.
+
+    Includes the 22 v1.18.2 predefined golden-strategy plugins
+    (numeric / format / business / aggregation) plus any
+    user-registered plugins.
+    """
+    return _build_response(category=category)

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.18.2"
+version = "1.19.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/tests/web/test_phase2_rest_crud.py
+++ b/packages/python/goldenmatch/tests/web/test_phase2_rest_crud.py
@@ -1,0 +1,205 @@
+"""Tests for Phase 2 of v1.19.0 surface-sync roadmap.
+
+Spec: docs/superpowers/specs/2026-05-22-phase-2-rest-api-crud-design.md
+
+Covers:
+- 2.1 POST /api/v1/memory/corrections (pair + field shapes; validation)
+- 2.2 GET /api/v1/plugins (22 builtins + category filter + user override)
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch) -> TestClient:
+    """Build an isolated TestClient with a fresh memory DB per test."""
+    from goldenmatch.web.app import create_app
+    from goldenmatch.web.state import AppState
+
+    db_path = tmp_path / "memory.db"
+    # Re-route default memory DB path through env so get_memory() picks it up.
+    monkeypatch.setenv("GOLDENMATCH_MEMORY_PATH", str(db_path))
+    # CWD-relative path for any code using it.
+    monkeypatch.chdir(tmp_path)
+
+    state = AppState.from_project_dir(tmp_path)
+    app = create_app(state)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# 2.1 POST /api/v1/memory/corrections
+# ---------------------------------------------------------------------------
+
+
+def test_post_correction_pair_level(client: TestClient):
+    payload = {
+        "decision": "approve",
+        "dataset": "test_dataset",
+        "id_a": 42,
+        "id_b": 99,
+        "reason": "verified by analyst",
+    }
+    resp = client.post("/api/v1/memory/corrections", json=payload)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["decision"] == "approve"
+    assert body["id_a"] == 42
+    assert body["id_b"] == 99
+    assert body["source"] == "rest"
+    assert body["trust"] == 0.8
+
+
+def test_post_correction_field_level(client: TestClient):
+    payload = {
+        "decision": "field_correct",
+        "dataset": "test_dataset",
+        "cluster_id": 42,
+        "field_name": "address1",
+        "original_value": "1 Elm St",
+        "corrected_value": "1 Elm Street, Apt 4B",
+    }
+    resp = client.post("/api/v1/memory/corrections", json=payload)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["decision"] == "field_correct"
+    assert body["field_name"] == "address1"
+    assert body["corrected_value"] == "1 Elm Street, Apt 4B"
+    assert body["original_value"] == "1 Elm St"
+
+
+def test_post_correction_pair_missing_id_b(client: TestClient):
+    resp = client.post(
+        "/api/v1/memory/corrections",
+        json={"decision": "approve", "dataset": "test", "id_a": 42},
+    )
+    assert resp.status_code == 400
+    assert "id_a and id_b" in resp.text
+
+
+def test_post_correction_field_missing_corrected_value(client: TestClient):
+    resp = client.post(
+        "/api/v1/memory/corrections",
+        json={
+            "decision": "field_correct",
+            "dataset": "test",
+            "cluster_id": 42,
+            "field_name": "address1",
+        },
+    )
+    assert resp.status_code == 400
+    assert "corrected_value" in resp.text
+
+
+def test_post_correction_field_missing_field_name(client: TestClient):
+    resp = client.post(
+        "/api/v1/memory/corrections",
+        json={
+            "decision": "field_correct",
+            "dataset": "test",
+            "cluster_id": 42,
+            "corrected_value": "X",
+        },
+    )
+    assert resp.status_code == 400
+    assert "field_name" in resp.text
+
+
+def test_post_correction_invalid_decision(client: TestClient):
+    resp = client.post(
+        "/api/v1/memory/corrections",
+        json={"decision": "shrug", "dataset": "test"},
+    )
+    assert resp.status_code == 400
+
+
+def test_post_correction_appears_in_list(client: TestClient):
+    """Post + GET roundtrip in the same TestClient session."""
+    client.post(
+        "/api/v1/memory/corrections",
+        json={
+            "decision": "field_correct",
+            "dataset": "test",
+            "cluster_id": 42,
+            "field_name": "email",
+            "corrected_value": "fixed@x.com",
+        },
+    )
+    resp = client.get("/api/v1/memory/corrections", params={"dataset": "test"})
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["field_name"] == "email"
+    assert items[0]["corrected_value"] == "fixed@x.com"
+
+
+# ---------------------------------------------------------------------------
+# 2.2 GET /api/v1/plugins
+# ---------------------------------------------------------------------------
+
+
+def test_get_plugins_default_returns_all_categories(client: TestClient):
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    PluginRegistry.reset()
+    resp = client.get("/api/v1/plugins")
+    PluginRegistry.reset()
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "golden_strategy" in body
+    # 22 v1.18.2 builtin plugins (+ any test contamination)
+    names = {p["name"] for p in body["golden_strategy"]}
+    for expected in (
+        "numeric_max", "numeric_mean", "email_normalize",
+        "phone_digits_only", "system_of_record", "lifecycle_stage",
+        "agreement_rate", "count_distinct",
+    ):
+        assert expected in names, f"{expected} not in /plugins response"
+
+
+def test_get_plugins_category_filter(client: TestClient):
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    PluginRegistry.reset()
+    resp = client.get(
+        "/api/v1/plugins", params={"category": "golden_strategy"},
+    )
+    PluginRegistry.reset()
+    assert resp.status_code == 200
+    assert set(resp.json().keys()) == {"golden_strategy"}
+
+
+def test_get_plugins_each_entry_has_required_fields(client: TestClient):
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    PluginRegistry.reset()
+    resp = client.get("/api/v1/plugins")
+    PluginRegistry.reset()
+    for entry in resp.json()["golden_strategy"]:
+        assert "name" in entry
+        assert "category" in entry
+        assert "source" in entry
+        assert "doc" in entry
+
+
+def test_get_plugins_marks_builtin_source(client: TestClient):
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    PluginRegistry.reset()
+    resp = client.get("/api/v1/plugins")
+    PluginRegistry.reset()
+    for entry in resp.json()["golden_strategy"]:
+        if entry["name"] in {"numeric_max", "email_normalize"}:
+            assert entry["source"] == "builtin"
+
+
+def test_get_plugins_invalid_category(client: TestClient):
+    resp = client.get("/api/v1/plugins", params={"category": "bogus"})
+    # FastAPI Query pattern validation returns 422 on regex mismatch.
+    assert resp.status_code == 422
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Phase 2 of v1.18 surface-sync roadmap. REST API parity for v1.18.2's field-level Corrections + 22 plugins. Unblocks the #437 Next.js review-queue use case.

## Deliverables (~400 LOC)

- `POST /api/v1/memory/corrections` -- pair AND field shapes; `source='rest'` trust=0.8
- `GET /api/v1/plugins` -- discovery endpoint; category filter; builtin/user tagging
- `GET /api/v1/memory/corrections` -- response gains field-level fields

## Test plan

- [x] 12 tests in tests/web/test_phase2_rest_crud.py
- [x] uv run ruff check clean
- CI is the gate

## Cuts v1.19.0 on merge

Spec: `docs/superpowers/specs/2026-05-22-phase-2-rest-api-crud-design.md`