### PR TITLE
feat(postgres): goldenflow_* transforms — full DuckDB↔Postgres parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,9 +644,10 @@ jobs:
 
       - name: Install goldenmatch (Python bridge target)
         # The pgrx extension embeds Python via pyo3 and imports goldenmatch
-        # at runtime. The package install here is what `init()` in the
+        # (and goldenflow, for the goldenflow_* transform functions) at
+        # runtime. The package install here is what `init()` in the
         # bridge will find when Postgres starts.
-        run: pip install --break-system-packages goldenmatch>=1.1.0 pyarrow
+        run: pip install --break-system-packages goldenmatch>=1.1.0 goldenflow pyarrow
 
       - name: Install cargo-pgrx
         # 0.12.9 pin matches the pgrx version in
@@ -675,7 +676,7 @@ jobs:
         run: |
           PYTHON_SITE=$(python -c "import site; print(site.getsitepackages()[0])")
           sudo rm -f /usr/lib/python3/dist-packages/typing_extensions.py
-          sudo pip install --break-system-packages goldenmatch>=1.1.0 2>/dev/null || true
+          sudo pip install --break-system-packages goldenmatch>=1.1.0 goldenflow 2>/dev/null || true
           echo "${PYTHON_SITE}" | sudo tee /usr/lib/python3/dist-packages/goldenmatch.pth
 
       - name: psql smoke (scalar scorer, dedupe, autoconfig)
@@ -692,6 +693,8 @@ jobs:
           # Confirm new v1.7-v1.12 functions registered alongside the originals.
           sudo -u postgres psql -p "${PGPORT}" -c "SELECT proname FROM pg_proc WHERE proname LIKE 'goldenmatch%' OR proname LIKE 'gm_%' ORDER BY proname;"
           sudo -u postgres psql -p "${PGPORT}" -v ON_ERROR_STOP=1 -c "SELECT goldenmatch.goldenmatch_score('John Smith'::TEXT, 'Jon Smyth'::TEXT, 'jaro_winkler'::TEXT);"
+          # goldenflow_* transforms (fail-open: pass input through if goldenflow absent).
+          sudo -u postgres psql -p "${PGPORT}" -v ON_ERROR_STOP=1 -c "SELECT goldenmatch.goldenflow_normalize_email('  John@Example.COM '::TEXT), goldenmatch.goldenflow_whitespace_normalize('a   b'::TEXT);"
           sudo -u postgres psql -p "${PGPORT}" -v ON_ERROR_STOP=1 <<'EOSQL'
             CREATE TABLE test_customers (name TEXT, email TEXT);
             INSERT INTO test_customers VALUES

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -1541,6 +1541,92 @@ pub fn score_probabilistic(
     })
 }
 
+// ─── GoldenFlow transforms (mirrors duckdb/goldenflow.py) ────────────────
+//
+// Single-value wrappers over `goldenflow.transforms.get_transform`, exposing
+// the same 8 transforms the DuckDB `goldenflow_*` UDFs register. The Postgres
+// extension layers 8 fixed-name scalar functions on top of this one generic
+// bridge fn.
+//
+// Fail-open contract (identical to the DuckDB UDF in
+// `goldenmatch_duckdb/goldenflow.py::_wrap_series_transform`): if goldenflow
+// (or polars) isn't importable, or the named transform is missing, or the
+// transform errors on the value, we return the *input value unchanged*
+// rather than raising. That keeps a `SELECT goldenflow_*(...)` query alive on
+// environments that didn't `pip install goldenflow`.
+
+/// Apply a single goldenflow Series-level transform to one string value.
+///
+/// `transform_name` is the underlying goldenflow registry key (e.g.
+/// `email_normalize`); `value` is the single input. Builds a 1-element
+/// `pl.Series`, dispatches through `goldenflow`'s transform registry, and
+/// unboxes the result -- the cheapest path to byte-equality with the DuckDB
+/// sibling and the Python transform itself.
+///
+/// **Fail-open**: returns `value` unchanged on ImportError / missing transform
+/// / any transform error. Never raises a `BridgeError` for those cases.
+pub fn goldenflow_transform(transform_name: &str, value: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+
+    Python::with_gil(|py| {
+        // fail-open closure: on any pyo3 error inside, fall back to the input.
+        let applied: Option<String> = (|| -> Result<Option<String>, BridgeError> {
+            // Lazy import: goldenflow + polars may be absent. Treat as
+            // pass-through (mirror the DuckDB `except ImportError: return value`).
+            let pl = match py.import("polars") {
+                Ok(m) => m,
+                Err(_) => return Ok(None),
+            };
+            let transforms = match py.import("goldenflow.transforms") {
+                Ok(m) => m,
+                Err(_) => return Ok(None),
+            };
+
+            let info = transforms.call_method1("get_transform", (transform_name,))?;
+            if info.is_none() {
+                return Ok(None); // unknown transform -> pass through
+            }
+
+            let mode: String = info.getattr("mode")?.extract()?;
+            let func = info.getattr("func")?;
+
+            // series = pl.Series([value])
+            let values = pyo3::types::PyList::new(py, [value])?;
+            let series = pl.call_method1("Series", (values,))?;
+
+            let out = match mode.as_str() {
+                "series" => func.call1((series,))?,
+                "expr" => {
+                    // expr-mode transforms take a column name; build a tiny
+                    // 1-col frame, apply, extract the column (mirror DuckDB).
+                    let frame_data = PyDict::new(py);
+                    frame_data.set_item("v", series)?;
+                    let df = pl.call_method1("DataFrame", (frame_data,))?;
+                    let expr = func.call1(("v",))?;
+                    let aliased = expr.call_method1("alias", ("v",))?;
+                    let df = df.call_method1("with_columns", (aliased,))?;
+                    df.get_item("v")?
+                }
+                // dataframe-mode -- not applicable to single-value calls.
+                _ => return Ok(None),
+            };
+
+            let result = out.get_item(0)?;
+            if result.is_none() {
+                // goldenflow produced NULL for this value -> pass input through.
+                // (Postgres side is STRICT, so a non-NULL in never maps to a
+                // NULL out via this path; preserve the input to be safe.)
+                return Ok(None);
+            }
+            let s: String = py.import("builtins")?.call_method1("str", (result,))?.extract()?;
+            Ok(Some(s))
+        })()
+        .unwrap_or(None);
+
+        Ok(applied.unwrap_or_else(|| value.to_string()))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.1.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.1.0.sql
@@ -515,3 +515,76 @@ GRANT EXECUTE ON FUNCTION goldenmatch.correction_add(
 REVOKE EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) TO goldenmatch_correction_writer;
 GRANT SELECT ON goldenmatch.corrections TO goldenmatch_correction_writer;
+
+-- ─── GoldenFlow transforms (src/goldenflow.rs) ────────────────────────────
+--
+-- 8 scalar text -> text wrappers over goldenflow's transform registry,
+-- mirroring the DuckDB goldenflow_* UDFs (goldenmatch_duckdb/goldenflow.py).
+-- Closes the last DuckDB <-> Postgres parity gap. All STRICT (NULL in -> NULL
+-- out); the bridge fails open (passes the input through unchanged when
+-- goldenflow isn't installed / the transform errors), so these are read-only
+-- and safe for PUBLIC -- no REVOKE.
+
+-- Normalize an email address. Wraps goldenflow `email_normalize`.
+CREATE FUNCTION "goldenflow_normalize_email"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_email_wrapper';
+
+-- Normalize a phone number to E.164. Wraps goldenflow `phone_e164`.
+CREATE FUNCTION "goldenflow_normalize_phone"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_phone_wrapper';
+
+-- Normalize a date to ISO-8601. Wraps goldenflow `date_iso8601`.
+CREATE FUNCTION "goldenflow_normalize_date"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_date_wrapper';
+
+-- Proper-case a personal name. Wraps goldenflow `name_proper`.
+CREATE FUNCTION "goldenflow_normalize_name_proper"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_name_proper_wrapper';
+
+-- Canonicalize a URL. Wraps goldenflow `url_normalize`.
+CREATE FUNCTION "goldenflow_canonicalize_url"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_url_wrapper';
+
+-- Standardize a postal address. Wraps goldenflow `address_standardize`.
+CREATE FUNCTION "goldenflow_canonicalize_address"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_address_wrapper';
+
+-- Strip leading/trailing whitespace. Wraps goldenflow `strip`.
+CREATE FUNCTION "goldenflow_strip"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_strip_wrapper';
+
+-- Collapse internal whitespace runs. Wraps goldenflow `collapse_whitespace`.
+CREATE FUNCTION "goldenflow_whitespace_normalize"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_whitespace_normalize_wrapper';

--- a/packages/rust/extensions/postgres/src/goldenflow.rs
+++ b/packages/rust/extensions/postgres/src/goldenflow.rs
@@ -1,0 +1,128 @@
+//! GoldenFlow transform functions for the goldenmatch Postgres extension.
+//!
+//! Mirrors the 8 DuckDB `goldenflow_*` UDFs in
+//! `packages/rust/extensions/duckdb/goldenmatch_duckdb/goldenflow.py` so the
+//! Postgres and DuckDB SQL surfaces expose the same goldenflow transforms with
+//! identical semantics -- closing the last DuckDB <-> Postgres parity gap.
+//!
+//! Each function is a scalar `text -> text` wrapper over the single generic
+//! bridge fn `goldenmatch_bridge::api::goldenflow_transform`, passing its fixed
+//! goldenflow registry key (e.g. `email_normalize`). The mapping of pg_extern
+//! name -> transform key matches the DuckDB `_UDF_REGISTRY` exactly:
+//!
+//! | pg_extern                          | goldenflow transform   |
+//! |------------------------------------|------------------------|
+//! | `goldenflow_normalize_email`       | `email_normalize`      |
+//! | `goldenflow_normalize_phone`       | `phone_e164`           |
+//! | `goldenflow_normalize_date`        | `date_iso8601`         |
+//! | `goldenflow_normalize_name_proper` | `name_proper`          |
+//! | `goldenflow_canonicalize_url`      | `url_normalize`        |
+//! | `goldenflow_canonicalize_address`  | `address_standardize`  |
+//! | `goldenflow_strip`                 | `strip`                |
+//! | `goldenflow_whitespace_normalize`  | `collapse_whitespace`  |
+//!
+//! ## Fail-open contract
+//! The bridge fn passes the input through unchanged when goldenflow isn't
+//! importable, the transform is missing, or the transform errors -- it never
+//! raises for those. A genuine `BridgeError` (e.g. goldenmatch/CPython init
+//! failure) still surfaces via `pgrx::error!`. The SQL functions are `STRICT`
+//! (NULL input -> NULL output) so these wrappers always receive a real string.
+
+use pgrx::prelude::*;
+
+/// Apply one named goldenflow transform to a single value via the bridge.
+/// Centralises the `Result` handling so each `#[pg_extern]` stays a one-liner.
+fn apply(transform_name: &str, value: String) -> String {
+    match goldenmatch_bridge::api::goldenflow_transform(transform_name, &value) {
+        Ok(out) => out,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Normalize an email address (lowercase, trim, provider canonicalisation).
+/// Wraps the goldenflow `email_normalize` transform.
+///
+/// ```sql
+/// SELECT goldenflow_normalize_email('  John.Doe@Example.COM ');
+/// ```
+#[pg_extern]
+pub fn goldenflow_normalize_email(value: String) -> String {
+    apply("email_normalize", value)
+}
+
+/// Normalize a phone number to E.164 form.
+/// Wraps the goldenflow `phone_e164` transform.
+///
+/// ```sql
+/// SELECT goldenflow_normalize_phone('(555) 123-4567');
+/// ```
+#[pg_extern]
+pub fn goldenflow_normalize_phone(value: String) -> String {
+    apply("phone_e164", value)
+}
+
+/// Normalize a date to ISO-8601 (`YYYY-MM-DD`).
+/// Wraps the goldenflow `date_iso8601` transform.
+///
+/// ```sql
+/// SELECT goldenflow_normalize_date('03/14/2025');
+/// ```
+#[pg_extern]
+pub fn goldenflow_normalize_date(value: String) -> String {
+    apply("date_iso8601", value)
+}
+
+/// Proper-case a personal name.
+/// Wraps the goldenflow `name_proper` transform.
+///
+/// ```sql
+/// SELECT goldenflow_normalize_name_proper('JOHN MCDONALD');
+/// ```
+#[pg_extern]
+pub fn goldenflow_normalize_name_proper(value: String) -> String {
+    apply("name_proper", value)
+}
+
+/// Canonicalize a URL (scheme/host lowercasing, tracking-param stripping).
+/// Wraps the goldenflow `url_normalize` transform.
+///
+/// ```sql
+/// SELECT goldenflow_canonicalize_url('HTTP://Example.com/Path/');
+/// ```
+#[pg_extern]
+pub fn goldenflow_canonicalize_url(value: String) -> String {
+    apply("url_normalize", value)
+}
+
+/// Standardize a postal address.
+/// Wraps the goldenflow `address_standardize` transform.
+///
+/// ```sql
+/// SELECT goldenflow_canonicalize_address('123 main st. apt 4');
+/// ```
+#[pg_extern]
+pub fn goldenflow_canonicalize_address(value: String) -> String {
+    apply("address_standardize", value)
+}
+
+/// Strip leading/trailing whitespace.
+/// Wraps the goldenflow `strip` transform.
+///
+/// ```sql
+/// SELECT goldenflow_strip('  hello  ');
+/// ```
+#[pg_extern]
+pub fn goldenflow_strip(value: String) -> String {
+    apply("strip", value)
+}
+
+/// Collapse internal runs of whitespace to a single space.
+/// Wraps the goldenflow `collapse_whitespace` transform.
+///
+/// ```sql
+/// SELECT goldenflow_whitespace_normalize('a    b   c');
+/// ```
+#[pg_extern]
+pub fn goldenflow_whitespace_normalize(value: String) -> String {
+    apply("collapse_whitespace", value)
+}

--- a/packages/rust/extensions/postgres/src/lib.rs
+++ b/packages/rust/extensions/postgres/src/lib.rs
@@ -4,6 +4,7 @@ pgrx::pg_module_magic!();
 
 mod core_apis;
 mod correction;
+mod goldenflow;
 mod pipeline;
 mod quick;
 mod spi;


### PR DESCRIPTION
Closes the last DuckDB↔Postgres parity gap by adding the **8 `goldenflow_*` transform functions** to the Postgres pgrx extension (they already exist on DuckDB).

## What's added
- **`bridge/src/api.rs`** — one fail-open `goldenflow_transform(name, value) -> String` (pyo3: imports `goldenflow.transforms.get_transform`, applies to a 1-element series, dispatches series/expr/dataframe modes; on ImportError/error/NULL → returns input unchanged). Mirrors `duckdb/.../goldenflow.py::_wrap_series_transform` exactly.
- **`postgres/src/goldenflow.rs`** (new, registered in `lib.rs`) — 8 scalar `text→text` `#[pg_extern]`s named to match the DuckDB UDFs: `goldenflow_normalize_email`/`_phone`/`_date`/`_name_proper`, `_canonicalize_url`/`_address`, `_strip`, `_whitespace_normalize` → goldenflow `email_normalize`/`phone_e164`/`date_iso8601`/`name_proper`/`url_normalize`/`address_standardize`/`strip`/`collapse_whitespace`.
- **`goldenmatch_pg--0.1.0.sql`** — 8 matching `CREATE FUNCTION (value TEXT) RETURNS TEXT STRICT` entries (1:1 with the pg_externs).
- **`ci.yml` (`rust_pgrx` lane)** — installs `goldenflow` into Postgres's embedded Python (both the pip + dist-packages-exposure steps) and smokes two transforms in the psql step.

## Verification
- Bridge (locally verifiable): `cargo check -p goldenmatch-bridge` ✅, `cargo clippy --workspace -- -D warnings` ✅.
- pgrx crate + SQL + the goldenflow runtime path: validated by the **`rust_pgrx` CI lane (PG 15/16/17)** — fail-open means the smoke passes even if goldenflow import has issues, and the install step provides it.

This brings **Postgres ↔ DuckDB to full parity** (core APIs from #477/#478 + these transforms). Scope: `bridge/` + `postgres/` + the rust_pgrx CI lane only. No version bump.

Draft until `rust_pgrx` is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx)_