### PR TITLE
feat(v1.20.0): Phase 4 -- TUI Corrections tab + Golden/Matches modals

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Added -- Phase 4 of v1.18 surface-sync roadmap (TUI)
+
+- **8th tab: Corrections** -- inspect MemoryStore corrections via
+  DataTable + filter-by-dataset + refresh/delete bindings.
+  `tui/tabs/corrections_tab.py`.
+- **`GoldenEditModal`** captures a field-level Correction
+  (`decision="field_correct"`) for Golden tab cells. Save writes to
+  MemoryStore. `tui/screens/golden_edit_modal.py`.
+- **`MatchesCorrectionModal`** captures a pair-level Correction
+  (`decision="approve"|"reject"`) for Matches tab rows. Save writes
+  to MemoryStore. `tui/screens/matches_correction_modal.py`.
+- **`GoldenMatchApp.memory_db_path: str | None`** -- new attribute
+  set by callers (CLI launcher etc.) when memory is enabled. Empty
+  state shown in Corrections tab when None.
+
+Spec: `docs/superpowers/specs/2026-05-22-phase-4-tui-corrections-tab-design.md`
+
 ## [1.19.0] - 2026-05-22
 
 ### Added -- v1.18 surface-sync roadmap (Phases 1 + 2)

--- a/packages/python/goldenmatch/goldenmatch/tui/app.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/app.py
@@ -12,6 +12,7 @@ from goldenmatch.tui.sidebar import Sidebar
 from goldenmatch.tui.tabs.boost_tab import BoostTab
 from goldenmatch.tui.tabs.config_tab import ConfigTab
 from goldenmatch.tui.tabs.controller_tab import ControllerTab
+from goldenmatch.tui.tabs.corrections_tab import CorrectionsTab
 from goldenmatch.tui.tabs.data_tab import DataTab
 from goldenmatch.tui.tabs.export_tab import ExportTab
 from goldenmatch.tui.tabs.golden_tab import GoldenTab
@@ -255,6 +256,10 @@ class GoldenMatchApp(App):
         self.engine = None
         self.current_config = None
         self.last_result = None
+        # Phase 4 (#437 surface sync): MemoryStore path consumed by the
+        # Corrections tab + Golden / Matches modals. Set by callers
+        # (e.g. CLI launcher) when memory is enabled in config.
+        self.memory_db_path: str | None = None
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -276,6 +281,11 @@ class GoldenMatchApp(App):
                         yield ExportTab()
                     with TabPane("Controller", id="tab-controller"):
                         yield ControllerTab()
+                    # Phase 4 of v1.18 surface-sync roadmap (#437):
+                    # inspect Learning Memory corrections + delete /
+                    # filter. Writes happen via Golden + Matches modals.
+                    with TabPane("Corrections", id="tab-corrections"):
+                        yield CorrectionsTab()
         yield Footer()
 
     def on_mount(self) -> None:

--- a/packages/python/goldenmatch/goldenmatch/tui/screens/golden_edit_modal.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/screens/golden_edit_modal.py
@@ -1,0 +1,197 @@
+"""Golden tab inline-edit modal (#437 surface sync, Phase 4).
+
+Spec: docs/superpowers/specs/2026-05-22-phase-4-tui-corrections-tab-design.md
+
+Opens when the operator hits ``e`` on a Golden tab cell. Captures a
+field-level Correction (``decision="field_correct"``) and writes it
+to MemoryStore. Returns the Correction on save, None on cancel.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, Static
+
+
+class GoldenEditModal(ModalScreen):
+    """Inline-edit modal that captures a field-level correction.
+
+    Use via:
+        result = await self.app.push_screen_wait(
+            GoldenEditModal(
+                cluster_id=42, field_name="address1",
+                original_value="1 Elm St", dataset="customers",
+            )
+        )
+
+    Returns:
+        The created Correction on save, None on cancel.
+    """
+
+    DEFAULT_CSS = """
+    GoldenEditModal {
+        align: center middle;
+    }
+    #modal-body {
+        background: $panel;
+        border: thick $primary;
+        padding: 1 2;
+        width: 70;
+        height: auto;
+    }
+    #modal-title {
+        text-style: bold;
+        color: $accent;
+        margin-bottom: 1;
+    }
+    .modal-row {
+        height: auto;
+        margin-bottom: 1;
+    }
+    .field-label {
+        color: $text-muted;
+        width: 16;
+    }
+    #modal-original {
+        color: $text-muted;
+    }
+    Input {
+        width: 1fr;
+    }
+    #modal-actions {
+        height: auto;
+        margin-top: 1;
+    }
+    #modal-actions Button {
+        margin: 0 1;
+    }
+    """
+
+    BINDINGS = [
+        ("ctrl+s", "save", "Save"),
+        ("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(
+        self,
+        *,
+        cluster_id: int,
+        field_name: str,
+        original_value: str,
+        dataset: str,
+        source: str = "steward",
+    ) -> None:
+        super().__init__()
+        self.cluster_id = int(cluster_id)
+        self.field_name = field_name
+        self.original_value = original_value
+        self.dataset = dataset
+        self.source = source
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="modal-body"):
+            yield Static(
+                f"Edit golden field: {self.field_name} (cluster {self.cluster_id})",
+                id="modal-title",
+            )
+            with Horizontal(classes="modal-row"):
+                yield Label("Original:", classes="field-label")
+                yield Static(self.original_value or "(empty)", id="modal-original")
+            with Horizontal(classes="modal-row"):
+                yield Label("Corrected:", classes="field-label")
+                yield Input(
+                    value=self.original_value or "",
+                    id="modal-corrected-input",
+                )
+            with Horizontal(classes="modal-row"):
+                yield Label("Reason:", classes="field-label")
+                yield Input(placeholder="optional", id="modal-reason-input")
+            with Horizontal(id="modal-actions"):
+                yield Button("Save (Ctrl+S)", id="modal-save", variant="primary")
+                yield Button("Cancel (Esc)", id="modal-cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "modal-save":
+            self.action_save()
+        elif event.button.id == "modal-cancel":
+            self.action_cancel()
+
+    def action_save(self) -> None:
+        corrected = self.query_one("#modal-corrected-input", Input).value
+        reason_input = self.query_one("#modal-reason-input", Input).value
+        correction = _build_correction(
+            cluster_id=self.cluster_id,
+            field_name=self.field_name,
+            original_value=self.original_value,
+            corrected_value=corrected,
+            dataset=self.dataset,
+            source=self.source,
+            reason=reason_input or None,
+        )
+        store = _get_store(self.app)
+        if store is not None:
+            try:
+                store.add_correction(correction)
+            finally:
+                try:
+                    store.close()
+                except Exception:
+                    pass
+        self.dismiss(correction)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+def _build_correction(
+    *,
+    cluster_id: int,
+    field_name: str,
+    original_value: str,
+    corrected_value: str,
+    dataset: str,
+    source: str,
+    reason: str | None,
+) -> Any:
+    """Construct a field-level Correction. Lazy import to keep
+    importing this module cheap when goldenmatch is not installed."""
+    from goldenmatch.core.memory.store import (
+        HIGH_TRUST_SOURCES,
+        Correction,
+    )
+
+    trust = 1.0 if source in {s.value for s in HIGH_TRUST_SOURCES} else 0.5
+    return Correction(
+        id=str(uuid.uuid4()),
+        id_a=cluster_id,
+        id_b=0,
+        decision="field_correct",
+        source=source,
+        trust=trust,
+        field_hash="",
+        record_hash="",
+        original_score=0.0,
+        matchkey_name=None,
+        reason=reason,
+        dataset=dataset,
+        created_at=datetime.now(),
+        field_name=field_name,
+        original_value=original_value,
+        corrected_value=corrected_value,
+    )
+
+
+def _get_store(app: Any) -> Any:
+    path = getattr(app, "memory_db_path", None)
+    if not path:
+        return None
+    try:
+        from goldenmatch.core.memory.store import MemoryStore
+        return MemoryStore(backend="sqlite", path=path)
+    except Exception:
+        return None

--- a/packages/python/goldenmatch/goldenmatch/tui/screens/matches_correction_modal.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/screens/matches_correction_modal.py
@@ -1,0 +1,184 @@
+"""Matches tab pair-correction modal (#437 surface sync, Phase 4).
+
+Spec: docs/superpowers/specs/2026-05-22-phase-4-tui-corrections-tab-design.md
+
+Opens when the operator hits ``c`` on a Matches tab row. Captures a
+pair-level Correction (``decision="approve"`` or ``"reject"``) and
+writes it to MemoryStore. Returns the Correction on save, None on
+cancel.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, RadioButton, RadioSet, Static
+
+
+class MatchesCorrectionModal(ModalScreen):
+    """Pair-correction modal: approve / reject + optional reason."""
+
+    DEFAULT_CSS = """
+    MatchesCorrectionModal {
+        align: center middle;
+    }
+    #modal-body {
+        background: $panel;
+        border: thick $primary;
+        padding: 1 2;
+        width: 60;
+        height: auto;
+    }
+    #modal-title {
+        text-style: bold;
+        color: $accent;
+        margin-bottom: 1;
+    }
+    .modal-row {
+        height: auto;
+        margin-bottom: 1;
+    }
+    .field-label {
+        color: $text-muted;
+        width: 12;
+    }
+    Input {
+        width: 1fr;
+    }
+    #modal-actions {
+        height: auto;
+        margin-top: 1;
+    }
+    #modal-actions Button {
+        margin: 0 1;
+    }
+    """
+
+    BINDINGS = [
+        ("ctrl+s", "save", "Save"),
+        ("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(
+        self,
+        *,
+        id_a: int,
+        id_b: int,
+        score: float | None = None,
+        dataset: str,
+        matchkey_name: str | None = None,
+        source: str = "steward",
+    ) -> None:
+        super().__init__()
+        self.id_a = int(id_a)
+        self.id_b = int(id_b)
+        self.score = score
+        self.dataset = dataset
+        self.matchkey_name = matchkey_name
+        self.source = source
+
+    def compose(self) -> ComposeResult:
+        score_text = (
+            f"current score: {self.score:.2f}" if self.score is not None else ""
+        )
+        with Vertical(id="modal-body"):
+            yield Static(
+                f"Correct pair: row {self.id_a} <-> row {self.id_b}    {score_text}",
+                id="modal-title",
+            )
+            with Horizontal(classes="modal-row"):
+                yield Label("Decision:", classes="field-label")
+                with RadioSet(id="modal-decision-set"):
+                    yield RadioButton("Approve (these ARE the same)", value=True, id="modal-decision-approve")
+                    yield RadioButton("Reject (these are NOT the same)", id="modal-decision-reject")
+            with Horizontal(classes="modal-row"):
+                yield Label("Reason:", classes="field-label")
+                yield Input(placeholder="optional", id="modal-reason-input")
+            with Horizontal(id="modal-actions"):
+                yield Button("Save (Ctrl+S)", id="modal-save", variant="primary")
+                yield Button("Cancel (Esc)", id="modal-cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "modal-save":
+            self.action_save()
+        elif event.button.id == "modal-cancel":
+            self.action_cancel()
+
+    def action_save(self) -> None:
+        approve_btn = self.query_one("#modal-decision-approve", RadioButton)
+        decision = "approve" if approve_btn.value else "reject"
+        reason = self.query_one("#modal-reason-input", Input).value
+        correction = _build_correction(
+            id_a=self.id_a,
+            id_b=self.id_b,
+            decision=decision,
+            dataset=self.dataset,
+            matchkey_name=self.matchkey_name,
+            source=self.source,
+            reason=reason or None,
+            original_score=self.score or 0.0,
+        )
+        store = _get_store(self.app)
+        if store is not None:
+            try:
+                store.add_correction(correction)
+            finally:
+                try:
+                    store.close()
+                except Exception:
+                    pass
+        self.dismiss(correction)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+def _build_correction(
+    *,
+    id_a: int,
+    id_b: int,
+    decision: str,
+    dataset: str,
+    matchkey_name: str | None,
+    source: str,
+    reason: str | None,
+    original_score: float,
+) -> Any:
+    from goldenmatch.core.memory.store import (
+        HIGH_TRUST_SOURCES,
+        Correction,
+        _canon_pair,
+    )
+
+    ca, cb = _canon_pair(id_a, id_b)
+    trust = 1.0 if source in {s.value for s in HIGH_TRUST_SOURCES} else 0.5
+    return Correction(
+        id=str(uuid.uuid4()),
+        id_a=ca,
+        id_b=cb,
+        decision=decision,
+        source=source,
+        trust=trust,
+        field_hash="",
+        record_hash="",
+        original_score=original_score,
+        matchkey_name=matchkey_name,
+        reason=reason,
+        dataset=dataset,
+        created_at=datetime.now(),
+    )
+
+
+def _get_store(app: Any) -> Any:
+    path = getattr(app, "memory_db_path", None)
+    if not path:
+        return None
+    try:
+        from goldenmatch.core.memory.store import MemoryStore
+        return MemoryStore(backend="sqlite", path=path)
+    except Exception:
+        return None

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/corrections_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/corrections_tab.py
@@ -1,0 +1,180 @@
+"""Corrections tab -- inspect MemoryStore corrections (#437 surface sync, Phase 4).
+
+Spec: docs/superpowers/specs/2026-05-22-phase-4-tui-corrections-tab-design.md
+
+Displays stored Learning Memory corrections in a DataTable.
+Operators can refresh from disk (`r`), delete a selected correction
+(`d` + confirm), or filter by dataset. Read-only inspection surface;
+writes happen via the Golden tab inline-edit modal + Matches tab
+pair-correction modal.
+
+The MemoryStore path is read from ``GoldenMatchApp.memory_db_path``
+(set when ``config.memory.enabled`` is True). When memory is
+disabled the tab shows an empty-state message.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, DataTable, Input, Static
+
+
+class CorrectionsTab(Static):
+    """DataTable of MemoryStore corrections + filter/refresh affordances."""
+
+    DEFAULT_CSS = """
+    CorrectionsTab {
+        height: 1fr;
+        padding: 1;
+    }
+    #corrections-controls {
+        height: auto;
+        margin-bottom: 1;
+    }
+    #corrections-controls Input {
+        width: 30;
+    }
+    #corrections-controls Button {
+        margin: 0 1;
+    }
+    #corrections-table {
+        height: 1fr;
+    }
+    #corrections-empty {
+        padding: 2;
+        color: $text-muted;
+    }
+    """
+
+    BINDINGS = [
+        ("r", "refresh", "Refresh"),
+        ("d", "delete_selected", "Delete"),
+    ]
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._last_filter: str = ""
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            with Horizontal(id="corrections-controls"):
+                yield Input(
+                    placeholder="filter by dataset",
+                    id="corrections-filter",
+                )
+                yield Button("Refresh (r)", id="corrections-refresh")
+                yield Button("Delete (d)", id="corrections-delete")
+            yield DataTable(id="corrections-table", zebra_stripes=True)
+            yield Static("", id="corrections-status")
+
+    def on_mount(self) -> None:
+        table: DataTable = self.query_one("#corrections-table", DataTable)
+        table.cursor_type = "row"
+        table.add_columns(
+            "id", "decision", "id_a", "id_b", "field",
+            "corrected", "dataset", "source", "trust", "created_at",
+        )
+        self.refresh_rows()
+
+    def action_refresh(self) -> None:
+        """Reload corrections from MemoryStore."""
+        self.refresh_rows()
+
+    def action_delete_selected(self) -> None:
+        """Delete the highlighted correction. No-op when none selected."""
+        table: DataTable = self.query_one("#corrections-table", DataTable)
+        if not table.row_count or table.cursor_row is None:
+            return
+        try:
+            row = table.get_row_at(table.cursor_row)
+        except Exception:
+            return
+        correction_id = str(row[0])
+        store = self._get_store()
+        if store is None:
+            self._set_status("Memory disabled -- cannot delete")
+            return
+        try:
+            # MemoryStore may not have a `delete_correction` method on
+            # older shapes; degrade gracefully.
+            if hasattr(store, "delete_correction"):
+                store.delete_correction(correction_id)
+                self._set_status(f"Deleted correction {correction_id}")
+            else:
+                self._set_status(
+                    "delete_correction not supported by this MemoryStore",
+                )
+        finally:
+            try:
+                store.close()
+            except Exception:
+                pass
+        self.refresh_rows()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "corrections-filter":
+            self._last_filter = (event.value or "").strip()
+            self.refresh_rows()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "corrections-refresh":
+            self.refresh_rows()
+        elif event.button.id == "corrections-delete":
+            self.action_delete_selected()
+
+    def refresh_rows(self) -> None:
+        """Reload rows from MemoryStore + render."""
+        table: DataTable = self.query_one("#corrections-table", DataTable)
+        table.clear()
+        store = self._get_store()
+        if store is None:
+            self._set_status(
+                "Memory disabled. Enable memory in config to use this tab.",
+            )
+            return
+        try:
+            dataset = self._last_filter or None
+            corrections = list(store.get_corrections(dataset=dataset))
+        finally:
+            try:
+                store.close()
+            except Exception:
+                pass
+        for c in corrections:
+            table.add_row(
+                str(c.id)[:8],
+                str(c.decision),
+                str(c.id_a),
+                str(c.id_b),
+                str(getattr(c, "field_name", "") or ""),
+                str(getattr(c, "corrected_value", "") or ""),
+                str(c.dataset or ""),
+                str(c.source),
+                f"{float(c.trust):.2f}",
+                c.created_at.isoformat(timespec="seconds") if c.created_at else "",
+            )
+        self._set_status(f"{len(corrections)} correction(s)")
+
+    def _set_status(self, text: str) -> None:
+        try:
+            status = self.query_one("#corrections-status", Static)
+            status.update(text)
+        except Exception:
+            pass
+
+    def _get_store(self) -> Any:
+        """Open the MemoryStore configured on the app, or None."""
+        app = self.app
+        path = getattr(app, "memory_db_path", None)
+        if not path:
+            return None
+        try:
+            from goldenmatch.core.memory.store import MemoryStore
+        except ImportError:
+            return None
+        try:
+            return MemoryStore(backend="sqlite", path=path)
+        except Exception:
+            return None

--- a/packages/python/goldenmatch/tests/test_tui.py
+++ b/packages/python/goldenmatch/tests/test_tui.py
@@ -31,12 +31,16 @@ class TestTUIApp:
 
     @pytest.mark.asyncio
     async def test_tabs_exist(self, sample_csv):
-        """All seven tab panes should be present (Controller added in v1.13+)."""
+        """All eight tab panes should be present.
+
+        Tabs: Data, Config, Matches, Golden, Boost, Export, Controller
+        (v1.13+), Corrections (v1.20.0 Phase 4 of #437 surface sync).
+        """
         app = GoldenMatchApp(files=[str(sample_csv)])
         async with app.run_test() as pilot:
             await pilot.pause()
             panes = app.query("TabPane")
-            assert len(panes) == 7
+            assert len(panes) == 8
 
     @pytest.mark.asyncio
     async def test_app_launches_without_files(self):

--- a/packages/python/goldenmatch/tests/test_tui_corrections.py
+++ b/packages/python/goldenmatch/tests/test_tui_corrections.py
@@ -1,0 +1,152 @@
+"""Phase 4 of v1.18 surface-sync roadmap: TUI Corrections tab + modals.
+
+Spec: docs/superpowers/specs/2026-05-22-phase-4-tui-corrections-tab-design.md
+
+Covers:
+- CorrectionsTab launches without crash + reads seeded MemoryStore
+- GoldenEditModal writes a field-level Correction on save
+- MatchesCorrectionModal writes a pair-level Correction on save
+
+These tests use Textual's pilot harness. They intentionally do
+NOT exercise the Golden / Matches tab key-binding wiring (that's a
+follow-up; the modals are independently tested by mounting them
+directly via `push_screen_wait`).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from goldenmatch.tui.app import GoldenMatchApp
+
+
+def _seed_store(path: Path) -> None:
+    """Seed a MemoryStore with one pair-level + one field-level correction."""
+    from goldenmatch.core.memory.store import Correction, MemoryStore
+
+    store = MemoryStore(backend="sqlite", path=str(path))
+    store.add_correction(Correction(
+        id=str(uuid.uuid4()), id_a=1, id_b=2,
+        decision="approve", source="steward", trust=1.0,
+        field_hash="", record_hash="", original_score=0.95,
+        matchkey_name=None, reason=None, dataset="customers",
+        created_at=datetime.now(),
+    ))
+    store.add_correction(Correction(
+        id=str(uuid.uuid4()), id_a=42, id_b=0,
+        decision="field_correct", source="steward", trust=1.0,
+        field_hash="", record_hash="", original_score=0.0,
+        matchkey_name=None, reason="USPS", dataset="customers",
+        created_at=datetime.now(),
+        field_name="address1",
+        original_value="1 Elm St",
+        corrected_value="1 Elm Street, Apt 4B",
+    ))
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_corrections_tab_renders_seeded_store(tmp_path, sample_csv):
+    """8th tab loads + DataTable shows the 2 seeded corrections."""
+    db_path = tmp_path / "memory.db"
+    _seed_store(db_path)
+
+    app = GoldenMatchApp(files=[str(sample_csv)])
+    app.memory_db_path = str(db_path)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        from goldenmatch.tui.tabs.corrections_tab import CorrectionsTab
+        tab = app.query_one(CorrectionsTab)
+        # Force the in-memory refresh AFTER memory_db_path is set on app.
+        tab.refresh_rows()
+        await pilot.pause()
+        table = tab.query_one("#corrections-table")
+        assert table.row_count == 2
+
+
+@pytest.mark.asyncio
+async def test_corrections_tab_empty_state_when_memory_disabled(sample_csv):
+    """No memory_db_path -> tab loads but shows empty-state status."""
+    app = GoldenMatchApp(files=[str(sample_csv)])
+    # memory_db_path intentionally unset (defaults to None)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        from goldenmatch.tui.tabs.corrections_tab import CorrectionsTab
+        tab = app.query_one(CorrectionsTab)
+        table = tab.query_one("#corrections-table")
+        assert table.row_count == 0
+
+
+@pytest.mark.asyncio
+async def test_golden_edit_modal_writes_field_correction(tmp_path, sample_csv):
+    """GoldenEditModal Save -> MemoryStore has a field_correct row."""
+    from goldenmatch.core.memory.store import MemoryStore
+    from goldenmatch.tui.screens.golden_edit_modal import GoldenEditModal
+
+    db_path = tmp_path / "memory.db"
+    app = GoldenMatchApp(files=[str(sample_csv)])
+    app.memory_db_path = str(db_path)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = GoldenEditModal(
+            cluster_id=42,
+            field_name="address1",
+            original_value="1 Elm St",
+            dataset="customers",
+        )
+
+        async def _push() -> None:
+            result = await app.push_screen_wait(modal)
+            app._test_modal_result = result  # type: ignore[attr-defined]
+
+        task = pilot.app.run_worker(_push, exclusive=True)
+        await pilot.pause()
+        # The modal's Input pre-populates with original_value; just save.
+        modal.action_save()
+        await pilot.pause()
+        task.cancel()
+        # Verify MemoryStore got the field-level row.
+        store = MemoryStore(backend="sqlite", path=str(db_path))
+        rows = list(store.get_corrections(dataset="customers"))
+        store.close()
+        assert len(rows) == 1
+        assert rows[0].decision == "field_correct"
+        assert rows[0].field_name == "address1"
+
+
+@pytest.mark.asyncio
+async def test_matches_correction_modal_writes_pair_correction(tmp_path, sample_csv):
+    """MatchesCorrectionModal Save -> MemoryStore has approve/reject row."""
+    from goldenmatch.core.memory.store import MemoryStore
+    from goldenmatch.tui.screens.matches_correction_modal import (
+        MatchesCorrectionModal,
+    )
+
+    db_path = tmp_path / "memory.db"
+    app = GoldenMatchApp(files=[str(sample_csv)])
+    app.memory_db_path = str(db_path)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = MatchesCorrectionModal(
+            id_a=5, id_b=10, score=0.82, dataset="customers",
+        )
+
+        async def _push() -> None:
+            result = await app.push_screen_wait(modal)
+            app._test_modal_result = result  # type: ignore[attr-defined]
+
+        task = pilot.app.run_worker(_push, exclusive=True)
+        await pilot.pause()
+        modal.action_save()
+        await pilot.pause()
+        task.cancel()
+        store = MemoryStore(backend="sqlite", path=str(db_path))
+        rows = list(store.get_corrections(dataset="customers"))
+        store.close()
+        assert len(rows) == 1
+        # Pair is canonicalized (min, max).
+        assert rows[0].id_a == 5
+        assert rows[0].id_b == 10
+        assert rows[0].decision == "approve"  # default radio selection


### PR DESCRIPTION
Phase 4 of the v1.18 surface-sync roadmap. Closes the last in-session-tractable surface gap.

## What ships
- 8th tab `Corrections` with DataTable + filter + refresh/delete
- `GoldenEditModal` for field-level corrections (Save -> MemoryStore)
- `MatchesCorrectionModal` for pair-level approve/reject
- `GoldenMatchApp.memory_db_path` attribute (set by CLI launcher)

## Tests
- `test_tabs_exist` bumped 7 -> 8
- 4 new pilot tests in `test_tui_corrections.py`

## Deferred to follow-up
Key-binding wiring to OPEN the modals from Golden/Matches tab cells (e/c keys). Modals are independently usable + tested; binding wiring needs a tab cell-selection audit.

Spec: `docs/superpowers/specs/2026-05-22-phase-4-tui-corrections-tab-design.md`