### PR TITLE
feat(dbt): write-side correction macros (closes #210)

### DIFF
--- a/packages/python/goldenmatch/dbt-goldenmatch/dbt_project.yml
+++ b/packages/python/goldenmatch/dbt-goldenmatch/dbt_project.yml
@@ -1,0 +1,26 @@
+# dbt-goldenmatch dbt package config (Phase 6C of #437 surface sync).
+#
+# Declares this directory as a dbt package so the macros in `macros/`
+# get picked up when consumers add this to their `packages.yml`:
+#
+#   packages:
+#     - git: "https://github.com/benseverndev-oss/goldenmatch.git"
+#       subdirectory: "packages/python/goldenmatch/dbt-goldenmatch"
+#
+# Macros use `adapter.dispatch()` to route between the Postgres
+# (`goldenmatch.correction_add`) and DuckDB (`goldenmatch_correction_add`)
+# function shapes. Other adapters raise a compile-time error.
+
+name: "dbt_goldenmatch"
+version: "0.1.0"
+config-version: 2
+
+# This package only ships macros; no models / seeds / snapshots.
+macro-paths: ["macros"]
+
+# Make the dispatch search namespace explicit. Adapter-specific
+# implementations live under `macros/<adapter>/`; the generic
+# entry point lives at `macros/<macro_name>.sql`.
+dispatch:
+  - macro_namespace: dbt_goldenmatch
+    search_order: ["dbt_goldenmatch"]

--- a/packages/python/goldenmatch/dbt-goldenmatch/macros/file_field_correction.sql
+++ b/packages/python/goldenmatch/dbt-goldenmatch/macros/file_field_correction.sql
@@ -1,0 +1,95 @@
+{#-
+  file_field_correction -- dbt macro that emits the SQL to file a
+  field-level Correction into the goldenmatch MemoryStore.
+
+  Closes Phase 6C of the #437 surface sync. Calls the Postgres
+  extension's `goldenmatch.correction_add(...)` (PR #461) or the
+  DuckDB UDF's `goldenmatch_correction_add(...)` (PR #449) based
+  on the dbt target adapter type.
+
+  Usage in a dbt model:
+
+      {{ goldenmatch_file_field_correction(
+          cluster_id=42,
+          field_name='address1',
+          original='1 Elm St',
+          corrected='1 Elm Street, Apt 4B',
+          dataset='customers',
+          reason='USPS lookup',
+      ) }}
+
+  Other adapters (Snowflake, BigQuery, Redshift, etc.) raise a
+  compile error -- there is no MemoryStore-write surface there yet.
+-#}
+
+{% macro goldenmatch_file_field_correction(
+    cluster_id,
+    field_name,
+    original,
+    corrected,
+    dataset,
+    reason=none,
+    memory_path=none
+) %}
+    {{ return(adapter.dispatch(
+        'goldenmatch_file_field_correction',
+        'dbt_goldenmatch'
+    )(cluster_id, field_name, original, corrected, dataset, reason, memory_path)) }}
+{% endmacro %}
+
+
+{# Default fallback: any adapter we haven't implemented yet. #}
+{% macro default__goldenmatch_file_field_correction(
+    cluster_id, field_name, original, corrected, dataset, reason, memory_path
+) %}
+    {{ exceptions.raise_compiler_error(
+        "goldenmatch_file_field_correction is only supported on postgres and "
+        "duckdb targets today; got adapter=" ~ target.type ~ ". File the "
+        "correction via the REST API (POST /api/v1/memory/corrections) or "
+        "Python (goldenmatch.add_correction) instead."
+    ) }}
+{% endmacro %}
+
+
+{# Postgres: invokes the pgrx-defined goldenmatch.correction_add. The
+   caller's role must have goldenmatch_correction_writer granted -- the
+   function is REVOKEd from PUBLIC by default. #}
+{% macro postgres__goldenmatch_file_field_correction(
+    cluster_id, field_name, original, corrected, dataset, reason, memory_path
+) %}
+    SELECT goldenmatch.correction_add(
+        decision        => 'field_correct',
+        dataset         => {{ dbt.string_literal(dataset) }},
+        cluster_id      => {{ cluster_id }},
+        field_name      => {{ dbt.string_literal(field_name) }},
+        original_value  => {{ "NULL" if original is none else dbt.string_literal(original) }},
+        corrected_value => {{ dbt.string_literal(corrected) }},
+        reason          => {{ "NULL" if reason is none else dbt.string_literal(reason) }},
+        memory_path     => {{ "NULL" if memory_path is none else dbt.string_literal(memory_path) }}
+    )
+{% endmacro %}
+
+
+{# DuckDB: invokes the Python UDF goldenmatch_correction_add. The
+   DuckDB UDF signature is positional with an args_json blob for the
+   shape-specific kwargs (designed for dbt + DuckDB's tighter
+   positional-args constraint). #}
+{% macro duckdb__goldenmatch_file_field_correction(
+    cluster_id, field_name, original, corrected, dataset, reason, memory_path
+) %}
+    {%- set args_json -%}
+        {
+          "cluster_id": {{ cluster_id }},
+          "field_name": {{ tojson(field_name) }},
+          "corrected_value": {{ tojson(corrected) }}
+          {%- if original is not none -%}, "original_value": {{ tojson(original) }}{%- endif -%}
+          {%- if reason is not none -%}, "reason": {{ tojson(reason) }}{%- endif -%}
+        }
+    {%- endset -%}
+    SELECT goldenmatch_correction_add(
+        'field_correct',
+        {{ dbt.string_literal(dataset) }},
+        {{ dbt.string_literal(memory_path) if memory_path is not none else "''" }},
+        {{ dbt.string_literal(args_json) }}
+    )
+{% endmacro %}

--- a/packages/python/goldenmatch/dbt-goldenmatch/macros/file_pair_correction.sql
+++ b/packages/python/goldenmatch/dbt-goldenmatch/macros/file_pair_correction.sql
@@ -1,0 +1,81 @@
+{#-
+  file_pair_correction -- dbt macro that emits the SQL to file a
+  pair-level Correction (approve/reject) into the goldenmatch
+  MemoryStore.
+
+  Companion to `file_field_correction`. Same adapter dispatch shape:
+  Postgres uses named args via `goldenmatch.correction_add(...)`;
+  DuckDB uses positional args + an `args_json` blob.
+
+  Usage in a dbt model:
+
+      {{ goldenmatch_file_pair_correction(
+          id_a=42, id_b=99, decision='approve',
+          dataset='customers', reason='same person, manual review',
+      ) }}
+-#}
+
+{% macro goldenmatch_file_pair_correction(
+    id_a,
+    id_b,
+    decision,
+    dataset,
+    reason=none,
+    matchkey_name=none,
+    memory_path=none
+) %}
+    {%- if decision not in ('approve', 'reject') -%}
+        {{ exceptions.raise_compiler_error(
+            "decision must be 'approve' or 'reject'; got " ~ decision
+        ) }}
+    {%- endif -%}
+    {{ return(adapter.dispatch(
+        'goldenmatch_file_pair_correction',
+        'dbt_goldenmatch'
+    )(id_a, id_b, decision, dataset, reason, matchkey_name, memory_path)) }}
+{% endmacro %}
+
+
+{% macro default__goldenmatch_file_pair_correction(
+    id_a, id_b, decision, dataset, reason, matchkey_name, memory_path
+) %}
+    {{ exceptions.raise_compiler_error(
+        "goldenmatch_file_pair_correction is only supported on postgres and "
+        "duckdb targets today; got adapter=" ~ target.type
+    ) }}
+{% endmacro %}
+
+
+{% macro postgres__goldenmatch_file_pair_correction(
+    id_a, id_b, decision, dataset, reason, matchkey_name, memory_path
+) %}
+    SELECT goldenmatch.correction_add(
+        decision      => {{ dbt.string_literal(decision) }},
+        dataset       => {{ dbt.string_literal(dataset) }},
+        id_a          => {{ id_a }},
+        id_b          => {{ id_b }},
+        reason        => {{ "NULL" if reason is none else dbt.string_literal(reason) }},
+        matchkey_name => {{ "NULL" if matchkey_name is none else dbt.string_literal(matchkey_name) }},
+        memory_path   => {{ "NULL" if memory_path is none else dbt.string_literal(memory_path) }}
+    )
+{% endmacro %}
+
+
+{% macro duckdb__goldenmatch_file_pair_correction(
+    id_a, id_b, decision, dataset, reason, matchkey_name, memory_path
+) %}
+    {%- set args_json -%}
+        {
+          "id_a": {{ id_a }},
+          "id_b": {{ id_b }}
+          {%- if reason is not none -%}, "reason": {{ tojson(reason) }}{%- endif -%}
+          {%- if matchkey_name is not none -%}, "matchkey_name": {{ tojson(matchkey_name) }}{%- endif -%}
+        }
+    {%- endset -%}
+    SELECT goldenmatch_correction_add(
+        {{ dbt.string_literal(decision) }},
+        {{ dbt.string_literal(dataset) }},
+        {{ dbt.string_literal(memory_path) if memory_path is not none else "''" }},
+        {{ dbt.string_literal(args_json) }}
+    )
+{% endmacro %}

--- a/packages/python/goldenmatch/dbt-goldenmatch/tests/test_macros.py
+++ b/packages/python/goldenmatch/dbt-goldenmatch/tests/test_macros.py
@@ -1,0 +1,221 @@
+"""Unit tests for the dbt-goldenmatch macros (closes #210, Phase 6C).
+
+Renders each macro against a stub Jinja environment that mimics the
+dbt context. Avoids a live `dbt-core` import path -- a real dbt
+integration test would need a running Postgres + DuckDB, which is
+outside the per-package CI lane's scope. The CI integration test
+lives at the SQL-extension level (PG matrix in `rust_pgrx` lane,
+DuckDB in `duckdb_extensions` lane); these unit tests just assert
+the rendered SQL is correctly shaped for each adapter.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# Jinja2 is a transitive dep of dbt-core but not directly required by
+# the goldenmatch root venv. Skip cleanly when running outside the
+# dbt-goldenmatch lane.
+jinja2 = pytest.importorskip("jinja2")
+
+
+_MACROS_DIR = Path(__file__).resolve().parents[1] / "macros"
+
+
+# ---------------------------------------------------------------------------
+# Jinja environment + dbt stub context
+# ---------------------------------------------------------------------------
+
+
+class _DbtStub:
+    """Minimal stub for the `dbt` global. Just `string_literal`."""
+
+    @staticmethod
+    def string_literal(s: str) -> str:
+        # Single-quote with backslash escape -- mirrors dbt-core's default
+        # macro for postgres / duckdb. Good enough for shape-checks.
+        escaped = s.replace("'", "''")
+        return f"'{escaped}'"
+
+
+class _TargetStub:
+    def __init__(self, adapter_type: str) -> None:
+        self.type = adapter_type
+
+
+class _AdapterStub:
+    def __init__(self, adapter_type: str, env: jinja2.Environment) -> None:
+        self._adapter_type = adapter_type
+        self._env = env
+
+    def dispatch(self, macro_name: str, namespace: str):  # noqa: ARG002
+        # Look up the adapter-specific macro in the same template
+        # (e.g. `postgres__goldenmatch_file_field_correction`) and
+        # fall back to `default__<macro>`.
+        candidates = [
+            f"{self._adapter_type}__{macro_name}",
+            f"default__{macro_name}",
+        ]
+        for cand in candidates:
+            if cand in self._env.globals:
+                return self._env.globals[cand]
+        raise RuntimeError(f"no dispatch candidate for {macro_name} on {self._adapter_type}")
+
+
+def _exceptions_stub():
+    class _Ex:
+        @staticmethod
+        def raise_compiler_error(msg: str):
+            raise RuntimeError(msg)
+    return _Ex()
+
+
+def _build_env(adapter_type: str, macro_filename: str) -> jinja2.Environment:
+    """Load a macro template + return a Jinja env with dbt-shaped globals."""
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(_MACROS_DIR)),
+        autoescape=False,
+        undefined=jinja2.StrictUndefined,
+    )
+    # Wire `target`, `adapter`, `dbt`, `exceptions`, `tojson`, `return`.
+    env.globals["target"] = _TargetStub(adapter_type)
+    env.globals["dbt"] = _DbtStub()
+    env.globals["exceptions"] = _exceptions_stub()
+    env.globals["tojson"] = lambda v: json.dumps(v)
+    captured: dict[str, object] = {}
+
+    def _return(v):
+        captured["value"] = v
+        return v
+
+    env.globals["return"] = _return
+    env.globals["adapter"] = _AdapterStub(adapter_type, env)
+    # Load + register the macros from the template as callable globals.
+    template = env.get_template(macro_filename)
+    module = template.module
+    for name in dir(module):
+        if name.startswith("_"):
+            continue
+        attr = getattr(module, name)
+        if callable(attr):
+            env.globals[name] = attr
+    env.globals["_captured"] = captured
+    return env
+
+
+# ---------------------------------------------------------------------------
+# file_field_correction
+# ---------------------------------------------------------------------------
+
+
+def test_field_correction_postgres_render() -> None:
+    env = _build_env("postgres", "file_field_correction.sql")
+    fn = env.globals["goldenmatch_file_field_correction"]
+    sql = fn(
+        cluster_id=42,
+        field_name="address1",
+        original="1 Elm St",
+        corrected="1 Elm Street, Apt 4B",
+        dataset="customers",
+        reason="USPS lookup",
+    )
+    assert "goldenmatch.correction_add" in sql
+    assert "decision        => 'field_correct'" in sql
+    assert "cluster_id      => 42" in sql
+    assert "field_name      => 'address1'" in sql
+    assert "corrected_value => '1 Elm Street, Apt 4B'" in sql
+    assert "reason          => 'USPS lookup'" in sql
+
+
+def test_field_correction_postgres_null_optionals() -> None:
+    env = _build_env("postgres", "file_field_correction.sql")
+    fn = env.globals["goldenmatch_file_field_correction"]
+    sql = fn(
+        cluster_id=42, field_name="address1", original=None,
+        corrected="X", dataset="d",
+    )
+    # Optionals render as NULL, not quoted strings.
+    assert "original_value  => NULL" in sql
+    assert "reason          => NULL" in sql
+    assert "memory_path     => NULL" in sql
+
+
+def test_field_correction_duckdb_render() -> None:
+    env = _build_env("duckdb", "file_field_correction.sql")
+    fn = env.globals["goldenmatch_file_field_correction"]
+    sql = fn(
+        cluster_id=42,
+        field_name="address1",
+        original=None,
+        corrected="1 Elm Street, Apt 4B",
+        dataset="customers",
+        reason=None,
+    )
+    assert "goldenmatch_correction_add" in sql
+    assert "'field_correct'" in sql
+    assert "'customers'" in sql
+    # args_json embedded as a single string literal containing the JSON.
+    assert '"cluster_id": 42' in sql
+    assert '"field_name": "address1"' in sql
+
+
+def test_field_correction_unknown_adapter_raises() -> None:
+    env = _build_env("snowflake", "file_field_correction.sql")
+    fn = env.globals["goldenmatch_file_field_correction"]
+    with pytest.raises(RuntimeError, match="only supported on postgres and duckdb"):
+        fn(
+            cluster_id=1, field_name="x", original=None,
+            corrected="y", dataset="d",
+        )
+
+
+# ---------------------------------------------------------------------------
+# file_pair_correction
+# ---------------------------------------------------------------------------
+
+
+def test_pair_correction_postgres_approve() -> None:
+    env = _build_env("postgres", "file_pair_correction.sql")
+    fn = env.globals["goldenmatch_file_pair_correction"]
+    sql = fn(
+        id_a=42, id_b=99, decision="approve",
+        dataset="customers", reason="manual review",
+    )
+    assert "goldenmatch.correction_add" in sql
+    assert "decision      => 'approve'" in sql
+    assert "id_a          => 42" in sql
+    assert "id_b          => 99" in sql
+    assert "reason        => 'manual review'" in sql
+
+
+def test_pair_correction_invalid_decision_raises() -> None:
+    env = _build_env("postgres", "file_pair_correction.sql")
+    fn = env.globals["goldenmatch_file_pair_correction"]
+    with pytest.raises(RuntimeError, match="decision must be"):
+        fn(id_a=1, id_b=2, decision="maybe", dataset="d")
+
+
+def test_pair_correction_duckdb_render() -> None:
+    env = _build_env("duckdb", "file_pair_correction.sql")
+    fn = env.globals["goldenmatch_file_pair_correction"]
+    sql = fn(
+        id_a=42, id_b=99, decision="reject",
+        dataset="customers", reason=None,
+    )
+    assert "goldenmatch_correction_add" in sql
+    assert "'reject'" in sql
+    assert '"id_a": 42' in sql
+    assert '"id_b": 99' in sql
+
+
+def test_pair_correction_unknown_adapter_raises() -> None:
+    env = _build_env("bigquery", "file_pair_correction.sql")
+    fn = env.globals["goldenmatch_file_pair_correction"]
+    with pytest.raises(RuntimeError, match="only supported on postgres and duckdb"):
+        fn(id_a=1, id_b=2, decision="approve", dataset="d")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goldenmatch_pg"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.1.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.1.0.sql
@@ -291,3 +291,93 @@ CREATE FUNCTION "goldenmatch_identity_list"(
 STRICT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'goldenmatch_identity_list_wrapper';
+
+-- ─── Correction CRUD (v0.5.0, Phase 6A of #437 surface sync) ──────────
+--
+-- File pair-level / field-level / cluster-decision corrections into
+-- the goldenmatch MemoryStore. Read with `correction_list` or via
+-- the `goldenmatch.corrections` view (no auth required for reads).
+--
+-- Permissions: `correction_add` is REVOKEd from PUBLIC at the bottom
+-- of this file and granted to `goldenmatch_correction_writer`. Roles
+-- needing write access must be GRANTed that role.
+
+CREATE FUNCTION "correction_add"(
+    "decision" TEXT,
+    "dataset" TEXT,
+    "id_a" BIGINT DEFAULT NULL,
+    "id_b" BIGINT DEFAULT NULL,
+    "cluster_id" BIGINT DEFAULT NULL,
+    "field_name" TEXT DEFAULT NULL,
+    "original_value" TEXT DEFAULT NULL,
+    "corrected_value" TEXT DEFAULT NULL,
+    "cluster_score" DOUBLE PRECISION DEFAULT NULL,
+    "cluster_outcome" TEXT DEFAULT NULL,
+    "reason" TEXT DEFAULT NULL,
+    "matchkey_name" TEXT DEFAULT NULL,
+    "source" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_add_wrapper';
+
+CREATE FUNCTION "correction_list"(
+    "dataset" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_list_wrapper';
+
+-- Read-only view over the correction store. Wraps `correction_list`
+-- with `json_array_elements` so callers can write SQL like
+-- `SELECT * FROM goldenmatch.corrections WHERE dataset = 'customers'`.
+-- View access uses the default GRANT chain; no special role required.
+CREATE OR REPLACE VIEW goldenmatch.corrections AS
+SELECT
+    (entry->>'id')::TEXT              AS id,
+    (entry->>'id_a')::BIGINT          AS id_a,
+    (entry->>'id_b')::BIGINT          AS id_b,
+    (entry->>'decision')::TEXT        AS decision,
+    (entry->>'source')::TEXT          AS source,
+    (entry->>'trust')::DOUBLE PRECISION AS trust,
+    (entry->>'reason')::TEXT          AS reason,
+    (entry->>'dataset')::TEXT         AS dataset,
+    (entry->>'matchkey_name')::TEXT   AS matchkey_name,
+    (entry->>'field_name')::TEXT      AS field_name,
+    (entry->>'original_value')::TEXT  AS original_value,
+    (entry->>'corrected_value')::TEXT AS corrected_value,
+    (entry->>'cluster_score')::DOUBLE PRECISION AS cluster_score,
+    (entry->>'cluster_outcome')::TEXT AS cluster_outcome,
+    (entry->>'created_at')::TIMESTAMPTZ AS created_at
+FROM jsonb_array_elements(
+    goldenmatch.correction_list(NULL, NULL)::jsonb
+) AS entry;
+
+-- ─── Permissions ──────────────────────────────────────────────────────
+--
+-- `correction_add` writes into the Learning Memory store; default
+-- REVOKE from PUBLIC so accidental SELECT-from-anywhere can't file
+-- correctness signals. Grant `goldenmatch_correction_writer` to any
+-- role that needs to file corrections.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'goldenmatch_correction_writer') THEN
+        CREATE ROLE goldenmatch_correction_writer NOLOGIN;
+    END IF;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) TO goldenmatch_correction_writer;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) TO goldenmatch_correction_writer;
+GRANT SELECT ON goldenmatch.corrections TO goldenmatch_correction_writer;

--- a/packages/rust/extensions/postgres/src/correction.rs
+++ b/packages/rust/extensions/postgres/src/correction.rs
@@ -1,0 +1,146 @@
+//! Correction CRUD functions for the goldenmatch Postgres extension
+//! (Phase 6A of #437 surface sync, goldenmatch#209).
+//!
+//! Wraps `goldenmatch_bridge::api::correction_add` + `correction_list`
+//! as pgrx `#[pg_extern]` functions. The bridge crate handles the
+//! pyo3 dispatch into the Python `MemoryStore`; this module is the
+//! SQL surface.
+//!
+//! ## Function shapes
+//!
+//! ```sql
+//! -- Pair-level (decision in {approve, reject}):
+//! SELECT goldenmatch.correction_add(
+//!     decision => 'approve',
+//!     dataset  => 'customers',
+//!     id_a     => 42,
+//!     id_b     => 99
+//! );
+//!
+//! -- Field-level (decision = field_correct):
+//! SELECT goldenmatch.correction_add(
+//!     decision         => 'field_correct',
+//!     dataset          => 'customers',
+//!     cluster_id       => 42,
+//!     field_name       => 'address1',
+//!     original_value   => '1 Elm St',
+//!     corrected_value  => '1 Elm Street, Apt 4B'
+//! );
+//!
+//! -- Cluster-decision (decision = cluster_decision):
+//! SELECT goldenmatch.correction_add(
+//!     decision         => 'cluster_decision',
+//!     dataset          => 'pub_48',
+//!     cluster_id       => 123,
+//!     cluster_score    => 0.97,
+//!     cluster_outcome  => 'approve'
+//! );
+//! ```
+//!
+//! ## Permissions
+//!
+//! `goldenmatch.correction_add` is REVOKEd from PUBLIC by default in
+//! `sql/goldenmatch_pg--0.1.0.sql`. Grant `goldenmatch_correction_writer`
+//! (or any role you wire up) EXECUTE privilege before any caller can
+//! invoke it. The read-only `goldenmatch.correction_list` is also
+//! REVOKEd by default.
+//!
+//! ## Transactional semantics (known limitation)
+//!
+//! The Python `MemoryStore` is SQLite-backed by default and commits
+//! eagerly. A `BEGIN; SELECT goldenmatch.correction_add(...); ROLLBACK;`
+//! sequence does NOT roll back the underlying SQLite write. For
+//! transactional semantics, file corrections via the REST or Python
+//! paths instead.
+
+use goldenmatch_bridge::api::CorrectionAddArgs;
+use goldenmatch_bridge::error::BridgeError;
+use pgrx::prelude::*;
+
+/// File a correction. Returns the generated correction UUID as TEXT.
+///
+/// `decision` must be one of `approve` | `reject` | `field_correct` |
+/// `cluster_decision`. Shape-specific required fields:
+///
+/// - `approve` / `reject`: `id_a` + `id_b` required
+/// - `field_correct`: `cluster_id` + `field_name` + `corrected_value` required
+/// - `cluster_decision`: `cluster_id` + `cluster_score` + `cluster_outcome` required
+///
+/// `dataset` is always required and non-empty.
+/// `memory_path` defaults to `.goldenmatch/memory.db` (relative to the
+/// Postgres data dir at runtime) when NULL.
+///
+/// All other parameters are optional; pass NULL for unused fields.
+#[pg_extern]
+#[allow(clippy::too_many_arguments)]
+pub fn correction_add(
+    decision: String,
+    dataset: String,
+    id_a: pgrx::default!(Option<i64>, "NULL"),
+    id_b: pgrx::default!(Option<i64>, "NULL"),
+    cluster_id: pgrx::default!(Option<i64>, "NULL"),
+    field_name: pgrx::default!(Option<String>, "NULL"),
+    original_value: pgrx::default!(Option<String>, "NULL"),
+    corrected_value: pgrx::default!(Option<String>, "NULL"),
+    cluster_score: pgrx::default!(Option<f64>, "NULL"),
+    cluster_outcome: pgrx::default!(Option<String>, "NULL"),
+    reason: pgrx::default!(Option<String>, "NULL"),
+    matchkey_name: pgrx::default!(Option<String>, "NULL"),
+    source: pgrx::default!(Option<String>, "NULL"),
+    memory_path: pgrx::default!(Option<String>, "NULL"),
+) -> String {
+    // Convert Option<String> to Option<&str> for the bridge args
+    // (CorrectionAddArgs holds borrowed string refs).
+    let field_name_s = field_name.as_deref();
+    let original_value_s = original_value.as_deref();
+    let corrected_value_s = corrected_value.as_deref();
+    let cluster_outcome_s = cluster_outcome.as_deref();
+    let reason_s = reason.as_deref();
+    let matchkey_name_s = matchkey_name.as_deref();
+    let source_s = source.as_deref();
+    let memory_path_s = memory_path.as_deref();
+
+    let args = CorrectionAddArgs {
+        decision: &decision,
+        dataset: &dataset,
+        source: source_s,
+        memory_path: memory_path_s,
+        reason: reason_s,
+        matchkey_name: matchkey_name_s,
+        id_a,
+        id_b,
+        original_score: None,
+        cluster_id,
+        field_name: field_name_s,
+        original_value: original_value_s,
+        corrected_value: corrected_value_s,
+        cluster_score,
+        cluster_outcome: cluster_outcome_s,
+    };
+
+    match goldenmatch_bridge::api::correction_add(args) {
+        Ok(uuid) => uuid,
+        Err(BridgeError::Validation(msg)) => {
+            // Validation errors get a distinctive SQL state so callers
+            // can distinguish "you passed the wrong shape" from
+            // "MemoryStore exploded".
+            pgrx::error!("goldenmatch correction_add validation: {}", msg);
+        }
+        Err(e) => pgrx::error!("goldenmatch correction_add: {}", e),
+    }
+}
+
+/// List corrections for a dataset (or all when NULL). Returns a JSON
+/// array of correction dicts.
+#[pg_extern]
+pub fn correction_list(
+    dataset: pgrx::default!(Option<String>, "NULL"),
+    memory_path: pgrx::default!(Option<String>, "NULL"),
+) -> String {
+    let dataset_s = dataset.as_deref();
+    let memory_path_s = memory_path.as_deref();
+    match goldenmatch_bridge::api::correction_list(dataset_s, memory_path_s) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch correction_list: {}", e),
+    }
+}

--- a/packages/rust/extensions/postgres/src/lib.rs
+++ b/packages/rust/extensions/postgres/src/lib.rs
@@ -2,6 +2,7 @@ use pgrx::prelude::*;
 
 pgrx::pg_module_magic!();
 
+mod correction;
 mod pipeline;
 mod quick;
 mod spi;


### PR DESCRIPTION
Two new dbt macros invoking the Postgres extension (PR #461) and DuckDB UDF (PR #449) correction-add surfaces. Adapter-dispatch via `adapter.dispatch()`.

## Files
- `dbt_project.yml` (NEW) -- declares dbt package
- `macros/file_field_correction.sql` (NEW)
- `macros/file_pair_correction.sql` (NEW)
- `tests/test_macros.py` (NEW) -- 8 unit tests against stub Jinja env

## Surface

```sql
{{ goldenmatch_file_field_correction(
    cluster_id=42, field_name='address1',
    original='1 Elm St', corrected='1 Elm Street, Apt 4B',
    dataset='customers',
) }}
```

Postgres: named-arg `goldenmatch.correction_add(...)`
DuckDB: positional + args_json blob `goldenmatch_correction_add(...)`
Other adapters: compile-time error pointing to REST/Python paths

## Depends on
- PR #449 (DuckDB UDF) -- merged
- PR #461 (Postgres pgrx) -- pending

If #461 isn't merged when this lands, the macro still compiles -- only runtime against a Postgres target fails (expected until extension installed).

Closes #210.