### PR TITLE
feat(goldenflow-ts): full surface parity — carceral domain, cloud connectors, A2A server

### DIFF
--- a/.github/workflows/publish-goldenflow-js.yml
+++ b/.github/workflows/publish-goldenflow-js.yml
@@ -1,0 +1,76 @@
+name: Publish goldenflow to npm
+
+on:
+  push:
+    tags:
+      - "goldenflow-js-v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      dry-run:
+        description: "Pack and validate without publishing"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/typescript/goldenflow
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: pnpm
+
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit
+
+      - name: Test
+        run: pnpm exec vitest run
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Verify version matches tag
+        if: startsWith(github.ref, 'refs/tags/goldenflow-js-v')
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/goldenflow-js-v}"
+          PKG_VERSION=$(jq -r .version package.json)
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version OK: $PKG_VERSION"
+
+      - name: Pack (dry-run validation)
+        if: github.event.inputs.dry-run == 'true'
+        # pnpm pack always writes a .tgz; running it in dry-run validates the
+        # package can be packed cleanly (file list, entry points, version)
+        # without publishing. The artifact is discarded on job teardown.
+        run: pnpm pack
+
+      - name: Publish to npm
+        if: github.event.inputs.dry-run != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --access public --provenance --no-git-checks

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,11 @@ labels.jsonl
 # Turborepo
 .turbo/
 
+# Claude Code agent worktrees (transient isolated checkouts created by
+# background subagents). Never tracked; project-level .claude settings can
+# still be committed since only the worktrees subdir is ignored.
+.claude/worktrees/
+
 # Local profiling artifacts (per CLAUDE.md convention — cProfile dumps,
 # scale-audit JSON outputs, synthetic fixtures). Documented as gitignored
 # in CLAUDE.md; this entry makes that real.

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -68,10 +68,16 @@
     "commander": "^13.0.0"
   },
   "peerDependencies": {
-    "yaml": "*"
+    "yaml": "*",
+    "@aws-sdk/client-s3": "*",
+    "@google-cloud/storage": "*",
+    "pg": "*"
   },
   "peerDependenciesMeta": {
-    "yaml": { "optional": true }
+    "yaml": { "optional": true },
+    "@aws-sdk/client-s3": { "optional": true },
+    "@google-cloud/storage": { "optional": true },
+    "pg": { "optional": true }
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",

--- a/packages/typescript/goldenflow/src/core/domains/carceral.ts
+++ b/packages/typescript/goldenflow/src/core/domains/carceral.ts
@@ -1,0 +1,236 @@
+/**
+ * Carceral (U.S. prisons, jails, detention centers) domain pack.
+ *
+ * Port of goldenflow/domains/carceral.py. Targets joining HIFLD Prison
+ * Boundaries, EPA ECHO, state DOC inventories, and SDWA registrations —
+ * datasets that share physical facilities but disagree on naming convention.
+ *
+ * Three carceral-specific problems this pack solves:
+ *
+ * 1. Operator-org prefixes. ECHO ships records like
+ *    "MDOC, SOUTH MISSISSIPPI CORRECTIONAL INSTITUTION" while HIFLD says
+ *    "SOUTH MISSISSIPPI CORRECTIONAL INSTITUTION". Stripping the leading
+ *    operating-agency prefix before any fuzzy comparison is the single
+ *    biggest precision win on this domain.
+ *
+ * 2. Federal facility-type abbreviations. USP / FCI / FCC / FPC / FMC /
+ *    FDC / ADC — Bureau of Prisons abbreviations that vary across HIFLD
+ *    (short form) and ECHO (long form). carceral_abbreviate expands them.
+ *
+ * 3. State-prison-complex aliases. Arizona's HIFLD names start with ASPC-
+ *    while ECHO files them as ASP - / APS- (typo). Aliasing both to the
+ *    long form lets the name scorer see a common prefix.
+ *
+ * The pack does NOT redefine address / ZIP / state / unit normalization —
+ * it composes the existing address_standardize, zip_normalize,
+ * state_abbreviate, and unit_normalize transforms in its defaultConfig.
+ */
+
+import type { ColumnValue, DomainPack, Row } from "../types.js";
+import { makeConfig } from "../types.js";
+import { registerTransform } from "../transforms/registry.js";
+
+// ---------------------------------------------------------------------------
+// Carceral-domain constants (exported so users can extend)
+// ---------------------------------------------------------------------------
+
+/**
+ * Single-token operator-org acronyms used by state DOCs and private
+ * corrections operators. Stripped only when they appear as a leading prefix
+ * followed by a separator (`,` / `-` / `:` / `/`); mid-string occurrences are
+ * left alone.
+ */
+export const CARCERAL_OPERATOR_ORGS: ReadonlySet<string> = new Set([
+  "MDOC", "TDCJ", "CDCR", "FDOC", "GDC", "IDOC", "NCDPS",
+  "DOC", "DOCR", "DOCS",
+  "CCA", "CORECIVIC", "GEO GROUP", "GEO",
+]);
+
+/**
+ * Federal Bureau of Prisons facility-type abbreviations. Expanded by
+ * carceral_abbreviate so HIFLD's "USP HAZELTON" and ECHO's "UNITED STATES
+ * PENITENTIARY HAZELTON" land in the same shape.
+ */
+export const CARCERAL_BOP_ABBREVIATIONS: Readonly<Record<string, string>> = {
+  USP: "UNITED STATES PENITENTIARY",
+  FCI: "FEDERAL CORRECTIONAL INSTITUTION",
+  FCC: "FEDERAL CORRECTIONAL COMPLEX",
+  FPC: "FEDERAL PRISON CAMP",
+  FMC: "FEDERAL MEDICAL CENTER",
+  FDC: "FEDERAL DETENTION CENTER",
+  ADC: "ADMINISTRATIVE DETENTION CENTER",
+};
+
+/**
+ * State-prison-complex name aliases. HIFLD uses one form; ECHO often uses a
+ * different one (sometimes a typo). Both sides map to the long form so the
+ * name scorer sees a common prefix.
+ */
+export const CARCERAL_STATE_COMPLEX_ALIASES: Readonly<Record<string, string>> = {
+  ASPC: "ARIZONA STATE PRISON COMPLEX",
+  ASP: "ARIZONA STATE PRISON",
+  APS: "ARIZONA STATE PRISON", // observed ECHO typo for "ASP"
+};
+
+// ---------------------------------------------------------------------------
+// Regex helpers (ported from the Python module)
+// ---------------------------------------------------------------------------
+
+/**
+ * Phrase-form operator-org prefixes. ECHO uses these long-form variants
+ * alongside the acronyms: "TX DEPT OF CRIM JUST- MCCONNELL UNIT",
+ * "PA DEPT OF CORR/CHESTER SCI".
+ */
+const OPERATOR_PHRASE_RE =
+  /^(?:(?:[A-Z]{2}|TEXAS|CALIFORNIA|FLORIDA|MISSISSIPPI|GEORGIA|INDIANA)\s+DEPT?\s+OF\s+(?:CORR(?:ECTIONS?)?|CRIM(?:INAL)?\s+JUST(?:ICE)?))\s*[,\-:/]\s*/;
+
+// Acronyms sorted by length descending so multi-word forms win (e.g.
+// "GEO GROUP" before "GEO"). Each must be a leading prefix followed by a
+// separator AND at least one whitespace char.
+const OPERATOR_ACRONYMS_SORTED = [...CARCERAL_OPERATOR_ORGS].sort(
+  (a, b) => b.length - a.length,
+);
+const OPERATOR_ACRONYM_RE = new RegExp(
+  "^(?:" + OPERATOR_ACRONYMS_SORTED.map(escapeRegExp).join("|") + ")\\s*[,\\-:/]\\s+",
+);
+
+const NON_ALNUM_RE = /[^A-Z0-9 ]+/g;
+const WHITESPACE_RE = /\s+/g;
+const OPERATOR_SUFFIX_RE = /\b(?:LLC|INC|CORP|CO|LTD)\b\.?\s*$/;
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripOperatorPrefix(s: string): string {
+  s = s.replace(OPERATOR_PHRASE_RE, "");
+  s = s.replace(OPERATOR_ACRONYM_RE, "");
+  return s;
+}
+
+function expandAbbreviations(s: string): string {
+  for (const [short, long] of Object.entries(CARCERAL_BOP_ABBREVIATIONS)) {
+    s = s.replace(new RegExp(`\\b${escapeRegExp(short)}\\b`, "g"), long);
+  }
+  for (const [short, long] of Object.entries(CARCERAL_STATE_COMPLEX_ALIASES)) {
+    s = s.replace(new RegExp(`\\b${escapeRegExp(short)}\\b`, "g"), long);
+  }
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Transforms
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip leading operator-org prefix from a carceral facility name.
+ *   "MDOC, SOUTH MISS CORRECTIONAL INSTITUTION" -> "SOUTH MISS CORRECTIONAL INSTITUTION"
+ *   "TX DEPT OF CRIM JUST- MCCONNELL UNIT"      -> "MCCONNELL UNIT"
+ *   "PA DEPT OF CORR/CHESTER SCI"               -> "CHESTER SCI"
+ */
+function carceralOrgStrip(values: readonly ColumnValue[]): ColumnValue[] {
+  return values.map((v) => {
+    if (v === null || typeof v !== "string") return v;
+    return stripOperatorPrefix(v.toUpperCase().trim()).trim();
+  });
+}
+
+/**
+ * Expand carceral facility-type abbreviations and state-complex aliases.
+ * Covers the BOP set (USP/FCI/FCC/FPC/FMC/FDC/ADC) plus the Arizona
+ * ASPC/ASP/APS alias cluster. Word-bounded; mid-token occurrences are left
+ * alone.
+ */
+function carceralAbbreviate(values: readonly ColumnValue[]): ColumnValue[] {
+  return values.map((v) => {
+    if (v === null || typeof v !== "string") return v;
+    return expandAbbreviations(v.toUpperCase().trim());
+  });
+}
+
+/**
+ * Full carceral name pipeline: org-strip + uppercase + punctuation strip +
+ * abbreviation expand + legal-suffix strip. Output is suitable for
+ * Jaro-Winkler / token-set scoring against another normalized name.
+ */
+function carceralNameNormalize(values: readonly ColumnValue[]): ColumnValue[] {
+  return values.map((v) => {
+    if (v === null || typeof v !== "string") return v;
+    let s = v.toUpperCase().trim();
+    s = stripOperatorPrefix(s);
+    s = s.replace(NON_ALNUM_RE, " ");
+    s = s.replace(WHITESPACE_RE, " ").trim();
+    s = expandAbbreviations(s);
+    s = s.replace(OPERATOR_SUFFIX_RE, "").trim();
+    s = s.replace(WHITESPACE_RE, " ").trim();
+    return s;
+  });
+}
+
+/**
+ * Pack `lat` + `lng` into a single `latlng` column shaped "<lat>|<lng>"
+ * (empty when either is null). Idempotent: skips silently if `lat` or `lng`
+ * is missing. dataframe-mode transform: receives all rows, returns all rows.
+ */
+function latlngPack(rows: readonly Row[]): Row[] {
+  if (rows.length === 0) return [...rows];
+  const first = rows[0]!;
+  if (!("lat" in first) || !("lng" in first)) return [...rows];
+  return rows.map((row) => {
+    const lat = row["lat"];
+    const lng = row["lng"];
+    const latlng =
+      lat === null || lat === undefined || lng === null || lng === undefined
+        ? ""
+        : `${String(lat)}|${String(lng)}`;
+    return { ...row, latlng };
+  });
+}
+
+registerTransform(
+  { name: "carceral_org_strip", inputTypes: ["string"], autoApply: false, priority: 55, mode: "series" },
+  carceralOrgStrip,
+);
+registerTransform(
+  { name: "carceral_abbreviate", inputTypes: ["string"], autoApply: false, priority: 50, mode: "series" },
+  carceralAbbreviate,
+);
+registerTransform(
+  { name: "carceral_name_normalize", inputTypes: ["string"], autoApply: false, priority: 60, mode: "series" },
+  carceralNameNormalize,
+);
+registerTransform(
+  { name: "latlng_pack", inputTypes: ["string"], autoApply: false, priority: 40, mode: "dataframe" },
+  latlngPack,
+);
+
+export const PACK: DomainPack = {
+  name: "carceral",
+  description:
+    "U.S. carceral facilities (prisons, jails, detention centers). " +
+    "Operator-org prefix stripping (state DOCs + private operators), " +
+    "BOP facility-type abbreviation expansion (USP/FCI/FCC/...), " +
+    "state-prison-complex aliasing (Arizona ASPC/ASP/APS), and " +
+    "lat/lng packing for geo-aware scorers. Composes with the existing " +
+    "address_standardize / zip_normalize / state_abbreviate transforms.",
+  transforms: [
+    "carceral_org_strip",
+    "carceral_abbreviate",
+    "carceral_name_normalize",
+    "latlng_pack",
+    // composed-from-existing-pack:
+    "address_standardize",
+    "unit_normalize",
+    "zip_normalize",
+    "state_abbreviate",
+  ],
+  defaultConfig: makeConfig({
+    transforms: [
+      { column: "name", ops: ["carceral_name_normalize"] },
+      { column: "address", ops: ["strip", "address_standardize", "unit_normalize"] },
+      { column: "city", ops: ["strip", "uppercase"] },
+      { column: "state", ops: ["state_abbreviate"] },
+      { column: "zip", ops: ["zip_normalize"] },
+    ],
+  }),
+};

--- a/packages/typescript/goldenflow/src/core/domains/index.ts
+++ b/packages/typescript/goldenflow/src/core/domains/index.ts
@@ -6,6 +6,7 @@ const DOMAIN_LOADERS: Readonly<Record<string, () => Promise<{ PACK: DomainPack }
   finance: () => import("./finance.js"),
   ecommerce: () => import("./ecommerce.js"),
   real_estate: () => import("./real-estate.js"),
+  carceral: () => import("./carceral.js"),
 };
 
 export async function loadDomain(name: string): Promise<DomainPack | null> {

--- a/packages/typescript/goldenflow/src/node/a2a/server.ts
+++ b/packages/typescript/goldenflow/src/node/a2a/server.ts
@@ -241,11 +241,14 @@ export function startA2aServer(
           task.result = result;
           sendJson(res, 200, { id, status: "completed", result });
         } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
+          // Log detail server-side; don't return exception/stack text to the
+          // client (CodeQL js/stack-trace-exposure).
+          // eslint-disable-next-line no-console
+          console.error("[goldenflow-a2a] skill failed:", err);
           task.status = "failed";
           task.completedAt = new Date().toISOString();
-          task.error = msg;
-          sendJson(res, 200, { id, status: "failed", error: msg });
+          task.error = "skill execution failed";
+          sendJson(res, 200, { id, status: "failed", error: "skill execution failed" });
         }
         return;
       }
@@ -271,8 +274,9 @@ export function startA2aServer(
 
       sendJson(res, 404, { error: `Not found: ${methodName} ${pathname}` });
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      sendJson(res, 500, { error: msg });
+      // eslint-disable-next-line no-console
+      console.error("[goldenflow-a2a] request error:", err);
+      sendJson(res, 500, { error: "internal server error" });
     }
   });
 

--- a/packages/typescript/goldenflow/src/node/a2a/server.ts
+++ b/packages/typescript/goldenflow/src/node/a2a/server.ts
@@ -1,0 +1,288 @@
+/**
+ * a2a/server.ts -- GoldenFlow A2A (Agent-to-Agent) protocol server.
+ *
+ * Node-only: uses node:http, node:crypto. NOT edge-safe.
+ *
+ * Port of goldenflow/a2a/server.py. Mirrors the goldenmatch / goldencheck
+ * TS A2A servers for structure (agent card at /.well-known/agent.json, skill
+ * dispatch, task lifecycle). Skills delegate to the GoldenFlow MCP tools via
+ * `handleTool`, exactly as the Python server delegates to its MCP `handle_tool`.
+ *
+ * Endpoints:
+ *   GET  /.well-known/agent.json   - agent card (6 skills)
+ *   GET  /health                   - liveness probe
+ *   POST /tasks                    - create a task (skill + params)
+ *   GET  /tasks/{id}               - fetch task status/result
+ */
+
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { randomUUID } from "node:crypto";
+import { handleTool } from "../mcp/server.js";
+
+// ---------------------------------------------------------------------------
+// Agent card
+// ---------------------------------------------------------------------------
+
+export interface AgentSkill {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly inputModes: readonly string[];
+  readonly outputModes: readonly string[];
+}
+
+export const AGENT_CARD: {
+  readonly name: string;
+  readonly description: string;
+  readonly version: string;
+  readonly provider: { readonly organization: string };
+  readonly url: string;
+  readonly skills: readonly AgentSkill[];
+} = {
+  name: "GoldenFlow",
+  description:
+    "Data transformation -- standardize, clean, and normalize data with auto-detection and domain-aware transforms",
+  version: "1.0.0",
+  provider: { organization: "Golden Suite" },
+  url: "http://localhost:8150",
+  skills: [
+    {
+      id: "transform-data",
+      name: "Transform Data",
+      description:
+        "Full transform workflow: profile data, apply transforms (zero-config or config-driven), return manifest of changes",
+      inputModes: ["text"],
+      outputModes: ["text"],
+    },
+    {
+      id: "map-schemas",
+      name: "Map Schemas",
+      description:
+        "Auto-map columns between source and target datasets with confidence scores",
+      inputModes: ["text"],
+      outputModes: ["text"],
+    },
+    {
+      id: "discover",
+      name: "Discover Capabilities",
+      description: "List all available transforms and domain packs",
+      inputModes: ["text"],
+      outputModes: ["text"],
+    },
+    {
+      id: "diff-results",
+      name: "Diff Results",
+      description: "Compare before and after datasets to show what changed",
+      inputModes: ["text"],
+      outputModes: ["text"],
+    },
+    {
+      id: "configure",
+      name: "Configure",
+      description:
+        "Auto-generate transform config from data patterns, with profile-based recommendations",
+      inputModes: ["text"],
+      outputModes: ["text"],
+    },
+    {
+      id: "handoff",
+      name: "Handoff from GoldenCheck",
+      description:
+        "Map GoldenCheck findings to GoldenFlow transforms -- bridge for Check-to-Flow pipeline",
+      inputModes: ["text"],
+      outputModes: ["text"],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Task store
+// ---------------------------------------------------------------------------
+
+interface Task {
+  readonly id: string;
+  readonly skill: string;
+  status: "pending" | "running" | "completed" | "failed";
+  readonly createdAt: string;
+  completedAt?: string;
+  result?: unknown;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Skill dispatch
+// ---------------------------------------------------------------------------
+
+/** Run an MCP tool and parse its JSON-string result. */
+function callTool(name: string, params: Record<string, unknown>): unknown {
+  return JSON.parse(handleTool(name, params));
+}
+
+function dispatchSkill(skill: string, params: Record<string, unknown>): unknown {
+  switch (skill) {
+    case "transform-data": {
+      // Workflow: profile then transform.
+      const parts: Array<{ step: string; result: unknown }> = [];
+      if ("path" in params) {
+        parts.push({ step: "profile", result: callTool("profile", { path: params["path"] }) });
+        parts.push({ step: "transform", result: callTool("transform", params) });
+      }
+      return parts;
+    }
+
+    case "map-schemas":
+      return callTool("map", params);
+
+    case "discover":
+      return {
+        transforms: callTool("list_transforms", {}),
+        domains: callTool("list_domains", {}),
+      };
+
+    case "diff-results":
+      return callTool("diff", params);
+
+    case "configure": {
+      const parts: Array<{ step: string; result: unknown }> = [];
+      if ("path" in params) {
+        parts.push({ step: "profile", result: callTool("profile", { path: params["path"] }) });
+        parts.push({ step: "config", result: callTool("learn", { path: params["path"] }) });
+      }
+      return parts;
+    }
+
+    case "handoff":
+      return callTool("select_from_findings", params);
+
+    default:
+      return { error: `Unknown skill: ${skill}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  let body = "";
+  for await (const chunk of req) {
+    body += typeof chunk === "string" ? chunk : (chunk as Buffer).toString("utf8");
+  }
+  if (!body) return {};
+  const parsed = JSON.parse(body);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("body must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function sendJson(res: ServerResponse, status: number, data: unknown): void {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(data));
+}
+
+// ---------------------------------------------------------------------------
+// Public: startA2aServer
+// ---------------------------------------------------------------------------
+
+export interface StartA2aOptions {
+  readonly port?: number;
+  readonly host?: string;
+}
+
+export function startA2aServer(
+  options: StartA2aOptions = {},
+): ReturnType<typeof createServer> {
+  const port = options.port ?? 8150;
+  const host = options.host ?? "127.0.0.1";
+  const tasks = new Map<string, Task>();
+
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+    const pathname = url.pathname;
+    const methodName = req.method ?? "GET";
+
+    try {
+      if (pathname === "/.well-known/agent.json" && methodName === "GET") {
+        sendJson(res, 200, AGENT_CARD);
+        return;
+      }
+
+      if (pathname === "/health" && methodName === "GET") {
+        sendJson(res, 200, { status: "ok", version: AGENT_CARD.version });
+        return;
+      }
+
+      if (pathname === "/tasks" && methodName === "POST") {
+        const body = await readJsonBody(req);
+        const skill = String(body["skill"] ?? "");
+        const params =
+          (body["params"] as Record<string, unknown> | undefined) ??
+          (body["input"] as Record<string, unknown> | undefined) ??
+          {};
+        if (!skill) {
+          sendJson(res, 400, { error: "skill is required" });
+          return;
+        }
+        const id = String(body["id"] ?? randomUUID());
+        const createdAt = new Date().toISOString();
+        const task: Task = { id, skill, status: "running", createdAt };
+        tasks.set(id, task);
+
+        try {
+          const result = dispatchSkill(skill, params);
+          task.status = "completed";
+          task.completedAt = new Date().toISOString();
+          task.result = result;
+          sendJson(res, 200, { id, status: "completed", result });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          task.status = "failed";
+          task.completedAt = new Date().toISOString();
+          task.error = msg;
+          sendJson(res, 200, { id, status: "failed", error: msg });
+        }
+        return;
+      }
+
+      if (pathname.startsWith("/tasks/") && methodName === "GET") {
+        const id = pathname.slice("/tasks/".length);
+        const task = tasks.get(id);
+        if (!task) {
+          sendJson(res, 404, { error: `Task not found: ${id}` });
+          return;
+        }
+        sendJson(res, 200, {
+          id: task.id,
+          skill: task.skill,
+          status: task.status,
+          created_at: task.createdAt,
+          completed_at: task.completedAt ?? null,
+          result: task.result ?? null,
+          error: task.error ?? null,
+        });
+        return;
+      }
+
+      sendJson(res, 404, { error: `Not found: ${methodName} ${pathname}` });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      sendJson(res, 500, { error: msg });
+    }
+  });
+
+  server.listen(port, host, () => {
+    // eslint-disable-next-line no-console
+    console.log(`GoldenFlow A2A agent listening on http://${host}:${port}`);
+  });
+  return server;
+}
+
+export function runServer(port: number = 8150): ReturnType<typeof createServer> {
+  return startA2aServer({ port });
+}

--- a/packages/typescript/goldenflow/src/node/connectors/database.ts
+++ b/packages/typescript/goldenflow/src/node/connectors/database.ts
@@ -1,0 +1,102 @@
+/**
+ * Database connector for GoldenFlow (Node-only).
+ *
+ * Port of goldenflow/connectors/database.py. Reads/writes a Postgres table as
+ * Row[]. The Python sibling uses connectorx (multi-engine); the TS port
+ * targets Postgres via the `pg` driver, which is the closest broadly-used
+ * Node analogue.
+ *
+ * `pg` is an OPTIONAL peer dependency. If it is not installed, every entry
+ * point throws a clear, actionable Error (fail-soft, mirroring the Python
+ * `ImportError`).
+ */
+
+import type { Row } from "../../core/types.js";
+
+const DB_INSTALL_HINT = "Database support requires: npm install pg";
+
+interface PgClientLike {
+  connect(): Promise<void>;
+  query(text: string, values?: unknown[]): Promise<{ rows: Row[] }>;
+  end(): Promise<void>;
+}
+
+interface PgModule {
+  Client: new (connectionString: string) => PgClientLike;
+}
+
+async function loadPg(): Promise<PgModule> {
+  try {
+    // `as string` defeats tsup's static resolution so the optional peer dep
+    // is only required at runtime.
+    const mod = (await import("pg" as string)) as PgModule | { default: PgModule };
+    // `pg` ships as CommonJS; the namespace may be under `default`.
+    return "Client" in mod ? (mod as PgModule) : (mod as { default: PgModule }).default;
+  } catch {
+    throw new Error(DB_INSTALL_HINT);
+  }
+}
+
+/**
+ * Quote a SQL identifier (table / column name) for Postgres. Rejects names
+ * containing a double-quote to avoid identifier-injection.
+ */
+function quoteIdent(name: string): string {
+  if (name.includes('"')) {
+    throw new Error(`Invalid identifier: ${name}`);
+  }
+  return `"${name}"`;
+}
+
+/** Read all rows of a database table into Row[]. */
+export async function readTable(connectionString: string, table: string): Promise<Row[]> {
+  const { Client } = await loadPg();
+  const client = new Client(connectionString);
+  await client.connect();
+  try {
+    const result = await client.query(`SELECT * FROM ${quoteIdent(table)}`);
+    return result.rows;
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Write Row[] to a database table. Mirrors the Python `if_table_exists="replace"`
+ * semantics: drops and recreates the table, then inserts all rows.
+ */
+export async function writeTable(
+  rows: readonly Row[],
+  connectionString: string,
+  table: string,
+): Promise<void> {
+  const { Client } = await loadPg();
+  const client = new Client(connectionString);
+  await client.connect();
+  try {
+    const ident = quoteIdent(table);
+    await client.query(`DROP TABLE IF EXISTS ${ident}`);
+    if (rows.length === 0) {
+      await client.query(`CREATE TABLE ${ident} ()`);
+      return;
+    }
+    const columns = Object.keys(rows[0]!);
+    const colDefs = columns.map((c) => `${quoteIdent(c)} TEXT`).join(", ");
+    await client.query(`CREATE TABLE ${ident} (${colDefs})`);
+
+    const colList = columns.map(quoteIdent).join(", ");
+    for (const row of rows) {
+      const placeholders = columns.map((_, i) => `$${i + 1}`).join(", ");
+      const values = columns.map((c) => {
+        const v = row[c];
+        return v === null || v === undefined ? null : String(v);
+      });
+      await client.query(
+        `INSERT INTO ${ident} (${colList}) VALUES (${placeholders})`,
+        values,
+      );
+    }
+  } finally {
+    await client.end();
+  }
+}

--- a/packages/typescript/goldenflow/src/node/connectors/gcs.ts
+++ b/packages/typescript/goldenflow/src/node/connectors/gcs.ts
@@ -11,8 +11,7 @@
 
 import { tmpdir } from "node:os";
 import { join, extname } from "node:path";
-import { randomUUID } from "node:crypto";
-import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import type { Row } from "../../core/types.js";
 import { readFile, writeFile } from "./file.js";
 
@@ -68,16 +67,15 @@ export async function readGcs(uri: string): Promise<Row[]> {
   const blob = storage.bucket(bucketName).file(blobName);
   const [buffer] = await blob.download();
 
-  const tmpPath = join(tmpdir(), `goldenflow-${randomUUID()}${ext}`);
+  // mkdtempSync creates a uniquely-named, private (0700) directory — avoids
+  // the insecure predictable-name-in-world-readable-tmpdir pattern.
+  const tmpDir = mkdtempSync(join(tmpdir(), "goldenflow-"));
+  const tmpPath = join(tmpDir, `data${ext}`);
   writeFileSync(tmpPath, buffer);
   try {
     return readFile(tmpPath);
   } finally {
-    try {
-      unlinkSync(tmpPath);
-    } catch {
-      /* best-effort cleanup */
-    }
+    rmSync(tmpDir, { recursive: true, force: true });
   }
 }
 
@@ -87,17 +85,14 @@ export async function writeGcs(rows: readonly Row[], uri: string): Promise<void>
   const [bucketName, blobName] = parseGcsUri(uri);
   const ext = extname(blobName) || ".csv";
 
-  const tmpPath = join(tmpdir(), `goldenflow-${randomUUID()}${ext}`);
+  const tmpDir = mkdtempSync(join(tmpdir(), "goldenflow-"));
+  const tmpPath = join(tmpDir, `data${ext}`);
   writeFile(rows, tmpPath);
   let body: string;
   try {
     body = readFileSync(tmpPath, "utf-8");
   } finally {
-    try {
-      unlinkSync(tmpPath);
-    } catch {
-      /* best-effort cleanup */
-    }
+    rmSync(tmpDir, { recursive: true, force: true });
   }
 
   const storage = new Storage();

--- a/packages/typescript/goldenflow/src/node/connectors/gcs.ts
+++ b/packages/typescript/goldenflow/src/node/connectors/gcs.ts
@@ -1,0 +1,106 @@
+/**
+ * Google Cloud Storage connector for GoldenFlow (Node-only).
+ *
+ * Port of goldenflow/connectors/gcs.py. Reads/writes CSV (or JSON) files on
+ * GCS by round-tripping through the local `file` connector.
+ *
+ * `@google-cloud/storage` is an OPTIONAL peer dependency. If it is not
+ * installed, every entry point throws a clear, actionable Error (fail-soft,
+ * mirroring the Python `ImportError`).
+ */
+
+import { tmpdir } from "node:os";
+import { join, extname } from "node:path";
+import { randomUUID } from "node:crypto";
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import type { Row } from "../../core/types.js";
+import { readFile, writeFile } from "./file.js";
+
+const GCS_INSTALL_HINT = "GCS support requires: npm install @google-cloud/storage";
+
+interface BlobLike {
+  download(): Promise<[Buffer]>;
+  save(data: string | Buffer): Promise<void>;
+}
+
+interface BucketLike {
+  file(name: string): BlobLike;
+}
+
+interface StorageLike {
+  bucket(name: string): BucketLike;
+}
+
+interface GcsModule {
+  Storage: new (config?: Record<string, unknown>) => StorageLike;
+}
+
+async function loadGcs(): Promise<GcsModule> {
+  try {
+    // `as string` defeats tsup's static resolution so the optional peer dep
+    // is only required at runtime.
+    return (await import("@google-cloud/storage" as string)) as GcsModule;
+  } catch {
+    throw new Error(GCS_INSTALL_HINT);
+  }
+}
+
+/** Parse gs://bucket/path into [bucket, path]. */
+export function parseGcsUri(uri: string): [string, string] {
+  if (!uri.startsWith("gs://")) {
+    throw new Error(`Invalid GCS URI: ${uri}. Must start with gs://`);
+  }
+  const path = uri.slice("gs://".length);
+  const slash = path.indexOf("/");
+  if (slash === -1) {
+    throw new Error(`Invalid GCS URI: ${uri}. Must be gs://bucket/path`);
+  }
+  return [path.slice(0, slash), path.slice(slash + 1)];
+}
+
+/** Read a file from GCS into Row[]. */
+export async function readGcs(uri: string): Promise<Row[]> {
+  const { Storage } = await loadGcs();
+  const [bucketName, blobName] = parseGcsUri(uri);
+  const ext = extname(blobName) || ".csv";
+
+  const storage = new Storage();
+  const blob = storage.bucket(bucketName).file(blobName);
+  const [buffer] = await blob.download();
+
+  const tmpPath = join(tmpdir(), `goldenflow-${randomUUID()}${ext}`);
+  writeFileSync(tmpPath, buffer);
+  try {
+    return readFile(tmpPath);
+  } finally {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+}
+
+/** Write Row[] to GCS. */
+export async function writeGcs(rows: readonly Row[], uri: string): Promise<void> {
+  const { Storage } = await loadGcs();
+  const [bucketName, blobName] = parseGcsUri(uri);
+  const ext = extname(blobName) || ".csv";
+
+  const tmpPath = join(tmpdir(), `goldenflow-${randomUUID()}${ext}`);
+  writeFile(rows, tmpPath);
+  let body: string;
+  try {
+    body = readFileSync(tmpPath, "utf-8");
+  } finally {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+
+  const storage = new Storage();
+  const blob = storage.bucket(bucketName).file(blobName);
+  await blob.save(body);
+}

--- a/packages/typescript/goldenflow/src/node/connectors/index.ts
+++ b/packages/typescript/goldenflow/src/node/connectors/index.ts
@@ -1,1 +1,4 @@
 export { readFile, writeFile } from "./file.js";
+export { readS3, writeS3, parseS3Uri } from "./s3.js";
+export { readGcs, writeGcs, parseGcsUri } from "./gcs.js";
+export { readTable, writeTable } from "./database.js";

--- a/packages/typescript/goldenflow/src/node/connectors/s3.ts
+++ b/packages/typescript/goldenflow/src/node/connectors/s3.ts
@@ -11,8 +11,7 @@
 
 import { tmpdir } from "node:os";
 import { join, extname } from "node:path";
-import { randomUUID } from "node:crypto";
-import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import type { Row } from "../../core/types.js";
 import { readFile, writeFile } from "./file.js";
 
@@ -86,16 +85,15 @@ export async function readS3(uri: string): Promise<Row[]> {
   const response = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
   const content = await streamToString(response.Body);
 
-  const tmpPath = join(tmpdir(), `goldenflow-${randomUUID()}${ext}`);
+  // mkdtempSync creates a uniquely-named, private (0700) directory — avoids
+  // the insecure predictable-name-in-world-readable-tmpdir pattern.
+  const tmpDir = mkdtempSync(join(tmpdir(), "goldenflow-"));
+  const tmpPath = join(tmpDir, `data${ext}`);
   writeFileSync(tmpPath, content);
   try {
     return readFile(tmpPath);
   } finally {
-    try {
-      unlinkSync(tmpPath);
-    } catch {
-      /* best-effort cleanup */
-    }
+    rmSync(tmpDir, { recursive: true, force: true });
   }
 }
 
@@ -105,17 +103,14 @@ export async function writeS3(rows: readonly Row[], uri: string): Promise<void> 
   const [bucket, key] = parseS3Uri(uri);
   const ext = extname(key) || ".csv";
 
-  const tmpPath = join(tmpdir(), `goldenflow-${randomUUID()}${ext}`);
+  const tmpDir = mkdtempSync(join(tmpdir(), "goldenflow-"));
+  const tmpPath = join(tmpDir, `data${ext}`);
   writeFile(rows, tmpPath);
   let body: string;
   try {
     body = readFileSync(tmpPath, "utf-8");
   } finally {
-    try {
-      unlinkSync(tmpPath);
-    } catch {
-      /* best-effort cleanup */
-    }
+    rmSync(tmpDir, { recursive: true, force: true });
   }
 
   const client = new S3Client();

--- a/packages/typescript/goldenflow/src/node/connectors/s3.ts
+++ b/packages/typescript/goldenflow/src/node/connectors/s3.ts
@@ -1,0 +1,123 @@
+/**
+ * AWS S3 connector for GoldenFlow (Node-only).
+ *
+ * Port of goldenflow/connectors/s3.py. Reads/writes CSV (or JSON) files on
+ * S3 by round-tripping through a temp file and the local `file` connector.
+ *
+ * The AWS SDK is an OPTIONAL peer dependency. If `@aws-sdk/client-s3` is not
+ * installed, every entry point throws a clear, actionable Error (fail-soft,
+ * mirroring the Python `ImportError`).
+ */
+
+import { tmpdir } from "node:os";
+import { join, extname } from "node:path";
+import { randomUUID } from "node:crypto";
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import type { Row } from "../../core/types.js";
+import { readFile, writeFile } from "./file.js";
+
+const S3_INSTALL_HINT = "S3 support requires: npm install @aws-sdk/client-s3";
+
+interface S3ClientLike {
+  send(command: unknown): Promise<{ Body?: unknown }>;
+}
+
+interface S3Module {
+  S3Client: new (config?: Record<string, unknown>) => S3ClientLike;
+  GetObjectCommand: new (input: { Bucket: string; Key: string }) => unknown;
+  PutObjectCommand: new (input: {
+    Bucket: string;
+    Key: string;
+    Body: string | Buffer;
+  }) => unknown;
+}
+
+async function loadS3(): Promise<S3Module> {
+  try {
+    // `as string` defeats tsup's static resolution so the optional peer dep
+    // is only required at runtime.
+    return (await import("@aws-sdk/client-s3" as string)) as S3Module;
+  } catch {
+    throw new Error(S3_INSTALL_HINT);
+  }
+}
+
+/** Parse s3://bucket/key into [bucket, key]. */
+export function parseS3Uri(uri: string): [string, string] {
+  if (!uri.startsWith("s3://")) {
+    throw new Error(`Invalid S3 URI: ${uri}. Must start with s3://`);
+  }
+  const path = uri.slice("s3://".length);
+  const slash = path.indexOf("/");
+  if (slash === -1) {
+    throw new Error(`Invalid S3 URI: ${uri}. Must be s3://bucket/key`);
+  }
+  return [path.slice(0, slash), path.slice(slash + 1)];
+}
+
+async function streamToString(body: unknown): Promise<string> {
+  if (body === null || body === undefined) return "";
+  if (typeof body === "string") return body;
+  // Node Buffer
+  if (Buffer.isBuffer(body)) return body.toString("utf-8");
+  // SDK v3 streaming body (has transformToString)
+  const maybe = body as { transformToString?: () => Promise<string> };
+  if (typeof maybe.transformToString === "function") {
+    return maybe.transformToString();
+  }
+  // Async iterable of chunks (Node Readable)
+  if (typeof (body as AsyncIterable<unknown>)[Symbol.asyncIterator] === "function") {
+    const chunks: Buffer[] = [];
+    for await (const chunk of body as AsyncIterable<Buffer | string>) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    }
+    return Buffer.concat(chunks).toString("utf-8");
+  }
+  return String(body);
+}
+
+/** Read a file from S3 into Row[]. */
+export async function readS3(uri: string): Promise<Row[]> {
+  const { S3Client, GetObjectCommand } = await loadS3();
+  const [bucket, key] = parseS3Uri(uri);
+  const ext = extname(key) || ".csv";
+
+  const client = new S3Client();
+  const response = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+  const content = await streamToString(response.Body);
+
+  const tmpPath = join(tmpdir(), `goldenflow-${randomUUID()}${ext}`);
+  writeFileSync(tmpPath, content);
+  try {
+    return readFile(tmpPath);
+  } finally {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+}
+
+/** Write Row[] to S3. */
+export async function writeS3(rows: readonly Row[], uri: string): Promise<void> {
+  const { S3Client, PutObjectCommand } = await loadS3();
+  const [bucket, key] = parseS3Uri(uri);
+  const ext = extname(key) || ".csv";
+
+  const tmpPath = join(tmpdir(), `goldenflow-${randomUUID()}${ext}`);
+  writeFile(rows, tmpPath);
+  let body: string;
+  try {
+    body = readFileSync(tmpPath, "utf-8");
+  } finally {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+
+  const client = new S3Client();
+  await client.send(new PutObjectCommand({ Bucket: bucket, Key: key, Body: body }));
+}

--- a/packages/typescript/goldenflow/src/node/index.ts
+++ b/packages/typescript/goldenflow/src/node/index.ts
@@ -7,9 +7,19 @@ export * from "../core/index.js";
 
 // Node-only features
 export { readFile, writeFile } from "./connectors/file.js";
+export { readS3, writeS3, parseS3Uri } from "./connectors/s3.js";
+export { readGcs, writeGcs, parseGcsUri } from "./connectors/gcs.js";
+export { readTable, writeTable } from "./connectors/database.js";
 export { saveRun, listRuns, getRun, generateRunId } from "./history.js";
 export { TOOL_DEFINITIONS, handleTool } from "./mcp/server.js";
 export { watchDirectory } from "./watch.js";
 export { runSchedule } from "./schedule.js";
 export { runWizard } from "./init-wizard.js";
 export { runServer as runApiServer, createApp as createApiApp } from "./api/server.js";
+export {
+  startA2aServer,
+  runServer as runA2aServer,
+  AGENT_CARD,
+  type AgentSkill,
+  type StartA2aOptions,
+} from "./a2a/server.js";

--- a/packages/typescript/goldenflow/tests/unit/a2a-server.test.ts
+++ b/packages/typescript/goldenflow/tests/unit/a2a-server.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the GoldenFlow A2A server.
+ * Mirrors goldenmatch's tests/unit/a2a-server.test.ts and the Python
+ * packages/python/goldenflow/tests/test_a2a.py cases.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { Server } from "node:http";
+import { writeFileSync, rmSync, mkdtempSync } from "node:fs";
+import { join, relative } from "node:path";
+import { startA2aServer, AGENT_CARD } from "../../src/node/a2a/server.js";
+
+let server: Server;
+let baseUrl: string;
+let csvRelPath: string;
+let tmpDir: string;
+
+beforeAll(async () => {
+  // MCP sanitizePath only allows files under cwd, so write the fixture there.
+  tmpDir = mkdtempSync(join(process.cwd(), "a2a-fixture-"));
+  const csvPath = join(tmpDir, "people.csv");
+  writeFileSync(
+    csvPath,
+    "name,email,phone\n  John Smith  ,JOHN@EXAMPLE.COM,(555) 123-4567\nJane Doe,jane@test.com,555.987.6543\n",
+  );
+  csvRelPath = relative(process.cwd(), csvPath);
+
+  server = startA2aServer({ port: 0, host: "127.0.0.1" });
+  await new Promise<void>((resolveFn) => {
+    if (server.listening) {
+      resolveFn();
+      return;
+    }
+    server.once("listening", () => resolveFn());
+  });
+  const addr = server.address();
+  const port = typeof addr === "object" && addr !== null && "port" in addr ? addr.port : 8150;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  if (server) {
+    await new Promise<void>((resolveFn, rejectFn) => {
+      server.close((err) => (err ? rejectFn(err) : resolveFn()));
+    });
+  }
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("A2A agent card (exported constant)", () => {
+  it("has name, description, version, provider, skills", () => {
+    expect(AGENT_CARD.name).toBe("GoldenFlow");
+    expect(typeof AGENT_CARD.description).toBe("string");
+    expect(typeof AGENT_CARD.version).toBe("string");
+    expect(typeof AGENT_CARD.provider.organization).toBe("string");
+    expect(Array.isArray(AGENT_CARD.skills)).toBe(true);
+  });
+
+  it("has exactly 6 skills (parity with Python)", () => {
+    expect(AGENT_CARD.skills.length).toBe(6);
+    const ids = AGENT_CARD.skills.map((s) => s.id);
+    expect(ids).toContain("transform-data");
+    expect(ids).toContain("map-schemas");
+    expect(ids).toContain("discover");
+    expect(ids).toContain("diff-results");
+    expect(ids).toContain("configure");
+    expect(ids).toContain("handoff");
+  });
+
+  it("every skill has id, name, description, inputModes, outputModes", () => {
+    for (const skill of AGENT_CARD.skills) {
+      expect(typeof skill.id).toBe("string");
+      expect(skill.id.length).toBeGreaterThan(0);
+      expect(typeof skill.name).toBe("string");
+      expect(typeof skill.description).toBe("string");
+      expect(skill.inputModes.length).toBeGreaterThan(0);
+      expect(skill.outputModes.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("A2A server HTTP endpoints", () => {
+  it("GET /.well-known/agent.json returns the AgentCard", async () => {
+    const res = await fetch(baseUrl + "/.well-known/agent.json");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      name: string;
+      skills: Array<{ id: string }>;
+    };
+    expect(body.name).toBe("GoldenFlow");
+    expect(body.skills.length).toBe(6);
+  });
+
+  it("GET /health returns ok", async () => {
+    const res = await fetch(baseUrl + "/health");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("ok");
+  });
+
+  it("POST /tasks discover returns transforms and domains", async () => {
+    const res = await fetch(baseUrl + "/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "t1", skill: "discover", params: {} }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      id: string;
+      status: string;
+      result: { transforms: unknown; domains: { domains: string[] } };
+    };
+    expect(body.status).toBe("completed");
+    expect(body.result.transforms).toBeDefined();
+    expect(body.result.domains).toBeDefined();
+    expect(body.result.domains.domains).toContain("carceral");
+  });
+
+  it("POST /tasks transform-data profiles then transforms a CSV", async () => {
+    const res = await fetch(baseUrl + "/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ skill: "transform-data", params: { path: csvRelPath } }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      result: Array<{ step: string; result: unknown }>;
+    };
+    expect(body.status).toBe("completed");
+    expect(body.result.length).toBe(2);
+    expect(body.result[0]!.step).toBe("profile");
+    expect(body.result[1]!.step).toBe("transform");
+  });
+
+  it("POST /tasks configure profiles then learns a config", async () => {
+    const res = await fetch(baseUrl + "/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ skill: "configure", params: { path: csvRelPath } }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      result: Array<{ step: string }>;
+    };
+    expect(body.status).toBe("completed");
+    expect(body.result.map((p) => p.step)).toEqual(["profile", "config"]);
+  });
+
+  it("POST /tasks handoff maps findings to transforms", async () => {
+    const res = await fetch(baseUrl + "/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        skill: "handoff",
+        params: { findings: [{ check: "whitespace_issues", column: "name" }] },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; result: unknown };
+    expect(body.status).toBe("completed");
+    expect(body.result).toBeDefined();
+  });
+
+  it("GET /tasks/{id} returns task status after creation", async () => {
+    const postRes = await fetch(baseUrl + "/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ skill: "discover", params: {} }),
+    });
+    const postBody = (await postRes.json()) as { id: string };
+    expect(typeof postBody.id).toBe("string");
+
+    const getRes = await fetch(baseUrl + "/tasks/" + postBody.id);
+    expect(getRes.status).toBe(200);
+    const getBody = (await getRes.json()) as { id: string; skill: string; status: string };
+    expect(getBody.id).toBe(postBody.id);
+    expect(getBody.skill).toBe("discover");
+    expect(["completed", "running", "pending", "failed"]).toContain(getBody.status);
+  });
+
+  it("GET /tasks/nonexistent returns 404", async () => {
+    const res = await fetch(baseUrl + "/tasks/does-not-exist-xyz");
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("POST /tasks with unknown skill returns completed with error result", async () => {
+    const res = await fetch(baseUrl + "/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ skill: "not_a_real_skill", params: {} }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result?: { error?: string } };
+    expect(body.result?.error).toContain("Unknown skill");
+  });
+
+  it("POST /tasks without skill returns 400", async () => {
+    const res = await fetch(baseUrl + "/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ params: {} }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(typeof body.error).toBe("string");
+  });
+});

--- a/packages/typescript/goldenflow/tests/unit/carceral-domain.test.ts
+++ b/packages/typescript/goldenflow/tests/unit/carceral-domain.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the `carceral` domain pack.
+ * Mirrors packages/python/goldenflow/tests/domains/test_carceral.py.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  PACK,
+  CARCERAL_OPERATOR_ORGS,
+  CARCERAL_BOP_ABBREVIATIONS,
+  CARCERAL_STATE_COMPLEX_ALIASES,
+} from "../../src/core/domains/carceral.js";
+import { getTransform } from "../../src/core/transforms/registry.js";
+import { loadDomain, listDomains } from "../../src/core/domains/index.js";
+import type { ColumnValue, Row } from "../../src/core/types.js";
+
+// Importing carceral.js registers the transforms as a side effect.
+function runSeries(name: string, values: ColumnValue[]): ColumnValue[] {
+  const info = getTransform(name);
+  expect(info).toBeDefined();
+  return info!.func(values) as ColumnValue[];
+}
+
+function runDataframe(name: string, rows: Row[]): Row[] {
+  const info = getTransform(name);
+  expect(info).toBeDefined();
+  return info!.func(rows, "name") as Row[];
+}
+
+// --- Metadata ---
+
+describe("carceral pack metadata", () => {
+  it("has the expected name and transforms", () => {
+    expect(PACK.name).toBe("carceral");
+    expect(PACK.transforms).toContain("carceral_org_strip");
+    expect(PACK.transforms).toContain("carceral_abbreviate");
+    expect(PACK.transforms).toContain("carceral_name_normalize");
+    expect(PACK.transforms).toContain("latlng_pack");
+    // Composes with existing transforms
+    expect(PACK.transforms).toContain("address_standardize");
+    expect(PACK.transforms).toContain("zip_normalize");
+  });
+
+  it("constants contain the expected members", () => {
+    expect(CARCERAL_OPERATOR_ORGS.has("TDCJ")).toBe(true);
+    expect(CARCERAL_OPERATOR_ORGS.has("MDOC")).toBe(true);
+    expect(CARCERAL_OPERATOR_ORGS.has("GEO")).toBe(true);
+    expect("USP" in CARCERAL_BOP_ABBREVIATIONS).toBe(true);
+    expect("ASPC" in CARCERAL_STATE_COMPLEX_ALIASES).toBe(true);
+  });
+
+  it("is loadable via loadDomain and listed", async () => {
+    expect(listDomains()).toContain("carceral");
+    const loaded = await loadDomain("carceral");
+    expect(loaded?.name).toBe("carceral");
+  });
+});
+
+// --- carceral_org_strip ---
+
+describe("carceral_org_strip", () => {
+  it("strips comma-separated operator prefix", () => {
+    const out = runSeries("carceral_org_strip", [
+      "MDOC, SOUTH MISSISSIPPI CORRECTIONAL INSTITUTION",
+      "TDCJ, ALLRED UNIT",
+    ]);
+    expect(out[0]).toBe("SOUTH MISSISSIPPI CORRECTIONAL INSTITUTION");
+    expect(out[1]).toBe("ALLRED UNIT");
+  });
+
+  it("strips hyphen-separated operator prefix", () => {
+    const out = runSeries("carceral_org_strip", ["TDCJ - DARRINGTON WWTP", "GEO - LAKEVIEW"]);
+    expect(out[0]).toBe("DARRINGTON WWTP");
+    expect(out[1]).toBe("LAKEVIEW");
+  });
+
+  it("strips phrase-form operator prefix", () => {
+    const out = runSeries("carceral_org_strip", [
+      "TX DEPT OF CRIM JUST- MCCONNELL UNIT",
+      "PA DEPT OF CORR/CHESTER SCI",
+      "TX DEPT OF CRIMINAL JUSTICE - ALLRED UNIT",
+    ]);
+    expect(out[0]).toBe("MCCONNELL UNIT");
+    expect(out[1]).toBe("CHESTER SCI");
+    expect(out[2]).toBe("ALLRED UNIT");
+  });
+
+  it("preserves names with no prefix", () => {
+    const out = runSeries("carceral_org_strip", ["ALLEGHENY COUNTY JAIL", "CALHOUN COUNTY JAIL"]);
+    expect(out[0]).toBe("ALLEGHENY COUNTY JAIL");
+    expect(out[1]).toBe("CALHOUN COUNTY JAIL");
+  });
+
+  it("preserves mid-string acronyms", () => {
+    const out = runSeries("carceral_org_strip", [
+      "NORTH END TRANSITIONAL HOUSING UNIT / WORK CENTER",
+    ]);
+    expect(out[0]).toBe("NORTH END TRANSITIONAL HOUSING UNIT / WORK CENTER");
+  });
+
+  it("passes null/empty through", () => {
+    const out = runSeries("carceral_org_strip", [null, ""]);
+    expect(out[0]).toBe(null);
+    expect(out[1]).toBe("");
+  });
+});
+
+// --- carceral_abbreviate ---
+
+describe("carceral_abbreviate", () => {
+  it("expands BOP facility types", () => {
+    const out = runSeries("carceral_abbreviate", [
+      "USP HAZELTON",
+      "FCI DUBLIN",
+      "FCC YAZOO CITY",
+      "FPC PENSACOLA",
+      "FMC SPRINGFIELD",
+    ]);
+    expect(out[0]).toBe("UNITED STATES PENITENTIARY HAZELTON");
+    expect(out[1]).toBe("FEDERAL CORRECTIONAL INSTITUTION DUBLIN");
+    expect(out[2]).toBe("FEDERAL CORRECTIONAL COMPLEX YAZOO CITY");
+    expect(out[3]).toBe("FEDERAL PRISON CAMP PENSACOLA");
+    expect(out[4]).toBe("FEDERAL MEDICAL CENTER SPRINGFIELD");
+  });
+
+  it("expands state-complex aliases", () => {
+    const out = runSeries("carceral_abbreviate", ["ASPC-LEWIS", "ASP - YUMA COMPLEX", "APS-PERRYVILLE"]);
+    expect(String(out[0])).toContain("ARIZONA STATE PRISON COMPLEX");
+    expect(String(out[1])).toContain("ARIZONA STATE PRISON");
+    expect(String(out[2])).toContain("ARIZONA STATE PRISON");
+  });
+
+  it("is word-bounded (no mid-token expansion)", () => {
+    const out = runSeries("carceral_abbreviate", ["NUSPACE", "CALLUSP"]);
+    expect(out[0]).toBe("NUSPACE");
+    expect(out[1]).toBe("CALLUSP");
+  });
+});
+
+// --- carceral_name_normalize (composite) ---
+
+describe("carceral_name_normalize", () => {
+  it("collapses HIFLD-form and ECHO-form to the same string", () => {
+    const out = runSeries("carceral_name_normalize", [
+      "USP HAZELTON",
+      "UNITED STATES PENITENTIARY HAZELTON",
+      "FDC HOUSTON",
+      "FEDERAL DETENTION CENTER HOUSTON",
+    ]);
+    expect(out[0]).toBe("UNITED STATES PENITENTIARY HAZELTON");
+    expect(out[1]).toBe("UNITED STATES PENITENTIARY HAZELTON");
+    expect(out[2]).toBe("FEDERAL DETENTION CENTER HOUSTON");
+    expect(out[3]).toBe("FEDERAL DETENTION CENTER HOUSTON");
+  });
+
+  it("strips punctuation", () => {
+    const out = runSeries("carceral_name_normalize", ["LT. SHERMAN WALKER CORRECTIONAL FACILITY"]);
+    expect(out[0]).toBe("LT SHERMAN WALKER CORRECTIONAL FACILITY");
+  });
+
+  it("handles operator prefix plus abbreviation", () => {
+    const out = runSeries("carceral_name_normalize", [
+      "MDOC, SOUTH MISSISSIPPI CORRECTIONAL INSTITUTION",
+      "SOUTH MISSISSIPPI CORRECTIONAL INSTITUTION",
+    ]);
+    expect(out[0]).toBe(out[1]);
+    expect(out[0]).toBe("SOUTH MISSISSIPPI CORRECTIONAL INSTITUTION");
+  });
+
+  it("collapses the Arizona ASPC/APS pattern to a common prefix", () => {
+    const out = runSeries("carceral_name_normalize", ["ASPC-LEWIS", "APS-LEWIS COMPLEX"]);
+    expect(String(out[0])).toContain("ARIZONA STATE PRISON");
+    expect(String(out[1])).toContain("ARIZONA STATE PRISON");
+    expect(String(out[0])).toContain("LEWIS");
+    expect(String(out[1])).toContain("LEWIS");
+  });
+});
+
+// --- latlng_pack ---
+
+describe("latlng_pack", () => {
+  it("packs when both present (JS number stringification)", () => {
+    const out = runDataframe("latlng_pack", [
+      { id: "a", lat: 39, lng: -90 },
+      { id: "b", lat: 32.5, lng: -116.5 },
+    ]);
+    expect(out[0]!["latlng"]).toBe("39|-90");
+    expect(out[1]!["latlng"]).toBe("32.5|-116.5");
+  });
+
+  it("emits empty string when either coordinate is null", () => {
+    const out = runDataframe("latlng_pack", [
+      { id: "a", lat: 39, lng: null },
+      { id: "b", lat: null, lng: -90 },
+      { id: "c", lat: 32.5, lng: -116.5 },
+    ]);
+    expect(out[0]!["latlng"]).toBe("");
+    expect(out[1]!["latlng"]).toBe("");
+    expect(out[2]!["latlng"]).toBe("32.5|-116.5");
+  });
+
+  it("is a no-op when lat/lng columns are missing", () => {
+    const rows: Row[] = [
+      { id: "a", name: "x" },
+      { id: "b", name: "y" },
+    ];
+    const out = runDataframe("latlng_pack", rows);
+    expect("latlng" in out[0]!).toBe(false);
+    expect(out.length).toBe(rows.length);
+  });
+});

--- a/packages/typescript/goldenflow/tests/unit/connectors.test.ts
+++ b/packages/typescript/goldenflow/tests/unit/connectors.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for the cloud connectors (s3, gcs, database).
+ *
+ * Fail-soft behavior mirrors packages/python/goldenflow/tests/connectors/.
+ * Happy paths mock the optional peer SDKs so the suite runs without installing
+ * @aws-sdk/client-s3, @google-cloud/storage, or pg.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  parseS3Uri,
+  parseGcsUri,
+} from "../../src/node/connectors/index.js";
+import type { Row } from "../../src/core/types.js";
+
+// ---------------------------------------------------------------------------
+// URI parsing (no SDK needed)
+// ---------------------------------------------------------------------------
+
+describe("S3 URI parsing", () => {
+  it("parses s3://bucket/key", () => {
+    expect(parseS3Uri("s3://my-bucket/path/to/file.csv")).toEqual([
+      "my-bucket",
+      "path/to/file.csv",
+    ]);
+  });
+  it("rejects non-s3 URIs", () => {
+    expect(() => parseS3Uri("https://x/y")).toThrow(/Must start with s3:\/\//);
+  });
+  it("rejects bucket-only URIs", () => {
+    expect(() => parseS3Uri("s3://bucket")).toThrow(/Must be s3:\/\/bucket\/key/);
+  });
+});
+
+describe("GCS URI parsing", () => {
+  it("parses gs://bucket/path", () => {
+    expect(parseGcsUri("gs://my-bucket/path/to/file.csv")).toEqual([
+      "my-bucket",
+      "path/to/file.csv",
+    ]);
+  });
+  it("rejects non-gs URIs", () => {
+    expect(() => parseGcsUri("s3://x/y")).toThrow(/Must start with gs:\/\//);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-soft: optional SDK not installed -> clear Error
+// ---------------------------------------------------------------------------
+
+describe("connectors fail-soft when SDK missing", () => {
+  // No vi.mock here, so the real (uninstalled) modules fail to import.
+  it("readS3 throws install hint", async () => {
+    const { readS3 } = await import("../../src/node/connectors/s3.js");
+    await expect(readS3("s3://bucket/file.csv")).rejects.toThrow(
+      "S3 support requires: npm install @aws-sdk/client-s3",
+    );
+  });
+
+  it("writeS3 throws install hint", async () => {
+    const { writeS3 } = await import("../../src/node/connectors/s3.js");
+    await expect(writeS3([], "s3://bucket/file.csv")).rejects.toThrow(
+      "S3 support requires: npm install @aws-sdk/client-s3",
+    );
+  });
+
+  it("readGcs throws install hint", async () => {
+    const { readGcs } = await import("../../src/node/connectors/gcs.js");
+    await expect(readGcs("gs://bucket/file.csv")).rejects.toThrow(
+      "GCS support requires: npm install @google-cloud/storage",
+    );
+  });
+
+  it("writeGcs throws install hint", async () => {
+    const { writeGcs } = await import("../../src/node/connectors/gcs.js");
+    await expect(writeGcs([], "gs://bucket/file.csv")).rejects.toThrow(
+      "GCS support requires: npm install @google-cloud/storage",
+    );
+  });
+
+  it("readTable throws install hint", async () => {
+    const { readTable } = await import("../../src/node/connectors/database.js");
+    await expect(readTable("postgresql://localhost/test", "users")).rejects.toThrow(
+      "Database support requires: npm install pg",
+    );
+  });
+
+  it("writeTable throws install hint", async () => {
+    const { writeTable } = await import("../../src/node/connectors/database.js");
+    await expect(
+      writeTable([{ a: 1 }], "postgresql://localhost/test", "users"),
+    ).rejects.toThrow("Database support requires: npm install pg");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy paths with mocked SDKs
+// ---------------------------------------------------------------------------
+
+describe("S3 happy path (mocked SDK)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("readS3 downloads CSV and parses to Row[]", async () => {
+    const captured: { command?: unknown } = {};
+    vi.doMock("@aws-sdk/client-s3", () => ({
+      S3Client: class {
+        async send(command: unknown) {
+          captured.command = command;
+          return { Body: "id,name\n1,Alice\n2,Bob\n" };
+        }
+      },
+      GetObjectCommand: class {
+        constructor(public input: unknown) {}
+      },
+      PutObjectCommand: class {
+        constructor(public input: unknown) {}
+      },
+    }));
+
+    const { readS3 } = await import("../../src/node/connectors/s3.js");
+    const rows = await readS3("s3://bucket/data.csv");
+    expect(rows.length).toBe(2);
+    expect(rows[0]).toMatchObject({ name: "Alice" });
+    expect(rows[1]).toMatchObject({ name: "Bob" });
+    vi.doUnmock("@aws-sdk/client-s3");
+  });
+
+  it("writeS3 uploads serialized CSV", async () => {
+    let putBody: string | undefined;
+    vi.doMock("@aws-sdk/client-s3", () => ({
+      S3Client: class {
+        async send(command: { input?: { Body?: string } }) {
+          if (command?.input?.Body !== undefined) putBody = command.input.Body;
+          return {};
+        }
+      },
+      GetObjectCommand: class {
+        constructor(public input: unknown) {}
+      },
+      PutObjectCommand: class {
+        constructor(public input: { Body?: string }) {}
+      },
+    }));
+
+    const { writeS3 } = await import("../../src/node/connectors/s3.js");
+    const rows: Row[] = [{ id: 1, name: "Alice" }];
+    await writeS3(rows, "s3://bucket/out.csv");
+    expect(putBody).toContain("id,name");
+    expect(putBody).toContain("Alice");
+    vi.doUnmock("@aws-sdk/client-s3");
+  });
+});
+
+describe("GCS happy path (mocked SDK)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("readGcs downloads CSV and parses to Row[]", async () => {
+    vi.doMock("@google-cloud/storage", () => ({
+      Storage: class {
+        bucket() {
+          return {
+            file() {
+              return {
+                async download() {
+                  return [Buffer.from("id,name\n1,Alice\n")];
+                },
+                async save() {},
+              };
+            },
+          };
+        }
+      },
+    }));
+
+    const { readGcs } = await import("../../src/node/connectors/gcs.js");
+    const rows = await readGcs("gs://bucket/data.csv");
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toMatchObject({ name: "Alice" });
+    vi.doUnmock("@google-cloud/storage");
+  });
+
+  it("writeGcs saves serialized CSV", async () => {
+    let saved: string | undefined;
+    vi.doMock("@google-cloud/storage", () => ({
+      Storage: class {
+        bucket() {
+          return {
+            file() {
+              return {
+                async download() {
+                  return [Buffer.from("")];
+                },
+                async save(data: string | Buffer) {
+                  saved = typeof data === "string" ? data : data.toString("utf-8");
+                },
+              };
+            },
+          };
+        }
+      },
+    }));
+
+    const { writeGcs } = await import("../../src/node/connectors/gcs.js");
+    await writeGcs([{ id: 1, name: "Alice" }], "gs://bucket/out.csv");
+    expect(saved).toContain("id,name");
+    expect(saved).toContain("Alice");
+    vi.doUnmock("@google-cloud/storage");
+  });
+});
+
+describe("Database happy path (mocked pg)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("readTable runs SELECT and returns rows", async () => {
+    let queryText: string | undefined;
+    vi.doMock("pg", () => ({
+      Client: class {
+        async connect() {}
+        async query(text: string) {
+          queryText = text;
+          return { rows: [{ id: 1, name: "Alice" }] };
+        }
+        async end() {}
+      },
+    }));
+
+    const { readTable } = await import("../../src/node/connectors/database.js");
+    const rows = await readTable("postgresql://localhost/test", "users");
+    expect(queryText).toBe('SELECT * FROM "users"');
+    expect(rows).toEqual([{ id: 1, name: "Alice" }]);
+    vi.doUnmock("pg");
+  });
+
+  it("writeTable drops, creates, and inserts", async () => {
+    const queries: string[] = [];
+    vi.doMock("pg", () => ({
+      Client: class {
+        async connect() {}
+        async query(text: string) {
+          queries.push(text);
+          return { rows: [] };
+        }
+        async end() {}
+      },
+    }));
+
+    const { writeTable } = await import("../../src/node/connectors/database.js");
+    await writeTable([{ id: 1, name: "Alice" }], "postgresql://localhost/test", "users");
+    expect(queries.some((q) => q.startsWith("DROP TABLE IF EXISTS"))).toBe(true);
+    expect(queries.some((q) => q.startsWith("CREATE TABLE"))).toBe(true);
+    expect(queries.some((q) => q.startsWith("INSERT INTO"))).toBe(true);
+    vi.doUnmock("pg");
+  });
+
+  it("rejects table names containing a quote", async () => {
+    vi.doMock("pg", () => ({
+      Client: class {
+        async connect() {}
+        async query() {
+          return { rows: [] };
+        }
+        async end() {}
+      },
+    }));
+    const { readTable } = await import("../../src/node/connectors/database.js");
+    await expect(readTable("postgresql://localhost/test", 'bad"name')).rejects.toThrow(
+      /Invalid identifier/,
+    );
+    vi.doUnmock("pg");
+  });
+});


### PR DESCRIPTION
Brings the **goldenflow** TypeScript port to full surface parity with the Python package. Second increment of the "make the README's TS claims true" work (after infermap #469).

## Ported surfaces (the actual gap vs Python)
- **carceral domain** (`src/core/domains/carceral.ts`) — registered in the domain index; mirrors the existing TS domain packs.
- **cloud connectors** (node-only): `src/node/connectors/{s3,gcs,database}.ts`, mirroring `file.ts`. SDKs are **optional peer deps** (`@aws-sdk/client-s3`, `@google-cloud/storage`, `pg`) loaded via dynamic `import(... as string)`; each fails soft with a clear install hint when the SDK is absent (matches Python's `ImportError`).
- **A2A server** (`src/node/a2a/server.ts`) — agent card at `/.well-known/agent.json`, 6 skills (transform-data, map-schemas, discover, diff-results, configure, handoff), task lifecycle — mirroring goldenmatch's and goldencheck's TS A2A servers.
- **`publish-goldenflow-js.yml`** — npm publish workflow (tag `goldenflow-js-v*`), copied from infermap's.

TS already had streaming/mcp/api/watch/schedule/wizard, so those weren't part of the gap. (Python goldenflow has no TUI.)

## Packaging
Already self-contained — `dependencies` stays `{commander}` only; the new SDKs are **optional peers** (no cross-package deps, lockfile unchanged). Verified via `pnpm pack`: manifest shows `dependencies: {commander}`, optional peers, `goldenflow-js` bin.

## Verification
- `tsc --noEmit` clean; **121 vitest tests pass** (50 new); `turbo build` OK.
- One documented language difference: `latlng_pack` stringifies `39.0`→`"39"` in JS vs `"39.0"` in Python/Polars (JS `String(Number)` semantics); test asserts the JS form.

## Publish
After merge: GitHub → Actions → "Publish goldenflow to npm" → Run workflow (or tag `goldenflow-js-v0.1.0`). `NPM_TOKEN` is already configured.

Also folds in a small `.gitignore` entry for `.claude/worktrees/` (transient agent checkouts).

Draft pending review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx)_