### PR TITLE
feat(postgres): core-API parity — 13 pgrx functions mirroring DuckDB

### DIFF
--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -991,6 +991,556 @@ pub fn correction_list(
     })
 }
 
+// ─── Core-API parity (mirrors duckdb/core_apis.py) ───────────────────────
+//
+// Wrappers over goldenmatch's function-shaped core APIs so the Postgres
+// extension reaches parity with the DuckDB UDFs registered in
+// `goldenmatch_duckdb/core_apis.py`. The JSON in / JSON out contract is
+// IDENTICAL to the DuckDB side so the two backends are interchangeable.
+//
+// Fail-soft semantics: like the DuckDB UDFs, optional-dep / bad-input
+// failures return a `{"error": ...}` JSON object instead of raising, so a
+// malformed call doesn't abort a whole SQL query. The bridge converts an
+// internal `PyErr` into that JSON object rather than propagating a
+// `BridgeError` (whereas a true *initialisation* failure -- goldenmatch
+// not importable -- still surfaces as `BridgeError::PythonImport`).
+//
+// Table-input functions take a `rows_json` JSON array of record objects
+// (the Postgres layer reads its table via `row_to_json` SPI, exactly like
+// `goldenmatch_dedupe_table`). The DuckDB side reads the table itself; both
+// converge on the same `json_to_polars_df` path inside goldenmatch.
+
+/// Serialise an arbitrary Python object to a JSON string via `json.dumps`,
+/// using `default=str` so dataclasses-converted dicts / datetimes / Paths
+/// stay JSON-safe (mirrors the `default=str` in core_apis.py).
+fn py_json_dumps<'py>(py: Python<'py>, obj: Bound<'py, PyAny>) -> Result<String, BridgeError> {
+    let json_mod = py.import("json")?;
+    let kwargs = PyDict::new(py);
+    kwargs.set_item("default", py.import("builtins")?.getattr("str")?)?;
+    let s: String = json_mod
+        .call_method("dumps", (obj,), Some(&kwargs))?
+        .extract()?;
+    Ok(s)
+}
+
+/// Build a `{"error": "<msg>"}` JSON string (fail-soft contract).
+fn error_json(msg: &str) -> String {
+    // Re-use serde-free hand assembly with minimal escaping for quotes and
+    // backslashes so we never depend on a JSON lib in the error path.
+    let escaped = msg.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("{{\"error\": \"{}\"}}", escaped)
+}
+
+/// Build a Polars DataFrame with the `__row_id__` column the probabilistic
+/// `train_em` / `score_probabilistic` functions index pairs by. Mirrors
+/// `core_apis._build_probabilistic_frame`: respects an existing
+/// `__row_id__`, otherwise adds a 0-based Int64 row index.
+fn build_probabilistic_frame<'py>(
+    py: Python<'py>,
+    rows_json: &str,
+) -> Result<Bound<'py, PyAny>, BridgeError> {
+    let pl = py.import("polars")?;
+    let io = py.import("io")?;
+    let string_io = io.call_method1("StringIO", (rows_json,))?;
+    let df = pl.call_method1("read_json", (string_io,))?;
+    let columns: Vec<String> = df.getattr("columns")?.extract()?;
+    if columns.iter().any(|c| c == "__row_id__") {
+        return Ok(df);
+    }
+    let df = df.call_method1("with_row_index", ("__row_id__",))?;
+    let int64 = pl.getattr("Int64")?;
+    let col = pl.call_method1("col", ("__row_id__",))?;
+    let cast = col.call_method1("cast", (int64,))?;
+    let df = df.call_method1("with_columns", (cast,))?;
+    Ok(df)
+}
+
+/// Wrap `goldenmatch.profile_dataframe` -- comprehensive table profile.
+///
+/// `rows_json` is a JSON array of record objects. Returns the profile report
+/// as a JSON object (or `{"error": ...}` on failure).
+pub fn profile_table(rows_json: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let gm = py.import("goldenmatch")?;
+            let df = convert::json_to_polars_df(py, rows_json)?;
+            let report = gm.call_method1("profile_dataframe", (df,))?;
+            py_json_dumps(py, report)
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
+/// Wrap `goldenmatch.suggest_threshold` -- Otsu threshold over a JSON list of
+/// scores. Returns `None` (SQL NULL) when the distribution is unimodal or
+/// there are too few scores -- identical semantics to the core function and
+/// the DuckDB `null_handling="special"` registration.
+pub fn suggest_threshold(scores_json: &str) -> Result<Option<f64>, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<Option<f64>, BridgeError> = (|| {
+            let gm = py.import("goldenmatch")?;
+            let json_mod = py.import("json")?;
+            let parsed = if scores_json.is_empty() {
+                py.import("builtins")?.call_method0("list")?
+            } else {
+                json_mod.call_method1("loads", (scores_json,))?
+            };
+            // Coerce each element to float (mirrors `[float(s) for s in ...]`).
+            let builtins = py.import("builtins")?;
+            let floats = pyo3::types::PyList::empty(py);
+            for item in parsed.try_iter()? {
+                let f = builtins.call_method1("float", (item?,))?;
+                floats.append(f)?;
+            }
+            let out = gm.call_method1("suggest_threshold", (floats,))?;
+            if out.is_none() {
+                Ok(None)
+            } else {
+                Ok(Some(out.extract()?))
+            }
+        })();
+        // Bad input -> NULL (matches core_apis: `except: return None`).
+        Ok(result.unwrap_or(None))
+    })
+}
+
+/// Wrap `goldenmatch.core.domain.detect_domain` -- domain profile for a JSON
+/// list of column names. Returns the dataclass as a JSON object.
+pub fn detect_domain(columns_json: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let domain = py.import("goldenmatch.core.domain")?;
+            let dataclasses = py.import("dataclasses")?;
+            let json_mod = py.import("json")?;
+            let builtins = py.import("builtins")?;
+            let parsed = if columns_json.is_empty() {
+                builtins.call_method0("list")?
+            } else {
+                json_mod.call_method1("loads", (columns_json,))?
+            };
+            // Coerce each element to str (mirrors `[str(c) for c in ...]`).
+            let columns = pyo3::types::PyList::empty(py);
+            for item in parsed.try_iter()? {
+                let s = builtins.call_method1("str", (item?,))?;
+                columns.append(s)?;
+            }
+            let profile = domain.call_method1("detect_domain", (columns,))?;
+            let dict = dataclasses.call_method1("asdict", (profile,))?;
+            py_json_dumps(py, dict)
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
+/// Wrap the three `extract_*_features` extractors. `kind` selects the
+/// extractor: `"product"` / `"electronics"` / `""` -> product;
+/// `"software"` -> software; `"biblio"` / `"bibliographic"` -> biblio.
+/// Mirrors `core_apis._extract_features` exactly, including its
+/// unknown-kind / missing-text error JSON.
+pub fn extract_features(text: &str, kind: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let domain = py.import("goldenmatch.core.domain")?;
+            let dataclasses = py.import("dataclasses")?;
+            let k = kind.trim().to_lowercase();
+            match k.as_str() {
+                "product" | "electronics" | "" => {
+                    let feats = domain.call_method1("extract_product_features", (text,))?;
+                    let dict = dataclasses.call_method1("asdict", (feats,))?;
+                    py_json_dumps(py, dict)
+                }
+                "software" => {
+                    let feats = domain.call_method1("extract_software_features", (text,))?;
+                    let dict = dataclasses.call_method1("asdict", (feats,))?;
+                    py_json_dumps(py, dict)
+                }
+                "biblio" | "bibliographic" => {
+                    // extract_biblio_features already returns a plain dict.
+                    let dict = domain.call_method1("extract_biblio_features", (text,))?;
+                    py_json_dumps(py, dict)
+                }
+                _ => Ok(error_json(&format!(
+                    "Unknown kind '{}'. Use 'product'/'electronics', 'software', or 'biblio'/'bibliographic'.",
+                    kind
+                ))),
+            }
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
+/// Wrap `evaluate_pairs` / `evaluate_clusters`. The first argument
+/// auto-selects by shape: a JSON array -> `evaluate_pairs`; a JSON object
+/// (`{cluster_id: {"members": [...]}}`) -> `evaluate_clusters`.
+/// `ground_truth_json` is a JSON array of `[a, b]` pairs. Returns the
+/// `EvalResult.summary()` dict.
+pub fn evaluate(pairs_json: &str, ground_truth_json: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let gm = py.import("goldenmatch")?;
+            let json_mod = py.import("json")?;
+            let builtins = py.import("builtins")?;
+
+            let predicted = if pairs_json.is_empty() {
+                builtins.call_method0("list")?
+            } else {
+                json_mod.call_method1("loads", (pairs_json,))?
+            };
+            let gt_raw = if ground_truth_json.is_empty() {
+                builtins.call_method0("list")?
+            } else {
+                json_mod.call_method1("loads", (ground_truth_json,))?
+            };
+            // ground_truth = {(p[0], p[1]) for p in gt_raw}
+            let ground_truth = pyo3::types::PySet::empty(py)?;
+            for p in gt_raw.try_iter()? {
+                let p = p?;
+                let tuple = pyo3::types::PyTuple::new(py, [p.get_item(0)?, p.get_item(1)?])?;
+                ground_truth.add(tuple)?;
+            }
+
+            let is_dict = predicted.is_instance(&builtins.getattr("dict")?)?;
+            let eval_result = if is_dict {
+                // clusters = {int(k): v for k, v in predicted.items()}
+                let clusters = PyDict::new(py);
+                let items = predicted.call_method0("items")?;
+                for kv in items.try_iter()? {
+                    let kv = kv?;
+                    let k = builtins.call_method1("int", (kv.get_item(0)?,))?;
+                    clusters.set_item(k, kv.get_item(1)?)?;
+                }
+                gm.call_method1("evaluate_clusters", (clusters, ground_truth))?
+            } else {
+                // pairs = [(p[0], p[1], float(p[2]) if len(p) > 2 else 1.0) for p in predicted]
+                let pairs = pyo3::types::PyList::empty(py);
+                for p in predicted.try_iter()? {
+                    let p = p?;
+                    let len: usize = builtins.call_method1("len", (&p,))?.extract()?;
+                    let score = if len > 2 {
+                        builtins.call_method1("float", (p.get_item(2)?,))?
+                    } else {
+                        builtins.call_method1("float", (1.0f64,))?
+                    };
+                    let tuple =
+                        pyo3::types::PyTuple::new(py, [p.get_item(0)?, p.get_item(1)?, score])?;
+                    pairs.append(tuple)?;
+                }
+                gm.call_method1("evaluate_pairs", (pairs, ground_truth))?
+            };
+            let summary = eval_result.call_method0("summary")?;
+            py_json_dumps(py, summary)
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
+/// Wrap `goldenmatch.compare_clusters` -- CCMS comparison of two clusterings.
+/// Both args are JSON objects of `{cluster_id: {"members": [...]}}`. Returns
+/// the `CompareResult.summary()` dict.
+pub fn compare_clusters(a_json: &str, b_json: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let gm = py.import("goldenmatch")?;
+            let json_mod = py.import("json")?;
+            let builtins = py.import("builtins")?;
+
+            let parse_int_keyed = |raw_json: &str| -> Result<Bound<'_, PyAny>, BridgeError> {
+                let parsed = if raw_json.is_empty() {
+                    builtins.call_method0("dict")?
+                } else {
+                    json_mod.call_method1("loads", (raw_json,))?
+                };
+                let out = PyDict::new(py);
+                let items = parsed.call_method0("items")?;
+                for kv in items.try_iter()? {
+                    let kv = kv?;
+                    let k = builtins.call_method1("int", (kv.get_item(0)?,))?;
+                    out.set_item(k, kv.get_item(1)?)?;
+                }
+                Ok(out.into_any())
+            };
+
+            let a = parse_int_keyed(a_json)?;
+            let b = parse_int_keyed(b_json)?;
+            let result = gm.call_method1("compare_clusters", (a, b))?;
+            let summary = result.call_method0("summary")?;
+            py_json_dumps(py, summary)
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
+/// Wrap `goldenmatch.core.validate.validate_dataframe` -- run validation
+/// rules over a table. `rows_json` is the table's records; `rules_json` is a
+/// JSON array of rule objects (`{"column", "rule_type", "params", "action"}`).
+/// Returns `{report, valid_rows, quarantine_rows, quarantine}` JSON.
+pub fn validate_table(rows_json: &str, rules_json: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let validate_mod = py.import("goldenmatch.core.validate")?;
+            let json_mod = py.import("json")?;
+            let builtins = py.import("builtins")?;
+
+            let df = convert::json_to_polars_df(py, rows_json)?;
+            let rules_spec = if rules_json.is_empty() {
+                builtins.call_method0("list")?
+            } else {
+                json_mod.call_method1("loads", (rules_json,))?
+            };
+            let rule_cls = validate_mod.getattr("ValidationRule")?;
+            let rules = pyo3::types::PyList::empty(py);
+            for r in rules_spec.try_iter()? {
+                let r = r?;
+                let kwargs = PyDict::new(py);
+                kwargs.set_item("column", r.get_item("column")?)?;
+                kwargs.set_item("rule_type", r.get_item("rule_type")?)?;
+                let params = match r.call_method1("get", ("params",)) {
+                    Ok(p) if !p.is_none() => p,
+                    _ => PyDict::new(py).into_any(),
+                };
+                kwargs.set_item("params", params)?;
+                let action = match r.call_method1("get", ("action",)) {
+                    Ok(a) if !a.is_none() => a,
+                    _ => pyo3::types::PyString::new(py, "flag").into_any(),
+                };
+                kwargs.set_item("action", action)?;
+                rules.append(rule_cls.call((), Some(&kwargs))?)?;
+            }
+
+            let out = validate_mod.call_method1("validate_dataframe", (df, rules))?;
+            let valid_df = out.get_item(0)?;
+            let quarantine_df = out.get_item(1)?;
+            let report = out.get_item(2)?;
+
+            let result = PyDict::new(py);
+            result.set_item("report", report)?;
+            result.set_item("valid_rows", valid_df.getattr("height")?)?;
+            result.set_item("quarantine_rows", quarantine_df.getattr("height")?)?;
+            result.set_item("quarantine", quarantine_df.call_method0("to_dicts")?)?;
+            py_json_dumps(py, result.into_any())
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
+/// Wrap `goldenmatch.auto_fix_dataframe` -- apply auto-fixes to a table.
+/// `rows_json` is the table's records. Returns `{fixes, fixed_rows, rows}`
+/// JSON.
+pub fn autofix_table(rows_json: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let gm = py.import("goldenmatch")?;
+            let df = convert::json_to_polars_df(py, rows_json)?;
+            let out = gm.call_method1("auto_fix_dataframe", (df,))?;
+            let fixed_df = out.get_item(0)?;
+            let fixes = out.get_item(1)?;
+            let result = PyDict::new(py);
+            result.set_item("fixes", fixes)?;
+            result.set_item("fixed_rows", fixed_df.getattr("height")?)?;
+            result.set_item("rows", fixed_df.call_method0("to_dicts")?)?;
+            py_json_dumps(py, result.into_any())
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
+/// Wrap `goldenmatch.detect_anomalies` -- flag suspicious records in a table.
+/// `rows_json` is the table's records; `sensitivity` is `"low"`/`"medium"`/
+/// `"high"` (empty -> `"medium"`). Returns the JSON array of anomaly dicts.
+pub fn detect_anomalies(rows_json: &str, sensitivity: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let gm = py.import("goldenmatch")?;
+            let df = convert::json_to_polars_df(py, rows_json)?;
+            let sens = if sensitivity.is_empty() {
+                "medium"
+            } else {
+                sensitivity
+            };
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("sensitivity", sens)?;
+            let anomalies = gm.call_method("detect_anomalies", (df,), Some(&kwargs))?;
+            py_json_dumps(py, anomalies)
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
+/// Wrap `goldenmatch.core.autoconfig_verify.preflight` -- validate
+/// `(df, config)` before a run. `rows_json` is the table's records;
+/// `config_json` is a full `GoldenMatchConfig` JSON. Returns
+/// `{has_errors, config_was_modified, findings}` JSON.
+pub fn preflight(rows_json: &str, config_json: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let verify = py.import("goldenmatch.core.autoconfig_verify")?;
+            let dataclasses = py.import("dataclasses")?;
+            let df = convert::json_to_polars_df(py, rows_json)?;
+            let config = build_full_config(py, config_json)?;
+            let report = verify.call_method1("preflight", (df, config))?;
+
+            let findings = pyo3::types::PyList::empty(py);
+            for f in report.getattr("findings")?.try_iter()? {
+                findings.append(dataclasses.call_method1("asdict", (f?,))?)?;
+            }
+            let result = PyDict::new(py);
+            result.set_item("has_errors", report.getattr("has_errors")?)?;
+            result.set_item("config_was_modified", report.getattr("config_was_modified")?)?;
+            result.set_item("findings", findings)?;
+            py_json_dumps(py, result.into_any())
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
+/// Wrap `goldenmatch.core.autoconfig_verify.postflight` -- post-run signal
+/// report for `(df, config)`. `postflight` needs `pair_scores`, which aren't
+/// in the table, so we derive them SQL-naturally: run `dedupe_df` on the
+/// table with the given config and feed its `scored_pairs` to `postflight`
+/// (identical to `core_apis._postflight`). Returns
+/// `{signals, adjustments, advisories}` JSON.
+pub fn postflight(rows_json: &str, config_json: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let gm = py.import("goldenmatch")?;
+            let verify = py.import("goldenmatch.core.autoconfig_verify")?;
+            let dataclasses = py.import("dataclasses")?;
+            let df = convert::json_to_polars_df(py, rows_json)?;
+            let config = build_full_config(py, config_json)?;
+
+            let dedupe_kwargs = PyDict::new(py);
+            dedupe_kwargs.set_item("config", config.clone())?;
+            let dedupe_result =
+                gm.call_method("dedupe_df", (df.clone_ref(py),), Some(&dedupe_kwargs))?;
+            let scored_pairs = dedupe_result.getattr("scored_pairs")?;
+
+            let post_kwargs = PyDict::new(py);
+            post_kwargs.set_item("pair_scores", scored_pairs)?;
+            let report =
+                verify.call_method("postflight", (df, config), Some(&post_kwargs))?;
+
+            let adjustments = pyo3::types::PyList::empty(py);
+            for a in report.getattr("adjustments")?.try_iter()? {
+                adjustments.append(dataclasses.call_method1("asdict", (a?,))?)?;
+            }
+            let result = PyDict::new(py);
+            result.set_item("signals", report.getattr("signals")?)?;
+            result.set_item("adjustments", adjustments)?;
+            result.set_item("advisories", report.getattr("advisories")?)?;
+            py_json_dumps(py, result.into_any())
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
+/// Wrap Fellegi-Sunter `train_em`. `rows_json` is a JSON array of record
+/// objects (a small training set); `matchkey_json` is a probabilistic
+/// `MatchkeyConfig` JSON; `params_json` is an optional JSON object of
+/// train_em kwargs (`n_sample_pairs`, `max_iterations`, `convergence`,
+/// `seed`, `blocking_fields`; empty -> defaults). Returns the `EMResult` as
+/// JSON -- pass it straight to `score_probabilistic`.
+pub fn train_em(
+    rows_json: &str,
+    matchkey_json: &str,
+    params_json: &str,
+) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let schemas = py.import("goldenmatch.config.schemas")?;
+            let prob = py.import("goldenmatch.core.probabilistic")?;
+            let dataclasses = py.import("dataclasses")?;
+            let json_mod = py.import("json")?;
+            let builtins = py.import("builtins")?;
+
+            let df = build_probabilistic_frame(py, rows_json)?;
+            let mk_cls = schemas.getattr("MatchkeyConfig")?;
+            let mk = mk_cls.call_method1("model_validate_json", (matchkey_json,))?;
+
+            let params = if params_json.is_empty() {
+                builtins.call_method0("dict")?
+            } else {
+                json_mod.call_method1("loads", (params_json,))?
+            };
+            let allowed = [
+                "n_sample_pairs",
+                "max_iterations",
+                "convergence",
+                "seed",
+                "blocking_fields",
+            ];
+            let kwargs = PyDict::new(py);
+            for key in allowed {
+                if let Ok(v) = params.get_item(key) {
+                    if !v.is_none() {
+                        kwargs.set_item(key, v)?;
+                    }
+                }
+            }
+            let em = prob.call_method("train_em", (df, mk), Some(&kwargs))?;
+            let dict = dataclasses.call_method1("asdict", (em,))?;
+            py_json_dumps(py, dict)
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
+/// Wrap Fellegi-Sunter `score_probabilistic`. `rows_json` is a JSON array of
+/// record objects (the block to score); `matchkey_json` is the same
+/// probabilistic `MatchkeyConfig` used for training; `em_result_json` is the
+/// JSON produced by `train_em`. Returns a JSON array of `[a, b, score]`
+/// triples for pairs above the link threshold.
+pub fn score_probabilistic(
+    rows_json: &str,
+    matchkey_json: &str,
+    em_result_json: &str,
+) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let schemas = py.import("goldenmatch.config.schemas")?;
+            let prob = py.import("goldenmatch.core.probabilistic")?;
+            let json_mod = py.import("json")?;
+
+            let df = build_probabilistic_frame(py, rows_json)?;
+            let mk_cls = schemas.getattr("MatchkeyConfig")?;
+            let mk = mk_cls.call_method1("model_validate_json", (matchkey_json,))?;
+
+            let em_cls = prob.getattr("EMResult")?;
+            let em_dict = json_mod.call_method1("loads", (em_result_json,))?;
+            let em_kwargs = em_dict.downcast::<PyDict>().map_err(|e| {
+                BridgeError::PythonRuntime(format!("em_result_json must be a JSON object: {}", e))
+            })?;
+            let em = em_cls.call((), Some(em_kwargs))?;
+
+            let pairs = prob.call_method1("score_probabilistic", (df, mk, em))?;
+            // pairs is an iterable of (a, b, score) tuples -> JSON array of arrays.
+            let out = pyo3::types::PyList::empty(py);
+            for p in pairs.try_iter()? {
+                let p = p?;
+                let triple = pyo3::types::PyTuple::new(
+                    py,
+                    [p.get_item(0)?, p.get_item(1)?, p.get_item(2)?],
+                )?;
+                out.append(triple)?;
+            }
+            py_json_dumps(py, out.into_any())
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.1.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.1.0.sql
@@ -292,6 +292,140 @@ STRICT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'goldenmatch_identity_list_wrapper';
 
+-- ══════════════════════════════════════════════════════════════════════
+-- Core-API parity (mirrors duckdb/core_apis.py -- 13 UDFs)
+-- ══════════════════════════════════════════════════════════════════════
+-- Wrappers over goldenmatch's function-shaped core APIs. IDENTICAL JSON
+-- in / JSON out contract to the DuckDB `goldenmatch_*` core-API UDFs so the
+-- two backends are interchangeable. Table-input functions read the table via
+-- SPI (`row_to_json`, like goldenmatch_dedupe_table); JSON-in functions take
+-- the payloads directly. All read-only -- no REVOKE.
+
+-- Profile a table (column stats, types, quality signals) as JSON.
+CREATE FUNCTION "goldenmatch_profile_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_profile_table_wrapper';
+
+-- Otsu threshold over a JSON array of scores. Returns SQL NULL when the
+-- distribution is unimodal / too few scores.
+CREATE FUNCTION "goldenmatch_suggest_threshold"(
+    "scores_json" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_suggest_threshold_wrapper';
+
+-- Domain profile for a JSON array of column names, as JSON.
+CREATE FUNCTION "goldenmatch_detect_domain"(
+    "columns_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_domain_wrapper';
+
+-- Extract structured features from text. kind: product/electronics (default),
+-- software, biblio/bibliographic. Returns the features as JSON.
+CREATE FUNCTION "goldenmatch_extract_features"(
+    "text" TEXT,
+    "kind" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_extract_features_wrapper';
+
+-- Evaluate predicted pairs (JSON array) or clusters (JSON object) against a
+-- ground-truth JSON array of [a, b] pairs. Returns EvalResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_evaluate"(
+    "pairs_json" TEXT,
+    "ground_truth_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_evaluate_wrapper';
+
+-- CCMS comparison of two clusterings (JSON objects). Returns
+-- CompareResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_compare_clusters"(
+    "a_json" TEXT,
+    "b_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_compare_clusters_wrapper';
+
+-- Run validation rules (JSON array of ValidationRule) over a table. Returns
+-- {report, valid_rows, quarantine_rows, quarantine} JSON.
+CREATE FUNCTION "goldenmatch_validate_table"(
+    "table_name" TEXT,
+    "rules_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_validate_table_wrapper';
+
+-- Apply auto-fixes to a table. Returns {fixes, fixed_rows, rows} JSON.
+CREATE FUNCTION "goldenmatch_autofix_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autofix_table_wrapper';
+
+-- Flag suspicious records in a table. sensitivity: low/medium/high. Returns
+-- a JSON array of anomaly dicts.
+CREATE FUNCTION "goldenmatch_detect_anomalies"(
+    "table_name" TEXT,
+    "sensitivity" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_anomalies_wrapper';
+
+-- Validate (table, full GoldenMatchConfig JSON) before a run. Returns
+-- {has_errors, config_was_modified, findings} JSON.
+CREATE FUNCTION "goldenmatch_preflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_preflight_wrapper';
+
+-- Post-run signal report for (table, config). Derives pair_scores by running
+-- dedupe_df on the table. Returns {signals, adjustments, advisories} JSON.
+CREATE FUNCTION "goldenmatch_postflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_postflight_wrapper';
+
+-- Train Fellegi-Sunter m/u probabilities via EM. Returns the EMResult JSON;
+-- pass it straight to goldenmatch_score_probabilistic.
+CREATE FUNCTION "goldenmatch_train_em"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "params_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_train_em_wrapper';
+
+-- Score record pairs with trained Fellegi-Sunter probabilities. Returns a
+-- JSON array of [a, b, score] triples above the link threshold.
+CREATE FUNCTION "goldenmatch_score_probabilistic"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "em_result_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_probabilistic_wrapper';
+
 -- ─── Correction CRUD (v0.5.0, Phase 6A of #437 surface sync) ──────────
 --
 -- File pair-level / field-level / cluster-decision corrections into

--- a/packages/rust/extensions/postgres/src/core_apis.rs
+++ b/packages/rust/extensions/postgres/src/core_apis.rs
@@ -1,0 +1,276 @@
+//! Core-API parity functions for the goldenmatch Postgres extension.
+//!
+//! Mirrors the 13 DuckDB UDFs in
+//! `packages/rust/extensions/duckdb/goldenmatch_duckdb/core_apis.py` so the
+//! Postgres and DuckDB SQL surfaces expose the same goldenmatch core APIs
+//! with an IDENTICAL JSON in / JSON out contract.
+//!
+//! Each function wraps a `goldenmatch_bridge::api::*` fn (added alongside
+//! this module). The bridge handles the pyo3 dispatch + JSON conversion;
+//! this module is the SQL surface.
+//!
+//! ## Conventions (match `quick.rs`)
+//! - Table-input functions take a `table_name TEXT` and read it via
+//!   `spi::read_table_as_json` (the same `row_to_json` SPI path as
+//!   `goldenmatch_dedupe_table`), then forward the records JSON to the bridge.
+//! - JSON-in functions take the JSON payloads directly as `TEXT`.
+//! - Outputs are JSON `TEXT` (the bridge already does `json.dumps`), except
+//!   `goldenmatch_suggest_threshold` which returns `Option<f64>` so it can
+//!   emit SQL NULL for unimodal / too-few-scores inputs.
+//! - The bridge fns are fail-soft (they return `{"error": ...}` JSON instead
+//!   of raising on bad input / optional-dep failure), matching the DuckDB
+//!   UDFs. A genuine `BridgeError` (e.g. goldenmatch not importable) still
+//!   surfaces via `pgrx::error!`.
+
+use pgrx::prelude::*;
+
+use crate::spi;
+
+// ── Profiling / threshold / domain ──────────────────────────────────────
+
+/// Profile a Postgres table (column stats, types, quality signals).
+/// Wraps `goldenmatch.profile_dataframe`. Returns the profile report as JSON.
+///
+/// ```sql
+/// SELECT goldenmatch_profile_table('customers');
+/// ```
+#[pg_extern]
+pub fn goldenmatch_profile_table(table_name: String) -> String {
+    let rows_json =
+        spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+    match goldenmatch_bridge::api::profile_table(&rows_json) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Suggest an Otsu match-threshold over a JSON array of scores.
+/// Wraps `goldenmatch.suggest_threshold`. Returns SQL NULL when the score
+/// distribution is unimodal or there are too few scores.
+///
+/// ```sql
+/// SELECT goldenmatch_suggest_threshold('[0.1, 0.2, 0.85, 0.9, 0.95]');
+/// ```
+#[pg_extern]
+pub fn goldenmatch_suggest_threshold(scores_json: String) -> Option<f64> {
+    match goldenmatch_bridge::api::suggest_threshold(&scores_json) {
+        Ok(value) => value,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Detect the data domain for a JSON array of column names.
+/// Wraps `goldenmatch.core.domain.detect_domain`. Returns the domain profile
+/// dataclass as JSON.
+///
+/// ```sql
+/// SELECT goldenmatch_detect_domain('["sku", "product_name", "price"]');
+/// ```
+#[pg_extern]
+pub fn goldenmatch_detect_domain(columns_json: String) -> String {
+    match goldenmatch_bridge::api::detect_domain(&columns_json) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Extract structured features from a free-text value. `kind` selects the
+/// extractor: `product`/`electronics` (default), `software`, or
+/// `biblio`/`bibliographic`. Wraps the `extract_*_features` functions.
+/// Returns the features as JSON.
+///
+/// ```sql
+/// SELECT goldenmatch_extract_features('iPhone 13 Pro 256GB', 'product');
+/// ```
+#[pg_extern]
+pub fn goldenmatch_extract_features(text: String, kind: String) -> String {
+    match goldenmatch_bridge::api::extract_features(&text, &kind) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+// ── Evaluation / cluster comparison ─────────────────────────────────────
+
+/// Evaluate predicted pairs/clusters against ground truth.
+/// `pairs_json` is a JSON array of `[a, b, score]` triples (-> evaluate_pairs)
+/// OR a JSON object `{cluster_id: {"members": [...]}}` (-> evaluate_clusters).
+/// `ground_truth_json` is a JSON array of `[a, b]` pairs. Returns the
+/// `EvalResult.summary()` (tp/fp/fn/precision/recall/f1/...) as JSON.
+///
+/// ```sql
+/// SELECT goldenmatch_evaluate('[[1,2,0.9],[3,4,0.8]]', '[[1,2]]');
+/// ```
+#[pg_extern]
+pub fn goldenmatch_evaluate(pairs_json: String, ground_truth_json: String) -> String {
+    match goldenmatch_bridge::api::evaluate(&pairs_json, &ground_truth_json) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Compare two clusterings via CCMS. Both args are JSON objects of
+/// `{cluster_id: {"members": [...]}}`. Wraps `goldenmatch.compare_clusters`.
+/// Returns the `CompareResult.summary()` (TWI + case counts) as JSON.
+///
+/// ```sql
+/// SELECT goldenmatch_compare_clusters(
+///     '{"1": {"members": [1, 2]}}',
+///     '{"1": {"members": [1, 2, 3]}}'
+/// );
+/// ```
+#[pg_extern]
+pub fn goldenmatch_compare_clusters(a_json: String, b_json: String) -> String {
+    match goldenmatch_bridge::api::compare_clusters(&a_json, &b_json) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+// ── Data-quality (validate / autofix / anomalies) ───────────────────────
+
+/// Run validation rules over a Postgres table.
+/// `rules_json` is a JSON array of rule objects matching the `ValidationRule`
+/// dataclass: `{"column", "rule_type", "params", "action"}`. Wraps
+/// `goldenmatch.core.validate.validate_dataframe`. Returns
+/// `{report, valid_rows, quarantine_rows, quarantine}` as JSON.
+///
+/// ```sql
+/// SELECT goldenmatch_validate_table(
+///     'customers',
+///     '[{"column": "email", "rule_type": "not_null", "action": "flag"}]'
+/// );
+/// ```
+#[pg_extern]
+pub fn goldenmatch_validate_table(table_name: String, rules_json: String) -> String {
+    let rows_json =
+        spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+    match goldenmatch_bridge::api::validate_table(&rows_json, &rules_json) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Apply auto-fixes to a Postgres table. Wraps `goldenmatch.auto_fix_dataframe`.
+/// Returns `{fixes, fixed_rows, rows}` as JSON.
+///
+/// ```sql
+/// SELECT goldenmatch_autofix_table('customers');
+/// ```
+#[pg_extern]
+pub fn goldenmatch_autofix_table(table_name: String) -> String {
+    let rows_json =
+        spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+    match goldenmatch_bridge::api::autofix_table(&rows_json) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Flag suspicious records in a Postgres table. `sensitivity` is
+/// `low`/`medium`/`high` (empty -> `medium`). Wraps
+/// `goldenmatch.detect_anomalies`. Returns a JSON array of anomaly dicts.
+///
+/// ```sql
+/// SELECT goldenmatch_detect_anomalies('customers', 'high');
+/// ```
+#[pg_extern]
+pub fn goldenmatch_detect_anomalies(table_name: String, sensitivity: String) -> String {
+    let rows_json =
+        spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+    match goldenmatch_bridge::api::detect_anomalies(&rows_json, &sensitivity) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+// ── AutoConfig verify (preflight / postflight) ──────────────────────────
+
+/// Validate a `(table, config)` pair before a dedupe run.
+/// `config_json` is a full `GoldenMatchConfig` JSON. Wraps
+/// `goldenmatch.core.autoconfig_verify.preflight`. Returns
+/// `{has_errors, config_was_modified, findings}` as JSON.
+///
+/// ```sql
+/// SELECT goldenmatch_preflight('customers', goldenmatch_autoconfig('customers'));
+/// ```
+#[pg_extern]
+pub fn goldenmatch_preflight(table_name: String, config_json: String) -> String {
+    let rows_json =
+        spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+    match goldenmatch_bridge::api::preflight(&rows_json, &config_json) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Post-run signal report for a `(table, config)` pair. Derives `pair_scores`
+/// by running `dedupe_df` on the table with the given config (postflight
+/// needs scored pairs not present in the table), then feeds them to
+/// `goldenmatch.core.autoconfig_verify.postflight`. Returns
+/// `{signals, adjustments, advisories}` as JSON.
+///
+/// ```sql
+/// SELECT goldenmatch_postflight('customers', goldenmatch_autoconfig('customers'));
+/// ```
+#[pg_extern]
+pub fn goldenmatch_postflight(table_name: String, config_json: String) -> String {
+    let rows_json =
+        spi::read_table_as_json(&table_name).unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+    match goldenmatch_bridge::api::postflight(&rows_json, &config_json) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+// ── Fellegi-Sunter probabilistic ────────────────────────────────────────
+
+/// Train Fellegi-Sunter m/u probabilities via EM.
+/// `rows_json` is a JSON array of record objects (a small training set);
+/// `matchkey_json` is a probabilistic `MatchkeyConfig` JSON; `params_json`
+/// is an optional JSON object of train_em kwargs (`n_sample_pairs`,
+/// `max_iterations`, `convergence`, `seed`, `blocking_fields`; pass `''` or
+/// `'{}'` for defaults). Returns the `EMResult` as JSON -- pass it straight
+/// to `goldenmatch_score_probabilistic`.
+///
+/// ```sql
+/// SELECT goldenmatch_train_em(
+///     '[{"name": "John"}, {"name": "Jon"}]',
+///     '{"name": "mk", "type": "probabilistic", "fields": [{"field": "name", "comparison": "jaro_winkler"}]}',
+///     '{}'
+/// );
+/// ```
+#[pg_extern]
+pub fn goldenmatch_train_em(
+    rows_json: String,
+    matchkey_json: String,
+    params_json: String,
+) -> String {
+    match goldenmatch_bridge::api::train_em(&rows_json, &matchkey_json, &params_json) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Score record pairs with trained Fellegi-Sunter probabilities.
+/// `rows_json` is a JSON array of record objects (the block to score);
+/// `matchkey_json` is the same probabilistic `MatchkeyConfig` used for
+/// training; `em_result_json` is the JSON produced by
+/// `goldenmatch_train_em`. Returns a JSON array of `[a, b, score]` triples
+/// for pairs above the link threshold.
+///
+/// ```sql
+/// SELECT goldenmatch_score_probabilistic(rows_json, matchkey_json, em_json);
+/// ```
+#[pg_extern]
+pub fn goldenmatch_score_probabilistic(
+    rows_json: String,
+    matchkey_json: String,
+    em_result_json: String,
+) -> String {
+    match goldenmatch_bridge::api::score_probabilistic(&rows_json, &matchkey_json, &em_result_json)
+    {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}

--- a/packages/rust/extensions/postgres/src/lib.rs
+++ b/packages/rust/extensions/postgres/src/lib.rs
@@ -2,6 +2,7 @@ use pgrx::prelude::*;
 
 pgrx::pg_module_magic!();
 
+mod core_apis;
 mod correction;
 mod pipeline;
 mod quick;


### PR DESCRIPTION
Brings the **Postgres (pgrx) extension** to parity with the 13 DuckDB core-API UDFs from #477, so both SQL surfaces expose the same goldenmatch core APIs.

## What's added (each = bridge fn + `#[pg_extern]` + hand-written SQL)
13 functions mirroring `duckdb/.../core_apis.py` 1:1 (same JSON in/out contract): `goldenmatch_profile_table`, `_suggest_threshold`, `_detect_domain`, `_extract_features`, `_evaluate`, `_compare_clusters`, `_validate_table`, `_autofix_table`, `_detect_anomalies`, `_preflight`, `_postflight`, `_train_em`, `_score_probabilistic`.

- **`bridge/src/api.rs`** — 13 pyo3 wrappers (call goldenmatch via `Python::with_gil`, JSON↔Polars via the existing convert helpers, fail-soft `{"error":...}`), mirroring the existing `dedupe`/`autoconfig`/`score` wrappers.
- **`postgres/src/core_apis.rs`** (new module, registered in `lib.rs`) — 13 `#[pg_extern]`s. Table-input fns read via `spi::read_table_as_json` (same as `goldenmatch_dedupe_table`); JSON-in fns pass through. All read-only.
- **`postgres/sql/goldenmatch_pg--0.1.0.sql`** — 13 hand-written `CREATE FUNCTION` entries (pgrx 0.12.9 doesn't autogen); verified 1:1 against the pg_externs (names, arg/return types, arities).

## Verification
- **Bridge crate (locally verifiable):** `cargo check -p goldenmatch-bridge` ✅, `cargo clippy --workspace -- -D warnings` ✅, `cargo test --workspace` ✅.
- **pgrx `postgres` crate: CI-only.** It's excluded from the workspace and needs `cargo pgrx` + Postgres + libclang, which aren't available in the dev sandbox — so it's validated by the **`rust_pgrx` CI lane (PG 15/16/17)**. I wrote it by faithfully mirroring `quick.rs`/`correction.rs`; expect this PR to iterate through that lane.

## Notes for review
- `goldenmatch_suggest_threshold` returns `Option<f64>` → `RETURNS DOUBLE PRECISION` + `STRICT` (it can return NULL from the body on unimodal/too-few input; STRICT only governs NULL *inputs*).
- `train_em` skips JSON-`null` params keys (behaviorally identical to forwarding `None` for the optional kwargs).

Scope: `bridge/` + `postgres/` only. No `duckdb/`, workflow, or version edits. The `goldenflow_*`→Postgres transforms remain a deferred follow-up.

Draft until the `rust_pgrx` lane is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx)_