### PR TITLE
feat(duckdb): core-API parity — 13 new UDFs (profile, evaluate, probabilistic, …)

### DIFF
--- a/packages/rust/extensions/CLAUDE.md
+++ b/packages/rust/extensions/CLAUDE.md
@@ -45,8 +45,12 @@ Native SQL extensions for [GoldenMatch](https://github.com/benseverndev-oss/gold
 
 ### duckdb/ (goldenmatch-duckdb)
 - Python package: `pip install goldenmatch-duckdb`
-- `functions.py` -- registers 7 DuckDB UDFs via `con.create_function()`
+- `functions.py` -- registers the core DuckDB UDFs via `con.create_function()`, then delegates to `goldenflow.py::register_goldenflow_functions` and `core_apis.py::register_core_api_functions`
+- `goldenflow.py` -- 8 goldenflow series-transform UDFs (fail-open if goldenflow not installed)
+- `core_apis.py` -- 13 parity UDFs wrapping goldenmatch's function-shaped core APIs (`goldenmatch_profile_table`, `goldenmatch_suggest_threshold`, `goldenmatch_detect_domain`, `goldenmatch_extract_features`, `goldenmatch_evaluate`, `goldenmatch_compare_clusters`, `goldenmatch_validate_table`, `goldenmatch_autofix_table`, `goldenmatch_detect_anomalies`, `goldenmatch_preflight`, `goldenmatch_postflight`, `goldenmatch_train_em`, `goldenmatch_score_probabilistic`). Pure-Python wrappers (import `goldenmatch` directly), JSON in/JSON out, fail-soft to `{"error": ...}`. Tests: `tests/test_core_apis.py`
 - Table-reading UDFs use `con.cursor()` to avoid deadlock (UDF can't query same connection)
+- `goldenmatch_suggest_threshold` registers with `null_handling="special"` because it legitimately returns SQL NULL (unimodal / too-few-scores). Other UDFs that may "fail" return a JSON `{"error": ...}` string instead.
+- `goldenmatch_postflight` derives `pair_scores` by running `dedupe_df` on the table (postflight needs scored pairs that aren't in the table). The Postgres-only table-returning `gm_pairs`/`gm_clusters` are NOT ported -- DuckDB returns JSON via `dedupe`/`dedupe_table` instead. PPRL (`pprl_link`, file-path args) and `run_sensitivity` (file_specs) are deferred as not SQL-natural.
 - Requires `pyarrow` for DuckDB `.pl()` Polars conversion
 
 ## Testing

--- a/packages/rust/extensions/duckdb/README.md
+++ b/packages/rust/extensions/duckdb/README.md
@@ -44,6 +44,47 @@ con.sql("SELECT goldenmatch_match_tables('prospects', 'reference', '{\"fuzzy\": 
 | `goldenmatch_dedupe(json, config)` | Deduplicate JSON records |
 | `goldenmatch_match(target_json, ref_json, config)` | Match JSON records |
 
+### Core-API functions
+
+Thin wrappers over goldenmatch's public core APIs. All return JSON strings
+(scalar functions noted otherwise); table-input functions read the named
+DuckDB table directly.
+
+| Function | Wraps | Description |
+|----------|-------|-------------|
+| `goldenmatch_profile_table(table)` | `profile_dataframe` | Full profile report for a table (JSON) |
+| `goldenmatch_suggest_threshold(scores_json)` | `suggest_threshold` | Otsu threshold over a JSON score list (DOUBLE; NULL when unimodal) |
+| `goldenmatch_detect_domain(columns_json)` | `detect_domain` | Detect data domain from a JSON column-name list |
+| `goldenmatch_extract_features(text, kind)` | `extract_product_features` / `extract_software_features` / `extract_biblio_features` | Extract structured features; `kind` = `product`/`electronics`, `software`, or `biblio` |
+| `goldenmatch_evaluate(pairs_json, ground_truth_json)` | `evaluate_pairs` / `evaluate_clusters` | Precision/recall/F1 vs. ground truth (auto-selects by shape) |
+| `goldenmatch_compare_clusters(a_json, b_json)` | `compare_clusters` | CCMS / TWI comparison of two clusterings |
+| `goldenmatch_validate_table(table, rules_json)` | `validate_dataframe` | Apply validation rules; returns report + quarantined rows |
+| `goldenmatch_autofix_table(table)` | `auto_fix_dataframe` | Apply common data fixes; returns fixes + fixed rows |
+| `goldenmatch_detect_anomalies(table, sensitivity)` | `detect_anomalies` | Flag suspicious records (`low`/`medium`/`high`) |
+| `goldenmatch_preflight(table, config_json)` | `preflight` | Pre-run config validation findings |
+| `goldenmatch_postflight(table, config_json)` | `postflight` | Post-run signal report (runs dedupe to derive pair scores) |
+| `goldenmatch_train_em(rows_json, matchkey_json, params_json)` | `train_em` | Train Fellegi-Sunter m/u probabilities; returns EMResult JSON |
+| `goldenmatch_score_probabilistic(rows_json, matchkey_json, em_result_json)` | `score_probabilistic` | Score pairs with a trained EMResult |
+
+```python
+# Otsu threshold suggestion
+con.sql("SELECT goldenmatch_suggest_threshold('[0.1,0.12,0.9,0.92]')").show()
+
+# Detect domain from columns
+con.sql("SELECT goldenmatch_detect_domain('[\"product_title\",\"brand\",\"sku\"]')").show()
+
+# Profile / validate / auto-fix a table
+con.sql("SELECT goldenmatch_profile_table('customers')").show()
+
+# Fellegi-Sunter: train, then score
+con.sql("""
+    SELECT goldenmatch_score_probabilistic(
+        :rows, :mk,
+        goldenmatch_train_em(:rows, :mk, '{}')
+    )
+""")
+```
+
 ## Requirements
 
 - Python 3.11+

--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/core_apis.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/core_apis.py
@@ -1,0 +1,470 @@
+"""DuckDB UDFs wrapping goldenmatch's function-shaped core APIs.
+
+Brings the DuckDB extension to parity with clean core APIs that were
+already in goldenmatch's public surface but not yet exposed in SQL.
+These are pure-Python UDFs that import ``goldenmatch`` directly -- they
+wrap the named core function, they do not reimplement it.
+
+Conventions mirror ``functions.py``:
+- Table-input UDFs read the table via ``con.cursor()`` + ``.pl()`` (the
+  same deadlock-avoidance pattern as ``_dedupe_table``) and validate the
+  table name with ``_validate_table_name``.
+- JSON in / JSON out -- inputs are JSON strings, outputs are
+  ``json.dumps(...)`` of the core function's return (dataclasses go
+  through ``dataclasses.asdict``; ``EvalResult`` / ``CompareResult`` use
+  their ``.summary()`` dict).
+- Optional-dep / bad-input failures are fail-soft: the UDF returns a
+  ``{"error": ...}`` JSON object rather than raising, so a malformed call
+  doesn't abort a whole SQL query (matches ``_correction_add``).
+
+Registered via ``register_core_api_functions(con)``, called from
+``functions.register(con)`` alongside the goldenflow registration.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import duckdb
+
+from goldenmatch_duckdb.functions import _validate_table_name
+
+
+# ── Registration ─────────────────────────────────────────────────────────
+
+
+def register_core_api_functions(con: duckdb.DuckDBPyConnection) -> None:
+    """Register the core-API parity UDFs on a DuckDB connection.
+
+    Mirrors ``register_goldenflow_functions`` -- safe to call once per
+    connection from ``functions.register``.
+    """
+    # Profiling / threshold / domain (scalar + table-in JSON-out)
+    con.create_function(
+        "goldenmatch_profile_table",
+        lambda table_name: _profile_table(con, table_name),
+        ["VARCHAR"], "VARCHAR",
+    )
+    # suggest_threshold legitimately returns None (unimodal / too-few
+    # scores) -- null_handling="special" lets the UDF emit SQL NULL.
+    con.create_function(
+        "goldenmatch_suggest_threshold", _suggest_threshold,
+        ["VARCHAR"], "DOUBLE", null_handling="special",
+    )
+    con.create_function(
+        "goldenmatch_detect_domain", _detect_domain,
+        ["VARCHAR"], "VARCHAR",
+    )
+    con.create_function(
+        "goldenmatch_extract_features", _extract_features,
+        ["VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+
+    # Evaluation / cluster comparison (JSON in / JSON out)
+    con.create_function(
+        "goldenmatch_evaluate", _evaluate,
+        ["VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+    con.create_function(
+        "goldenmatch_compare_clusters", _compare_clusters,
+        ["VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+
+    # Data-quality (table in, JSON out)
+    con.create_function(
+        "goldenmatch_validate_table",
+        lambda table_name, rules_json: _validate_table(con, table_name, rules_json),
+        ["VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+    con.create_function(
+        "goldenmatch_autofix_table",
+        lambda table_name: _autofix_table(con, table_name),
+        ["VARCHAR"], "VARCHAR",
+    )
+    con.create_function(
+        "goldenmatch_detect_anomalies",
+        lambda table_name, sensitivity: _detect_anomalies(con, table_name, sensitivity),
+        ["VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+
+    # AutoConfig verify (table + config in, JSON out)
+    con.create_function(
+        "goldenmatch_preflight",
+        lambda table_name, config_json: _preflight(con, table_name, config_json),
+        ["VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+    con.create_function(
+        "goldenmatch_postflight",
+        lambda table_name, config_json: _postflight(con, table_name, config_json),
+        ["VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+
+    # Fellegi-Sunter probabilistic (JSON in / JSON out)
+    con.create_function(
+        "goldenmatch_train_em", _train_em,
+        # rows_json, matchkey_json, params_json
+        ["VARCHAR", "VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+    con.create_function(
+        "goldenmatch_score_probabilistic", _score_probabilistic,
+        # rows_json, matchkey_json, em_result_json
+        ["VARCHAR", "VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _read_table(con: duckdb.DuckDBPyConnection, table_name: str):
+    """Read a DuckDB table into a Polars frame via a cursor.
+
+    Same deadlock-avoidance pattern as ``functions._dedupe_table`` -- a
+    UDF cannot query the connection it's running on.
+    """
+    _validate_table_name(table_name)
+    cursor = con.cursor()
+    df = cursor.sql(f"SELECT * FROM {table_name}").pl()
+    cursor.close()
+    return df
+
+
+def _parse_json(value: str, default):
+    """Parse a JSON string, returning ``default`` for empty/None input."""
+    if value is None or value == "":
+        return default
+    return json.loads(value)
+
+
+# ── Profiling / threshold / domain ─────────────────────────────────────────
+
+
+def _profile_table(con: duckdb.DuckDBPyConnection, table_name: str) -> str:
+    """Wrap ``profile_dataframe`` -- comprehensive table profile as JSON."""
+    from goldenmatch import profile_dataframe
+    try:
+        df = _read_table(con, table_name)
+        report = profile_dataframe(df)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps(report, default=str)
+
+
+def _suggest_threshold(scores_json: str) -> float | None:
+    """Wrap ``suggest_threshold`` -- Otsu threshold over a JSON score list.
+
+    Returns NULL (None) when the distribution is unimodal or there are
+    too few scores -- the same semantics as the core function.
+    """
+    from goldenmatch import suggest_threshold
+    try:
+        scores = _parse_json(scores_json, [])
+        scores = [float(s) for s in scores]
+    except Exception:  # noqa: BLE001
+        return None
+    return suggest_threshold(scores)
+
+
+def _detect_domain(columns_json: str) -> str:
+    """Wrap ``detect_domain`` -- domain profile for a JSON list of columns."""
+    from goldenmatch.core.domain import detect_domain
+    try:
+        columns = _parse_json(columns_json, [])
+        columns = [str(c) for c in columns]
+        profile = detect_domain(columns)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps(dataclasses.asdict(profile), default=str)
+
+
+def _extract_features(text: str, kind: str) -> str:
+    """Wrap the three ``extract_*_features`` extractors.
+
+    ``kind`` selects the extractor: ``"product"`` / ``"electronics"`` ->
+    ``extract_product_features``, ``"software"`` ->
+    ``extract_software_features``, ``"biblio"`` /
+    ``"bibliographic"`` -> ``extract_biblio_features``.
+    """
+    from goldenmatch.core.domain import (
+        extract_biblio_features,
+        extract_product_features,
+        extract_software_features,
+    )
+    if text is None:
+        return json.dumps({"error": "text is required"})
+    k = (kind or "").strip().lower()
+    try:
+        if k in ("product", "electronics", ""):
+            return json.dumps(dataclasses.asdict(extract_product_features(text)))
+        if k == "software":
+            return json.dumps(dataclasses.asdict(extract_software_features(text)))
+        if k in ("biblio", "bibliographic"):
+            # extract_biblio_features already returns a plain dict.
+            return json.dumps(extract_biblio_features(text))
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps({
+        "error": (
+            f"Unknown kind {kind!r}. Use 'product'/'electronics', "
+            "'software', or 'biblio'/'bibliographic'."
+        ),
+    })
+
+
+# ── Evaluation / cluster comparison ────────────────────────────────────────
+
+
+def _evaluate(pairs_json: str, ground_truth_json: str) -> str:
+    """Wrap ``evaluate_pairs`` / ``evaluate_clusters``.
+
+    The first argument auto-selects the core function by shape:
+    - a JSON array (list of ``[a, b, score]`` triples) -> ``evaluate_pairs``
+    - a JSON object (``{cluster_id: {"members": [...]}}``) ->
+      ``evaluate_clusters``
+
+    ``ground_truth_json`` is a JSON array of ``[a, b]`` pairs. Returns the
+    ``EvalResult.summary()`` dict (tp/fp/fn/precision/recall/f1/...).
+    """
+    from goldenmatch import evaluate_clusters, evaluate_pairs
+    try:
+        predicted = _parse_json(pairs_json, [])
+        gt_raw = _parse_json(ground_truth_json, [])
+        ground_truth = {(p[0], p[1]) for p in gt_raw}
+
+        if isinstance(predicted, dict):
+            # Cluster shape: {cluster_id: {"members": [...]}}.
+            clusters = {int(k): v for k, v in predicted.items()}
+            result = evaluate_clusters(clusters, ground_truth)
+        else:
+            pairs = [(p[0], p[1], float(p[2]) if len(p) > 2 else 1.0) for p in predicted]
+            result = evaluate_pairs(pairs, ground_truth)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps(result.summary())
+
+
+def _compare_clusters(a_json: str, b_json: str) -> str:
+    """Wrap ``compare_clusters`` -- CCMS comparison of two clusterings.
+
+    Both args are JSON objects of ``{cluster_id: {"members": [...]}}``.
+    Returns the ``CompareResult.summary()`` dict (TWI + case counts).
+    """
+    from goldenmatch import compare_clusters
+    try:
+        a = {int(k): v for k, v in _parse_json(a_json, {}).items()}
+        b = {int(k): v for k, v in _parse_json(b_json, {}).items()}
+        result = compare_clusters(a, b)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps(result.summary())
+
+
+# ── Data-quality (validate / autofix / anomalies) ──────────────────────────
+
+
+def _validate_table(
+    con: duckdb.DuckDBPyConnection, table_name: str, rules_json: str,
+) -> str:
+    """Wrap ``validate_dataframe`` -- run validation rules over a table.
+
+    ``rules_json`` is a JSON array of rule objects matching the
+    ``ValidationRule`` dataclass:
+    ``{"column": ..., "rule_type": ..., "params": {...}, "action": ...}``.
+
+    Returns a JSON object with the validation report plus row counts and
+    the quarantined rows (as records) -- table-shaped JSON, since DuckDB
+    UDFs can only return a scalar.
+    """
+    from goldenmatch.core.validate import ValidationRule, validate_dataframe
+    try:
+        df = _read_table(con, table_name)
+        rules_spec = _parse_json(rules_json, [])
+        rules = [
+            ValidationRule(
+                column=r["column"],
+                rule_type=r["rule_type"],
+                params=r.get("params", {}),
+                action=r.get("action", "flag"),
+            )
+            for r in rules_spec
+        ]
+        valid_df, quarantine_df, report = validate_dataframe(df, rules)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps({
+        "report": report,
+        "valid_rows": valid_df.height,
+        "quarantine_rows": quarantine_df.height,
+        "quarantine": quarantine_df.to_dicts(),
+    }, default=str)
+
+
+def _autofix_table(con: duckdb.DuckDBPyConnection, table_name: str) -> str:
+    """Wrap ``auto_fix_dataframe`` -- apply auto-fixes to a table.
+
+    Returns a JSON object: the list of fixes applied + the fixed rows
+    (table-shaped JSON).
+    """
+    from goldenmatch import auto_fix_dataframe
+    try:
+        df = _read_table(con, table_name)
+        fixed_df, fixes = auto_fix_dataframe(df)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps({
+        "fixes": fixes,
+        "fixed_rows": fixed_df.height,
+        "rows": fixed_df.to_dicts(),
+    }, default=str)
+
+
+def _detect_anomalies(
+    con: duckdb.DuckDBPyConnection, table_name: str, sensitivity: str,
+) -> str:
+    """Wrap ``detect_anomalies`` -- flag suspicious records in a table.
+
+    ``sensitivity`` is ``"low"`` / ``"medium"`` / ``"high"`` (empty ->
+    ``"medium"``). Returns the JSON array of anomaly dicts.
+    """
+    from goldenmatch import detect_anomalies
+    try:
+        df = _read_table(con, table_name)
+        sens = sensitivity or "medium"
+        anomalies = detect_anomalies(df, sensitivity=sens)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps(anomalies, default=str)
+
+
+# ── AutoConfig verify (preflight / postflight) ─────────────────────────────
+
+
+def _preflight(
+    con: duckdb.DuckDBPyConnection, table_name: str, config_json: str,
+) -> str:
+    """Wrap ``preflight`` -- validate (df, config) before a run.
+
+    ``config_json`` is a full ``GoldenMatchConfig`` JSON. Returns a JSON
+    object with ``has_errors``, ``config_was_modified``, and the list of
+    findings.
+    """
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    from goldenmatch.core.autoconfig_verify import preflight
+    try:
+        df = _read_table(con, table_name)
+        config = GoldenMatchConfig.model_validate_json(config_json)
+        report = preflight(df, config)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps({
+        "has_errors": report.has_errors,
+        "config_was_modified": report.config_was_modified,
+        "findings": [dataclasses.asdict(f) for f in report.findings],
+    }, default=str)
+
+
+def _postflight(
+    con: duckdb.DuckDBPyConnection, table_name: str, config_json: str,
+) -> str:
+    """Wrap ``postflight`` -- post-run signal report for (df, config).
+
+    ``postflight`` needs ``pair_scores``, which aren't in the table, so we
+    derive them SQL-naturally: run ``dedupe_df`` on the table with the
+    given config and feed its ``scored_pairs`` to ``postflight``. Returns
+    a JSON object with the stable ``signals`` schema plus any adjustments
+    and advisories.
+    """
+    from goldenmatch import dedupe_df
+    from goldenmatch.config.schemas import GoldenMatchConfig
+    from goldenmatch.core.autoconfig_verify import postflight
+    try:
+        df = _read_table(con, table_name)
+        config = GoldenMatchConfig.model_validate_json(config_json)
+        result = dedupe_df(df, config=config)
+        report = postflight(df, config, pair_scores=result.scored_pairs)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps({
+        "signals": report.signals,
+        "adjustments": [dataclasses.asdict(a) for a in report.adjustments],
+        "advisories": report.advisories,
+    }, default=str)
+
+
+# ── Fellegi-Sunter probabilistic ───────────────────────────────────────────
+
+
+def _build_probabilistic_frame(rows):
+    """Build a Polars frame with the ``__row_id__`` column train_em wants.
+
+    ``train_em`` / ``score_probabilistic`` index pairs by ``__row_id__``.
+    Rows that already carry one are respected; otherwise we add a 0-based
+    row id so the caller can map results back.
+    """
+    import polars as pl
+    df = pl.DataFrame(rows)
+    if "__row_id__" not in df.columns:
+        df = df.with_row_index("__row_id__").with_columns(
+            pl.col("__row_id__").cast(pl.Int64)
+        )
+    return df
+
+
+def _train_em(rows_json: str, matchkey_json: str, params_json: str) -> str:
+    """Wrap Fellegi-Sunter ``train_em``.
+
+    Args:
+        rows_json: JSON array of record objects (a small training set).
+        matchkey_json: JSON for a probabilistic ``MatchkeyConfig``
+            (``{"name": ..., "type": "probabilistic", "fields": [...]}``).
+        params_json: optional JSON object of train_em kwargs
+            (``n_sample_pairs``, ``max_iterations``, ``convergence``,
+            ``seed``, ``blocking_fields``). Empty -> defaults.
+
+    Returns the ``EMResult`` as JSON (``m_probs`` / ``u_probs`` /
+    ``match_weights`` / ``converged`` / ``iterations`` /
+    ``proportion_matched``) -- pass it straight to
+    ``goldenmatch_score_probabilistic``.
+    """
+    from goldenmatch.config.schemas import MatchkeyConfig
+    from goldenmatch.core.probabilistic import train_em
+    try:
+        rows = _parse_json(rows_json, [])
+        df = _build_probabilistic_frame(rows)
+        mk = MatchkeyConfig.model_validate_json(matchkey_json)
+        params = _parse_json(params_json, {})
+        allowed = {
+            "n_sample_pairs", "max_iterations", "convergence",
+            "seed", "blocking_fields",
+        }
+        kwargs = {k: v for k, v in params.items() if k in allowed}
+        em = train_em(df, mk, **kwargs)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps(dataclasses.asdict(em), default=str)
+
+
+def _score_probabilistic(
+    rows_json: str, matchkey_json: str, em_result_json: str,
+) -> str:
+    """Wrap Fellegi-Sunter ``score_probabilistic``.
+
+    Args:
+        rows_json: JSON array of record objects (the block to score).
+        matchkey_json: JSON for the same probabilistic ``MatchkeyConfig``
+            used for training.
+        em_result_json: the JSON produced by ``goldenmatch_train_em``.
+
+    Returns a JSON array of ``[row_id_a, row_id_b, score]`` triples for
+    pairs above the link threshold.
+    """
+    from goldenmatch.config.schemas import MatchkeyConfig
+    from goldenmatch.core.probabilistic import EMResult, score_probabilistic
+    try:
+        rows = _parse_json(rows_json, [])
+        df = _build_probabilistic_frame(rows)
+        mk = MatchkeyConfig.model_validate_json(matchkey_json)
+        em = EMResult(**_parse_json(em_result_json, {}))
+        pairs = score_probabilistic(df, mk, em)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
+    return json.dumps([[a, b, score] for (a, b, score) in pairs])

--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
@@ -157,6 +157,15 @@ def register(con: duckdb.DuckDBPyConnection) -> None:
     from goldenmatch_duckdb.goldenflow import register_goldenflow_functions
     register_goldenflow_functions(con)
 
+    # ── Core-API parity UDFs ──────────────────────────────────────────────
+    # 13 UDFs wrapping goldenmatch's function-shaped core APIs that were
+    # already public but not yet exposed in SQL (profiling, threshold,
+    # domain extraction, evaluation, cluster comparison, data-quality,
+    # autoconfig verify, Fellegi-Sunter). Pure-Python wrappers that import
+    # `goldenmatch` directly; see `core_apis.py`.
+    from goldenmatch_duckdb.core_apis import register_core_api_functions
+    register_core_api_functions(con)
+
 
 # ── Implementation ──────────────────────────────────────────────────────
 

--- a/packages/rust/extensions/duckdb/tests/test_core_apis.py
+++ b/packages/rust/extensions/duckdb/tests/test_core_apis.py
@@ -1,0 +1,390 @@
+"""Tests for the core-API parity UDFs in ``core_apis.py``.
+
+Each test registers the UDFs on a DuckDB connection, runs the UDF on a
+small fixture, and asserts the JSON result shape + key values AGAINST
+what the underlying goldenmatch core function returns directly -- so it's
+real parity, not a tautology.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import duckdb
+import pytest
+from goldenmatch_duckdb.functions import register
+
+
+@pytest.fixture()
+def con():
+    c = duckdb.connect()
+    register(c)
+    return c
+
+
+# ── profile / threshold / domain ───────────────────────────────────────────
+
+
+class TestProfileTable:
+    def test_matches_core(self, con):
+        con.sql("""
+            CREATE TABLE prof_t AS SELECT * FROM (VALUES
+                ('a@x.com', 'A'),
+                ('a@x.com', 'A'),
+                ('b@y.com', 'B')
+            ) AS t(email, name)
+        """)
+        result = json.loads(
+            con.sql("SELECT goldenmatch_profile_table('prof_t')").fetchone()[0]
+        )
+        # Parity against the core function on the same data.
+        import polars as pl
+        from goldenmatch import profile_dataframe
+        expected = profile_dataframe(
+            pl.DataFrame({"email": ["a@x.com", "a@x.com", "b@y.com"],
+                          "name": ["A", "A", "B"]})
+        )
+        assert result["total_rows"] == expected["total_rows"] == 3
+        assert result["total_columns"] == expected["total_columns"] == 2
+        assert result["duplicate_row_count"] == expected["duplicate_row_count"]
+
+
+class TestSuggestThreshold:
+    def test_bimodal_matches_core(self, con):
+        scores = [0.05, 0.1, 0.08, 0.12, 0.9, 0.92, 0.88, 0.95]
+        result = con.sql(
+            "SELECT goldenmatch_suggest_threshold(?)",
+            params=[json.dumps(scores)],
+        ).fetchone()[0]
+        from goldenmatch import suggest_threshold
+        assert result == pytest.approx(suggest_threshold(scores))
+        assert result is not None
+
+    def test_too_few_returns_null(self, con):
+        result = con.sql(
+            "SELECT goldenmatch_suggest_threshold('[0.5]')"
+        ).fetchone()[0]
+        assert result is None
+
+
+class TestDetectDomain:
+    def test_matches_core(self, con):
+        cols = ["product_title", "brand", "sku", "price"]
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_detect_domain(?)", params=[json.dumps(cols)],
+        ).fetchone()[0])
+        from goldenmatch.core.domain import detect_domain
+        expected = dataclasses.asdict(detect_domain(cols))
+        assert result["name"] == expected["name"] == "product"
+        assert result["confidence"] == pytest.approx(expected["confidence"])
+
+
+class TestExtractFeatures:
+    def test_product_matches_core(self, con):
+        text = "Sony DSC-T77 Black 10MP Camera"
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_extract_features(?, 'product')", params=[text],
+        ).fetchone()[0])
+        from goldenmatch.core.domain import extract_product_features
+        expected = dataclasses.asdict(extract_product_features(text))
+        assert result["brand"] == expected["brand"] == "Sony"
+        assert result["color"] == expected["color"]
+
+    def test_software_matches_core(self, con):
+        text = "Microsoft Office 2010 Professional Win"
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_extract_features(?, 'software')", params=[text],
+        ).fetchone()[0])
+        from goldenmatch.core.domain import extract_software_features
+        expected = dataclasses.asdict(extract_software_features(text))
+        assert result["version"] == expected["version"] == "2010"
+        assert result["edition"] == expected["edition"] == "pro"
+
+    def test_biblio_matches_core(self, con):
+        text = "A Study on Entity Resolution 2019"
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_extract_features(?, 'biblio')", params=[text],
+        ).fetchone()[0])
+        from goldenmatch.core.domain import extract_biblio_features
+        assert result == extract_biblio_features(text)
+        assert result["year"] == "2019"
+
+    def test_unknown_kind_returns_error(self, con):
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_extract_features('x', 'bogus')"
+        ).fetchone()[0])
+        assert "error" in result
+
+
+# ── evaluate / compare_clusters ─────────────────────────────────────────────
+
+
+class TestEvaluate:
+    def test_pairs_matches_core(self, con):
+        predicted = [[0, 1, 0.9], [2, 3, 0.8]]
+        gt = [[0, 1], [4, 5]]
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_evaluate(?, ?)",
+            params=[json.dumps(predicted), json.dumps(gt)],
+        ).fetchone()[0])
+        from goldenmatch import evaluate_pairs
+        expected = evaluate_pairs(
+            [(0, 1, 0.9), (2, 3, 0.8)], {(0, 1), (4, 5)}
+        ).summary()
+        assert result == expected
+        assert result["tp"] == 1 and result["fp"] == 1 and result["fn"] == 1
+
+    def test_clusters_matches_core(self, con):
+        clusters = {"0": {"members": [0, 1]}, "1": {"members": [2, 3, 4]}}
+        gt = [[0, 1], [2, 3]]
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_evaluate(?, ?)",
+            params=[json.dumps(clusters), json.dumps(gt)],
+        ).fetchone()[0])
+        from goldenmatch import evaluate_clusters
+        expected = evaluate_clusters(
+            {0: {"members": [0, 1]}, 1: {"members": [2, 3, 4]}}, {(0, 1), (2, 3)}
+        ).summary()
+        assert result == expected
+
+
+class TestCompareClusters:
+    def test_matches_core(self, con):
+        a = {"0": {"members": [0, 1]}, "1": {"members": [2, 3]}}
+        b = {"0": {"members": [0, 1, 2, 3]}}
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_compare_clusters(?, ?)",
+            params=[json.dumps(a), json.dumps(b)],
+        ).fetchone()[0])
+        from goldenmatch import compare_clusters
+        expected = compare_clusters(
+            {0: {"members": [0, 1]}, 1: {"members": [2, 3]}},
+            {0: {"members": [0, 1, 2, 3]}},
+        ).summary()
+        assert result == expected
+        assert result["merged"] == 2
+
+
+# ── validate / autofix / anomalies ──────────────────────────────────────────
+
+
+class TestValidateTable:
+    def test_quarantine_matches_core(self, con):
+        con.sql("""
+            CREATE TABLE val_t AS SELECT * FROM (VALUES
+                ('a@x.com'),
+                ('not-an-email'),
+                ('b@y.com')
+            ) AS t(email)
+        """)
+        rules = [{
+            "column": "email", "rule_type": "format",
+            "params": {"type": "email"}, "action": "quarantine",
+        }]
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_validate_table('val_t', ?)",
+            params=[json.dumps(rules)],
+        ).fetchone()[0])
+
+        import polars as pl
+        from goldenmatch.core.validate import ValidationRule, validate_dataframe
+        valid_df, quarantine_df, report = validate_dataframe(
+            pl.DataFrame({"email": ["a@x.com", "not-an-email", "b@y.com"]}),
+            [ValidationRule(column="email", rule_type="format",
+                            params={"type": "email"}, action="quarantine")],
+        )
+        assert result["valid_rows"] == valid_df.height == 2
+        assert result["quarantine_rows"] == quarantine_df.height == 1
+        assert result["report"][0]["failed"] == report[0]["failed"] == 1
+
+
+class TestAutofixTable:
+    def test_matches_core(self, con):
+        con.sql("""
+            CREATE TABLE fix_t AS SELECT * FROM (VALUES
+                ('  John  ', 'a@x.com'),
+                ('NULL', 'b@y.com')
+            ) AS t(name, email)
+        """)
+        result = json.loads(
+            con.sql("SELECT goldenmatch_autofix_table('fix_t')").fetchone()[0]
+        )
+        import polars as pl
+        from goldenmatch import auto_fix_dataframe
+        fixed_df, fixes = auto_fix_dataframe(
+            pl.DataFrame({"name": ["  John  ", "NULL"],
+                          "email": ["a@x.com", "b@y.com"]})
+        )
+        assert result["fixed_rows"] == fixed_df.height
+        assert {f["fix"] for f in result["fixes"]} == {f["fix"] for f in fixes}
+        # Trim-whitespace fix should have run.
+        assert any(f["fix"] == "trim_whitespace" for f in result["fixes"])
+
+
+class TestDetectAnomalies:
+    def test_matches_core(self, con):
+        con.sql("""
+            CREATE TABLE anom_t AS SELECT * FROM (VALUES
+                ('test@test.com'),
+                ('real@example.org')
+            ) AS t(email)
+        """)
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_detect_anomalies('anom_t', 'medium')"
+        ).fetchone()[0])
+        import polars as pl
+        from goldenmatch import detect_anomalies
+        expected = detect_anomalies(
+            pl.DataFrame({"email": ["test@test.com", "real@example.org"]}),
+            sensitivity="medium",
+        )
+        assert len(result) == len(expected)
+        assert any(a["type"] == "fake_email" for a in result)
+
+
+# ── preflight / postflight ──────────────────────────────────────────────────
+
+
+_EXACT_CONFIG = json.dumps({
+    "matchkeys": [{
+        "name": "k", "type": "exact",
+        "fields": [{"field": "email", "scorer": "exact"}],
+    }],
+})
+
+
+class TestPreflight:
+    def test_clean_config_no_errors(self, con):
+        con.sql("""
+            CREATE TABLE pre_t AS SELECT * FROM (VALUES
+                ('a@x.com', 'A'),
+                ('a@x.com', 'A'),
+                ('b@y.com', 'B')
+            ) AS t(email, name)
+        """)
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_preflight('pre_t', ?)", params=[_EXACT_CONFIG],
+        ).fetchone()[0])
+        import polars as pl
+        from goldenmatch.config.schemas import GoldenMatchConfig
+        from goldenmatch.core.autoconfig_verify import preflight
+        report = preflight(
+            pl.DataFrame({"email": ["a@x.com", "a@x.com", "b@y.com"],
+                          "name": ["A", "A", "B"]}),
+            GoldenMatchConfig.model_validate_json(_EXACT_CONFIG),
+        )
+        assert result["has_errors"] == report.has_errors is False
+        assert "findings" in result
+
+    def test_missing_column_surfaces_finding(self, con):
+        con.sql("""
+            CREATE TABLE pre_bad AS SELECT * FROM (VALUES ('A')) AS t(name)
+        """)
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_preflight('pre_bad', ?)", params=[_EXACT_CONFIG],
+        ).fetchone()[0])
+        # email column is absent -> preflight should report it.
+        assert result["has_errors"] is True
+        assert any(f["severity"] == "error" for f in result["findings"])
+
+
+class TestPostflight:
+    def test_signals_shape(self, con):
+        con.sql("""
+            CREATE TABLE post_t AS SELECT * FROM (VALUES
+                ('a@x.com', 'A'),
+                ('a@x.com', 'A'),
+                ('b@y.com', 'B'),
+                ('c@z.com', 'C')
+            ) AS t(email, name)
+        """)
+        result = json.loads(con.sql(
+            "SELECT goldenmatch_postflight('post_t', ?)", params=[_EXACT_CONFIG],
+        ).fetchone()[0])
+        assert "signals" in result
+        # Stable PostflightSignals schema keys.
+        for key in ("score_histogram", "threshold_overlap_pct",
+                    "total_pairs_scored", "current_threshold"):
+            assert key in result["signals"]
+        assert "adjustments" in result and "advisories" in result
+
+
+# ── Fellegi-Sunter train_em / score_probabilistic ───────────────────────────
+
+
+_PROB_ROWS = [
+    {"name": "john smith", "city": "nyc"},
+    {"name": "john smith", "city": "nyc"},
+    {"name": "jane doe", "city": "la"},
+    {"name": "jane doe", "city": "la"},
+    {"name": "bob jones", "city": "sf"},
+    {"name": "robert jones", "city": "sf"},
+]
+_PROB_MK = json.dumps({
+    "name": "p", "type": "probabilistic",
+    "fields": [
+        {"field": "name", "scorer": "jaro_winkler", "levels": 3},
+        {"field": "city", "scorer": "exact", "levels": 2},
+    ],
+})
+
+
+class TestProbabilistic:
+    def test_train_then_score_roundtrip(self, con):
+        params = json.dumps({"n_sample_pairs": 50, "max_iterations": 10, "seed": 1})
+        em_json = con.sql(
+            "SELECT goldenmatch_train_em(?, ?, ?)",
+            params=[json.dumps(_PROB_ROWS), _PROB_MK, params],
+        ).fetchone()[0]
+        em = json.loads(em_json)
+        # EMResult shape.
+        for key in ("m_probs", "u_probs", "match_weights",
+                    "converged", "iterations", "proportion_matched"):
+            assert key in em
+        assert "name" in em["match_weights"] and "city" in em["match_weights"]
+
+        pairs_json = con.sql(
+            "SELECT goldenmatch_score_probabilistic(?, ?, ?)",
+            params=[json.dumps(_PROB_ROWS), _PROB_MK, em_json],
+        ).fetchone()[0]
+        pairs = json.loads(pairs_json)
+        # Each result is [a, b, score].
+        assert all(len(p) == 3 for p in pairs)
+        scored = {(p[0], p[1]) for p in pairs}
+        # The two identical dup pairs must be linked.
+        assert (0, 1) in scored
+        assert (2, 3) in scored
+
+    def test_parity_with_core(self, con):
+        """The UDF chain must reproduce the core train_em+score result."""
+        import polars as pl
+        from goldenmatch.config.schemas import MatchkeyConfig
+        from goldenmatch.core.probabilistic import (
+            EMResult,
+            score_probabilistic,
+            train_em,
+        )
+        df = pl.DataFrame(_PROB_ROWS).with_row_index("__row_id__").with_columns(
+            pl.col("__row_id__").cast(pl.Int64)
+        )
+        mk = MatchkeyConfig.model_validate_json(_PROB_MK)
+        core_em = train_em(df, mk, n_sample_pairs=50, max_iterations=10, seed=1)
+        core_pairs = score_probabilistic(df, mk, core_em)
+
+        params = json.dumps({"n_sample_pairs": 50, "max_iterations": 10, "seed": 1})
+        em_json = con.sql(
+            "SELECT goldenmatch_train_em(?, ?, ?)",
+            params=[json.dumps(_PROB_ROWS), _PROB_MK, params],
+        ).fetchone()[0]
+        pairs_json = con.sql(
+            "SELECT goldenmatch_score_probabilistic(?, ?, ?)",
+            params=[json.dumps(_PROB_ROWS), _PROB_MK, em_json],
+        ).fetchone()[0]
+        udf_pairs = [tuple(p) for p in json.loads(pairs_json)]
+
+        # Same linked pairs as the in-process core call.
+        assert {(a, b) for a, b, _ in udf_pairs} == {
+            (a, b) for a, b, _ in core_pairs
+        }
+        # Reconstructed EMResult round-trips.
+        EMResult(**json.loads(em_json))


### PR DESCRIPTION
Brings the **DuckDB UDF** package to parity with goldenmatch's clean, function-shaped core APIs that weren't yet exposed in SQL (from the extension audit). Pure-Python UDFs that import goldenmatch directly — wrapping work, locally tested, no pgrx/CI dependency.

## 13 new UDFs (`goldenmatch_duckdb/core_apis.py`, registered via `register_core_api_functions` from `functions.register`)

| UDF | Core API |
|---|---|
| `goldenmatch_profile_table(table)` | `profile_dataframe` |
| `goldenmatch_suggest_threshold(scores_json)` | `suggest_threshold` |
| `goldenmatch_detect_domain(columns_json)` | `detect_domain` |
| `goldenmatch_extract_features(text, kind)` | `extract_{product,software,biblio}_features` |
| `goldenmatch_evaluate(pairs_json, gt_json)` | `evaluate_pairs` / `evaluate_clusters` |
| `goldenmatch_compare_clusters(a_json, b_json)` | `compare_clusters` |
| `goldenmatch_validate_table(table, rules_json)` | `validate_dataframe` |
| `goldenmatch_autofix_table(table)` | `auto_fix_dataframe` |
| `goldenmatch_detect_anomalies(table, sensitivity)` | `detect_anomalies` |
| `goldenmatch_preflight(table, config_json)` | `preflight` |
| `goldenmatch_postflight(table, config_json)` | `postflight` |
| `goldenmatch_train_em(rows_json, mk_json, params_json)` | Fellegi-Sunter `train_em` |
| `goldenmatch_score_probabilistic(rows_json, mk_json, em_json)` | `score_probabilistic` |

Follows the existing conventions exactly: table UDFs use the `con.cursor()` + `.pl()` + `_validate_table_name` read (like `_dedupe_table`); JSON-string outputs via `json.dumps`/`dataclasses.asdict`/`.summary()`; fail-soft `{"error": ...}` on bad input/missing optional deps. `suggest_threshold` registers with `null_handling="special"` (it can return SQL NULL).

**Deferred** (not SQL-natural): PPRL `pprl_link` + `run_sensitivity` (file-path args). The Postgres-only table-returning `gm_pairs`/`gm_clusters` aren't ported (DuckDB returns JSON via the existing `dedupe_pairs`/`dedupe_clusters`).

## Verification
19 new tests in `tests/test_core_apis.py` (each asserts the UDF's JSON vs the core function called directly); full suite **50/50**. Verified locally against workspace goldenmatch 1.19.0 — which is exactly how the `duckdb_extensions` CI lane installs it (`pip install -e ../../../python/goldenmatch[web]`).

Scope: only the duckdb package (+ shared extensions CLAUDE.md function listing). No postgres/bridge/workflow edits, no version bump. (`goldenmatch-duckdb` ships on PyPI — a version bump + publish is a separate follow-up.)

Postgres parity (mirroring this set + the `goldenflow_*` transforms) is next, on the CI-only pgrx side.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx)_