### PR TITLE
feat(dbt): v0.5.0 -- GoldenFlow transform macros + DuckDB UDFs

### DIFF
--- a/packages/python/goldenmatch/dbt-goldensuite/dbt_goldensuite/__init__.py
+++ b/packages/python/goldenmatch/dbt-goldensuite/dbt_goldensuite/__init__.py
@@ -1,2 +1,2 @@
 """dbt integration for the Golden Suite: ER + data quality + transforms."""
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/packages/python/goldenmatch/dbt-goldensuite/macros/transforms.sql
+++ b/packages/python/goldenmatch/dbt-goldensuite/macros/transforms.sql
@@ -1,0 +1,236 @@
+{#-
+  GoldenFlow transform macros (v0.5 of dbt-goldensuite, #465 Tier 1.1).
+
+  Wraps the 8 most-used goldenflow standardizers as in-database
+  dbt-callable SQL expressions. Each macro returns an SQL expression
+  (NOT a SELECT) so it composes inside larger queries:
+
+      SELECT
+          customer_id,
+          {{ dbt_goldensuite.normalize_email('email_raw') }} AS email,
+          {{ dbt_goldensuite.normalize_phone('phone_raw') }} AS phone,
+          {{ dbt_goldensuite.normalize_date('signup_date') }} AS signup_date
+      FROM {{ ref('raw_customers') }}
+
+  ## Adapter coverage
+
+  | Adapter   | Status |
+  |-----------|--------|
+  | Postgres  | Compile error in v0.5 -- pgrx functions not yet shipped. Tracked as a follow-up issue under #465. |
+  | DuckDB    | Live -- uses Python UDFs registered by `goldenmatch_duckdb.goldenflow.register_goldenflow_functions`. Requires `pip install goldenflow` on the dbt-runner host. |
+  | Others    | Compile error with a remediation hint pointing to the Python helper `goldenflow.transform_df()`. |
+
+  ## Why v0.5 ships DuckDB-only
+
+  Postgres requires shipping new `#[pg_extern]` wrappers in
+  `goldenmatch_pg` (pgrx 0.12.9) that call into goldenflow via the
+  existing bridge crate. Build/test cycle is Linux-CI-only per the
+  monorepo `packages/rust/extensions/CLAUDE.md`. Splitting the PR
+  keeps the dbt-side surface shippable while the pgrx layer follows
+  up on its own timeline. Macro stubs render Postgres-error today
+  so consumers see the right shape + know what's coming.
+-#}
+
+
+{#--- normalize_email ----------------------------------------------------#}
+{% macro normalize_email(column) %}
+    {{ return(adapter.dispatch('normalize_email_impl', 'dbt_goldensuite')(column)) }}
+{% endmacro %}
+
+{% macro default__normalize_email_impl(column) %}
+    {{ exceptions.raise_compiler_error(
+        "normalize_email is supported on duckdb today; postgres pgrx
+         wrappers ship in a follow-up. For other adapters, run
+         `goldenflow.transform_df(df)` out-of-band before dbt."
+    ) }}
+{% endmacro %}
+
+{% macro duckdb__normalize_email_impl(column) %}
+    goldenflow_normalize_email({{ column }})
+{% endmacro %}
+
+{% macro postgres__normalize_email_impl(column) %}
+    {{ exceptions.raise_compiler_error(
+        "normalize_email Postgres support requires goldenmatch_pg pgrx
+         wrappers (v0.5.x follow-up to #465). DuckDB target works today;
+         out-of-band: SELECT * FROM goldenflow.transform_df(...) via Python."
+    ) }}
+{% endmacro %}
+
+
+{#--- normalize_phone ----------------------------------------------------#}
+{% macro normalize_phone(column, region='US') %}
+    {{ return(adapter.dispatch('normalize_phone_impl', 'dbt_goldensuite')(column, region)) }}
+{% endmacro %}
+
+{% macro default__normalize_phone_impl(column, region) %}
+    {{ exceptions.raise_compiler_error(
+        "normalize_phone is supported on duckdb today; other adapters: run
+         goldenflow out-of-band."
+    ) }}
+{% endmacro %}
+
+{% macro duckdb__normalize_phone_impl(column, region) %}
+    {#- region kwarg is reserved for future phonenumbers tuning; today
+        the UDF uses goldenflow.phone_e164 which defaults to E.164. -#}
+    goldenflow_normalize_phone({{ column }})
+{% endmacro %}
+
+{% macro postgres__normalize_phone_impl(column, region) %}
+    {{ exceptions.raise_compiler_error(
+        "normalize_phone Postgres support requires pgrx wrappers
+         (v0.5.x follow-up to #465)."
+    ) }}
+{% endmacro %}
+
+
+{#--- normalize_date -----------------------------------------------------#}
+{% macro normalize_date(column, target_format='iso8601') %}
+    {{ return(adapter.dispatch('normalize_date_impl', 'dbt_goldensuite')(column, target_format)) }}
+{% endmacro %}
+
+{% macro default__normalize_date_impl(column, target_format) %}
+    {{ exceptions.raise_compiler_error(
+        "normalize_date is supported on duckdb today; other adapters: run
+         goldenflow out-of-band."
+    ) }}
+{% endmacro %}
+
+{% macro duckdb__normalize_date_impl(column, target_format) %}
+    goldenflow_normalize_date({{ column }})
+{% endmacro %}
+
+{% macro postgres__normalize_date_impl(column, target_format) %}
+    {{ exceptions.raise_compiler_error(
+        "normalize_date Postgres support requires pgrx wrappers
+         (v0.5.x follow-up to #465)."
+    ) }}
+{% endmacro %}
+
+
+{#--- normalize_name -----------------------------------------------------#}
+{% macro normalize_name(column, mode='proper') %}
+    {%- if mode not in ('proper', 'upper', 'lower') -%}
+        {{ exceptions.raise_compiler_error(
+            "normalize_name mode must be one of: proper, upper, lower; got " ~ mode
+        ) }}
+    {%- endif -%}
+    {{ return(adapter.dispatch('normalize_name_impl', 'dbt_goldensuite')(column, mode)) }}
+{% endmacro %}
+
+{% macro default__normalize_name_impl(column, mode) %}
+    {{ exceptions.raise_compiler_error(
+        "normalize_name is supported on duckdb today; other adapters: run
+         goldenflow out-of-band."
+    ) }}
+{% endmacro %}
+
+{% macro duckdb__normalize_name_impl(column, mode) %}
+    {%- if mode == 'proper' -%}
+        goldenflow_normalize_name_proper({{ column }})
+    {%- elif mode == 'upper' -%}
+        UPPER({{ column }})
+    {%- elif mode == 'lower' -%}
+        LOWER({{ column }})
+    {%- endif -%}
+{% endmacro %}
+
+{% macro postgres__normalize_name_impl(column, mode) %}
+    {{ exceptions.raise_compiler_error(
+        "normalize_name Postgres support requires pgrx wrappers
+         (v0.5.x follow-up to #465)."
+    ) }}
+{% endmacro %}
+
+
+{#--- canonicalize_url ---------------------------------------------------#}
+{% macro canonicalize_url(column) %}
+    {{ return(adapter.dispatch('canonicalize_url_impl', 'dbt_goldensuite')(column)) }}
+{% endmacro %}
+
+{% macro default__canonicalize_url_impl(column) %}
+    {{ exceptions.raise_compiler_error(
+        "canonicalize_url is supported on duckdb today; other adapters: run
+         goldenflow out-of-band."
+    ) }}
+{% endmacro %}
+
+{% macro duckdb__canonicalize_url_impl(column) %}
+    goldenflow_canonicalize_url({{ column }})
+{% endmacro %}
+
+{% macro postgres__canonicalize_url_impl(column) %}
+    {{ exceptions.raise_compiler_error(
+        "canonicalize_url Postgres support requires pgrx wrappers
+         (v0.5.x follow-up to #465)."
+    ) }}
+{% endmacro %}
+
+
+{#--- canonicalize_address -----------------------------------------------#}
+{% macro canonicalize_address(column) %}
+    {{ return(adapter.dispatch('canonicalize_address_impl', 'dbt_goldensuite')(column)) }}
+{% endmacro %}
+
+{% macro default__canonicalize_address_impl(column) %}
+    {{ exceptions.raise_compiler_error(
+        "canonicalize_address is supported on duckdb today; other adapters:
+         run goldenflow out-of-band."
+    ) }}
+{% endmacro %}
+
+{% macro duckdb__canonicalize_address_impl(column) %}
+    goldenflow_canonicalize_address({{ column }})
+{% endmacro %}
+
+{% macro postgres__canonicalize_address_impl(column) %}
+    {{ exceptions.raise_compiler_error(
+        "canonicalize_address Postgres support requires pgrx wrappers
+         (v0.5.x follow-up to #465)."
+    ) }}
+{% endmacro %}
+
+
+{#--- strip_whitespace + whitespace_normalize ----------------------------#}
+{% macro strip_whitespace(column) %}
+    {{ return(adapter.dispatch('strip_whitespace_impl', 'dbt_goldensuite')(column)) }}
+{% endmacro %}
+
+{% macro default__strip_whitespace_impl(column) %}
+    TRIM({{ column }})
+{% endmacro %}
+
+{% macro duckdb__strip_whitespace_impl(column) %}
+    goldenflow_strip({{ column }})
+{% endmacro %}
+
+{% macro postgres__strip_whitespace_impl(column) %}
+    {{ exceptions.raise_compiler_error(
+        "strip_whitespace Postgres support requires pgrx wrappers
+         (v0.5.x follow-up to #465). Note: standard SQL TRIM works on
+         all adapters via the default__ branch."
+    ) }}
+{% endmacro %}
+
+
+{% macro whitespace_normalize(column) %}
+    {{ return(adapter.dispatch('whitespace_normalize_impl', 'dbt_goldensuite')(column)) }}
+{% endmacro %}
+
+{% macro default__whitespace_normalize_impl(column) %}
+    {{ exceptions.raise_compiler_error(
+        "whitespace_normalize is supported on duckdb today; other adapters:
+         run goldenflow out-of-band."
+    ) }}
+{% endmacro %}
+
+{% macro duckdb__whitespace_normalize_impl(column) %}
+    goldenflow_whitespace_normalize({{ column }})
+{% endmacro %}
+
+{% macro postgres__whitespace_normalize_impl(column) %}
+    {{ exceptions.raise_compiler_error(
+        "whitespace_normalize Postgres support requires pgrx wrappers
+         (v0.5.x follow-up to #465)."
+    ) }}
+{% endmacro %}

--- a/packages/python/goldenmatch/dbt-goldensuite/pyproject.toml
+++ b/packages/python/goldenmatch/dbt-goldensuite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dbt-goldensuite"
-version = "0.4.0"
+version = "0.5.0"
 description = "dbt integration for the Golden Suite: entity resolution (goldenmatch) + data quality (goldencheck) + transforms (goldenflow)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -12,7 +12,7 @@ license = "MIT"
 authors = [{ name = "Ben Severn", email = "benzsevern@gmail.com" }]
 classifiers = ["Private :: Do Not Upload"]
 dependencies = [
-    "goldenmatch>=0.4.0",
+    "goldenmatch>=0.5.0",
     "dbt-core>=1.7",
     "duckdb>=0.9",
 ]

--- a/packages/python/goldenmatch/dbt-goldensuite/tests/test_transform_macros.py
+++ b/packages/python/goldenmatch/dbt-goldensuite/tests/test_transform_macros.py
@@ -1,0 +1,154 @@
+"""Tests for v0.5 GoldenFlow transform macros."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+jinja2 = pytest.importorskip("jinja2")
+
+_MACROS_DIR = Path(__file__).resolve().parents[1] / "macros"
+
+
+class _DbtStub:
+    @staticmethod
+    def string_literal(s):  # noqa: ANN001
+        return "'" + str(s).replace("'", "''") + "'"
+
+
+class _TargetStub:
+    def __init__(self, adapter_type) -> None:  # noqa: ANN001
+        self.type = adapter_type
+
+
+class _AdapterStub:
+    def __init__(self, adapter_type, env) -> None:  # noqa: ANN001
+        self._adapter_type = adapter_type
+        self._env = env
+
+    def dispatch(self, macro_name, namespace):  # noqa: ANN001, ARG002
+        for cand in (f"{self._adapter_type}__{macro_name}",
+                     f"default__{macro_name}"):
+            if cand in self._env.globals:
+                return self._env.globals[cand]
+        raise RuntimeError(f"no dispatch for {macro_name}")
+
+
+class _ExceptionsStub:
+    @staticmethod
+    def raise_compiler_error(msg):  # noqa: ANN001
+        raise RuntimeError(msg)
+
+
+def _build_env(adapter_type: str):
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(_MACROS_DIR)),
+        autoescape=False,
+    )
+    env.globals["target"] = _TargetStub(adapter_type)
+    env.globals["dbt"] = _DbtStub()
+    env.globals["exceptions"] = _ExceptionsStub()
+    env.globals["return"] = lambda v: v
+    env.globals["adapter"] = _AdapterStub(adapter_type, env)
+    template = env.get_template("transforms.sql")
+    module = template.module
+    for name in dir(module):
+        if name.startswith("_"):
+            continue
+        attr = getattr(module, name)
+        if callable(attr):
+            env.globals[name] = attr
+    return env
+
+
+# DuckDB rendering -- the v0.5 happy path.
+@pytest.mark.parametrize("macro,udf", [
+    ("normalize_email", "goldenflow_normalize_email"),
+    ("normalize_phone", "goldenflow_normalize_phone"),
+    ("normalize_date", "goldenflow_normalize_date"),
+    ("canonicalize_url", "goldenflow_canonicalize_url"),
+    ("canonicalize_address", "goldenflow_canonicalize_address"),
+    ("strip_whitespace", "goldenflow_strip"),
+    ("whitespace_normalize", "goldenflow_whitespace_normalize"),
+])
+def test_duckdb_renders_udf_call(macro, udf) -> None:
+    env = _build_env("duckdb")
+    fn = env.globals[macro]
+    sql = fn("email_raw")
+    assert udf in sql
+    assert "email_raw" in sql
+
+
+def test_normalize_name_proper_duckdb() -> None:
+    env = _build_env("duckdb")
+    fn = env.globals["normalize_name"]
+    sql = fn("name_raw", mode="proper")
+    assert "goldenflow_normalize_name_proper" in sql
+
+
+def test_normalize_name_upper_uses_sql_builtin() -> None:
+    """upper mode skips the UDF + uses standard SQL UPPER()."""
+    env = _build_env("duckdb")
+    fn = env.globals["normalize_name"]
+    sql = fn("name_raw", mode="upper")
+    assert "UPPER(name_raw)" in sql
+    assert "goldenflow_normalize_name" not in sql
+
+
+def test_normalize_name_lower_uses_sql_builtin() -> None:
+    env = _build_env("duckdb")
+    fn = env.globals["normalize_name"]
+    sql = fn("name_raw", mode="lower")
+    assert "LOWER(name_raw)" in sql
+
+
+def test_normalize_name_invalid_mode_errors() -> None:
+    env = _build_env("duckdb")
+    fn = env.globals["normalize_name"]
+    with pytest.raises(RuntimeError, match="mode must be one of"):
+        fn("name_raw", mode="screaming-snake")
+
+
+# Postgres -- compile-error in v0.5 (pgrx wrappers deferred).
+@pytest.mark.parametrize("macro", [
+    "normalize_email",
+    "normalize_phone",
+    "normalize_date",
+    "canonicalize_url",
+    "canonicalize_address",
+    "whitespace_normalize",
+])
+def test_postgres_errors_with_pgrx_followup_hint(macro) -> None:
+    env = _build_env("postgres")
+    fn = env.globals[macro]
+    with pytest.raises(RuntimeError, match="(?s).*pgrx.*wrappers"):
+        fn("col")
+
+
+def test_strip_whitespace_default_falls_back_to_sql_trim() -> None:
+    """strip_whitespace is the only transform with a usable default__
+    branch (standard SQL TRIM works everywhere)."""
+    env = _build_env("snowflake")
+    fn = env.globals["strip_whitespace"]
+    sql = fn("col")
+    assert "TRIM(col)" in sql
+
+
+# Other adapters -- compile error pointing at the Python helper.
+@pytest.mark.parametrize("macro", [
+    "normalize_email",
+    "normalize_phone",
+    "normalize_date",
+    "canonicalize_url",
+    "canonicalize_address",
+    "whitespace_normalize",
+])
+def test_unknown_adapter_errors(macro) -> None:
+    env = _build_env("snowflake")
+    fn = env.globals[macro]
+    with pytest.raises(RuntimeError, match="(?s).*out-of-band"):
+        fn("col")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
@@ -150,6 +150,13 @@ def register(con: duckdb.DuckDBPyConnection) -> None:
         ["VARCHAR", "VARCHAR"], "VARCHAR",
     )
 
+    # ── GoldenFlow transforms (v0.5 of dbt-goldensuite, #465 Tier 1.1) ──
+    # 8 UDFs wrapping goldenflow's series-level transforms. Safe to
+    # register even if goldenflow isn't installed -- the UDFs
+    # fail-open + pass through. `pip install goldenflow` to enable.
+    from goldenmatch_duckdb.goldenflow import register_goldenflow_functions
+    register_goldenflow_functions(con)
+
 
 # ── Implementation ──────────────────────────────────────────────────────
 

--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/goldenflow.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/goldenflow.py
@@ -1,0 +1,106 @@
+"""DuckDB UDFs for GoldenFlow transforms (v0.5 of dbt-goldensuite).
+
+Closes part of goldenmatch issue #465 Tier 1.1 (DuckDB layer). The
+Postgres pgrx wrappers + dbt macros land alongside this.
+
+Each UDF wraps the equivalent goldenflow Series-level transform. We
+construct a 1-element pl.Series, dispatch through goldenflow's
+transform registry, and unbox the result. That's the cheapest path
+to byte-equality with the Python sibling.
+
+Registered alongside the other goldenmatch UDFs via
+`register_goldenflow_functions(con)`. Call site:
+`goldenmatch_duckdb.functions.register(con)` already imports + calls
+this when goldenflow is available; consumers who don't have
+goldenflow installed get a clear ImportError + skip.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+def _try_import_goldenflow() -> bool:
+    try:
+        import goldenflow  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _wrap_series_transform(transform_name: str) -> Callable[[str | None], str | None]:
+    """Build a per-value UDF that defers to a goldenflow series transform.
+
+    Lazy-imports goldenflow + polars to keep the DuckDB extension
+    loadable without goldenflow installed (only matters when the
+    UDF is actually called).
+    """
+    def _udf(value: str | None) -> str | None:
+        if value is None:
+            return None
+        try:
+            import polars as pl
+            from goldenflow.transforms import get_transform
+        except ImportError:
+            return value  # fail-open: pass through when goldenflow missing
+        info = get_transform(transform_name)
+        if info is None:
+            return value
+        series = pl.Series([value])
+        try:
+            if info.mode == "series":
+                out = info.func(series)
+            elif info.mode == "expr":
+                # expr-mode transforms take a column name; build a tiny
+                # frame, apply, extract.
+                df = pl.DataFrame({"v": series})
+                out = df.with_columns(info.func("v").alias("v"))["v"]
+            else:
+                # dataframe-mode -- not applicable to single-value UDFs.
+                return value
+            result = out[0]
+        except Exception as exc:
+            logger.warning(
+                "goldenflow %s failed on value %r: %s",
+                transform_name, value, exc,
+            )
+            return value
+        return None if result is None else str(result)
+    return _udf
+
+
+# Public mapping: DuckDB UDF name -> underlying goldenflow transform.
+# Each name matches the dbt-goldensuite macro that consumes it.
+_UDF_REGISTRY: dict[str, str] = {
+    "goldenflow_normalize_email": "email_normalize",
+    "goldenflow_normalize_phone": "phone_e164",
+    "goldenflow_normalize_date": "date_iso8601",
+    "goldenflow_normalize_name_proper": "name_proper",
+    "goldenflow_canonicalize_url": "url_normalize",
+    "goldenflow_canonicalize_address": "address_standardize",
+    "goldenflow_strip": "strip",
+    "goldenflow_whitespace_normalize": "collapse_whitespace",
+}
+
+
+def register_goldenflow_functions(con) -> None:  # noqa: ANN001
+    """Register 8 goldenflow transform UDFs on a DuckDB connection.
+
+    Safe to call even when goldenflow isn't installed -- the UDFs
+    fail-open and pass through inputs unchanged with a debug log.
+    Callers should still `pip install goldenflow` for the UDFs to
+    actually transform.
+    """
+    if not _try_import_goldenflow():
+        logger.info(
+            "goldenflow not installed; goldenflow_* UDFs registered as "
+            "pass-throughs. `pip install goldenflow` to enable.",
+        )
+    for udf_name, transform_name in _UDF_REGISTRY.items():
+        fn = _wrap_series_transform(transform_name)
+        con.create_function(
+            udf_name, fn,
+            ["VARCHAR"], "VARCHAR",
+        )


### PR DESCRIPTION
Stacks on PR #467. 8 standardization macros wrapping GoldenFlow, available on DuckDB today via new UDFs. Postgres pgrx deferred.

## Macros (8)
- normalize_email / normalize_phone / normalize_date / normalize_name (proper|upper|lower)
- canonicalize_url / canonicalize_address
- strip_whitespace (default fallback to SQL TRIM) / whitespace_normalize

## DuckDB UDFs (8)
goldenflow_normalize_email, goldenflow_normalize_phone, etc.
Registered via `register_goldenflow_functions`. Fail-open when goldenflow not installed.

## Tests
26 new + 75 total in dbt-goldensuite passing.

## Deferred to v0.5.1
- Postgres pgrx `goldenflow_normalize_*` wrappers (Linux-CI-only build)
- Parity fixtures + integration tests

Spec: `docs/superpowers/specs/2026-05-23-dbt-goldenflow-transform-macros-design.md`
Refs #465 Tier 1.1.