### PR TITLE
feat(goldencheck): identity-safe PK preflight (closes #207)

### DIFF
--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -26,6 +26,7 @@ from goldencheck.profilers.sequence_detection import SequenceDetectionProfiler
 from goldencheck.profilers.type_inference import TypeInferenceProfiler
 from goldencheck.profilers.uniqueness import UniquenessProfiler
 from goldencheck.relations.age_validation import AgeValidationProfiler
+from goldencheck.relations.identity_safe_pk import IdentitySafePkProfiler
 from goldencheck.relations.null_correlation import NullCorrelationProfiler
 from goldencheck.relations.numeric_cross import NumericCrossColumnProfiler
 from goldencheck.relations.temporal import TemporalOrderProfiler
@@ -52,6 +53,10 @@ RELATION_PROFILERS = [
     NullCorrelationProfiler(),
     NumericCrossColumnProfiler(),
     AgeValidationProfiler(),
+    # Preflight: warn when no stable PK column exists (goldenmatch #207).
+    # Identity Graph downstreams need source_pk_column to avoid record_id
+    # collisions on duplicate raw rows.
+    IdentitySafePkProfiler(),
 ]
 
 def _post_classification_checks(

--- a/packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py
+++ b/packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py
@@ -1,0 +1,200 @@
+"""Identity-safe PK preflight profiler (closes goldenmatch issue #207).
+
+Warns when the input table has NO viable stable unique identifier
+column. Without one, downstream consumers like goldenmatch's Identity
+Graph fall back to a payload-hash record_id (`{source}:hash:{12 hex}`),
+which silently collides on physically-different rows that happen to
+have identical column values -- breaking entity_id stability across
+runs.
+
+This is a dataset-level relation check: we want to assert that AT
+LEAST ONE column qualifies as a stable PK candidate. If none do, emit
+a single WARNING-severity finding with a suggestion that the caller
+either:
+
+1. Pass an explicit `source_pk_column` to the downstream resolver
+2. Or add a stable surrogate key column (UUID, autoincrement)
+
+Heuristic for a "PK candidate":
+- All values non-null (no NULLs in the column)
+- Fully unique (n_unique == n_rows)
+- Not blocked by name heuristics that mean "this is value data, not ID"
+  (e.g. `email`, `phone`, `name`, `address` -- those CAN be unique in
+  small samples but are semantically value columns, not stable PKs)
+- Reasonable type for an identifier (int / string -- not float / bool)
+"""
+from __future__ import annotations
+
+import polars as pl
+
+from goldencheck.models.finding import Finding, Severity
+
+# Column-name prefixes/substrings that imply "this is data the user
+# could plausibly edit later", not a stable PK. Even when fully unique
+# in a small sample these are unsafe long-term PK candidates.
+_VALUE_COLUMN_PATTERNS: tuple[str, ...] = (
+    "email",
+    "phone",
+    "fax",
+    "address",
+    "street",
+    "city",
+    "name",
+    "first_name",
+    "last_name",
+    "company",
+    "title",
+    "description",
+    "notes",
+    "comment",
+    "url",
+    "website",
+    "ssn",  # PII; even when unique, downstream may strip it
+)
+
+# Column-name patterns that *strongly* suggest a PK / surrogate-key.
+_PK_NAME_PATTERNS: tuple[str, ...] = (
+    "id",
+    "uuid",
+    "guid",
+    "key",
+    "pk",
+    "primary_key",
+    "row_id",
+    "record_id",
+    "ext_id",
+    "external_id",
+)
+
+
+def _looks_like_value_column(name: str) -> bool:
+    lower = name.lower()
+    return any(p in lower for p in _VALUE_COLUMN_PATTERNS)
+
+
+def _looks_like_pk_column(name: str) -> bool:
+    lower = name.lower()
+    # Exact match or `<thing>_id` style; substring `id` would FP on
+    # `paid`, `said`, etc., so we anchor on word-boundary-ish suffixes.
+    for p in _PK_NAME_PATTERNS:
+        if lower == p or lower.endswith(f"_{p}") or lower.startswith(f"{p}_"):
+            return True
+    return False
+
+
+def _column_qualifies_as_pk(
+    df: pl.DataFrame,
+    column: str,
+) -> tuple[bool, str]:
+    """Return (qualifies, why_or_disqualifier).
+
+    A column qualifies as a stable PK candidate when:
+    1. No NULL values
+    2. Fully unique (n_unique == n_rows)
+    3. Not a value-shaped column (per _VALUE_COLUMN_PATTERNS)
+    4. Reasonable dtype for an identifier (Int*, String/Utf8; NOT Float
+       since float equality is unsafe, NOT Bool since bool is binary)
+    """
+    if _looks_like_value_column(column):
+        return False, "value-shaped name (email/name/address/etc.)"
+    col = df[column]
+    dtype = col.dtype
+    if dtype.is_float() or dtype == pl.Boolean:
+        return False, f"unsuitable dtype ({dtype})"
+    n_rows = len(col)
+    if n_rows == 0:
+        return False, "empty sample"
+    n_nulls = col.null_count()
+    if n_nulls > 0:
+        return False, f"{n_nulls} null value(s)"
+    if col.n_unique() != n_rows:
+        return False, "non-unique values"
+    return True, "stable unique non-null"
+
+
+class IdentitySafePkProfiler:
+    """Dataset-level preflight: at least one viable stable PK column.
+
+    Emits at most one Finding (a single dataset-level warning when no
+    column qualifies). When at least one column qualifies, returns
+    `[]` -- the dataset is safe to feed to goldenmatch's Identity
+    Graph without explicit `source_pk_column`.
+    """
+
+    def profile(self, df: pl.DataFrame) -> list[Finding]:
+        if df.width == 0:
+            return []
+
+        candidates: list[str] = []
+        disqualifiers: dict[str, str] = {}
+        named_pk_disqualifiers: dict[str, str] = {}
+
+        for column in df.columns:
+            qualifies, reason = _column_qualifies_as_pk(df, column)
+            if qualifies:
+                candidates.append(column)
+            else:
+                disqualifiers[column] = reason
+                if _looks_like_pk_column(column):
+                    named_pk_disqualifiers[column] = reason
+
+        if candidates:
+            # At least one viable PK; no preflight warning.
+            return []
+
+        # No qualifying PK column. Decide how loud to be.
+        # If a column LOOKS like a PK (e.g. `customer_id`) but failed
+        # the uniqueness/null test, that's a stronger signal: the
+        # caller intended this to be a PK and we should call it out
+        # specifically rather than emit a generic "no PK" warning.
+        if named_pk_disqualifiers:
+            target = next(iter(named_pk_disqualifiers))
+            why = named_pk_disqualifiers[target]
+            return [Finding(
+                severity=Severity.WARNING,
+                column=target,
+                check="identity_safe_pk",
+                message=(
+                    f"Column '{target}' looks like a PK by name but "
+                    f"isn't stable ({why}). Identity-graph downstreams "
+                    f"will fall back to payload-hash record_ids, which "
+                    f"silently collide on duplicate raw rows."
+                ),
+                affected_rows=len(df),
+                sample_values=[],
+                suggestion=(
+                    f"Either fix the column ('{target}' should be "
+                    f"non-null + unique), OR pass an explicit "
+                    f"source_pk_column to the Identity Graph resolver, "
+                    f"OR add a stable surrogate key (UUID / "
+                    f"autoincrement) to the dataset."
+                ),
+                confidence=0.9,
+            )]
+
+        # No named-PK column either. Generic warning -- treat as
+        # dataset-level (no specific column anchor).
+        sample_cols = ", ".join(df.columns[:5])
+        if df.width > 5:
+            sample_cols += ", ..."
+        return [Finding(
+            severity=Severity.WARNING,
+            column="__dataset__",
+            check="identity_safe_pk",
+            message=(
+                "No viable stable PK column detected. Columns "
+                f"({sample_cols}) have nulls, duplicates, or look "
+                "like editable value columns (email/name/address)."
+            ),
+            affected_rows=len(df),
+            sample_values=[],
+            suggestion=(
+                "If feeding this dataset to goldenmatch's Identity "
+                "Graph, pass an explicit source_pk_column on "
+                "IdentityConfig OR add a stable surrogate key "
+                "(UUID / autoincrement). Without one, record_ids fall "
+                "back to a payload-hash that collides on duplicate "
+                "raw rows."
+            ),
+            confidence=0.8,
+        )]

--- a/packages/python/goldencheck/tests/relations/test_identity_safe_pk.py
+++ b/packages/python/goldencheck/tests/relations/test_identity_safe_pk.py
@@ -1,0 +1,157 @@
+"""Tests for IdentitySafePkProfiler (closes goldenmatch #207).
+
+The profiler warns when no column in the dataset qualifies as a
+stable PK candidate. Downstream consumers (notably goldenmatch's
+Identity Graph) fall back to a payload-hash record_id when no
+source_pk_column is configured, which silently collides on
+duplicate raw rows.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldencheck.models.finding import Severity
+from goldencheck.relations.identity_safe_pk import IdentitySafePkProfiler
+
+
+@pytest.fixture
+def profiler() -> IdentitySafePkProfiler:
+    return IdentitySafePkProfiler()
+
+
+def test_clean_pk_column_no_warning(profiler: IdentitySafePkProfiler) -> None:
+    """A column named 'id' that's fully unique + non-null is a viable PK."""
+    df = pl.DataFrame({
+        "id": [1, 2, 3, 4, 5],
+        "name": ["Alice", "Bob", "Carol", "Dave", "Eve"],
+        "email": ["a@x", "b@x", "c@x", "d@x", "e@x"],
+    })
+    findings = profiler.profile(df)
+    assert findings == []
+
+
+def test_uuid_string_pk_no_warning(profiler: IdentitySafePkProfiler) -> None:
+    """String UUIDs in a 'guid' column qualify as PK."""
+    df = pl.DataFrame({
+        "guid": ["a1", "b2", "c3"],
+        "value": [10, 20, 30],
+    })
+    findings = profiler.profile(df)
+    assert findings == []
+
+
+def test_no_pk_column_emits_warning(profiler: IdentitySafePkProfiler) -> None:
+    """No column qualifies -> dataset-level WARNING."""
+    df = pl.DataFrame({
+        "first_name": ["Alice", "Alice", "Bob"],  # duplicates
+        "last_name": ["Smith", "Smith", "Jones"],
+        "city": ["NYC", "NYC", "LA"],
+    })
+    findings = profiler.profile(df)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.severity == Severity.WARNING
+    assert f.check == "identity_safe_pk"
+    assert f.column == "__dataset__"
+    assert "stable PK" in f.message or "PK" in f.message
+    assert "source_pk_column" in f.suggestion
+
+
+def test_named_pk_column_with_nulls_emits_specific_warning(
+    profiler: IdentitySafePkProfiler,
+) -> None:
+    """A column named like a PK ('customer_id') but with nulls -> WARNING
+    anchored to that column, not the generic dataset-level finding."""
+    df = pl.DataFrame({
+        "customer_id": [1, 2, None, 4],
+        "name": ["A", "B", "C", "D"],
+    })
+    findings = profiler.profile(df)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.severity == Severity.WARNING
+    assert f.column == "customer_id"
+    assert "null" in f.message.lower()
+
+
+def test_named_pk_column_with_duplicates_emits_specific_warning(
+    profiler: IdentitySafePkProfiler,
+) -> None:
+    """'record_id' that's not unique -> column-specific warning.
+
+    Other columns intentionally have duplicates too so the
+    record_id-named-but-broken column is the only viable signal.
+    """
+    df = pl.DataFrame({
+        "record_id": [1, 1, 2, 3],  # duplicate
+        "city": ["NYC", "LA", "NYC", "LA"],  # duplicates
+    })
+    findings = profiler.profile(df)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.column == "record_id"
+    assert "non-unique" in f.message or "unique" in f.message.lower()
+
+
+def test_value_column_unique_does_not_qualify(
+    profiler: IdentitySafePkProfiler,
+) -> None:
+    """A unique 'email' column doesn't qualify as a stable PK
+    (emails are editable; that's value data, not identity data)."""
+    df = pl.DataFrame({
+        "email": ["a@x", "b@x", "c@x"],
+        "name": ["Alice", "Bob", "Carol"],
+    })
+    findings = profiler.profile(df)
+    # No id/uuid column; email is a value column. Should warn.
+    assert len(findings) == 1
+    assert findings[0].check == "identity_safe_pk"
+
+
+def test_float_column_not_eligible_pk(
+    profiler: IdentitySafePkProfiler,
+) -> None:
+    """Unique floats don't qualify (float equality is unsafe)."""
+    df = pl.DataFrame({
+        "score": [0.1, 0.2, 0.3, 0.4],
+        "label": ["a", "b", "c", "d"],
+    })
+    findings = profiler.profile(df)
+    # 'label' is unique + non-null + not a value column -> qualifies.
+    # No warning expected.
+    assert findings == []
+
+
+def test_boolean_column_not_eligible_pk(
+    profiler: IdentitySafePkProfiler,
+) -> None:
+    """A column with only True/False can't be a unique PK at scale."""
+    df = pl.DataFrame({
+        "is_active": [True, False, True, False],  # not unique
+        "city": ["NYC", "LA", "NYC", "LA"],
+    })
+    findings = profiler.profile(df)
+    # No PK candidate; expect dataset-level warning.
+    assert len(findings) == 1
+    assert findings[0].check == "identity_safe_pk"
+
+
+def test_empty_dataframe_no_findings(profiler: IdentitySafePkProfiler) -> None:
+    """Empty DF -> no findings (degenerate case; not our problem)."""
+    df = pl.DataFrame()
+    findings = profiler.profile(df)
+    assert findings == []
+
+
+def test_multiple_pk_candidates_no_warning(
+    profiler: IdentitySafePkProfiler,
+) -> None:
+    """When several columns qualify (e.g. both 'id' and 'sku'), still
+    no warning -- any one viable PK is enough."""
+    df = pl.DataFrame({
+        "id": [1, 2, 3],
+        "sku": ["a", "b", "c"],
+        "name": ["A", "B", "C"],
+    })
+    findings = profiler.profile(df)
+    assert findings == []


### PR DESCRIPTION
Bet #3 from the v2.0 audit. Identity Graph's `{source}:hash:{payload}` record_id fallback silently collides on physically-different rows that share column values; warn at preflight when no stable PK column exists.

## Changes

`packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py` -- new `IdentitySafePkProfiler`. Dataset-level relation check: returns [] when at least one column qualifies as a stable PK; otherwise emits one WARNING (anchored to a named-PK column when that's the failure point, dataset-level otherwise).

## Tests

10 new in `tests/relations/test_identity_safe_pk.py`. All 104 existing engine tests still pass.

## Heuristic

- PK names: id, uuid, guid, key, pk, primary_key, row_id, record_id, ext_id, external_id
- Value names: email, phone, name, address, city, etc. (unique-in-sample but unsafe long-term)
- Dtypes: Float* + Bool excluded

Closes #207.