### PR TITLE
fix(autoconfig): drop rule_demote_clustered_identity from DEFAULT_RULES

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -1186,7 +1186,14 @@ DEFAULT_RULES = [
     rule_blocking_too_coarse,              # 5  structural: p99 outlier (skewed distribution)
     rule_uniform_heavy_blocking,           # 6  structural: uniform-large blocks
     rule_corruption_normalize,             # 7  NEW v1.10: normalize on high-corruption blocking col
-    rule_demote_clustered_identity,        # 8  NEW v1.11: demote collision-prone exact matchkeys (before generic refit rules)
+    # v1.20.x #124: rule_demote_clustered_identity removed from rotation.
+    # v1.11 Phase 7 diagnostic showed it never reaches position 8 in
+    # iteration -- rule_blocking_too_coarse exhausts the budget first --
+    # AND v1.12 Path Y (NE on exact matchkeys) addressed T3 directly,
+    # making the rule's mechanism redundant. The function + helper +
+    # indicator are kept as dead code for now so direct-invocation tests
+    # still pass; full surface removal is a follow-up once
+    # telemetry confirms zero invocations from external callers.
     rule_unimodal_scoring,                 # 9  tuning: dip statistic low
     rule_low_reduction_ratio,              # 10 structural: too-tight blocking
     rule_cross_blocking_disagreement,      # 11 NEW v1.10: multi-pass on low cross-blocking overlap

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -436,7 +436,7 @@ def test_default_rules_list_has_five_entries():
     # Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1)
     # Updated to 13: Phase 5 added rule_corruption_normalize, rule_cross_blocking_disagreement,
     # rule_sparse_match_expand (v1.10)
-    assert len(DEFAULT_RULES) == 15
+    assert len(DEFAULT_RULES) == 14  # v1.20.x #124: rule_demote_clustered_identity removed from rotation
 
 
 def test_heuristic_policy_with_default_rules_fires_on_red_blocking():
@@ -619,7 +619,7 @@ def test_default_rules_now_has_six_entries():
     Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 15
+    assert len(DEFAULT_RULES) == 14  # v1.20.x #124: rule_demote_clustered_identity removed from rotation
 
 
 def test_singleton_trap_runs_before_blocking_too_coarse():
@@ -835,7 +835,7 @@ def test_default_rules_now_has_seven_entries():
     Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 15
+    assert len(DEFAULT_RULES) == 14  # v1.20.x #124: rule_demote_clustered_identity removed from rotation
 
 
 def test_rule_key_swap_is_before_rule_no_matches():
@@ -1159,7 +1159,7 @@ def test_default_rules_now_has_nine_entries():
     AutoConfigController._maybe_decorate_with_llm_scorer post-iteration decoration.)
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 15
+    assert len(DEFAULT_RULES) == 14  # v1.20.x #124: rule_demote_clustered_identity removed from rotation
 
 
 def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_last():
@@ -1300,7 +1300,7 @@ def test_default_rules_now_has_ten_entries():
     Updated to 13: Phase 5 added rule_corruption_normalize, rule_cross_blocking_disagreement,
     rule_sparse_match_expand (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 15
+    assert len(DEFAULT_RULES) == 14  # v1.20.x #124: rule_demote_clustered_identity removed from rotation
 
 
 def test_rule_enable_llm_scorer_not_in_default_rules():
@@ -1548,7 +1548,7 @@ def test_default_rules_now_has_ten_entries_final():
     """Fix 1 (reorder) + Fix 2 (new rule) → 10 rules total.
     Updated to 13: Phase 5 added 3 new indicator-aware rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 15
+    assert len(DEFAULT_RULES) == 14  # v1.20.x #124: rule_demote_clustered_identity removed from rotation
 
 
 # ============================================================


### PR DESCRIPTION
Minimal-blast-radius removal for #124. Take the rule out of DEFAULT_RULES rotation so it doesn't compete for iteration budget. Function + helper + indicator + dataclass + context method stay as dead code so the 64 direct-invocation tests still pass.

## Why this is safe
- v1.11 Phase 7 diagnostic: rule never reaches position 8 (`rule_blocking_too_coarse` exhausts budget first)
- v1.12 Path Y addressed T3 directly via NE on exact matchkeys -- rule's mechanism is redundant
- T3 recovery test (`tests/test_dqbench_t3_recovery.py`) still passes -- Path Y maintains `n_clusters >= 200`

## Verification
```
pytest tests/test_dqbench_t3_recovery.py tests/test_autoconfig_rules.py
31 passed in 5.01s
```

## Follow-up
Full surface removal (function + helper + indicator + dataclass + context method + 64 tests) is a separate cleanup PR once this has been on main for telemetry-confirmation. Will open a follow-up issue.

Closes #124 (minimal removal).