### PR TITLE
chore(infermap-ts): bump 0.4.0 -> 0.5.0 for full-parity npm release

### DIFF
--- a/packages/typescript/infermap/package.json
+++ b/packages/typescript/infermap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infermap",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Schema-to-schema field mapping engine. TypeScript port of the infermap Python library.",
   "keywords": [
     "schema",

--- a/packages/typescript/infermap/src/node/mcp/server.ts
+++ b/packages/typescript/infermap/src/node/mcp/server.ts
@@ -552,7 +552,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "infermap", version: "0.4.0" },
+              serverInfo: { name: "infermap", version: "0.5.0" },
               capabilities: { tools: {}, resources: {}, prompts: {} },
             },
           });


### PR DESCRIPTION
npm already has `infermap@0.4.0` (the pre-fold standalone port), so the full-parity build merged in #469 — which is still labelled `0.4.0` — can't publish (E403 "cannot publish over previously published versions: 0.4.0").

#469 added the MCP server + identity bridge (new features, no breaking changes), so this bumps **0.4.0 → 0.5.0** (semver minor) so the full-parity build can publish.

- `package.json`: `0.4.0` → `0.5.0`
- `src/node/mcp/server.ts`: MCP `serverInfo.version` `0.4.0` → `0.5.0`

Verified: tsc clean, 227 tests pass.

After merge: re-run Actions → "Publish infermap to npm" (Run workflow) → publishes `0.5.0`. (`goldencheck-types@0.1.0` is already live, so infermap's `goldencheck-types: ^0.1.0` dep resolves.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx)_