### PR TITLE
feat(v1.20.1): Phase 4 follow-up -- TUI key bindings wire to modals

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/golden_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/golden_tab.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.widgets import DataTable, Static
 
@@ -21,6 +22,14 @@ class GoldenTab(Static):
         border: solid $primary;
     }
     """
+
+    BINDINGS = [
+        # Phase 4 follow-up (#437 surface sync, 2026-05-22): open the
+        # GoldenEditModal on the currently highlighted DataTable row to
+        # file a field-level Correction. `e` chosen over Enter to avoid
+        # clashing with DataTable's row-selection default.
+        Binding("e", "edit_golden_field", "Edit field"),
+    ]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -86,3 +95,55 @@ class GoldenTab(Static):
 
             values = [str(row.get(c, "")) for c in data_cols]
             table.add_row(cluster_id, conf_str, *values)
+
+    def action_edit_golden_field(self) -> None:
+        """Open GoldenEditModal for the highlighted cell.
+
+        Reads `cluster_id` from the row's first column (always present)
+        and `field_name` + `original_value` from the cursor column. The
+        first two columns (Cluster ID, Confidence) are non-editable; the
+        action exits silently when the cursor is on either.
+        """
+        from goldenmatch.tui.screens.golden_edit_modal import GoldenEditModal
+
+        try:
+            table = self.query_one("#golden-table", DataTable)
+        except Exception:
+            return
+        if not table.display or table.row_count == 0:
+            return
+        row_idx = table.cursor_row
+        col_idx = table.cursor_column
+        if row_idx is None or col_idx is None:
+            return
+        # Cursor on Cluster ID (0) or Confidence (1) -- no editable target.
+        if col_idx < 2:
+            return
+        try:
+            row = table.get_row_at(row_idx)
+        except Exception:
+            return
+        try:
+            cluster_id = int(str(row[0]))
+        except (ValueError, TypeError):
+            return
+
+        # Resolve column name + original value from the same row.
+        columns = list(table.columns.values())
+        if col_idx >= len(columns):
+            return
+        field_name = str(columns[col_idx].label)
+        original_value = str(row[col_idx])
+
+        dataset = (
+            getattr(self.app, "memory_dataset", None)
+            or getattr(self.app, "current_dataset", None)
+            or "tui"
+        )
+        modal = GoldenEditModal(
+            cluster_id=cluster_id,
+            field_name=field_name,
+            original_value=original_value,
+            dataset=dataset,
+        )
+        self.app.push_screen(modal)

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/matches_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/matches_tab.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import polars as pl
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Vertical
 from textual.widgets import DataTable, Static
 
@@ -29,6 +30,13 @@ class MatchesTab(Static):
         padding: 2;
     }
     """
+
+    BINDINGS = [
+        # Phase 4 follow-up (#437 surface sync, 2026-05-22): open the
+        # MatchesCorrectionModal on the highlighted detail-table row to
+        # file a pair-level (approve/reject) Correction.
+        Binding("c", "correct_pair", "Correct pair"),
+    ]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -155,3 +163,63 @@ class MatchesTab(Static):
         for row in member_df.iter_rows(named=True):
             values = [str(row.get(c, "")) for c in display_cols]
             detail_table.add_row(*values)
+
+    def action_correct_pair(self) -> None:
+        """Open MatchesCorrectionModal for two members of the currently
+        selected cluster.
+
+        Pair-level corrections take two record IDs. The detail-table
+        shows the cluster's members; we use the two highest-row-id
+        members of the selected cluster as the pair (operator can
+        narrow this later via a follow-up "select pair" UI). When the
+        detail table isn't populated yet (no cluster selected), the
+        action exits silently.
+        """
+        from goldenmatch.tui.screens.matches_correction_modal import (
+            MatchesCorrectionModal,
+        )
+
+        if self._clusters is None or self._data is None:
+            return
+        try:
+            cluster_table = self.query_one("#cluster-table", DataTable)
+        except Exception:
+            return
+        if cluster_table.row_count == 0:
+            return
+        row_idx = cluster_table.cursor_row
+        if row_idx is None:
+            return
+        try:
+            row = cluster_table.get_row_at(row_idx)
+            cluster_id = int(str(row[0]))
+        except (ValueError, TypeError, IndexError):
+            return
+
+        cluster_info = self._clusters.get(cluster_id) if self._clusters else None
+        if cluster_info is None:
+            return
+        members = list(cluster_info.get("members", []))
+        if len(members) < 2:
+            return
+
+        # Pick the first two members as the representative pair. A
+        # later iteration could surface a 2-row selection UI.
+        id_a, id_b = members[0], members[1]
+        # Try to pull the pair's score from the cluster's pair_scores
+        # map for context in the modal title bar.
+        pair_scores = cluster_info.get("pair_scores", {}) or {}
+        score = pair_scores.get((min(id_a, id_b), max(id_a, id_b)))
+
+        dataset = (
+            getattr(self.app, "memory_dataset", None)
+            or getattr(self.app, "current_dataset", None)
+            or "tui"
+        )
+        modal = MatchesCorrectionModal(
+            id_a=int(id_a),
+            id_b=int(id_b),
+            score=float(score) if score is not None else None,
+            dataset=dataset,
+        )
+        self.app.push_screen(modal)

--- a/packages/python/goldenmatch/tests/test_tui_binding_wiring.py
+++ b/packages/python/goldenmatch/tests/test_tui_binding_wiring.py
@@ -1,0 +1,40 @@
+"""Phase 4 follow-up: Golden / Matches key-binding wiring (task #211).
+
+Confirms the `e` binding on the Golden tab + the `c` binding on the
+Matches tab dispatch to the respective modals. Full pilot-driven UX
+testing of the modal-open flow is covered by the existing pilot tests
+in test_tui_corrections.py; this file is a focused binding presence +
+action-shape check.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_golden_tab_binds_e_to_edit_action():
+    """`e` keybinding on GoldenTab maps to action_edit_golden_field."""
+    from goldenmatch.tui.tabs.golden_tab import GoldenTab
+
+    bindings = list(GoldenTab.BINDINGS)
+    assert any(
+        (b.key, b.action) == ("e", "edit_golden_field")
+        for b in bindings
+    ), f"GoldenTab missing 'e' binding (have: {[(b.key, b.action) for b in bindings]})"
+    # Action handler exists.
+    assert hasattr(GoldenTab, "action_edit_golden_field")
+
+
+def test_matches_tab_binds_c_to_correct_action():
+    """`c` keybinding on MatchesTab maps to action_correct_pair."""
+    from goldenmatch.tui.tabs.matches_tab import MatchesTab
+
+    bindings = list(MatchesTab.BINDINGS)
+    assert any(
+        (b.key, b.action) == ("c", "correct_pair")
+        for b in bindings
+    ), f"MatchesTab missing 'c' binding (have: {[(b.key, b.action) for b in bindings]})"
+    assert hasattr(MatchesTab, "action_correct_pair")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes task #211. Phase 4 (#448) shipped the modals + Corrections tab but deferred the keybinding wiring on the Golden + Matches tabs.

## Changes
- GoldenTab: 'e' opens GoldenEditModal with cluster_id + field_name + original_value pulled from the cursor cell
- MatchesTab: 'c' opens MatchesCorrectionModal for the first 2 members of the selected cluster
- 2 new tests confirming bindings + action handlers exist

## Why 'e' not Enter on Golden
DataTable's default Enter handler triggers row-selection events. 'e' avoids the clash, single-keystroke, no surprise.