### PR TITLE
chore(extensions): release-prep — goldenmatch-duckdb 0.4.0; goldenmatch_pg ready at v0.5.0

### DIFF
--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/__init__.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/__init__.py
@@ -16,7 +16,7 @@ Usage:
     # Deduplicate a table
     con.sql("SELECT goldenmatch_dedupe_table('customers', '{\"exact\": [\"email\"]}')")
 """
-__version__ = "0.2.0"
+__version__ = "0.4.0"
 
 import duckdb
 

--- a/packages/rust/extensions/duckdb/pyproject.toml
+++ b/packages/rust/extensions/duckdb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenmatch-duckdb"
-version = "0.3.0"
+version = "0.4.0"
 description = "GoldenMatch entity resolution functions for DuckDB"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "goldenmatch>=1.1.0",
+    "goldenmatch>=1.15.0",
     "duckdb>=1.0",
     "pyarrow>=14.0",
 ]


### PR DESCRIPTION
Release-prep for both SQL extensions so the new parity functions (#477/#478/#479) reach users.

## goldenmatch-duckdb (PyPI) — needs a bump
Last release was `goldenmatch-duckdb-v0.3.0` (= current pyproject), so it must bump to publish the **13 new core-API UDFs**:
- `pyproject.toml`: `0.3.0` → **`0.4.0`**
- `__init__.py`: `__version__` `0.2.0` → `0.4.0` (it had drifted — was stale even at the 0.3.0 release)
- dependency floor: `goldenmatch>=1.1.0` → **`>=1.15.0`** — the package already needs 1.15+ for its identity UDFs, and the new `preflight`/`postflight`/`compare_clusters` wraps need a recent goldenmatch too. 1.15.0 is satisfiable on PyPI.

**To publish:** create a release tagged `goldenmatch-duckdb-v0.4.0` (or run `publish-goldenmatch-duckdb.yml` via dispatch). It verifies tag == pyproject version, then builds + PyPI.

## goldenmatch_pg (Postgres) — already release-ready, no code change
Last release was `goldenmatch-pg-v0.4.0`; the crate is already at the **unreleased `0.5.0`**, and all **21 new parity functions** (13 core-API + 8 goldenflow) are in `sql/goldenmatch_pg--0.1.0.sql` on main. So nothing to bump.

**To publish:** create a GitHub release tagged **`goldenmatch-pg-v0.5.0`** (matches Cargo.toml — the workflow verifies that) or run `publish-goldenmatch-pg.yml` via dispatch → it runs `cargo pgrx package` and uploads the `.so` + `.control` + SQL artifacts for PG 15/16/17.

*(Note: the extension's internal SQL version stays `0.1.0` — that's the long-standing scheme here; the crate version is what the release tag tracks. Reworking the pgrx `default_version`/upgrade-script scheme is a separate, larger change I deliberately didn't fold in.)*

Scope: DuckDB package metadata only. No Postgres/bridge code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx)_