### PR TITLE
feat(autoconfig): Febrl3 F1 0.83 -> 0.90 via DOB + surname-substring blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,7 +488,9 @@ jobs:
           uv run python -c "
           import json
           r = json.load(open('/tmp/febrl3_smoke.json'))['results'][0]
-          assert r['f1'] >= 0.80, f'Febrl3 smoke regressed: {r}'
+          # #438 raised this from 0.80 -> 0.85 after blocking improvements
+          # (DOB pass + surname-substring pass) lifted F1 from 0.83 -> 0.90.
+          assert r['f1'] >= 0.85, f'Febrl3 smoke regressed: {r}'
           print('febrl3 smoke F1=', r['f1'])
           "
       - name: Smoke summary

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1107,6 +1107,36 @@ def _make_quality_column_profile(
     )
 
 
+def _pick_date_blocking_col(
+    profiles: list[ColumnProfile],
+    null_rate_fn,
+    *,
+    max_null_rate: float = 0.20,
+) -> str | None:
+    """#438: pick a date column suitable as a blocking pass.
+
+    Returns the first profile whose ``col_type == "date"`` (or
+    name-classified as a date by `_classify_by_name`) and whose null
+    rate is <= `max_null_rate`. Date-only blocking catches pairs that
+    share birthdates but disagree on geo+name fields, which is the
+    dominant recall-loss case on synthetic-typo data (Febrl3).
+
+    Returns None when no date column qualifies.
+    """
+    for p in profiles:
+        is_date_by_type = getattr(p, "col_type", None) == "date"
+        is_date_by_name = _classify_by_name(p.name) == "date"
+        if not (is_date_by_type or is_date_by_name):
+            continue
+        try:
+            if null_rate_fn(p.name) > max_null_rate:
+                continue
+        except Exception:
+            continue
+        return p.name
+    return None
+
+
 def build_blocking(
     profiles: list[ColumnProfile],
     df: pl.DataFrame,
@@ -1323,11 +1353,36 @@ def build_blocking(
             if secondary_candidates:
                 secondary_name = secondary_candidates[0].name
 
+        # #438: when a date column exists with low null rate, add it as
+        # an extra blocking pass. Catches pairs that share DOB but
+        # disagree on geo+name (typo'd name vs intact DOB) -- this is
+        # the dominant recall-loss case on Febrl3-shape synthetic data.
+        # Recall: 0.7229 -> 0.95+ on Febrl3 in local measurement.
+        date_block_col = _pick_date_blocking_col(profiles, _null_rate)
+
+        # #438: extra surname-substring pass complements the soundex
+        # pass on the secondary name. Soundex collapses typos but is
+        # noisy on short names; substring catches first-N-letter
+        # corruption patterns ("Smith" -> "Smiht").
+        secondary_name_substring = (
+            secondary_name if secondary_name else None
+        )
+
         if best_geo:
             extra_passes = []
             if secondary_name:
                 extra_passes.append(BlockingKeyConfig(
                     fields=[secondary_name], transforms=["lowercase", "soundex"],
+                ))
+            if secondary_name_substring:
+                extra_passes.append(BlockingKeyConfig(
+                    fields=[secondary_name_substring],
+                    transforms=["lowercase", "substring:0:5"],
+                ))
+            if date_block_col:
+                extra_passes.append(BlockingKeyConfig(
+                    fields=[date_block_col],
+                    transforms=["lowercase", "strip"],
                 ))
             return BlockingConfig(
                 keys=[BlockingKeyConfig(fields=[best_geo, best_name], transforms=["lowercase", "strip"])],
@@ -1346,6 +1401,16 @@ def build_blocking(
         if secondary_name:
             extra_passes.append(BlockingKeyConfig(
                 fields=[secondary_name], transforms=["lowercase", "soundex"],
+            ))
+        if secondary_name_substring:
+            extra_passes.append(BlockingKeyConfig(
+                fields=[secondary_name_substring],
+                transforms=["lowercase", "substring:0:5"],
+            ))
+        if date_block_col:
+            extra_passes.append(BlockingKeyConfig(
+                fields=[date_block_col],
+                transforms=["lowercase", "strip"],
             ))
         return BlockingConfig(
             keys=[BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "soundex"])],

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -8,6 +8,7 @@ import re
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
@@ -1109,7 +1110,7 @@ def _make_quality_column_profile(
 
 def _pick_date_blocking_col(
     profiles: list[ColumnProfile],
-    null_rate_fn,
+    null_rate_fn: Callable[[str], float],
     *,
     max_null_rate: float = 0.20,
 ) -> str | None:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import logging
 import os
 import re
+from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import polars as pl


### PR DESCRIPTION
## Measurements

| Dataset    | Before | After  | Δ        |
|------------|--------|--------|----------|
| Febrl3     | 0.8305 | 0.8970 | +6.65 pp |
| DBLP-ACM   | 0.9641 | 0.9641 | flat     |

## Changes
- New helper `_pick_date_blocking_col` in `core/autoconfig.py`
- Two new blocking passes emitted by the name-cols branch:
  - DOB pass (when a date column with null rate <= 20% exists)
  - Secondary-name substring pass (when 2+ name columns exist)
- Smoke gate raised 0.80 -> 0.85 in `.github/workflows/ci.yml`

## Honest scoping
Issue target was F1 >= 0.95. Current 0.897 doesn't hit it. Threshold sweep (0.75-0.85) confirms 0.80 is the local maximum; lower kills precision. Pushing higher needs matchkey-shape changes (DOB/SSN as fuzzy fields, per-field weight tuning) which are larger surface-area changes deferred to a follow-up.

Refs #438 (stays open for scoring-side follow-up).