### PR TITLE
feat(dbt): v0.4.0 -- goldenmatch_dedupe custom materialization

### DIFF
--- a/packages/python/goldenmatch/dbt-goldensuite/dbt_goldensuite/__init__.py
+++ b/packages/python/goldenmatch/dbt-goldensuite/dbt_goldensuite/__init__.py
@@ -1,2 +1,2 @@
 """dbt integration for the Golden Suite: ER + data quality + transforms."""
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/packages/python/goldenmatch/dbt-goldensuite/macros/materializations/_helpers.sql
+++ b/packages/python/goldenmatch/dbt-goldensuite/macros/materializations/_helpers.sql
@@ -1,0 +1,71 @@
+{#-
+  Helper macros for the goldenmatch_dedupe materialization. Lives in
+  a separate file so the materialization itself (which contains
+  dbt-specific `{% statement %}` / `{% materialization %}` tags that
+  plain Jinja2 can't parse) doesn't block unit-testing the helpers
+  in isolation.
+
+  Loaded by dbt automatically alongside `goldenmatch_dedupe.sql`.
+-#}
+
+
+{#--- Serialize match_config to a JSON string literal. ---#}
+{% macro goldenmatch_dedupe_config_json(match_config) %}
+    {%- if match_config is string -%}
+        {%- set raw = load_file_contents(match_config) -%}
+        {%- if raw is none -%}
+            {{ exceptions.raise_compiler_error(
+                "match_config file not found: " ~ match_config
+            ) }}
+        {%- endif -%}
+        {{ return(dbt.string_literal(raw)) }}
+    {%- elif match_config is mapping -%}
+        {{ return(dbt.string_literal(tojson(match_config))) }}
+    {%- else -%}
+        {{ exceptions.raise_compiler_error(
+            "match_config must be a string (file path) or dict (inline config); got "
+            ~ match_config | string
+        ) }}
+    {%- endif -%}
+{% endmacro %}
+
+
+{#--- Pick the warehouse SQL function name for the requested output. ---#}
+{% macro goldenmatch_dedupe_fn_name(output_kind, adapter_type) %}
+    {%- if adapter_type not in ('postgres', 'duckdb') -%}
+        {{ exceptions.raise_compiler_error(
+            "goldenmatch_dedupe materialization is only supported on "
+            "postgres and duckdb; got adapter=" ~ adapter_type
+        ) }}
+    {%- endif -%}
+    {%- if output_kind == 'golden' -%}
+        {%- if adapter_type == 'postgres' -%}
+            {{ return('goldenmatch.goldenmatch_dedupe_full') }}
+        {%- else -%}
+            {{ return('goldenmatch_dedupe_full') }}
+        {%- endif -%}
+    {%- elif output_kind == 'clusters' -%}
+        {%- if adapter_type == 'postgres' -%}
+            {{ return('goldenmatch.goldenmatch_dedupe_clusters') }}
+        {%- else -%}
+            {{ exceptions.raise_compiler_error(
+                "output='clusters' is not yet implemented on DuckDB. "
+                "v0.4.0 ships clusters/pairs on Postgres only; DuckDB "
+                "UDFs land in v0.4.1. Use output='golden' or switch to "
+                "Postgres target."
+            ) }}
+        {%- endif -%}
+    {%- elif output_kind == 'pairs' -%}
+        {%- if adapter_type == 'postgres' -%}
+            {{ return('goldenmatch.goldenmatch_dedupe_pairs') }}
+        {%- else -%}
+            {{ exceptions.raise_compiler_error(
+                "output='pairs' is not yet implemented on DuckDB."
+            ) }}
+        {%- endif -%}
+    {%- else -%}
+        {{ exceptions.raise_compiler_error(
+            "output must be one of: golden, clusters, pairs; got " ~ output_kind
+        ) }}
+    {%- endif -%}
+{% endmacro %}

--- a/packages/python/goldenmatch/dbt-goldensuite/macros/materializations/goldenmatch_dedupe.sql
+++ b/packages/python/goldenmatch/dbt-goldensuite/macros/materializations/goldenmatch_dedupe.sql
@@ -1,0 +1,97 @@
+{#-
+  goldenmatch_dedupe -- custom dbt materialization that runs the
+  goldenmatch entity-resolution pipeline against a model's body SQL
+  and materializes one of three output shapes (golden / clusters /
+  pairs).
+
+  v0.4 of dbt-goldensuite (closes part of #465 Tier 1.2).
+
+  Usage:
+
+      {{ config(
+          materialized = 'goldenmatch_dedupe',
+          match_config = 'configs/customers.yaml',  -- file path or inline dict
+          output = 'golden',                         -- golden|clusters|pairs
+          memory_db_path = none,                     -- optional MemoryStore path
+      ) }}
+
+      SELECT * FROM {{ ref('stg_customers_clean') }}
+
+  ## Flow
+
+  1. Body SQL -> CREATE TEMP TABLE (dbt's standard staging-of-input).
+  2. Resolve match_config: file path (read + JSON-stringify) OR dict
+     literal (JSON-stringify directly).
+  3. Pick the right warehouse function for the requested output:
+     - golden   -> goldenmatch_dedupe_full (Postgres + DuckDB)
+     - clusters -> goldenmatch_dedupe_clusters (Postgres only in v0.4.0)
+     - pairs    -> goldenmatch_dedupe_pairs   (Postgres only in v0.4.0)
+  4. CREATE TABLE <model> AS SELECT * FROM <function>(...)
+  5. DROP TEMP staging table.
+
+  Out of scope for v0.4.0:
+  - DuckDB UDFs for dedupe_clusters / dedupe_pairs -- these exist on
+    the Postgres extension but not yet on the DuckDB Python UDF
+    surface. v0.4.0 ships golden-only on DuckDB; clusters + pairs
+    land in v0.4.1 once the UDFs are added.
+  - Snowflake / BigQuery / Redshift -- no goldenmatch extension; use
+    `goldenmatch.dedupe_df()` Python helper out-of-band instead.
+-#}
+
+
+{#- Helpers (`goldenmatch_dedupe_config_json`, `goldenmatch_dedupe_fn_name`)
+    live in `_helpers.sql` -- split so they unit-test under plain Jinja2
+    without the materialization block. -#}
+
+
+{% materialization goldenmatch_dedupe, default %}
+    {#- Required config -#}
+    {%- set match_config = config.require('match_config') -%}
+    {%- set output_kind = config.get('output', 'golden') -%}
+    {%- set memory_db_path = config.get('memory_db_path', none) -%}
+
+    {%- if target.type not in ('postgres', 'duckdb') -%}
+        {{ exceptions.raise_compiler_error(
+            "goldenmatch_dedupe materialization is only supported on "
+            "postgres and duckdb today; got adapter=" ~ target.type ~
+            ". For other adapters, use the Python helper "
+            "`dbt_goldensuite.materialize.run_goldenmatch_dedupe`."
+        ) }}
+    {%- endif -%}
+
+    {%- set target_relation = this -%}
+    {%- set staging_relation = make_temp_relation(target_relation, '__gm_stage') -%}
+    {%- set config_json_literal = dbt_goldensuite.goldenmatch_dedupe_config_json(match_config) -%}
+    {%- set fn_name = dbt_goldensuite.goldenmatch_dedupe_fn_name(output_kind, target.type) -%}
+
+    {#- Step 1: stash body SQL into a TEMP table so the goldenmatch
+        function has a real table to scan. -#}
+    {%- call statement('create_staging', auto_begin=True) -%}
+        CREATE TEMPORARY TABLE {{ staging_relation }} AS (
+            {{ sql }}
+        );
+    {%- endcall -%}
+
+    {#- Step 2: drop any prior incarnation of the target relation. -#}
+    {%- call statement('drop_target', auto_begin=True) -%}
+        DROP TABLE IF EXISTS {{ target_relation }} CASCADE;
+    {%- endcall -%}
+
+    {#- Step 3: invoke the dedupe function + materialize. -#}
+    {%- call statement('main', auto_begin=True) -%}
+        CREATE TABLE {{ target_relation }} AS
+        SELECT * FROM {{ fn_name }}(
+            {{ dbt.string_literal(staging_relation.identifier) }},
+            {{ config_json_literal }}
+        );
+    {%- endcall -%}
+
+    {#- Step 4: drop staging. Inside a transaction so a failure leaves
+        the temp table for diagnosis. -#}
+    {%- call statement('drop_staging', auto_begin=True) -%}
+        DROP TABLE IF EXISTS {{ staging_relation }};
+    {%- endcall -%}
+
+    {{ adapter.commit() }}
+    {{ return({'relations': [target_relation]}) }}
+{% endmaterialization %}

--- a/packages/python/goldenmatch/dbt-goldensuite/pyproject.toml
+++ b/packages/python/goldenmatch/dbt-goldensuite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dbt-goldensuite"
-version = "0.3.0"
+version = "0.4.0"
 description = "dbt integration for the Golden Suite: entity resolution (goldenmatch) + data quality (goldencheck) + transforms (goldenflow)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -12,7 +12,7 @@ license = "MIT"
 authors = [{ name = "Ben Severn", email = "benzsevern@gmail.com" }]
 classifiers = ["Private :: Do Not Upload"]
 dependencies = [
-    "goldenmatch>=0.3.0",
+    "goldenmatch>=0.4.0",
     "dbt-core>=1.7",
     "duckdb>=0.9",
 ]

--- a/packages/python/goldenmatch/dbt-goldensuite/tests/test_dedupe_materialization.py
+++ b/packages/python/goldenmatch/dbt-goldensuite/tests/test_dedupe_materialization.py
@@ -1,0 +1,148 @@
+"""Tests for v0.4 goldenmatch_dedupe materialization.
+
+The `{% materialization %}` block itself contains dbt-specific Jinja
+tags (`statement`, `make_temp_relation`, `auto_begin`, etc.) that
+plain Jinja2 can't parse. We test the two HELPER macros that contain
+the meaningful logic instead -- those live in
+`_helpers.sql` and parse cleanly under plain Jinja2.
+
+End-to-end materialization behavior is covered by dbt's own
+integration-test harness (out-of-band -- requires running Postgres +
+DuckDB targets).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+jinja2 = pytest.importorskip("jinja2")
+
+_HELPERS_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "macros" / "materializations" / "_helpers.sql"
+)
+
+
+class _DbtStub:
+    @staticmethod
+    def string_literal(s):  # noqa: ANN001
+        return "'" + str(s).replace("'", "''") + "'"
+
+
+class _ExceptionsStub:
+    @staticmethod
+    def raise_compiler_error(msg):  # noqa: ANN001
+        raise RuntimeError(msg)
+
+
+def _load_helpers():
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(_HELPERS_PATH.parent)),
+        autoescape=False,
+    )
+    env.globals["dbt"] = _DbtStub()
+    env.globals["exceptions"] = _ExceptionsStub()
+    env.globals["return"] = lambda v: v
+    env.globals["tojson"] = lambda v: json.dumps(v)
+    env.globals["load_file_contents"] = lambda p: (
+        '{"exact": ["ssn"]}' if p == "ok.yaml" else None
+    )
+    template = env.get_template(_HELPERS_PATH.name)
+    module = template.module
+    return module
+
+
+# ---------------------------------------------------------------------------
+# goldenmatch_dedupe_config_json
+# ---------------------------------------------------------------------------
+
+
+def test_config_json_dict_serializes() -> None:
+    helpers = _load_helpers()
+    result = helpers.goldenmatch_dedupe_config_json(
+        {"exact": ["ssn"], "fuzzy": {"name": 0.85}},
+    )
+    # Should be a quoted JSON string literal.
+    assert result.startswith("'")
+    assert result.endswith("'")
+    assert "ssn" in result
+    assert "name" in result
+
+
+def test_config_json_file_path_reads() -> None:
+    helpers = _load_helpers()
+    result = helpers.goldenmatch_dedupe_config_json("ok.yaml")
+    assert result.startswith("'")
+    assert "ssn" in result
+
+
+def test_config_json_missing_file_errors() -> None:
+    helpers = _load_helpers()
+    with pytest.raises(RuntimeError, match="file not found"):
+        helpers.goldenmatch_dedupe_config_json("missing.yaml")
+
+
+def test_config_json_invalid_type_errors() -> None:
+    helpers = _load_helpers()
+    with pytest.raises(RuntimeError, match="string .file path. or dict"):
+        helpers.goldenmatch_dedupe_config_json(12345)
+
+
+# ---------------------------------------------------------------------------
+# goldenmatch_dedupe_fn_name
+# ---------------------------------------------------------------------------
+
+
+def test_fn_name_golden_postgres() -> None:
+    helpers = _load_helpers()
+    assert helpers.goldenmatch_dedupe_fn_name("golden", "postgres") == \
+        "goldenmatch.goldenmatch_dedupe_full"
+
+
+def test_fn_name_golden_duckdb() -> None:
+    helpers = _load_helpers()
+    assert helpers.goldenmatch_dedupe_fn_name("golden", "duckdb") == \
+        "goldenmatch_dedupe_full"
+
+
+def test_fn_name_clusters_postgres() -> None:
+    helpers = _load_helpers()
+    assert helpers.goldenmatch_dedupe_fn_name("clusters", "postgres") == \
+        "goldenmatch.goldenmatch_dedupe_clusters"
+
+
+def test_fn_name_pairs_postgres() -> None:
+    helpers = _load_helpers()
+    assert helpers.goldenmatch_dedupe_fn_name("pairs", "postgres") == \
+        "goldenmatch.goldenmatch_dedupe_pairs"
+
+
+def test_fn_name_clusters_duckdb_errors() -> None:
+    """v0.4.0 ships clusters on Postgres only -- DuckDB raises."""
+    helpers = _load_helpers()
+    with pytest.raises(RuntimeError, match="clusters.*not yet implemented on DuckDB"):
+        helpers.goldenmatch_dedupe_fn_name("clusters", "duckdb")
+
+
+def test_fn_name_pairs_duckdb_errors() -> None:
+    helpers = _load_helpers()
+    with pytest.raises(RuntimeError, match="pairs.*not yet implemented on DuckDB"):
+        helpers.goldenmatch_dedupe_fn_name("pairs", "duckdb")
+
+
+def test_fn_name_invalid_output_errors() -> None:
+    helpers = _load_helpers()
+    with pytest.raises(RuntimeError, match="output must be one of"):
+        helpers.goldenmatch_dedupe_fn_name("wat", "postgres")
+
+
+def test_fn_name_unknown_adapter_errors() -> None:
+    helpers = _load_helpers()
+    with pytest.raises(RuntimeError, match="only supported on postgres and duckdb"):
+        helpers.goldenmatch_dedupe_fn_name("golden", "snowflake")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Stacks on PR #466. Custom dbt materialization so a model can declare itself a dedupe output with one config line.

## Usage
```sql
{{ config(materialized='goldenmatch_dedupe', match_config='customers.yaml', output='golden') }}
SELECT * FROM {{ ref('stg_customers') }}
```

## Tests
12 passing in test_dedupe_materialization.py (helpers split out for Jinja2-parseability).

## Output variants
- golden (Postgres + DuckDB)
- clusters / pairs (Postgres only in v0.4.0; DuckDB UDFs in v0.4.1)

Spec: `docs/superpowers/specs/2026-05-23-dbt-goldenmatch-dedupe-materialization-design.md`
Refs #465 Tier 1.2.