### PR TITLE
feat(dbt): v0.3.0 -- Identity Graph read macros

### DIFF
--- a/packages/python/goldenmatch/dbt-goldensuite/dbt_goldensuite/__init__.py
+++ b/packages/python/goldenmatch/dbt-goldensuite/dbt_goldensuite/__init__.py
@@ -1,2 +1,2 @@
-"""dbt integration for GoldenMatch entity resolution."""
-__version__ = "0.1.0"
+"""dbt integration for the Golden Suite: ER + data quality + transforms."""
+__version__ = "0.3.0"

--- a/packages/python/goldenmatch/dbt-goldensuite/macros/identity_conflicts.sql
+++ b/packages/python/goldenmatch/dbt-goldensuite/macros/identity_conflicts.sql
@@ -1,0 +1,37 @@
+{#-
+  identity_conflicts -- conflict edges (records flagged as
+  conflicts_with) for a dataset as JSON array.
+
+  v0.3 of dbt-goldensuite (closes part of #465).
+-#}
+
+{% macro identity_conflicts(dataset, db_path=none) %}
+    {{ return(adapter.dispatch(
+        'identity_conflicts_impl',
+        'dbt_goldensuite'
+    )(dataset, db_path)) }}
+{% endmacro %}
+
+
+{% macro default__identity_conflicts_impl(dataset, db_path) %}
+    {{ exceptions.raise_compiler_error(
+        "identity_conflicts is only supported on postgres and duckdb;
+         got adapter=" ~ target.type
+    ) }}
+{% endmacro %}
+
+
+{% macro postgres__identity_conflicts_impl(dataset, db_path) %}
+    goldenmatch.goldenmatch_identity_conflicts(
+        {{ dbt.string_literal(dataset) }},
+        {{ "''" if db_path is none else dbt.string_literal(db_path) }}
+    )
+{% endmacro %}
+
+
+{% macro duckdb__identity_conflicts_impl(dataset, db_path) %}
+    goldenmatch_identity_conflicts(
+        {{ dbt.string_literal(dataset) }},
+        {{ "''" if db_path is none else dbt.string_literal(db_path) }}
+    )
+{% endmacro %}

--- a/packages/python/goldenmatch/dbt-goldensuite/macros/identity_history.sql
+++ b/packages/python/goldenmatch/dbt-goldensuite/macros/identity_history.sql
@@ -1,0 +1,37 @@
+{#-
+  identity_history -- append-only event log for an entity_id as JSON
+  array of event records.
+
+  v0.3 of dbt-goldensuite (closes part of #465).
+-#}
+
+{% macro identity_history(entity_id, db_path=none) %}
+    {{ return(adapter.dispatch(
+        'identity_history_impl',
+        'dbt_goldensuite'
+    )(entity_id, db_path)) }}
+{% endmacro %}
+
+
+{% macro default__identity_history_impl(entity_id, db_path) %}
+    {{ exceptions.raise_compiler_error(
+        "identity_history is only supported on postgres and duckdb;
+         got adapter=" ~ target.type
+    ) }}
+{% endmacro %}
+
+
+{% macro postgres__identity_history_impl(entity_id, db_path) %}
+    goldenmatch.goldenmatch_identity_history(
+        {{ dbt.string_literal(entity_id) }},
+        {{ "''" if db_path is none else dbt.string_literal(db_path) }}
+    )
+{% endmacro %}
+
+
+{% macro duckdb__identity_history_impl(entity_id, db_path) %}
+    goldenmatch_identity_history(
+        {{ dbt.string_literal(entity_id) }},
+        {{ "''" if db_path is none else dbt.string_literal(db_path) }}
+    )
+{% endmacro %}

--- a/packages/python/goldenmatch/dbt-goldensuite/macros/identity_list.sql
+++ b/packages/python/goldenmatch/dbt-goldensuite/macros/identity_list.sql
@@ -1,0 +1,44 @@
+{#-
+  identity_list -- list identities in a dataset, optionally filtered
+  by status. Returns JSON array of identity summaries.
+
+  v0.3 of dbt-goldensuite (closes part of #465).
+
+  Args:
+    dataset -- dataset key (NULL/none = all datasets)
+    status  -- optional filter: "active", "merged", "split", "deleted".
+               NULL/none = no filter.
+-#}
+
+{% macro identity_list(dataset=none, status=none, db_path=none) %}
+    {{ return(adapter.dispatch(
+        'identity_list_impl',
+        'dbt_goldensuite'
+    )(dataset, status, db_path)) }}
+{% endmacro %}
+
+
+{% macro default__identity_list_impl(dataset, status, db_path) %}
+    {{ exceptions.raise_compiler_error(
+        "identity_list is only supported on postgres and duckdb;
+         got adapter=" ~ target.type
+    ) }}
+{% endmacro %}
+
+
+{% macro postgres__identity_list_impl(dataset, status, db_path) %}
+    goldenmatch.goldenmatch_identity_list(
+        {{ "''" if dataset is none else dbt.string_literal(dataset) }},
+        {{ "''" if status is none else dbt.string_literal(status) }},
+        {{ "''" if db_path is none else dbt.string_literal(db_path) }}
+    )
+{% endmacro %}
+
+
+{% macro duckdb__identity_list_impl(dataset, status, db_path) %}
+    goldenmatch_identity_list(
+        {{ "''" if dataset is none else dbt.string_literal(dataset) }},
+        {{ "''" if status is none else dbt.string_literal(status) }},
+        {{ "''" if db_path is none else dbt.string_literal(db_path) }}
+    )
+{% endmacro %}

--- a/packages/python/goldenmatch/dbt-goldensuite/macros/identity_resolve.sql
+++ b/packages/python/goldenmatch/dbt-goldensuite/macros/identity_resolve.sql
@@ -1,0 +1,54 @@
+{#-
+  identity_resolve -- look up a record_id's current identity.
+  Returns a JSON object: {entity_id, members, recent_events, ...}.
+
+  v0.3 of dbt-goldensuite (closes part of #465). Wraps the existing
+  Identity Graph SQL function from packages/rust/extensions on both
+  Postgres (`goldenmatch.goldenmatch_identity_resolve`) and DuckDB
+  (`goldenmatch_identity_resolve` UDF).
+
+  Args:
+    record_id -- the `{source}:{source_pk}` (or hash-fallback) identifier
+    db_path   -- optional explicit IdentityStore path. NULL/none defaults
+                 to `.goldenmatch/identity.db` on the warehouse host.
+
+  Usage in a model:
+
+      SELECT
+          customer_id,
+          {{ dbt_goldensuite.identity_resolve('customer_id') }}::JSONB AS identity
+      FROM {{ ref('raw_customers') }}
+-#}
+
+{% macro identity_resolve(record_id, db_path=none) %}
+    {{ return(adapter.dispatch(
+        'identity_resolve_impl',
+        'dbt_goldensuite'
+    )(record_id, db_path)) }}
+{% endmacro %}
+
+
+{% macro default__identity_resolve_impl(record_id, db_path) %}
+    {{ exceptions.raise_compiler_error(
+        "identity_resolve is only supported on postgres and duckdb;
+         got adapter=" ~ target.type ~ ".
+         For other adapters, query the identity store via REST
+         (GET /identities/resolve/<record_id>) or Python."
+    ) }}
+{% endmacro %}
+
+
+{% macro postgres__identity_resolve_impl(record_id, db_path) %}
+    goldenmatch.goldenmatch_identity_resolve(
+        {{ dbt.string_literal(record_id) }},
+        {{ "''" if db_path is none else dbt.string_literal(db_path) }}
+    )
+{% endmacro %}
+
+
+{% macro duckdb__identity_resolve_impl(record_id, db_path) %}
+    goldenmatch_identity_resolve(
+        {{ dbt.string_literal(record_id) }},
+        {{ "''" if db_path is none else dbt.string_literal(db_path) }}
+    )
+{% endmacro %}

--- a/packages/python/goldenmatch/dbt-goldensuite/macros/identity_view.sql
+++ b/packages/python/goldenmatch/dbt-goldensuite/macros/identity_view.sql
@@ -1,0 +1,37 @@
+{#-
+  identity_view -- full IdentityView JSON for an entity_id.
+  Returns: {entity_id, status, members, edges, events, aliases}.
+
+  v0.3 of dbt-goldensuite (closes part of #465).
+-#}
+
+{% macro identity_view(entity_id, db_path=none) %}
+    {{ return(adapter.dispatch(
+        'identity_view_impl',
+        'dbt_goldensuite'
+    )(entity_id, db_path)) }}
+{% endmacro %}
+
+
+{% macro default__identity_view_impl(entity_id, db_path) %}
+    {{ exceptions.raise_compiler_error(
+        "identity_view is only supported on postgres and duckdb;
+         got adapter=" ~ target.type
+    ) }}
+{% endmacro %}
+
+
+{% macro postgres__identity_view_impl(entity_id, db_path) %}
+    goldenmatch.goldenmatch_identity_view(
+        {{ dbt.string_literal(entity_id) }},
+        {{ "''" if db_path is none else dbt.string_literal(db_path) }}
+    )
+{% endmacro %}
+
+
+{% macro duckdb__identity_view_impl(entity_id, db_path) %}
+    goldenmatch_identity_view(
+        {{ dbt.string_literal(entity_id) }},
+        {{ "''" if db_path is none else dbt.string_literal(db_path) }}
+    )
+{% endmacro %}

--- a/packages/python/goldenmatch/dbt-goldensuite/pyproject.toml
+++ b/packages/python/goldenmatch/dbt-goldensuite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dbt-goldensuite"
-version = "0.2.0"
+version = "0.3.0"
 description = "dbt integration for the Golden Suite: entity resolution (goldenmatch) + data quality (goldencheck) + transforms (goldenflow)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/dbt-goldensuite/tests/test_identity_macros.py
+++ b/packages/python/goldenmatch/dbt-goldensuite/tests/test_identity_macros.py
@@ -1,0 +1,184 @@
+"""Tests for v0.3 Identity Graph read macros.
+
+Uses the same stub-Jinja harness as test_quality_macros.py /
+test_macros.py -- no live dbt-core, no warehouse needed.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+jinja2 = pytest.importorskip("jinja2")
+
+_MACROS_DIR = Path(__file__).resolve().parents[1] / "macros"
+
+
+class _DbtStub:
+    @staticmethod
+    def string_literal(s: str) -> str:
+        return "'" + s.replace("'", "''") + "'"
+
+
+class _TargetStub:
+    def __init__(self, adapter_type: str) -> None:
+        self.type = adapter_type
+
+
+class _AdapterStub:
+    def __init__(self, adapter_type, env) -> None:  # noqa: ANN001
+        self._adapter_type = adapter_type
+        self._env = env
+
+    def dispatch(self, macro_name, namespace):  # noqa: ANN001, ARG002
+        for cand in (f"{self._adapter_type}__{macro_name}",
+                     f"default__{macro_name}"):
+            if cand in self._env.globals:
+                return self._env.globals[cand]
+        raise RuntimeError(f"no dispatch for {macro_name}")
+
+
+class _ExceptionsStub:
+    @staticmethod
+    def raise_compiler_error(msg):  # noqa: ANN001
+        raise RuntimeError(msg)
+
+
+def _build_env(adapter_type: str, macro_filename: str):
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(_MACROS_DIR)),
+        autoescape=False,
+        undefined=jinja2.StrictUndefined,
+    )
+    env.globals["target"] = _TargetStub(adapter_type)
+    env.globals["dbt"] = _DbtStub()
+    env.globals["exceptions"] = _ExceptionsStub()
+    env.globals["return"] = lambda v: v
+    env.globals["adapter"] = _AdapterStub(adapter_type, env)
+    template = env.get_template(macro_filename)
+    module = template.module
+    for name in dir(module):
+        if name.startswith("_"):
+            continue
+        attr = getattr(module, name)
+        if callable(attr):
+            env.globals[name] = attr
+    return env
+
+
+# Single-arg macros: resolve, view, history (text arg + optional db_path)
+@pytest.mark.parametrize("macro_name,sql_pg,sql_duck", [
+    ("identity_resolve",
+     "goldenmatch.goldenmatch_identity_resolve",
+     "goldenmatch_identity_resolve"),
+    ("identity_view",
+     "goldenmatch.goldenmatch_identity_view",
+     "goldenmatch_identity_view"),
+    ("identity_history",
+     "goldenmatch.goldenmatch_identity_history",
+     "goldenmatch_identity_history"),
+    ("identity_conflicts",
+     "goldenmatch.goldenmatch_identity_conflicts",
+     "goldenmatch_identity_conflicts"),
+])
+def test_single_arg_macro_postgres(macro_name, sql_pg, sql_duck) -> None:
+    env = _build_env("postgres", f"{macro_name}.sql")
+    fn = env.globals[macro_name]
+    sql = fn("ent-abc")
+    assert sql_pg in sql
+    assert "'ent-abc'" in sql
+    # NULL/none db_path renders as empty string literal.
+    assert "''" in sql
+
+
+@pytest.mark.parametrize("macro_name,sql_pg,sql_duck", [
+    ("identity_resolve",
+     "goldenmatch.goldenmatch_identity_resolve",
+     "goldenmatch_identity_resolve"),
+    ("identity_view",
+     "goldenmatch.goldenmatch_identity_view",
+     "goldenmatch_identity_view"),
+    ("identity_history",
+     "goldenmatch.goldenmatch_identity_history",
+     "goldenmatch_identity_history"),
+    ("identity_conflicts",
+     "goldenmatch.goldenmatch_identity_conflicts",
+     "goldenmatch_identity_conflicts"),
+])
+def test_single_arg_macro_duckdb(macro_name, sql_pg, sql_duck) -> None:
+    env = _build_env("duckdb", f"{macro_name}.sql")
+    fn = env.globals[macro_name]
+    sql = fn("ent-abc")
+    assert sql_duck in sql
+    # DuckDB path doesn't use the schema prefix.
+    assert "goldenmatch." not in sql.replace(sql_duck, "")
+
+
+@pytest.mark.parametrize("macro_name", [
+    "identity_resolve", "identity_view", "identity_history",
+    "identity_conflicts",
+])
+def test_single_arg_macro_unknown_adapter(macro_name) -> None:
+    env = _build_env("snowflake", f"{macro_name}.sql")
+    fn = env.globals[macro_name]
+    with pytest.raises(RuntimeError, match="only supported on postgres and duckdb"):
+        fn("ent-abc")
+
+
+@pytest.mark.parametrize("macro_name", [
+    "identity_resolve", "identity_view", "identity_history",
+])
+def test_db_path_explicit_renders_literal(macro_name) -> None:
+    env = _build_env("postgres", f"{macro_name}.sql")
+    fn = env.globals[macro_name]
+    sql = fn("ent-abc", db_path="/var/lib/goldenmatch/identity.db")
+    assert "'/var/lib/goldenmatch/identity.db'" in sql
+
+
+# identity_list -- 3-arg shape (dataset, status, db_path) all optional
+def test_identity_list_postgres_no_filters() -> None:
+    env = _build_env("postgres", "identity_list.sql")
+    fn = env.globals["identity_list"]
+    sql = fn()
+    assert "goldenmatch.goldenmatch_identity_list" in sql
+    # All three args default to empty-string literals.
+    assert sql.count("''") == 3
+
+
+def test_identity_list_postgres_dataset_filter() -> None:
+    env = _build_env("postgres", "identity_list.sql")
+    fn = env.globals["identity_list"]
+    sql = fn(dataset="customers")
+    assert "'customers'" in sql
+    # status + db_path still empty.
+    assert sql.count("''") == 2
+
+
+def test_identity_list_postgres_all_filters() -> None:
+    env = _build_env("postgres", "identity_list.sql")
+    fn = env.globals["identity_list"]
+    sql = fn(dataset="customers", status="active", db_path="/x/y.db")
+    assert "'customers'" in sql
+    assert "'active'" in sql
+    assert "'/x/y.db'" in sql
+    assert sql.count("''") == 0
+
+
+def test_identity_list_duckdb() -> None:
+    env = _build_env("duckdb", "identity_list.sql")
+    fn = env.globals["identity_list"]
+    sql = fn(dataset="customers", status="active")
+    assert "goldenmatch_identity_list" in sql
+    # No schema prefix on DuckDB.
+    assert "goldenmatch.goldenmatch_identity_list" not in sql
+
+
+def test_identity_list_unknown_adapter_errors() -> None:
+    env = _build_env("snowflake", "identity_list.sql")
+    fn = env.globals["identity_list"]
+    with pytest.raises(RuntimeError, match="only supported on postgres and duckdb"):
+        fn()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Stacks on PR #464. Wraps the 5 Identity Graph SQL functions (Postgres + DuckDB) as dbt-callable macros.

## Macros (5)
- `identity_resolve(record_id, db_path?)`
- `identity_view(entity_id, db_path?)`
- `identity_history(entity_id, db_path?)`
- `identity_conflicts(dataset, db_path?)`
- `identity_list(dataset?, status?, db_path?)`

All read-only, no permission gating. Postgres + DuckDB only.

## Tests
20 passing in `tests/test_identity_macros.py`.

Spec: `docs/superpowers/specs/2026-05-23-dbt-identity-graph-read-macros-design.md`
Refs #465 Tier 1.3.