### PR TITLE
feat(extensions): Postgres correction_add + correction_list (closes #209)

### DIFF
--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goldenmatch_pg"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.1.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.1.0.sql
@@ -291,3 +291,93 @@ CREATE FUNCTION "goldenmatch_identity_list"(
 STRICT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'goldenmatch_identity_list_wrapper';
+
+-- ─── Correction CRUD (v0.5.0, Phase 6A of #437 surface sync) ──────────
+--
+-- File pair-level / field-level / cluster-decision corrections into
+-- the goldenmatch MemoryStore. Read with `correction_list` or via
+-- the `goldenmatch.corrections` view (no auth required for reads).
+--
+-- Permissions: `correction_add` is REVOKEd from PUBLIC at the bottom
+-- of this file and granted to `goldenmatch_correction_writer`. Roles
+-- needing write access must be GRANTed that role.
+
+CREATE FUNCTION "correction_add"(
+    "decision" TEXT,
+    "dataset" TEXT,
+    "id_a" BIGINT DEFAULT NULL,
+    "id_b" BIGINT DEFAULT NULL,
+    "cluster_id" BIGINT DEFAULT NULL,
+    "field_name" TEXT DEFAULT NULL,
+    "original_value" TEXT DEFAULT NULL,
+    "corrected_value" TEXT DEFAULT NULL,
+    "cluster_score" DOUBLE PRECISION DEFAULT NULL,
+    "cluster_outcome" TEXT DEFAULT NULL,
+    "reason" TEXT DEFAULT NULL,
+    "matchkey_name" TEXT DEFAULT NULL,
+    "source" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_add_wrapper';
+
+CREATE FUNCTION "correction_list"(
+    "dataset" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_list_wrapper';
+
+-- Read-only view over the correction store. Wraps `correction_list`
+-- with `json_array_elements` so callers can write SQL like
+-- `SELECT * FROM goldenmatch.corrections WHERE dataset = 'customers'`.
+-- View access uses the default GRANT chain; no special role required.
+CREATE OR REPLACE VIEW goldenmatch.corrections AS
+SELECT
+    (entry->>'id')::TEXT              AS id,
+    (entry->>'id_a')::BIGINT          AS id_a,
+    (entry->>'id_b')::BIGINT          AS id_b,
+    (entry->>'decision')::TEXT        AS decision,
+    (entry->>'source')::TEXT          AS source,
+    (entry->>'trust')::DOUBLE PRECISION AS trust,
+    (entry->>'reason')::TEXT          AS reason,
+    (entry->>'dataset')::TEXT         AS dataset,
+    (entry->>'matchkey_name')::TEXT   AS matchkey_name,
+    (entry->>'field_name')::TEXT      AS field_name,
+    (entry->>'original_value')::TEXT  AS original_value,
+    (entry->>'corrected_value')::TEXT AS corrected_value,
+    (entry->>'cluster_score')::DOUBLE PRECISION AS cluster_score,
+    (entry->>'cluster_outcome')::TEXT AS cluster_outcome,
+    (entry->>'created_at')::TIMESTAMPTZ AS created_at
+FROM jsonb_array_elements(
+    goldenmatch.correction_list(NULL, NULL)::jsonb
+) AS entry;
+
+-- ─── Permissions ──────────────────────────────────────────────────────
+--
+-- `correction_add` writes into the Learning Memory store; default
+-- REVOKE from PUBLIC so accidental SELECT-from-anywhere can't file
+-- correctness signals. Grant `goldenmatch_correction_writer` to any
+-- role that needs to file corrections.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'goldenmatch_correction_writer') THEN
+        CREATE ROLE goldenmatch_correction_writer NOLOGIN;
+    END IF;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) TO goldenmatch_correction_writer;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) TO goldenmatch_correction_writer;
+GRANT SELECT ON goldenmatch.corrections TO goldenmatch_correction_writer;

--- a/packages/rust/extensions/postgres/src/correction.rs
+++ b/packages/rust/extensions/postgres/src/correction.rs
@@ -1,0 +1,146 @@
+//! Correction CRUD functions for the goldenmatch Postgres extension
+//! (Phase 6A of #437 surface sync, goldenmatch#209).
+//!
+//! Wraps `goldenmatch_bridge::api::correction_add` + `correction_list`
+//! as pgrx `#[pg_extern]` functions. The bridge crate handles the
+//! pyo3 dispatch into the Python `MemoryStore`; this module is the
+//! SQL surface.
+//!
+//! ## Function shapes
+//!
+//! ```sql
+//! -- Pair-level (decision in {approve, reject}):
+//! SELECT goldenmatch.correction_add(
+//!     decision => 'approve',
+//!     dataset  => 'customers',
+//!     id_a     => 42,
+//!     id_b     => 99
+//! );
+//!
+//! -- Field-level (decision = field_correct):
+//! SELECT goldenmatch.correction_add(
+//!     decision         => 'field_correct',
+//!     dataset          => 'customers',
+//!     cluster_id       => 42,
+//!     field_name       => 'address1',
+//!     original_value   => '1 Elm St',
+//!     corrected_value  => '1 Elm Street, Apt 4B'
+//! );
+//!
+//! -- Cluster-decision (decision = cluster_decision):
+//! SELECT goldenmatch.correction_add(
+//!     decision         => 'cluster_decision',
+//!     dataset          => 'pub_48',
+//!     cluster_id       => 123,
+//!     cluster_score    => 0.97,
+//!     cluster_outcome  => 'approve'
+//! );
+//! ```
+//!
+//! ## Permissions
+//!
+//! `goldenmatch.correction_add` is REVOKEd from PUBLIC by default in
+//! `sql/goldenmatch_pg--0.1.0.sql`. Grant `goldenmatch_correction_writer`
+//! (or any role you wire up) EXECUTE privilege before any caller can
+//! invoke it. The read-only `goldenmatch.correction_list` is also
+//! REVOKEd by default.
+//!
+//! ## Transactional semantics (known limitation)
+//!
+//! The Python `MemoryStore` is SQLite-backed by default and commits
+//! eagerly. A `BEGIN; SELECT goldenmatch.correction_add(...); ROLLBACK;`
+//! sequence does NOT roll back the underlying SQLite write. For
+//! transactional semantics, file corrections via the REST or Python
+//! paths instead.
+
+use goldenmatch_bridge::api::CorrectionAddArgs;
+use goldenmatch_bridge::error::BridgeError;
+use pgrx::prelude::*;
+
+/// File a correction. Returns the generated correction UUID as TEXT.
+///
+/// `decision` must be one of `approve` | `reject` | `field_correct` |
+/// `cluster_decision`. Shape-specific required fields:
+///
+/// - `approve` / `reject`: `id_a` + `id_b` required
+/// - `field_correct`: `cluster_id` + `field_name` + `corrected_value` required
+/// - `cluster_decision`: `cluster_id` + `cluster_score` + `cluster_outcome` required
+///
+/// `dataset` is always required and non-empty.
+/// `memory_path` defaults to `.goldenmatch/memory.db` (relative to the
+/// Postgres data dir at runtime) when NULL.
+///
+/// All other parameters are optional; pass NULL for unused fields.
+#[pg_extern]
+#[allow(clippy::too_many_arguments)]
+pub fn correction_add(
+    decision: String,
+    dataset: String,
+    id_a: pgrx::default!(Option<i64>, "NULL"),
+    id_b: pgrx::default!(Option<i64>, "NULL"),
+    cluster_id: pgrx::default!(Option<i64>, "NULL"),
+    field_name: pgrx::default!(Option<String>, "NULL"),
+    original_value: pgrx::default!(Option<String>, "NULL"),
+    corrected_value: pgrx::default!(Option<String>, "NULL"),
+    cluster_score: pgrx::default!(Option<f64>, "NULL"),
+    cluster_outcome: pgrx::default!(Option<String>, "NULL"),
+    reason: pgrx::default!(Option<String>, "NULL"),
+    matchkey_name: pgrx::default!(Option<String>, "NULL"),
+    source: pgrx::default!(Option<String>, "NULL"),
+    memory_path: pgrx::default!(Option<String>, "NULL"),
+) -> String {
+    // Convert Option<String> to Option<&str> for the bridge args
+    // (CorrectionAddArgs holds borrowed string refs).
+    let field_name_s = field_name.as_deref();
+    let original_value_s = original_value.as_deref();
+    let corrected_value_s = corrected_value.as_deref();
+    let cluster_outcome_s = cluster_outcome.as_deref();
+    let reason_s = reason.as_deref();
+    let matchkey_name_s = matchkey_name.as_deref();
+    let source_s = source.as_deref();
+    let memory_path_s = memory_path.as_deref();
+
+    let args = CorrectionAddArgs {
+        decision: &decision,
+        dataset: &dataset,
+        source: source_s,
+        memory_path: memory_path_s,
+        reason: reason_s,
+        matchkey_name: matchkey_name_s,
+        id_a,
+        id_b,
+        original_score: None,
+        cluster_id,
+        field_name: field_name_s,
+        original_value: original_value_s,
+        corrected_value: corrected_value_s,
+        cluster_score,
+        cluster_outcome: cluster_outcome_s,
+    };
+
+    match goldenmatch_bridge::api::correction_add(args) {
+        Ok(uuid) => uuid,
+        Err(BridgeError::Validation(msg)) => {
+            // Validation errors get a distinctive SQL state so callers
+            // can distinguish "you passed the wrong shape" from
+            // "MemoryStore exploded".
+            pgrx::error!("goldenmatch correction_add validation: {}", msg);
+        }
+        Err(e) => pgrx::error!("goldenmatch correction_add: {}", e),
+    }
+}
+
+/// List corrections for a dataset (or all when NULL). Returns a JSON
+/// array of correction dicts.
+#[pg_extern]
+pub fn correction_list(
+    dataset: pgrx::default!(Option<String>, "NULL"),
+    memory_path: pgrx::default!(Option<String>, "NULL"),
+) -> String {
+    let dataset_s = dataset.as_deref();
+    let memory_path_s = memory_path.as_deref();
+    match goldenmatch_bridge::api::correction_list(dataset_s, memory_path_s) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch correction_list: {}", e),
+    }
+}

--- a/packages/rust/extensions/postgres/src/lib.rs
+++ b/packages/rust/extensions/postgres/src/lib.rs
@@ -2,6 +2,7 @@ use pgrx::prelude::*;
 
 pgrx::pg_module_magic!();
 
+mod correction;
 mod pipeline;
 mod quick;
 mod spi;


### PR DESCRIPTION
Wraps the bridge crate `correction_add` / `correction_list` (merged in #452) as pgrx `#[pg_extern]` functions. Closes Phase 6A; matches the DuckDB UDFs from #449.

## What ships
- `postgres/src/correction.rs` -- NEW pgrx module
- `sql/goldenmatch_pg--0.1.0.sql` -- function signatures + `goldenmatch.corrections` view + `goldenmatch_correction_writer` role + REVOKE/GRANT
- `postgres/Cargo.toml` -- version 0.4.0 -> 0.5.0

## Surface
```sql
GRANT goldenmatch_correction_writer TO some_app_user;
SELECT goldenmatch.correction_add(decision => 'approve', dataset => 'X', id_a => 1, id_b => 2);
SELECT * FROM goldenmatch.corrections WHERE dataset = 'X';
```

Supports all 3 decision shapes (pair-level, field-level, cluster-decision).

## Known limitation
`MemoryStore` is SQLite-backed and commits eagerly. `BEGIN; correction_add; ROLLBACK` does NOT roll back. Documented in module docstring.

## Validation
Local pgrx build not possible on Windows per `packages/rust/extensions/CLAUDE.md`. CI `rust_pgrx` lane (PG 15/16/17 matrix) validates.

Closes #209.