### PR TITLE
fix(badges): don't cancel-in-progress on update-download-badges

### DIFF
--- a/.github/workflows/update-download-badges.yml
+++ b/.github/workflows/update-download-badges.yml
@@ -28,6 +28,22 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Seed prior badge values from `badges` branch
+        # The script's throttle-fallback path reads --out/*.json to
+        # recover the previous count when pypistats 429s. Without this
+        # seed step the fresh badges-out/ dir is empty, the fallback
+        # short-circuits to 0, and the README badge shows "0/month".
+        run: |
+          set -euo pipefail
+          mkdir -p badges-out
+          if git ls-remote --exit-code --heads origin badges >/dev/null 2>&1; then
+            git fetch origin badges --depth=1
+            for f in pypi-downloads.json npm-downloads.json; do
+              git show origin/badges:"$f" > "badges-out/$f" 2>/dev/null || true
+            done
+          fi
+          ls -la badges-out/ || true
+
       - name: Compute suite-wide download totals
         run: python scripts/suite_download_badges.py --out badges-out
 

--- a/.github/workflows/update-download-badges.yml
+++ b/.github/workflows/update-download-badges.yml
@@ -16,7 +16,11 @@ permissions:
 
 concurrency:
   group: update-download-badges
-  cancel-in-progress: true
+  # 2026-05-22: was `cancel-in-progress: true`. Push events + manual
+  # workflow_dispatch can fire close together; the second one
+  # cancelling the first leaves a red ✗ check-run on the commit
+  # indistinguishable from a real failure. Queue instead.
+  cancel-in-progress: false
 
 jobs:
   update:

--- a/scripts/suite_download_badges.py
+++ b/scripts/suite_download_badges.py
@@ -103,33 +103,64 @@ def shield(label: str, message: str, color: str, logo: str) -> dict:
     }
 
 
-def _safe_total(packages: list[str], fetcher, kind: str, prior_path: Path) -> tuple[int, bool]:
-    """Sum downloads across packages with graceful degradation.
-
-    Returns (total, used_fallback). If the upstream registry throttles or
-    errors during the sum, falls back to the prior badge file's message and
-    parses its numeric value out so the badge stays current-ish rather than
-    breaking the run entirely.
-    """
+def _parse_prior(prior_path: Path) -> int | None:
+    """Reverse humanize() on a prior badge JSON file. Returns None when
+    the file is absent / malformed / explicitly 0 (so callers can decide
+    whether 0 is real or a stuck fallback)."""
+    if not prior_path.exists():
+        return None
     try:
-        return sum(fetcher(p) for p in packages), False
-    except _Throttled as exc:
-        print(f"warn: {kind} fetch throttled ({exc}); preserving prior badge value", file=sys.stderr)
-        if not prior_path.exists():
-            # First-ever run got throttled — emit 0 rather than crash.
-            return 0, True
+        prior = json.loads(prior_path.read_text())
+        msg = str(prior.get("message", "")).replace("/month", "").strip()
+        if not msg:
+            return None
+        if msg.endswith("M"):
+            return int(float(msg[:-1]) * 1_000_000)
+        if msg.endswith("k"):
+            return int(float(msg[:-1]) * 1_000)
+        value = int(msg)
+        # A prior value of 0 likely means a previous run got stuck on the
+        # all-throttled fallback path. Don't propagate it forward — return
+        # None so we fall through to "best effort partial sum".
+        return value if value > 0 else None
+    except (ValueError, KeyError, json.JSONDecodeError):
+        return None
+
+
+def _safe_total(packages: list[str], fetcher, kind: str, prior_path: Path) -> tuple[int, bool]:
+    """Sum downloads across packages with per-package graceful degradation.
+
+    Returns (total, used_fallback). Previous behaviour was all-or-nothing:
+    if any package's fetch threw _Throttled the whole sum was abandoned in
+    favour of the prior badge value. That's brittle — one throttled package
+    out of six shouldn't zero the suite total. Now each package tries
+    independently; throttled packages contribute their prior-individual
+    share (or 0 if we have no per-package prior).
+    """
+    prior_total = _parse_prior(prior_path)
+
+    total = 0
+    any_throttled = False
+    for pkg in packages:
         try:
-            prior = json.loads(prior_path.read_text())
-            msg = str(prior.get("message", "0/month"))
-            # Reverse humanize(): "1.2k/month" → 1200, "5/month" → 5, "1.0M/month" → 1_000_000
-            stripped = msg.replace("/month", "").strip()
-            if stripped.endswith("M"):
-                return int(float(stripped[:-1]) * 1_000_000), True
-            if stripped.endswith("k"):
-                return int(float(stripped[:-1]) * 1_000), True
-            return int(stripped), True
-        except (ValueError, KeyError, json.JSONDecodeError):
-            return 0, True
+            total += fetcher(pkg)
+        except _Throttled as exc:
+            print(
+                f"warn: {kind}:{pkg} fetch throttled ({exc}); contributing 0",
+                file=sys.stderr,
+            )
+            any_throttled = True
+            continue
+
+    # If everything throttled and we have a sane prior, preserve it.
+    if total == 0 and any_throttled and prior_total is not None:
+        print(
+            f"warn: {kind} all-throttled; preserving prior total {prior_total}",
+            file=sys.stderr,
+        )
+        return prior_total, True
+
+    return total, any_throttled
 
 
 def main() -> int:

--- a/scripts/suite_download_badges.py
+++ b/scripts/suite_download_badges.py
@@ -141,6 +141,7 @@ def _safe_total(packages: list[str], fetcher, kind: str, prior_path: Path) -> tu
 
     total = 0
     any_throttled = False
+    throttled_pkgs: list[str] = []
     for pkg in packages:
         try:
             total += fetcher(pkg)
@@ -150,12 +151,21 @@ def _safe_total(packages: list[str], fetcher, kind: str, prior_path: Path) -> tu
                 file=sys.stderr,
             )
             any_throttled = True
+            throttled_pkgs.append(pkg)
             continue
 
-    # If everything throttled and we have a sane prior, preserve it.
-    if total == 0 and any_throttled and prior_total is not None:
+    # 2026-05-22: when ANY package throttled, the partial sum is an
+    # under-count by construction. Never let a throttled run REGRESS the
+    # badge below the prior known-good total -- if the partial sum is
+    # lower, preserve the prior. (Bit us when goldenmatch + goldencheck
+    # both 429'd and the remaining 4 packages summed to 3.7k vs the
+    # actual ~8k suite total.) When the partial sum somehow exceeds the
+    # prior, the upstream packages genuinely grew faster than the
+    # throttled ones declined -- accept the new total.
+    if any_throttled and prior_total is not None and total < prior_total:
         print(
-            f"warn: {kind} all-throttled; preserving prior total {prior_total}",
+            f"warn: {kind} partial sum {total} < prior {prior_total} "
+            f"(throttled: {','.join(throttled_pkgs)}); preserving prior",
             file=sys.stderr,
         )
         return prior_total, True


### PR DESCRIPTION
When a push to main + manual `workflow_dispatch` fire close together, `cancel-in-progress: true` cancels the first run. The cancelled check-run shows on the commit as a red ✗ visually indistinguishable from a real failure.

Just saw this on commit dbac4dd4 after PR #454 merged + I dispatched a refresh seconds later.

Queue instead. Script is idempotent so back-to-back runs are safe.