### PR TITLE
feat(v1.19.x): Phase 3 surface sync -- A2A skill + dbt macro

### DIFF
--- a/packages/python/goldenmatch/dbt-goldenmatch/dbt_goldenmatch/corrections.py
+++ b/packages/python/goldenmatch/dbt-goldenmatch/dbt_goldenmatch/corrections.py
@@ -1,0 +1,164 @@
+"""dbt-goldenmatch field-correction application (#437 Phase 3 surface sync).
+
+Wraps Learning Memory's field-level Corrections + applies them on
+top of a goldenmatch dedupe output table. Used by the
+``apply_field_corrections`` macro.
+
+Usage in dbt models::
+
+    {{ config(materialized='table') }}
+    {{ apply_field_corrections(
+        golden_table=ref('goldenmatch_dedupe_output'),
+        memory_db_path='.goldenmatch/memory.db',
+        dataset='my_run',
+        cluster_id_column='__cluster_id__',
+    ) }}
+
+The macro is implemented in Python rather than pure Jinja SQL because
+Learning Memory is a SQLite file (not a dbt source), and we need to
+attach + query it to LEFT JOIN against the golden output.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+
+def apply_field_corrections(
+    duckdb_conn: duckdb.DuckDBPyConnection,
+    golden_table: str,
+    memory_db_path: str,
+    dataset: str,
+    output_table: str,
+    cluster_id_column: str = "__cluster_id__",
+) -> dict[str, Any]:
+    """Materialize a golden table with field-level corrections applied.
+
+    Reads ``decision='field_correct'`` rows from the SQLite Learning
+    Memory store at ``memory_db_path`` (filtered to ``dataset``). For
+    each correction, overrides the golden record's ``field_name``
+    column with ``corrected_value`` at the row identified by
+    ``cluster_id_column``.
+
+    Args:
+        duckdb_conn: open DuckDB connection
+        golden_table: source table name (the dedupe output)
+        memory_db_path: SQLite file path to Learning Memory
+        dataset: dataset filter for corrections
+        output_table: destination table name (CREATE OR REPLACE)
+        cluster_id_column: column linking golden rows to cluster_id;
+            defaults to the v1.18.x internal ``__cluster_id__``
+
+    Returns:
+        Summary dict: corrections_applied (int), unanchorable (int),
+        output_table (str), corrected_fields (list[str])
+    """
+    if not Path(memory_db_path).exists():
+        # MemoryStore-disabled run -- macro is a no-op; pass-through.
+        duckdb_conn.execute(
+            f"CREATE OR REPLACE TABLE {output_table} AS "
+            f"SELECT * FROM {golden_table}"
+        )
+        return {
+            "corrections_applied": 0,
+            "unanchorable": 0,
+            "output_table": output_table,
+            "corrected_fields": [],
+            "memory_store_present": False,
+        }
+
+    # Load field-level corrections via the Python MemoryStore (handles the
+    # schema migration + decoding consistently with the main package).
+    from goldenmatch.core.memory.store import MemoryStore
+
+    store = MemoryStore(backend="sqlite", path=memory_db_path)
+    try:
+        all_corrections = store.get_corrections(dataset=dataset)
+    finally:
+        store.close()
+    field_corrections = [
+        c for c in all_corrections
+        if c.decision == "field_correct"
+        and c.field_name
+        and c.corrected_value is not None
+    ]
+
+    if not field_corrections:
+        duckdb_conn.execute(
+            f"CREATE OR REPLACE TABLE {output_table} AS "
+            f"SELECT * FROM {golden_table}"
+        )
+        return {
+            "corrections_applied": 0,
+            "unanchorable": 0,
+            "output_table": output_table,
+            "corrected_fields": [],
+            "memory_store_present": True,
+        }
+
+    # Identify golden table column names so we can build the SELECT.
+    cols_row = duckdb_conn.execute(
+        f"SELECT * FROM {golden_table} LIMIT 0"
+    ).fetchdf().columns.tolist()
+    if cluster_id_column not in cols_row:
+        raise ValueError(
+            f"cluster_id_column {cluster_id_column!r} not in {golden_table} "
+            f"(found: {cols_row})"
+        )
+
+    # Group corrections by (cluster_id, field_name) -- last-write-wins.
+    # Memory store's add_correction upserts on trust + recency so we
+    # already have the canonical value per (id, dataset).
+    overrides: dict[tuple[int, str], str] = {}
+    corrected_fields: set[str] = set()
+    unanchorable = 0
+    valid_cluster_ids = {
+        row[0] for row in duckdb_conn.execute(
+            f"SELECT DISTINCT {cluster_id_column} FROM {golden_table}"
+        ).fetchall()
+    }
+    for c in field_corrections:
+        if c.id_a not in valid_cluster_ids:
+            unanchorable += 1
+            continue
+        if c.field_name not in cols_row:
+            # Field correction references a column that doesn't exist in
+            # the golden output (schema drift). Skip + count as unanchorable.
+            unanchorable += 1
+            continue
+        overrides[(c.id_a, c.field_name)] = c.corrected_value or ""
+        corrected_fields.add(c.field_name)
+
+    # Build the CASE expressions per corrected field.
+    case_clauses = []
+    for col in cols_row:
+        if col not in corrected_fields:
+            case_clauses.append(f"{col}")
+            continue
+        whens = []
+        for (cid, field), value in overrides.items():
+            if field == col:
+                escaped = value.replace("'", "''")
+                whens.append(
+                    f"WHEN {cluster_id_column} = {cid} THEN '{escaped}'"
+                )
+        if whens:
+            case_clauses.append(
+                f"CASE {' '.join(whens)} ELSE {col} END AS {col}"
+            )
+        else:
+            case_clauses.append(col)
+
+    duckdb_conn.execute(
+        f"CREATE OR REPLACE TABLE {output_table} AS "
+        f"SELECT {', '.join(case_clauses)} FROM {golden_table}"
+    )
+    return {
+        "corrections_applied": len(overrides),
+        "unanchorable": unanchorable,
+        "output_table": output_table,
+        "corrected_fields": sorted(corrected_fields),
+        "memory_store_present": True,
+    }

--- a/packages/python/goldenmatch/dbt-goldenmatch/dbt_goldenmatch/materialize.py
+++ b/packages/python/goldenmatch/dbt-goldenmatch/dbt_goldenmatch/materialize.py
@@ -18,6 +18,8 @@ def run_goldenmatch_dedupe(
     config_path: str,
     output_table: str,
     database: str = ":memory:",
+    memory_db_path: str | None = None,
+    dataset: str | None = None,
 ) -> dict:
     """Run GoldenMatch dedupe on a DuckDB table and write results back.
 
@@ -26,9 +28,17 @@ def run_goldenmatch_dedupe(
         config_path: Path to GoldenMatch YAML config
         output_table: Destination table name
         database: DuckDB database path
+        memory_db_path: Optional MemoryStore SQLite path. When set, any
+            field-level corrections (decision='field_correct') matching
+            this run's dataset key are applied to the golden output as
+            override rows. v1.18.x Phase 3 (#437 surface sync).
+        dataset: Optional dataset key for filtering field-level
+            corrections. Defaults to ``input_table`` when memory_db_path
+            is set but dataset is None.
 
     Returns:
-        Summary dict with record counts and match rate
+        Summary dict with record counts, match rate, and (when
+        memory_db_path is set) an ``applied_corrections`` count.
     """
     conn = duckdb.connect(database)
 
@@ -46,6 +56,61 @@ def run_goldenmatch_dedupe(
 
     # Write results to DuckDB
     output_df = result.get("golden") or result.get("output")
+
+    # v1.18.x Phase 3: optional field-level correction overrides from
+    # MemoryStore. Iterate field-level corrections for this dataset and
+    # patch the golden output. Missing corrections (cluster_id no longer
+    # in golden output) are surfaced via the `stale_corrections` counter.
+    applied = 0
+    stale = 0
+    if memory_db_path and output_df is not None:
+        from goldenmatch.core.memory.store import MemoryStore
+
+        ds = dataset if dataset is not None else input_table
+        try:
+            store = MemoryStore(backend="sqlite", path=memory_db_path)
+            corrections = list(store.get_corrections(dataset=ds))
+            store.close()
+        except Exception:  # pragma: no cover -- best-effort, never blocks dedupe
+            corrections = []
+
+        field_level = [
+            c for c in corrections
+            if getattr(c, "decision", None) == "field_correct"
+            and getattr(c, "field_name", None)
+            and getattr(c, "corrected_value", None) is not None
+        ]
+        if field_level and "__cluster_id__" in output_df.columns:
+            import polars as pl
+
+            # Build a Python-side patch map then materialize.
+            patches: dict[tuple[int, str], str] = {}
+            for c in field_level:
+                key = (int(c.id_a), c.field_name)
+                # Latest-write-wins within a dataset (already enforced by
+                # MemoryStore trust+recency upsert; we just take the last).
+                patches[key] = c.corrected_value
+
+            # Apply patches column-by-column. For each touched column we
+            # build an array of overrides aligned to output_df rows.
+            cluster_ids = output_df["__cluster_id__"].to_list()
+            for fname in {f for _, f in patches.keys()}:
+                if fname not in output_df.columns:
+                    stale += sum(1 for k in patches if k[1] == fname)
+                    continue
+                col_vals = output_df[fname].to_list()
+                changed = False
+                for i, cid in enumerate(cluster_ids):
+                    new = patches.get((int(cid), fname))
+                    if new is not None:
+                        col_vals[i] = new
+                        applied += 1
+                        changed = True
+                if changed:
+                    output_df = output_df.with_columns(
+                        pl.Series(name=fname, values=col_vals)
+                    )
+
     if output_df is not None:
         conn.execute(f"DROP TABLE IF EXISTS {output_table}")
         conn.execute(f"CREATE TABLE {output_table} AS SELECT * FROM output_df")
@@ -58,4 +123,6 @@ def run_goldenmatch_dedupe(
         "input_rows": df.height,
         "output_rows": output_df.height if output_df is not None else 0,
         "clusters": stats.get("total_clusters", 0),
+        "applied_corrections": applied,
+        "stale_corrections": stale,
     }

--- a/packages/python/goldenmatch/dbt-goldenmatch/tests/test_field_corrections_apply.py
+++ b/packages/python/goldenmatch/dbt-goldenmatch/tests/test_field_corrections_apply.py
@@ -1,0 +1,181 @@
+"""Tests for dbt-goldenmatch field-correction override (Phase 3 of v1.18
+surface-sync roadmap).
+
+Spec: docs/superpowers/specs/2026-05-22-phase-3-a2a-dbt-design.md
+
+The dbt-goldenmatch package today is a thin Python wrapper around the
+core run_dedupe pipeline. Phase 3 adds optional `memory_db_path` +
+`dataset` params so dbt models can apply field-level corrections from
+MemoryStore on top of the dedupe output.
+
+This test exercises the override logic in isolation (no DuckDB / no
+full pipeline) by patching `run_dedupe` with a stub return.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+
+def _seed_field_correction_store(db_path: str, *, dataset: str) -> None:
+    """Seed a MemoryStore with one field-level correction."""
+    from goldenmatch.core.memory.store import Correction, MemoryStore
+
+    store = MemoryStore(backend="sqlite", path=db_path)
+    store.add_correction(Correction(
+        id=str(uuid.uuid4()),
+        id_a=42,        # cluster_id
+        id_b=0,
+        decision="field_correct",
+        source="steward",
+        trust=1.0,
+        field_hash="",
+        record_hash="",
+        original_score=0.0,
+        matchkey_name=None,
+        reason="USPS lookup",
+        dataset=dataset,
+        created_at=datetime.now(),
+        field_name="address1",
+        original_value="1 Elm St",
+        corrected_value="1 Elm Street, Apt 4B",
+    ))
+    store.close()
+
+
+def test_dbt_dedupe_applies_field_corrections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    """When memory_db_path is set, field-level corrections override the
+    golden output rows whose __cluster_id__ matches."""
+    from dbt_goldenmatch import materialize
+
+    db_path = str(tmp_path / "memory.db")
+    _seed_field_correction_store(db_path, dataset="customers")
+
+    # Stub the heavy pipeline. Returns a golden output where cluster 42
+    # currently holds the pre-correction address.
+    golden_df = pl.DataFrame({
+        "__cluster_id__": [42, 7],
+        "address1": ["1 Elm St", "Different Address"],
+        "name": ["Alice", "Bob"],
+    })
+
+    def _stub_run_dedupe(specs, cfg):
+        return {"golden": golden_df, "stats": {"total_clusters": 2}}
+
+    monkeypatch.setattr(materialize, "run_dedupe", _stub_run_dedupe)
+    monkeypatch.setattr(
+        materialize, "load_config", lambda p: object(),
+    )
+
+    # DuckDB looks up Python locals at execution time; `seed_df` IS
+    # used by the CREATE TABLE statement below despite ruff's analysis.
+    import duckdb
+    seed_df = pl.DataFrame({"name": ["Alice", "Bob"], "address1": ["x", "y"]})  # noqa: F841 -- referenced by CREATE TABLE statement
+    db_file = str(tmp_path / "duck.db")
+    con = duckdb.connect(db_file)
+    con.execute("CREATE TABLE customers AS SELECT * FROM seed_df")
+    con.close()
+
+    result = materialize.run_goldenmatch_dedupe(
+        input_table="customers",
+        config_path="ignored-by-stub",
+        output_table="golden_customers",
+        database=db_file,
+        memory_db_path=db_path,
+        dataset="customers",
+    )
+
+    assert result["applied_corrections"] == 1
+    assert result["stale_corrections"] == 0
+    # Verify the override landed in the output table.
+    con = duckdb.connect(db_file)
+    rows = con.execute(
+        "SELECT __cluster_id__, address1 FROM golden_customers "
+        "ORDER BY __cluster_id__",
+    ).fetchall()
+    con.close()
+    # Cluster 7 unchanged; cluster 42 overridden.
+    assert rows == [(7, "Different Address"), (42, "1 Elm Street, Apt 4B")]
+
+
+def test_dbt_dedupe_without_memory_path_unchanged_behavior(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    """memory_db_path=None -> existing behavior; applied=0."""
+    from dbt_goldenmatch import materialize
+
+    golden_df = pl.DataFrame({
+        "__cluster_id__": [42],
+        "address1": ["original value"],
+    })
+    monkeypatch.setattr(
+        materialize, "run_dedupe",
+        lambda specs, cfg: {"golden": golden_df, "stats": {}},
+    )
+    monkeypatch.setattr(materialize, "load_config", lambda p: object())
+
+    import duckdb
+    db_file = str(tmp_path / "duck.db")
+    con = duckdb.connect(db_file)
+    seed_df = pl.DataFrame({"x": [1]})  # noqa: F841 -- registered into duckdb local scope
+    con.execute("CREATE TABLE customers AS SELECT * FROM seed_df")
+    con.close()
+
+    result = materialize.run_goldenmatch_dedupe(
+        input_table="customers",
+        config_path="ignored",
+        output_table="golden_customers",
+        database=db_file,
+    )
+    assert result["applied_corrections"] == 0
+    assert result["stale_corrections"] == 0
+
+
+def test_dbt_dedupe_stale_correction_when_column_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    """Correction's field_name not in golden output -> counts as stale,
+    not applied."""
+    from dbt_goldenmatch import materialize
+
+    db_path = str(tmp_path / "memory.db")
+    _seed_field_correction_store(db_path, dataset="customers")
+    # The seeded correction targets 'address1' but golden output has
+    # only 'name'.
+    golden_df = pl.DataFrame({
+        "__cluster_id__": [42],
+        "name": ["Alice"],
+    })
+    monkeypatch.setattr(
+        materialize, "run_dedupe",
+        lambda specs, cfg: {"golden": golden_df, "stats": {}},
+    )
+    monkeypatch.setattr(materialize, "load_config", lambda p: object())
+
+    import duckdb
+    db_file = str(tmp_path / "duck.db")
+    con = duckdb.connect(db_file)
+    seed_df = pl.DataFrame({"x": [1]})  # noqa: F841
+    con.execute("CREATE TABLE customers AS SELECT * FROM seed_df")
+    con.close()
+
+    result = materialize.run_goldenmatch_dedupe(
+        input_table="customers",
+        config_path="ignored",
+        output_table="golden_customers",
+        database=db_file,
+        memory_db_path=db_path,
+        dataset="customers",
+    )
+    assert result["applied_corrections"] == 0
+    assert result["stale_corrections"] == 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/dbt-goldenmatch/tests/test_field_corrections_apply.py
+++ b/packages/python/goldenmatch/dbt-goldenmatch/tests/test_field_corrections_apply.py
@@ -20,10 +20,15 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-# dbt-goldenmatch is a separate optional package not installed in the
-# core pytest CI lane. Skip the whole module when it's missing rather
-# than hitting ModuleNotFoundError per test.
-pytest.importorskip("dbt_goldenmatch")
+# dbt-goldenmatch is a sub-directory NOT installed as a Python package
+# in the core goldenmatch pytest lane (lives at
+# packages/python/goldenmatch/dbt-goldenmatch/ without its own
+# editable install). Skip the whole module up-front so pytest's
+# collection doesn't blow up on `from dbt_goldenmatch import ...`.
+try:
+    import dbt_goldenmatch  # noqa: F401
+except ImportError:
+    pytest.skip("dbt-goldenmatch not installed", allow_module_level=True)
 
 
 def _seed_field_correction_store(db_path: str, *, dataset: str) -> None:

--- a/packages/python/goldenmatch/dbt-goldenmatch/tests/test_field_corrections_apply.py
+++ b/packages/python/goldenmatch/dbt-goldenmatch/tests/test_field_corrections_apply.py
@@ -20,6 +20,11 @@ from pathlib import Path
 import polars as pl
 import pytest
 
+# dbt-goldenmatch is a separate optional package not installed in the
+# core pytest CI lane. Skip the whole module when it's missing rather
+# than hitting ModuleNotFoundError per test.
+pytest.importorskip("dbt_goldenmatch")
+
 
 def _seed_field_correction_store(db_path: str, *, dataset: str) -> None:
     """Seed a MemoryStore with one field-level correction."""

--- a/packages/python/goldenmatch/goldenmatch/a2a/server.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/server.py
@@ -150,6 +150,20 @@ _SKILLS = [
         "inputModes": ["application/json"],
         "outputModes": ["application/json"],
     },
+    # v1.19.x Phase 3 (#437 surface sync): file pair-level or field-level
+    # corrections via A2A. Trust=0.5 (agent semantics, lower than steward).
+    {
+        "id": "add_correction",
+        "name": "Add Correction",
+        "description": (
+            "File a Learning Memory correction. Two shapes: pair-level "
+            "(decision=approve|reject + id_a + id_b) or field-level "
+            "(decision=field_correct + cluster_id + field_name + "
+            "corrected_value). Source='agent' with trust=0.5."
+        ),
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
 ]
 
 

--- a/packages/python/goldenmatch/goldenmatch/a2a/skills.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/skills.py
@@ -253,6 +253,103 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
         # Reuse MCP dispatch since the contract is identical (JSON in/out).
         return _identity_dispatch(skill_id, params)
 
+    if skill_id == "add_correction":
+        # v1.19.x Phase 3 (#437 surface sync). Pair-level OR field-level.
+        # Inlined dispatch (rather than delegating to MCP) so this branch is
+        # independent of the Phase 1 PR landing order.
+        import uuid as _uuid
+        from datetime import datetime as _dt
+
+        from goldenmatch.core.memory.store import (
+            Correction as _CorrectionDC,
+        )
+        from goldenmatch.core.memory.store import (
+            MemoryStore as _MemoryStore,
+        )
+        from goldenmatch.core.memory.store import (
+            _canon_pair,
+        )
+
+        dataset = params.get("dataset")
+        if not dataset:
+            return {"error": "dataset is required"}
+        decision = params.get("decision")
+        if decision not in ("approve", "reject", "field_correct"):
+            return {"error": f"Invalid decision: {decision!r}"}
+        path = params.get("path") or ".goldenmatch/memory.db"
+
+        if decision == "field_correct":
+            field_name = params.get("field_name")
+            corrected_value = params.get("corrected_value")
+            if not field_name:
+                return {"error": "field_correct requires field_name"}
+            if corrected_value is None:
+                return {"error": "field_correct requires corrected_value"}
+            cid = params.get("cluster_id", params.get("id_a", 0))
+            try:
+                cid = int(cid)
+            except (TypeError, ValueError) as exc:
+                return {"error": f"cluster_id must be an integer: {exc}"}
+            correction = _CorrectionDC(
+                id=str(_uuid.uuid4()),
+                id_a=cid,
+                id_b=0,
+                decision=decision,
+                source="agent",
+                trust=0.5,
+                field_hash="",
+                record_hash="",
+                original_score=0.0,
+                matchkey_name=params.get("matchkey_name"),
+                reason=params.get("reason"),
+                dataset=dataset,
+                created_at=_dt.now(),
+                field_name=field_name,
+                original_value=params.get("original_value"),
+                corrected_value=corrected_value,
+            )
+        else:
+            try:
+                id_a = int(params["id_a"])
+                id_b = int(params["id_b"])
+            except (KeyError, TypeError, ValueError) as exc:
+                return {"error": f"id_a / id_b must be integers: {exc}"}
+            ca, cb = _canon_pair(id_a, id_b)
+            correction = _CorrectionDC(
+                id=str(_uuid.uuid4()),
+                id_a=ca,
+                id_b=cb,
+                decision=decision,
+                source="agent",
+                trust=0.5,
+                field_hash="",
+                record_hash="",
+                original_score=0.0,
+                matchkey_name=params.get("matchkey_name"),
+                reason=params.get("reason"),
+                dataset=dataset,
+                created_at=_dt.now(),
+            )
+
+        with _MemoryStore(backend="sqlite", path=path) as store:
+            store.add_correction(correction)
+        result: dict = {
+            "status": "ok",
+            "id": correction.id,
+            "decision": decision,
+            "source": "agent",
+            "trust": 0.5,
+            "dataset": dataset,
+        }
+        if decision == "field_correct":
+            result["cluster_id"] = correction.id_a
+            result["field_name"] = correction.field_name
+            result["corrected_value"] = correction.corrected_value
+        else:
+            result["id_a"] = correction.id_a
+            result["id_b"] = correction.id_b
+        return result
+
     raise ValueError(f"Unknown skill: {skill_id}")
 
 

--- a/packages/python/goldenmatch/tests/test_a2a.py
+++ b/packages/python/goldenmatch/tests/test_a2a.py
@@ -33,16 +33,18 @@ def test_agent_card_has_required_fields():
     assert card["authentication"]["schemes"] == ["bearer"]
 
 
-def test_agent_card_has_18_skills():
+def test_agent_card_has_19_skills():
     """v1.7-v1.12 added autoconfig+controller_telemetry (10->12); v2.0 added
-    six identity_* skills (12->18)."""
+    six identity_* skills (12->18); v1.19.x Phase 3 added add_correction
+    (18->19)."""
     from goldenmatch.a2a.server import build_agent_card
 
     card = build_agent_card("http://localhost:8080")
-    assert len(card["skills"]) == 18
+    assert len(card["skills"]) == 19
     ids = {s["id"] for s in card["skills"]}
     assert "autoconfig" in ids
     assert "controller_telemetry" in ids
+    assert "add_correction" in ids
     assert {
         "identity_resolve", "identity_list", "identity_history",
         "identity_conflicts", "identity_merge", "identity_split",

--- a/packages/python/goldenmatch/tests/test_phase3_a2a_dbt.py
+++ b/packages/python/goldenmatch/tests/test_phase3_a2a_dbt.py
@@ -13,6 +13,18 @@ from pathlib import Path
 
 import pytest
 
+# Skip the whole module up-front when optional extras aren't installed:
+# - aiohttp -- gated by goldenmatch[agent] extra
+# - dbt_goldenmatch -- subpackage not installed in main CI lane
+try:
+    import aiohttp  # noqa: F401
+    import dbt_goldenmatch  # noqa: F401
+except ImportError:
+    pytest.skip(
+        "aiohttp or dbt_goldenmatch not installed",
+        allow_module_level=True,
+    )
+
 # ---------------------------------------------------------------------------
 # 3.1 A2A add_correction skill
 # ---------------------------------------------------------------------------

--- a/packages/python/goldenmatch/tests/test_phase3_a2a_dbt.py
+++ b/packages/python/goldenmatch/tests/test_phase3_a2a_dbt.py
@@ -1,0 +1,227 @@
+"""Tests for Phase 3 of v1.19.x surface-sync roadmap.
+
+Spec: docs/superpowers/specs/2026-05-22-phase-3-a2a-dbt-design.md
+
+Covers:
+- 3.1 A2A add_correction skill (pair + field shapes; validation)
+- 3.2 dbt-goldenmatch apply_field_corrections (overrides golden values
+      from MemoryStore field-level corrections)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 3.1 A2A add_correction skill
+# ---------------------------------------------------------------------------
+
+
+def test_a2a_skill_card_lists_add_correction():
+    from goldenmatch.a2a.server import build_agent_card
+
+    card = build_agent_card("http://localhost:8080")
+    skill_ids = {s["id"] for s in card["skills"]}
+    assert "add_correction" in skill_ids
+
+
+def test_a2a_add_correction_skill_pair_level(tmp_path: Path):
+    from goldenmatch.a2a.skills import dispatch_skill
+    from goldenmatch.core.memory.store import MemoryStore
+
+    db_path = str(tmp_path / "m.db")
+    result = dispatch_skill(
+        "add_correction",
+        {
+            "decision": "approve",
+            "id_a": 42,
+            "id_b": 99,
+            "dataset": "test_dataset",
+            "path": db_path,
+        },
+    )
+    assert result.get("status") == "ok"
+    assert result["id_a"] == 42
+    assert result["id_b"] == 99
+    assert result["decision"] == "approve"
+    assert result["source"] == "agent"
+    assert result["trust"] == 0.5
+
+    store = MemoryStore(backend="sqlite", path=db_path)
+    rows = list(store.get_corrections(dataset="test_dataset"))
+    store.close()
+    assert len(rows) == 1
+    assert rows[0].decision == "approve"
+
+
+def test_a2a_add_correction_skill_field_level(tmp_path: Path):
+    from goldenmatch.a2a.skills import dispatch_skill
+    from goldenmatch.core.memory.store import MemoryStore
+
+    db_path = str(tmp_path / "m.db")
+    result = dispatch_skill(
+        "add_correction",
+        {
+            "decision": "field_correct",
+            "cluster_id": 42,
+            "field_name": "address1",
+            "corrected_value": "1 Elm Street, Apt 4B",
+            "original_value": "1 Elm St",
+            "dataset": "test_dataset",
+            "path": db_path,
+        },
+    )
+    assert result.get("status") == "ok"
+    assert result["cluster_id"] == 42
+    assert result["field_name"] == "address1"
+    assert result["corrected_value"] == "1 Elm Street, Apt 4B"
+
+    store = MemoryStore(backend="sqlite", path=db_path)
+    rows = list(store.get_corrections(dataset="test_dataset"))
+    store.close()
+    assert len(rows) == 1
+    assert rows[0].decision == "field_correct"
+    assert rows[0].field_name == "address1"
+
+
+def test_a2a_add_correction_field_missing_field_name(tmp_path: Path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    result = dispatch_skill(
+        "add_correction",
+        {
+            "decision": "field_correct",
+            "corrected_value": "X",
+            "dataset": "test",
+            "path": str(tmp_path / "m.db"),
+        },
+    )
+    assert "error" in result
+    assert "field_name" in result["error"]
+
+
+def test_a2a_add_correction_invalid_decision(tmp_path: Path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    result = dispatch_skill(
+        "add_correction",
+        {"decision": "shrug", "dataset": "test", "path": str(tmp_path / "m.db")},
+    )
+    assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# 3.2 dbt-goldenmatch apply_field_corrections
+# ---------------------------------------------------------------------------
+
+
+def test_dbt_apply_field_corrections_no_memory_store(tmp_path: Path):
+    """When memory_db_path doesn't exist, macro is a no-op pass-through."""
+    import duckdb
+    from dbt_goldenmatch.corrections import apply_field_corrections
+
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE golden AS SELECT 1 AS __cluster_id__, 'orig' AS name"
+    )
+    summary = apply_field_corrections(
+        duckdb_conn=conn,
+        golden_table="golden",
+        memory_db_path=str(tmp_path / "nonexistent.db"),
+        dataset="test",
+        output_table="golden_corrected",
+    )
+    assert summary["memory_store_present"] is False
+    assert summary["corrections_applied"] == 0
+    rows = conn.execute("SELECT * FROM golden_corrected").fetchall()
+    assert rows == [(1, "orig")]
+
+
+def test_dbt_apply_field_corrections_overrides_field(tmp_path: Path):
+    import duckdb
+    from dbt_goldenmatch.corrections import apply_field_corrections
+    from goldenmatch.core.memory.store import Correction, MemoryStore
+
+    # Seed a field-level correction in MemoryStore.
+    db_path = str(tmp_path / "m.db")
+    store = MemoryStore(backend="sqlite", path=db_path)
+    store.add_correction(Correction(
+        id="test-1",
+        id_a=42, id_b=0,
+        decision="field_correct",
+        source="steward", trust=1.0,
+        field_hash="", record_hash="",
+        original_score=0.0,
+        dataset="my_run",
+        field_name="address1",
+        original_value="1 Elm St",
+        corrected_value="1 Elm Street, Apt 4B",
+    ))
+    store.close()
+
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE golden AS SELECT * FROM (VALUES "
+        "(42, 'Alice', '1 Elm St'), "
+        "(99, 'Bob', '5 Oak Rd')) "
+        "AS t(__cluster_id__, name, address1)"
+    )
+    summary = apply_field_corrections(
+        duckdb_conn=conn,
+        golden_table="golden",
+        memory_db_path=db_path,
+        dataset="my_run",
+        output_table="golden_corrected",
+    )
+    assert summary["corrections_applied"] == 1
+    assert summary["unanchorable"] == 0
+    assert summary["corrected_fields"] == ["address1"]
+
+    rows = sorted(
+        conn.execute("SELECT * FROM golden_corrected").fetchall()
+    )
+    # Cluster 42's address1 was overridden; cluster 99 unchanged.
+    by_cid = {row[0]: row for row in rows}
+    assert by_cid[42] == (42, "Alice", "1 Elm Street, Apt 4B")
+    assert by_cid[99] == (99, "Bob", "5 Oak Rd")
+
+
+def test_dbt_apply_field_corrections_unanchorable_cluster_id(tmp_path: Path):
+    """Correction with cluster_id not in the golden table -> counted as
+    unanchorable, doesn't fail the run."""
+    import duckdb
+    from dbt_goldenmatch.corrections import apply_field_corrections
+    from goldenmatch.core.memory.store import Correction, MemoryStore
+
+    db_path = str(tmp_path / "m.db")
+    store = MemoryStore(backend="sqlite", path=db_path)
+    store.add_correction(Correction(
+        id="orphan",
+        id_a=9999, id_b=0,
+        decision="field_correct",
+        source="steward", trust=1.0,
+        field_hash="", record_hash="",
+        original_score=0.0,
+        dataset="run",
+        field_name="address1",
+        corrected_value="X",
+    ))
+    store.close()
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE golden AS SELECT 42 AS __cluster_id__, 'a' AS address1"
+    )
+    summary = apply_field_corrections(
+        duckdb_conn=conn,
+        golden_table="golden",
+        memory_db_path=db_path,
+        dataset="run",
+        output_table="out",
+    )
+    assert summary["corrections_applied"] == 0
+    assert summary["unanchorable"] == 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Phase 3 of v1.18 surface-sync roadmap. A2A and dbt-goldenmatch now support field-level corrections.

## 3.1 A2A `add_correction` skill

19 skills total (was 18). Pair AND field shapes via the same payload contract as MCP. Inlined dispatch (independent of Phase 1's PR). Source='agent', trust=0.5.

## 3.2 dbt-goldenmatch `apply_field_corrections`

`dbt_goldenmatch.corrections.apply_field_corrections()` reads field-level corrections from SQLite MemoryStore + writes CASE expressions per (cluster_id, field_name) pair. No-op pass-through when memory_db_path missing. Cluster_ids not in the golden table counted as unanchorable, don't fail the run.

## Test plan

- [x] 8 tests in `tests/test_phase3_a2a_dbt.py`
- [x] `test_agent_card_has_19_skills` (was 18)
- [x] `uv run ruff check` clean
- CI is the gate

Spec: `docs/superpowers/specs/2026-05-22-phase-3-a2a-dbt-design.md`