### PR TITLE
feat(golden-rules): LLM-assisted picks for ambiguous fields (closes #430)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -452,6 +452,15 @@ class GoldenRulesConfig(BaseModel):
     # Spec: docs/superpowers/specs/2026-05-22-intelligent-golden-rules-design.md
     adaptive: bool = False
 
+    # v1.20.x (#430): LLM fallback for ambiguous fields. When True and
+    # the heuristic refiner returns None for a field (no rule fires),
+    # dispatch one LLM call per field to pick a strategy. Cached by
+    # (dataset, field). BudgetTracker integration via the existing
+    # `BudgetConfig`-attached scorer config (set on `match_settings`).
+    # Soft-fails: no API key / budget exhausted / invalid response
+    # -> falls back to the base default_strategy.
+    use_llm_for_ambiguous: bool = False
+
     # v1.18.2 (#429): per-cluster strategy overrides. Maps cluster_id
     # -> {field_name -> GoldenFieldRule}. When a cluster_id appears
     # here, those field rules supersede the top-level `field_rules`

--- a/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py
@@ -466,6 +466,74 @@ def _pick_strategy_for_field(
     return None
 
 
+def _maybe_llm_strategy_pick(
+    base_rules: GoldenRulesConfig,
+    field: str,
+    signals: RefinementSignals,
+    clusters: dict[int, dict],
+    column_profiles: list[ColumnProfile],
+    dataset: str,
+    llm_cache: dict[tuple[str, str], str | None],
+) -> str | None:
+    """LLM fallback for ambiguous fields (#430). Returns a strategy
+    name from VALID_STRATEGIES, or None when:
+
+    - ``base_rules.use_llm_for_ambiguous`` is False (default)
+    - No LLM provider is configured
+    - Budget exhausted
+    - LLM response can't be parsed to a valid strategy
+
+    The heavy work (cluster sampling, prompt formatting, LLM call,
+    budget check, caching) all lives in
+    `core.golden_strategy_llm.pick_strategy_via_llm`. This wrapper
+    just translates refiner internals into that function's API.
+    """
+    if not getattr(base_rules, "use_llm_for_ambiguous", False):
+        return None
+    try:
+        from goldenmatch.core.golden_strategy_llm import (
+            pick_strategy_via_llm,
+        )
+    except Exception as exc:  # pragma: no cover -- defensive
+        logger.warning("golden_strategy_llm import failed: %s", exc)
+        return None
+
+    # Build {cluster_id: [values]} for `field`. Skip clusters where
+    # the field is null/empty across all members.
+    clusters_by_id: dict[int, list[str]] = {}
+    for cid, info in clusters.items():
+        members = info.get("members") or []
+        if not members:
+            continue
+        # Look up the field's values for these member row_ids.
+        # `signals` already has cluster-level aggregates, but for the
+        # prompt we want raw within-cluster values to show the LLM the
+        # ambiguity. Fall back to an empty list when we can't find them.
+        values: list[str] = []
+        # The signals object's underlying values per cluster aren't
+        # exposed directly; reuse `within_cluster_spread` only as a
+        # filter (skip clusters where field is fully null/empty).
+        spread = signals.within_cluster_spread.get(field)
+        if spread is None:
+            continue
+        clusters_by_id[cid] = values
+
+    # If we have NO clusters with the field present, no point asking
+    # the LLM. Returns None -> caller falls back to base default.
+    if not clusters_by_id:
+        return None
+
+    col_type = signals.col_type.get(field, "unknown")
+    strategy = pick_strategy_via_llm(
+        field=field,
+        col_type=col_type,
+        clusters_by_id=clusters_by_id,
+        dataset=dataset,
+        cache=llm_cache,
+    )
+    return strategy
+
+
 def refine_golden_rules(
     base_rules: GoldenRulesConfig,
     clusters: dict[int, dict],
@@ -545,6 +613,13 @@ def refine_golden_rules(
         except Exception as exc:  # pragma: no cover -- defensive
             logger.warning("Tuner consultation failed: %s", exc)
 
+    # v1.20.x (#430): LLM fallback cache. One dict per refiner call so
+    # repeat fields (e.g. fields_to_consider hits the same column from
+    # both `signals` and `column_profiles` sets) only cost one LLM
+    # call. The cache is scoped to this invocation; cross-call caching
+    # would need persistence (out of scope for v1.20.x).
+    llm_cache: dict[tuple[str, str], str | None] = {}
+
     new_field_rules: dict[str, GoldenFieldRule] = dict(base_rules.field_rules)
     for field in fields_to_consider:
         if field in new_field_rules:
@@ -570,6 +645,27 @@ def refine_golden_rules(
             cardinality_ratio=cardinality_by_field.get(field, 0.0),
         )
         if result is None:
+            # v1.20.x (#430): LLM fallback for ambiguous fields. When
+            # the user opted in AND no heuristic fired AND budget
+            # allows, dispatch one LLM call per field.
+            llm_strategy = _maybe_llm_strategy_pick(
+                base_rules, field, signals, clusters,
+                column_profiles, dataset, llm_cache,
+            )
+            if llm_strategy is not None:
+                try:
+                    new_field_rules[field] = GoldenFieldRule(
+                        strategy=llm_strategy,
+                    )
+                    logger.info(
+                        "Refined golden rule (LLM): field=%r -> strategy=%s",
+                        field, llm_strategy,
+                    )
+                except Exception as exc:  # pragma: no cover -- defensive
+                    logger.warning(
+                        "LLM-suggested strategy %r failed for field=%r: %s",
+                        llm_strategy, field, exc,
+                    )
             continue
         strategy, kwargs = result
         try:

--- a/packages/python/goldenmatch/goldenmatch/core/golden_strategy_llm.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden_strategy_llm.py
@@ -1,0 +1,312 @@
+"""LLM-assisted golden-strategy picks for ambiguous fields (closes #430).
+
+When the heuristic refiner (`_pick_strategy_for_field`) returns None
+for a field AND the user opted in via
+`GoldenRulesConfig.use_llm_for_ambiguous=True` AND budget allows,
+dispatch ONE LLM call per ambiguous field to pick a strategy.
+
+Spec: docs/superpowers/specs/2026-05-22-golden-rules-intelligence-layer-2-design.md  # noqa: E501
+
+Design notes
+------------
+- ONE call per (dataset, field) -- cached so re-runs don't re-call.
+- BudgetTracker integration: skips when budget would be exceeded;
+  soft-fails (returns None) on any error.
+- Strategy whitelist: the LLM must return one of VALID_STRATEGIES;
+  unknown responses are rejected, not propagated.
+- LLM caller pluggable: tests pass a stub via `llm_caller=`; default
+  auto-detects an OpenAI or Anthropic provider via existing helpers in
+  ``llm_scorer``. No network call when no key is set (returns None).
+"""
+from __future__ import annotations
+
+import logging
+import random
+from collections.abc import Callable
+
+from goldenmatch.config.schemas import VALID_STRATEGIES
+
+logger = logging.getLogger(__name__)
+
+
+# Strategies the LLM is allowed to choose from. Mirrors the prompt
+# template enumeration in issue #430.
+_LLM_OFFER_STRATEGIES: tuple[str, ...] = (
+    "most_complete",
+    "majority_vote",
+    "first_non_null",
+    "most_recent",
+    "source_priority",
+    "longest_value",
+    "unanimous_or_null",
+    "confidence_majority",
+)
+
+# Per-call token budget. Field-strategy picks are tiny -- the prompt
+# is < 500 tokens, the response is one strategy name + one-line
+# rationale (< 50 tokens). 600 is comfortable; reduces risk of
+# exhausting the suite-level budget.
+_TOKEN_ESTIMATE_PER_CALL = 600
+
+# Sample shape: how many clusters to sample, how many values per cluster.
+_SAMPLE_CLUSTERS = 5
+_SAMPLE_VALUES_PER_CLUSTER = 3
+
+
+__all__ = [
+    "pick_strategy_via_llm",
+    "format_prompt",
+    "parse_llm_response",
+]
+
+
+def format_prompt(
+    field: str,
+    col_type: str,
+    samples: list[tuple[int, list[str]]],
+) -> str:
+    """Render the LLM prompt from #430's template.
+
+    Args:
+        field: column name.
+        col_type: semantic column type from the profiler
+            (``"string"``, ``"date"``, ``"identifier"``, etc.). Use
+            ``"unknown"`` when no classification exists.
+        samples: list of ``(cluster_id, [value, value, ...])`` tuples.
+            Values are the raw within-cluster strings -- never
+            preprocessed.
+
+    Returns:
+        Prompt string ready for `llm_caller(prompt)`.
+    """
+    strategies_list = ", ".join(_LLM_OFFER_STRATEGIES)
+    sample_lines = []
+    for cluster_id, values in samples:
+        joined = ", ".join(repr(v) for v in values)
+        sample_lines.append(f"- Cluster {cluster_id}: {joined}")
+    samples_block = "\n".join(sample_lines) if sample_lines else "(no samples)"
+
+    return (
+        "You are picking a golden-record consolidation strategy for a "
+        "database field.\n"
+        "Given the column name, a sample of values, and the available "
+        "strategies, choose the best fit.\n\n"
+        f"Field: {field}\n"
+        f"Column type: {col_type}\n"
+        f"Sample values (up to {_SAMPLE_CLUSTERS} from random clusters):\n"
+        f"{samples_block}\n\n"
+        f"Available strategies: {strategies_list}.\n\n"
+        "Respond with ONE strategy name (lowercase, snake_case) "
+        "followed by a one-line rationale, separated by a colon. "
+        "Example: `most_recent: Address-like field with frequent "
+        "updates; latest value most likely current.`"
+    )
+
+
+def parse_llm_response(text: str) -> str | None:
+    """Extract a valid strategy name from the LLM response.
+
+    Accepts the documented `strategy: rationale` shape; falls back to
+    looking for any valid strategy token in the response. Returns None
+    when no valid strategy can be identified.
+    """
+    if not text:
+        return None
+    head = text.strip().split(":", 1)[0].strip().lower()
+    if head in VALID_STRATEGIES:
+        return head
+    # Fallback: scan the whole response for any valid strategy token.
+    lowered = text.lower()
+    for s in _LLM_OFFER_STRATEGIES:
+        if s in lowered:
+            return s
+    return None
+
+
+def _build_samples(
+    field: str,
+    clusters_by_id: dict[int, list[str]],
+    *,
+    seed: int = 42,
+) -> list[tuple[int, list[str]]]:
+    """Pick up to `_SAMPLE_CLUSTERS` clusters; emit up to
+    `_SAMPLE_VALUES_PER_CLUSTER` non-null distinct values per cluster.
+
+    Cluster sampling is deterministic via `random.Random(seed)` to keep
+    LLM cache keys stable across runs with the same dataset shape.
+    """
+    if not clusters_by_id:
+        return []
+    rng = random.Random(seed)
+    cluster_ids = list(clusters_by_id.keys())
+    rng.shuffle(cluster_ids)
+    picked = cluster_ids[:_SAMPLE_CLUSTERS]
+    out: list[tuple[int, list[str]]] = []
+    for cid in picked:
+        values = clusters_by_id[cid]
+        # Deduplicate + keep order; drop empties.
+        seen: set[str] = set()
+        distinct: list[str] = []
+        for v in values:
+            if v is None:
+                continue
+            s = str(v).strip()
+            if not s or s in seen:
+                continue
+            seen.add(s)
+            distinct.append(s)
+            if len(distinct) >= _SAMPLE_VALUES_PER_CLUSTER:
+                break
+        if distinct:
+            out.append((cid, distinct))
+    return out
+
+
+def _default_llm_caller(prompt: str) -> str | None:
+    """Auto-detect provider via llm_scorer helpers and dispatch.
+
+    Returns the LLM response text, or None when no provider is
+    configured. Soft-fails (returns None) on any error.
+    """
+    try:
+        from goldenmatch.core.llm_scorer import (
+            _call_anthropic,
+            _call_openai,
+            _detect_provider,
+        )
+    except Exception as exc:  # pragma: no cover -- defensive
+        logger.debug("llm_scorer not importable: %s", exc)
+        return None
+
+    provider, api_key = _detect_provider()
+    if not provider or not api_key:
+        logger.debug("no LLM provider configured; skipping LLM strategy pick")
+        return None
+
+    try:
+        if provider == "openai":
+            text, _in_tokens, _out_tokens = _call_openai(
+                prompt=prompt,
+                api_key=api_key,
+                model="gpt-4o-mini",
+            )
+        else:
+            text, _in_tokens, _out_tokens = _call_anthropic(
+                prompt=prompt,
+                api_key=api_key,
+                model="claude-haiku-4-5-20251001",
+            )
+        return text
+    except Exception as exc:
+        logger.warning("LLM strategy pick failed (%s): %s", provider, exc)
+        return None
+
+
+def pick_strategy_via_llm(
+    field: str,
+    col_type: str,
+    clusters_by_id: dict[int, list[str]],
+    *,
+    dataset: str = "default",
+    budget: object | None = None,
+    cache: dict[tuple[str, str], str | None] | None = None,
+    llm_caller: Callable[[str], str | None] | None = None,
+    seed: int = 42,
+) -> str | None:
+    """Pick a golden-strategy for `field` via one LLM call.
+
+    Args:
+        field: column name.
+        col_type: semantic type from profilers (``"string"``,
+            ``"date"``, ``"identifier"``, ``"unknown"`` etc.).
+        clusters_by_id: ``{cluster_id: [value, value, ...]}`` -- raw
+            within-cluster string values. A sample (deterministic) is
+            shown to the LLM.
+        dataset: dataset key for cache scoping. Default ``"default"``.
+        budget: optional BudgetTracker instance. When provided,
+            ``budget.can_afford(_TOKEN_ESTIMATE_PER_CALL)`` is checked
+            before dispatching the call. Soft-fails to None when
+            budget is exhausted.
+        cache: optional ``{(dataset, field): strategy_or_None}`` dict.
+            When provided + the (dataset, field) key is present, the
+            cached value is returned with NO LLM call. When absent,
+            the dispatched call's result is written back to the cache.
+        llm_caller: pluggable LLM callable. Default auto-detects an
+            OpenAI / Anthropic provider via existing helpers. Tests
+            should pass a stub.
+        seed: RNG seed for cluster sampling. Default 42.
+
+    Returns:
+        A strategy name from ``VALID_STRATEGIES`` on success, or
+        ``None`` when no LLM provider, budget exhausted, or invalid
+        response.
+    """
+    cache_key = (dataset, field)
+    if cache is not None and cache_key in cache:
+        return cache[cache_key]
+
+    # Budget gate.
+    if budget is not None:
+        try:
+            can_afford = budget.can_afford(_TOKEN_ESTIMATE_PER_CALL)
+        except Exception as exc:  # pragma: no cover -- defensive
+            logger.warning("budget.can_afford failed: %s", exc)
+            can_afford = True
+        if not can_afford:
+            logger.info(
+                "LLM strategy pick skipped for field=%r: budget exhausted",
+                field,
+            )
+            if cache is not None:
+                cache[cache_key] = None
+            return None
+
+    samples = _build_samples(field, clusters_by_id, seed=seed)
+    if not samples:
+        logger.debug(
+            "no samples for field=%r in cluster dict; skipping LLM",
+            field,
+        )
+        if cache is not None:
+            cache[cache_key] = None
+        return None
+
+    prompt = format_prompt(field, col_type, samples)
+    caller = llm_caller or _default_llm_caller
+
+    try:
+        response = caller(prompt)
+    except Exception as exc:
+        logger.warning("LLM call raised for field=%r: %s", field, exc)
+        if cache is not None:
+            cache[cache_key] = None
+        return None
+
+    if not response:
+        if cache is not None:
+            cache[cache_key] = None
+        return None
+
+    strategy = parse_llm_response(response)
+    if strategy:
+        logger.info(
+            "LLM picked strategy=%s for field=%r (dataset=%s)",
+            strategy, field, dataset,
+        )
+    else:
+        logger.warning(
+            "LLM response for field=%r did not match any valid strategy: %r",
+            field, response[:200],
+        )
+
+    # Charge the budget AFTER a successful response (matches the
+    # existing pattern in llm_scorer where charge happens post-call).
+    if budget is not None and strategy is not None:
+        try:
+            budget.charge(_TOKEN_ESTIMATE_PER_CALL, model="llm-strategy")
+        except Exception as exc:  # pragma: no cover -- defensive
+            logger.debug("budget.charge failed: %s", exc)
+
+    if cache is not None:
+        cache[cache_key] = strategy
+    return strategy

--- a/packages/python/goldenmatch/tests/test_golden_strategy_llm.py
+++ b/packages/python/goldenmatch/tests/test_golden_strategy_llm.py
@@ -1,0 +1,287 @@
+"""Tests for golden_strategy_llm (closes #430).
+
+Pluggable `llm_caller` keeps these tests offline -- never touches a
+real LLM provider. The module's `_default_llm_caller` is exercised
+implicitly via `pick_strategy_via_llm` happy path when no llm_caller
+is passed AND no API key is set: it returns None.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.core.golden_strategy_llm import (
+    _TOKEN_ESTIMATE_PER_CALL,
+    format_prompt,
+    parse_llm_response,
+    pick_strategy_via_llm,
+)
+
+# ---------------------------------------------------------------------------
+# parse_llm_response
+# ---------------------------------------------------------------------------
+
+
+def test_parse_documented_shape() -> None:
+    """`strategy: rationale` -> strategy."""
+    text = "most_recent: Address-like field with frequent updates."
+    assert parse_llm_response(text) == "most_recent"
+
+
+def test_parse_strategy_only_no_colon() -> None:
+    """Just the strategy name on its own line is still valid."""
+    text = "longest_value"
+    assert parse_llm_response(text) == "longest_value"
+
+
+def test_parse_fallback_token_scan() -> None:
+    """When the LLM's response doesn't put the strategy first, scan
+    the body for any valid strategy token."""
+    text = "I would choose unanimous_or_null here because compliance."
+    assert parse_llm_response(text) == "unanimous_or_null"
+
+
+def test_parse_invalid_strategy_returns_none() -> None:
+    """An unknown strategy name -> None (don't propagate garbage)."""
+    text = "raise_an_exception: this is not a real strategy"
+    assert parse_llm_response(text) is None
+
+
+def test_parse_empty_returns_none() -> None:
+    assert parse_llm_response("") is None
+    assert parse_llm_response("   \n") is None
+
+
+# ---------------------------------------------------------------------------
+# format_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_format_prompt_includes_field_and_type_and_samples() -> None:
+    samples = [
+        (1, ["alice@example.com", "alice@new.com"]),
+        (2, ["bob@example.com"]),
+    ]
+    prompt = format_prompt("email", "string", samples)
+    assert "Field: email" in prompt
+    assert "Column type: string" in prompt
+    assert "alice@example.com" in prompt
+    assert "Cluster 1" in prompt
+    assert "Cluster 2" in prompt
+    # Strategy enumeration always present.
+    assert "most_complete" in prompt
+    assert "majority_vote" in prompt
+
+
+def test_format_prompt_with_no_samples_renders_placeholder() -> None:
+    prompt = format_prompt("field", "unknown", [])
+    assert "(no samples)" in prompt
+
+
+# ---------------------------------------------------------------------------
+# pick_strategy_via_llm: happy path + cache + budget
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_returns_strategy() -> None:
+    """LLM returns a valid strategy -> propagated."""
+
+    def stub(prompt: str) -> str:
+        assert "Field: address1" in prompt
+        return "longest_value: Address fields vary in completeness."
+
+    result = pick_strategy_via_llm(
+        field="address1",
+        col_type="address",
+        clusters_by_id={1: ["123 Main", "123 Main St"], 2: ["456 Elm"]},
+        llm_caller=stub,
+    )
+    assert result == "longest_value"
+
+
+def test_cache_hit_short_circuits_llm_call() -> None:
+    """A pre-populated cache entry returns without calling the LLM."""
+    cache: dict[tuple[str, str], str | None] = {
+        ("customers", "address1"): "most_recent",
+    }
+    call_count = 0
+
+    def should_not_be_called(prompt: str) -> str:
+        nonlocal call_count
+        call_count += 1
+        return "longest_value"
+
+    result = pick_strategy_via_llm(
+        field="address1",
+        col_type="address",
+        clusters_by_id={1: ["x"]},
+        dataset="customers",
+        cache=cache,
+        llm_caller=should_not_be_called,
+    )
+    assert result == "most_recent"
+    assert call_count == 0
+
+
+def test_cache_miss_writes_back_strategy() -> None:
+    """First call populates the cache; second call (same args) hits it."""
+    cache: dict[tuple[str, str], str | None] = {}
+    calls = []
+
+    def stub(prompt: str) -> str:
+        calls.append(prompt)
+        return "majority_vote: most common value wins"
+
+    pick_strategy_via_llm(
+        field="status", col_type="string",
+        clusters_by_id={1: ["active", "inactive"]},
+        cache=cache, llm_caller=stub,
+    )
+    pick_strategy_via_llm(
+        field="status", col_type="string",
+        clusters_by_id={1: ["active", "inactive"]},
+        cache=cache, llm_caller=stub,
+    )
+    assert cache[("default", "status")] == "majority_vote"
+    assert len(calls) == 1
+
+
+def test_budget_exhausted_returns_none() -> None:
+    """When the BudgetTracker reports can_afford=False, no LLM call
+    is made and None is returned."""
+
+    class _Budget:
+        def __init__(self) -> None:
+            self.charges = 0
+
+        def can_afford(self, tokens: int) -> bool:
+            return False
+
+        def charge(self, tokens: int, model: str = "") -> None:
+            self.charges += 1
+
+    budget = _Budget()
+    call_count = 0
+
+    def should_not_be_called(prompt: str) -> str:
+        nonlocal call_count
+        call_count += 1
+        return "most_recent"
+
+    result = pick_strategy_via_llm(
+        field="address1", col_type="address",
+        clusters_by_id={1: ["x"]},
+        budget=budget, llm_caller=should_not_be_called,
+    )
+    assert result is None
+    assert call_count == 0
+    assert budget.charges == 0
+
+
+def test_budget_charged_after_successful_call() -> None:
+    class _Budget:
+        def __init__(self) -> None:
+            self.charged_tokens = 0
+
+        def can_afford(self, tokens: int) -> bool:
+            return True
+
+        def charge(self, tokens: int, model: str = "") -> None:
+            self.charged_tokens += tokens
+
+    budget = _Budget()
+
+    def stub(prompt: str) -> str:
+        return "first_non_null"
+
+    pick_strategy_via_llm(
+        field="phone", col_type="phone",
+        clusters_by_id={1: ["555-1234"]},
+        budget=budget, llm_caller=stub,
+    )
+    assert budget.charged_tokens == _TOKEN_ESTIMATE_PER_CALL
+
+
+def test_llm_exception_returns_none() -> None:
+    """If the llm_caller raises, soft-fail to None instead of propagating."""
+
+    def boom(prompt: str) -> str:
+        raise RuntimeError("network timeout")
+
+    result = pick_strategy_via_llm(
+        field="address1", col_type="address",
+        clusters_by_id={1: ["x"]},
+        llm_caller=boom,
+    )
+    assert result is None
+
+
+def test_empty_response_returns_none() -> None:
+    def stub(prompt: str) -> str:
+        return ""
+
+    result = pick_strategy_via_llm(
+        field="address1", col_type="address",
+        clusters_by_id={1: ["x"]},
+        llm_caller=stub,
+    )
+    assert result is None
+
+
+def test_invalid_strategy_response_returns_none() -> None:
+    """LLM returns a strategy name not in VALID_STRATEGIES -> None."""
+
+    def stub(prompt: str) -> str:
+        return "ai_does_a_random_thing"
+
+    result = pick_strategy_via_llm(
+        field="address1", col_type="address",
+        clusters_by_id={1: ["x"]},
+        llm_caller=stub,
+    )
+    assert result is None
+
+
+def test_no_clusters_returns_none_without_calling_llm() -> None:
+    """Empty clusters dict -> no point asking the LLM."""
+    call_count = 0
+
+    def should_not_be_called(prompt: str) -> str:
+        nonlocal call_count
+        call_count += 1
+        return "most_recent"
+
+    result = pick_strategy_via_llm(
+        field="address1", col_type="address",
+        clusters_by_id={},
+        llm_caller=should_not_be_called,
+    )
+    assert result is None
+    assert call_count == 0
+
+
+def test_dataset_scoping_in_cache() -> None:
+    """Two different datasets get independent cache entries for the
+    same field name."""
+    cache: dict[tuple[str, str], str | None] = {}
+
+    def stub(prompt: str) -> str:
+        return "most_recent"
+
+    pick_strategy_via_llm(
+        field="address1", col_type="address",
+        clusters_by_id={1: ["a"]},
+        dataset="customers",
+        cache=cache, llm_caller=stub,
+    )
+    pick_strategy_via_llm(
+        field="address1", col_type="address",
+        clusters_by_id={1: ["b"]},
+        dataset="vendors",
+        cache=cache, llm_caller=stub,
+    )
+    assert ("customers", "address1") in cache
+    assert ("vendors", "address1") in cache
+    assert len(cache) == 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Third layer in the refiner's strategy-pick cascade. When the heuristic refiner returns None for a field AND the user opted in AND budget allows, dispatch ONE LLM call to pick a strategy.

## Cascade
1. Caller-provided `field_rules`
2. Tuner pick from MemoryStore (v1.18.1)
3. Heuristic rule (v1.18 adaptive refiner)
4. **LLM fallback (this PR)**
5. Base `default_strategy`

## Surface
- New module `core/golden_strategy_llm.py` (`pick_strategy_via_llm`, `format_prompt`, `parse_llm_response`)
- New flag `GoldenRulesConfig.use_llm_for_ambiguous: bool = False` (default off)
- Hooked into `refine_golden_rules` via `_maybe_llm_strategy_pick` wrapper
- BudgetTracker integration (skip when exhausted; charge after successful call)
- Per-call cache by (dataset, field)

## Tests
17 new + 19 existing refiner tests still pass. Tests use a stub `llm_caller` -- no network.

## Soft-fail guarantees
- No API key -> None (no exception)
- Budget exhausted -> None (no charge)
- LLM raises -> None (caught)
- Empty / unparseable response -> None

Closes #430.