### PR TITLE
feat(v2.0): Phase 5 -- TS port field-level Correction parity

### DIFF
--- a/packages/typescript/goldenmatch/src/core/memory/types.ts
+++ b/packages/typescript/goldenmatch/src/core/memory/types.ts
@@ -23,10 +23,20 @@ export type CorrectionSource =
   | "unmerge"
   | "agent"
   | "llm"
-  | "api";
+  | "api"
+  // v1.19.0 (#437 surface sync Phase 2):
+  | "rest"
+  // v2.x (#437 surface sync Phase 6B):
+  | "duckdb";
 
-/** Canonical correction decisions. Mirrors Python's `Decision` StrEnum. */
-export type Decision = "approve" | "reject";
+/** Canonical correction decisions. Mirrors Python's `Decision` StrEnum.
+ *
+ * `"field_correct"` added in v1.18.2 (#437) for inline-edit feedback on
+ * golden-record fields. When `Correction.decision === "field_correct"`,
+ * the row carries `fieldName` + `correctedValue` (see Correction
+ * interface).
+ */
+export type Decision = "approve" | "reject" | "field_correct";
 
 /**
  * Sources that confer human-level trust. Pair decisions originating here are
@@ -47,6 +57,10 @@ export const HIGH_TRUST_SOURCES: ReadonlySet<CorrectionSource> = new Set<Correct
  * fall back to the agent-tier 0.5 trust.
  */
 export function trustForSource(source: CorrectionSource | string): number {
+  // v1.19.0 Phase 2 + v2.x Phase 6B (#437): explicit trust tiers for
+  // the new sources so they don't fall to the agent-tier 0.5 default.
+  if (source === "rest") return 0.8;
+  if (source === "duckdb") return 0.7;
   return HIGH_TRUST_SOURCES.has(source as CorrectionSource) ? 1.0 : 0.5;
 }
 
@@ -76,6 +90,15 @@ export interface Correction {
   readonly reason: string | null;
   readonly dataset: string | null;
   readonly createdAt: Date;
+  // ── v1.18.2 field-level corrections (#437) ──────────────────────────
+  // All three default to null for pair-level (decision in
+  // {approve, reject}). Set when decision === "field_correct":
+  //   - fieldName: the column being corrected (e.g. "address1")
+  //   - originalValue: what build_golden_record chose
+  //   - correctedValue: what the reviewer changed it to
+  readonly fieldName?: string | null;
+  readonly originalValue?: string | null;
+  readonly correctedValue?: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/typescript/goldenmatch/src/node/memory/sqlite-store.ts
+++ b/packages/typescript/goldenmatch/src/node/memory/sqlite-store.ts
@@ -40,6 +40,12 @@ CREATE TABLE IF NOT EXISTS corrections (
     matchkey_name TEXT,
     reason TEXT, dataset TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    -- v1.18.2 field-level golden corrections (#437). NULL for pair-
+    -- level (decision in {approve, reject}). Set when
+    -- decision='field_correct'.
+    field_name TEXT,
+    original_value TEXT,
+    corrected_value TEXT,
     UNIQUE(id_a, id_b, dataset)
 );
 CREATE INDEX IF NOT EXISTS idx_corrections_pair ON corrections(id_a, id_b, dataset);
@@ -70,6 +76,10 @@ interface CorrectionRow {
   reason: string | null;
   dataset: string | null;
   created_at: string;
+  // v1.18.2 field-level (nullable for pair-level corrections):
+  field_name?: string | null;
+  original_value?: string | null;
+  corrected_value?: string | null;
 }
 
 interface AdjustmentRow {
@@ -95,6 +105,9 @@ function rowToCorrection(row: CorrectionRow): Correction {
     reason: row.reason,
     dataset: row.dataset,
     createdAt: new Date(row.created_at),
+    fieldName: row.field_name ?? null,
+    originalValue: row.original_value ?? null,
+    correctedValue: row.corrected_value ?? null,
   };
 }
 
@@ -169,8 +182,9 @@ export class SqliteMemoryStore implements MemoryStore {
     const ins = this.db.prepare(
       "INSERT INTO corrections " +
         "(id, id_a, id_b, decision, source, trust, field_hash, record_hash, " +
-        "original_score, matchkey_name, reason, dataset, created_at) " +
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "original_score, matchkey_name, reason, dataset, created_at, " +
+        "field_name, original_value, corrected_value) " +
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     );
     const tx = this.db.transaction((corr: Correction, a: number, b: number) => {
       del.run(a, b, corr.dataset);
@@ -188,6 +202,9 @@ export class SqliteMemoryStore implements MemoryStore {
         corr.reason,
         corr.dataset,
         corr.createdAt.toISOString(),
+        corr.fieldName ?? null,
+        corr.originalValue ?? null,
+        corr.correctedValue ?? null,
       );
     });
     tx(c, ca, cb);

--- a/packages/typescript/goldenmatch/tests/memory_field_level.test.ts
+++ b/packages/typescript/goldenmatch/tests/memory_field_level.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Field-level Correction round-trip (Phase 5 of v1.18 surface-sync
+ * roadmap, TS port v2.0 foundation).
+ *
+ * Verifies that the v1.18.2 #437 field-level fields (`fieldName`,
+ * `originalValue`, `correctedValue`) + `decision: "field_correct"` +
+ * the new `"rest"` / `"duckdb"` CorrectionSource values round-trip
+ * through the in-memory store.
+ *
+ * SQLite-backed sqlite-store.ts has the same schema additions but
+ * needs `better-sqlite3` installed for its tests -- covered in the
+ * existing parity-test suite.
+ */
+import { describe, expect, it } from "vitest";
+
+import { InMemoryStore } from "../src/core/memory/store.js";
+import {
+  type Correction,
+  trustForSource,
+} from "../src/core/memory/types.js";
+
+function makeFieldCorrection(overrides: Partial<Correction> = {}): Correction {
+  return {
+    id: "fc-1",
+    idA: 42,
+    idB: 0,
+    decision: "field_correct",
+    source: "steward",
+    trust: 1.0,
+    fieldHash: "",
+    recordHash: "",
+    originalScore: 0.0,
+    matchkeyName: null,
+    reason: null,
+    dataset: "customers",
+    createdAt: new Date("2026-05-22T18:00:00Z"),
+    fieldName: "address1",
+    originalValue: "1 Elm St",
+    correctedValue: "1 Elm Street, Apt 4B",
+    ...overrides,
+  };
+}
+
+describe("field-level Correction (Phase 5 foundation)", () => {
+  it("round-trips via InMemoryStore", async () => {
+    const store = new InMemoryStore({ enabled: true });
+    const correction = makeFieldCorrection();
+    await store.addCorrection(correction);
+    const out = await store.getCorrections({ dataset: "customers" });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.decision).toBe("field_correct");
+    expect(out[0]!.fieldName).toBe("address1");
+    expect(out[0]!.correctedValue).toBe("1 Elm Street, Apt 4B");
+  });
+
+  it("pair-level Correction still works without field-level fields", async () => {
+    const store = new InMemoryStore({ enabled: true });
+    await store.addCorrection({
+      id: "pl-1",
+      idA: 5,
+      idB: 10,
+      decision: "approve",
+      source: "steward",
+      trust: 1.0,
+      fieldHash: "",
+      recordHash: "",
+      originalScore: 0.95,
+      matchkeyName: null,
+      reason: null,
+      dataset: "customers",
+      createdAt: new Date("2026-05-22T18:00:00Z"),
+    });
+    const out = await store.getCorrections({ dataset: "customers" });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.decision).toBe("approve");
+    expect(out[0]!.fieldName ?? null).toBeNull();
+    expect(out[0]!.correctedValue ?? null).toBeNull();
+  });
+});
+
+describe("trustForSource (Phase 5: new sources)", () => {
+  it("steward / boost / unmerge -> 1.0", () => {
+    expect(trustForSource("steward")).toBe(1.0);
+    expect(trustForSource("boost")).toBe(1.0);
+    expect(trustForSource("unmerge")).toBe(1.0);
+  });
+
+  it("rest -> 0.8 (Phase 2 source)", () => {
+    expect(trustForSource("rest")).toBe(0.8);
+  });
+
+  it("duckdb -> 0.7 (Phase 6B source)", () => {
+    expect(trustForSource("duckdb")).toBe(0.7);
+  });
+
+  it("agent / llm / api -> 0.5", () => {
+    expect(trustForSource("agent")).toBe(0.5);
+    expect(trustForSource("llm")).toBe(0.5);
+    expect(trustForSource("api")).toBe(0.5);
+  });
+});

--- a/packages/typescript/goldenmatch/tests/memory_field_level.test.ts
+++ b/packages/typescript/goldenmatch/tests/memory_field_level.test.ts
@@ -43,7 +43,11 @@ function makeFieldCorrection(overrides: Partial<Correction> = {}): Correction {
 
 describe("field-level Correction (Phase 5 foundation)", () => {
   it("round-trips via InMemoryStore", async () => {
-    const store = new InMemoryStore({ enabled: true });
+    const store = new InMemoryStore({
+      enabled: true,
+      backend: "memory",
+      learning: { thresholdMinCorrections: 10, weightsMinCorrections: 50 },
+    });
     const correction = makeFieldCorrection();
     await store.addCorrection(correction);
     const out = await store.getCorrections({ dataset: "customers" });
@@ -54,7 +58,11 @@ describe("field-level Correction (Phase 5 foundation)", () => {
   });
 
   it("pair-level Correction still works without field-level fields", async () => {
-    const store = new InMemoryStore({ enabled: true });
+    const store = new InMemoryStore({
+      enabled: true,
+      backend: "memory",
+      learning: { thresholdMinCorrections: 10, weightsMinCorrections: 50 },
+    });
     await store.addCorrection({
       id: "pl-1",
       idA: 5,


### PR DESCRIPTION
Smallest-meaningful Phase 5 deliverable. TS port already has the MemoryStore foundation (v0.4.0 InMemoryStore + v0.9.0 SqliteMemoryStore); v1.18.2 field-level fields hadn't been ported. This PR adds them with byte-identical schema parity.

## Changes
- `Decision` adds `'field_correct'`
- `CorrectionSource` adds `'rest'` (Phase 2) + `'duckdb'` (Phase 6B)
- `Correction` interface gains `fieldName` / `originalValue` / `correctedValue`
- `trustForSource`: rest=0.8, duckdb=0.7
- SqliteMemoryStore schema + INSERT updated
- 3 new tests in `memory_field_level.test.ts`

## Out of scope
- Plugin system port (22 builtins) -- Week 2 of roadmap
- Parity fixture regen
- npm v2.0.0 tag

Spec: `docs/superpowers/specs/2026-05-22-phase-5-typescript-port-design.md`