### PR TITLE
docs(readme): full TS suite on npm — table, npm downloads badge, workspace fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ flowchart LR
 | Package | Lang | What it does | Install |
 |---|---|---|---|
 | **[GoldenMatch](packages/python/goldenmatch/README.md)** 🟡 | Python · TS | Zero-config entity resolution. Fuzzy + exact + probabilistic + LLM. Headline package. | `pip install goldenmatch` · `npm i goldenmatch` |
-| **[GoldenCheck](packages/python/goldencheck/README.md)** | Python · TS types | Data-quality scanning: encoding, Unicode, format validation, anomaly detection. | `pip install goldencheck` |
-| **[GoldenFlow](packages/python/goldenflow/README.md)** | Python · TS | Transforms & standardizers: phone, date, address, categorical normalization. | `pip install goldenflow` |
-| **[GoldenPipe](packages/python/goldenpipe/README.md)** | Python | Orchestrator that wires Check → Flow → Match into one declarative pipeline. | `pip install goldenpipe` |
+| **[GoldenCheck](packages/python/goldencheck/README.md)** | Python · TS | Data-quality scanning: encoding, Unicode, format validation, anomaly detection. | `pip install goldencheck` · `npm i goldencheck` |
+| **[GoldenFlow](packages/python/goldenflow/README.md)** | Python · TS | Transforms & standardizers: phone, date, address, categorical normalization. | `pip install goldenflow` · `npm i goldenflow` |
+| **[GoldenPipe](packages/python/goldenpipe/README.md)** | Python · TS | Orchestrator that wires Check → Flow → Match into one declarative pipeline. | `pip install goldenpipe` · `npm i goldenpipe` |
 | **[InferMap](packages/python/infermap/README.md)** | Python · TS | Schema mapping engine — auto-aligns columns across heterogeneous sources. | `pip install infermap` · `npm i infermap` |
 | **[goldenmatch-extensions](packages/rust/extensions/README.md)** | Rust | Postgres extension (pgrx) + DuckDB UDFs. SQL-native fuzzy matching. | source build |
 | **[dbt-goldensuite](packages/python/goldenmatch/dbt-goldensuite/README.md)** | dbt · Python | dbt package — quality-gate tests, correction CRUD macros + GoldenCheck assertions for warehouse models. | `pip install dbt-goldensuite` |
@@ -259,7 +259,7 @@ GoldenMatch is hosted as an MCP server on [Smithery](https://smithery.ai/servers
 }
 ```
 
-35+ MCP tools across the suite: deduplicate, match, explain, review, link privately, configure, scan quality, transform, synthesize golden records, and manage Learning Memory corrections.
+36+ MCP tools across the suite: deduplicate, match, explain, review, link privately, configure, scan quality, transform, synthesize golden records, and manage Learning Memory corrections.
 
 ---
 
@@ -336,14 +336,15 @@ goldenmatch/
 ├── docs/superpowers/         # design specs and implementation plans
 ├── justfile                  # install / test / lint / build, all languages
 ├── pyproject.toml            # uv workspace (root)
-├── package.json              # per-package npm (Windows-symlink-safe; no root workspace)
+├── pnpm-workspace.yaml       # TypeScript pnpm workspace (Turborepo)
+├── package.json              # root scripts + pnpm workspace root
 └── .github/workflows/ci.yml
 ```
 
-### Why no root Cargo or npm workspace?
+### Workspaces (Cargo vs pnpm)
 
-- **Cargo:** `packages/rust/extensions/` is itself a Cargo workspace (the `postgres` crate is excluded for pgrx-specific build requirements). Cargo doesn't allow nested workspaces sharing members. Cargo commands run from inside `packages/rust/extensions/`.
-- **npm:** A real npm workspace causes Windows symlink issues for some users. Each TypeScript package installs independently. The root `package.json` provides convenience scripts (`install:all`, `test:all`, `build:all`) but isn't a workspace.
+- **Cargo — no root workspace.** `packages/rust/extensions/` is itself a Cargo workspace (the `postgres` crate is excluded for pgrx-specific build requirements). Cargo doesn't allow nested workspaces sharing members, so Cargo commands run from inside `packages/rust/extensions/`.
+- **TypeScript — a single pnpm workspace.** `packages/typescript/*` form one pnpm + Turborepo workspace (see [TypeScript dev setup](#typescript-dev-setup-pnpm--turborepo)). `.npmrc` pins `node-linker=hoisted`, giving a flat `node_modules` that avoids the Windows symlink issues an earlier per-package layout hit.
 
 ### Build / test / lint everything
 

--- a/scripts/suite_download_badges.py
+++ b/scripts/suite_download_badges.py
@@ -29,6 +29,7 @@ PYPI_PACKAGES = [
 NPM_PACKAGES = [
     "goldenmatch",
     "goldencheck",
+    "goldenpipe",
     "goldenflow",
     "infermap",
     "goldencheck-types",


### PR DESCRIPTION
Now that all six TS packages are published to npm (goldenmatch 0.11.0, goldencheck 0.2.0, goldenflow 0.2.0, infermap 0.5.0, goldenpipe 0.1.0, goldencheck-types 0.1.0), the README's Suite table + npm download badge undercounted reality.

### 1) npm downloads badge (like the PyPI one)
The badge markup already mirrors the PyPI one (shields endpoint), and `suite_download_badges.py` already computes npm downloads — but `NPM_PACKAGES` was missing **`goldenpipe`** (PyPI list had 6, npm had 5). Added it, so the suite-wide npm `dl/mo` badge now sums the same package set as PyPI. (The scheduled `update-download-badges.yml` regenerates the JSON.)

### 2) The Suite "chart" (table)
- **GoldenCheck**: `Python · TS types` → `Python · TS`; added `npm i goldencheck`.
- **GoldenFlow**: added `npm i goldenflow`.
- **GoldenPipe**: `Python` → `Python · TS`; added `npm i goldenpipe`.
- GoldenMatch / InferMap already listed npm. All five core packages now read `Python · TS` with both installs.

### 3) Anything else I caught
- **MCP-tool count** was inconsistent (`36+` in the headline bullet vs `35+` in the MCP section) → both `36+` now.
- **Stale workspace claim**: the "Why no root … npm workspace?" section said "each TS package installs independently … isn't a workspace," which **contradicted** the same README's "TypeScript dev setup (pnpm + Turborepo)" section. Rewrote it: Cargo has no root workspace (pgrx exclusion), but TypeScript **is** a single pnpm + Turborepo workspace (`node-linker=hoisted` for Windows symlink safety). Fixed the repo-layout comment to match.

Docs/script only — no code paths touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx)_