### PR TITLE
docs: SQL-extensions + full-npm-suite surface — READMEs, examples, wiki, About

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ flowchart LR
 - **Privacy-preserving record linkage** — match across organizations without sharing raw data (PPRL, 92.4% F1 on FEBRL4).
 - **AI-native by design** — every package ships an MCP server, a REST API, and an A2A agent surface. 36+ MCP tools across the suite, including `auto_configure` + `controller_telemetry` for v1.7-v1.12 introspection.
 - **AutoConfigController visible everywhere** (v1.7-v1.12 surface-parity arc) — web `ControllerPanel`, TUI `Ctrl+A`, CLI `goldenmatch autoconfig`, REST `/autoconfig` + `/controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDFs, MCP/A2A telemetry tools. One JSON shape across every interface.
-- **Polyglot parity** — Python and TypeScript implementations track the same scorer outputs to 4-decimal precision via a parity harness.
+- **Polyglot parity** — the full suite ships on **npm** (goldenmatch, goldencheck, goldenflow, infermap, goldenpipe) alongside PyPI; the TypeScript and Python implementations track the same outputs to 4-decimal precision via a cross-language parity harness.
+- **SQL-native, both engines at parity** — the same functions run inside **PostgreSQL** (pgrx extension) and **DuckDB**: dedupe / match / score / auto-config + telemetry / identity graph, plus data profiling, `evaluate`, Fellegi-Sunter probabilistic scoring, and GoldenFlow transforms.
 - **Production paths** — Postgres sync, daemon mode, lineage tracking, review queues, dbt integration, GitHub Actions, and a Rust extension layer for Postgres / DuckDB.
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,8 @@ Runnable demos for the Golden Suite, organized by host.
 | Directory | Audience | Highlights |
 |---|---|---|
 | [`python/`](python/README.md) | Python users | 6 scripts: zero-config quickstart, full Suite composed, customer 360, PPRL, review workflow, MCP client. |
-| [`typescript/`](typescript/README.md) | TypeScript / edge users | 3 scripts: quickstart, Vercel-Edge route, MCP client. |
+| [`typescript/`](typescript/README.md) | TypeScript / edge users | 4 scripts: quickstart, Vercel-Edge route, MCP client, goldenpipe orchestration. |
+| [`sql/`](sql/README.md) | SQL / warehouse users | DuckDB + Postgres core-API + GoldenFlow examples (profile, evaluate, suggest threshold, normalize). |
 | [`airflow/`](airflow/README.md) | Data-platform users | 12 drop-in DAGs: daily/incremental/warehouse-native dedupe, customer 360, PPRL, schema align + drift alarm, quality gate, review worker, active learning, reverse ETL, backfill. |
 
 ## Where to start
@@ -15,7 +16,8 @@ Runnable demos for the Golden Suite, organized by host.
 - **Unifying customers across systems?** → [`python/03_multi_source_unify.py`](python/03_multi_source_unify.py) (in-process), [`airflow/golden_suite_customer_360.py`](airflow/golden_suite_customer_360.py) (production).
 - **Linking across organizations?** → [`python/04_pprl_two_party.py`](python/04_pprl_two_party.py), [`airflow/golden_suite_pprl_linkage.py`](airflow/golden_suite_pprl_linkage.py).
 - **Calling the suite from Claude / agents?** → run the [`goldensuite-mcp`](../packages/python/goldensuite-mcp/README.md) container, then point an MCP client at it: [`python/06_mcp_client.py`](python/06_mcp_client.py) or [`typescript/03-mcp-client.ts`](typescript/03-mcp-client.ts).
-- **TypeScript / edge runtime?** → [`typescript/01-quickstart.ts`](typescript/01-quickstart.ts), [`typescript/02-edge-runtime.ts`](typescript/02-edge-runtime.ts).
+- **TypeScript / edge runtime?** → [`typescript/01-quickstart.ts`](typescript/01-quickstart.ts), [`typescript/02-edge-runtime.ts`](typescript/02-edge-runtime.ts). Orchestrating the whole suite? → [`typescript/04-goldenpipe-orchestration.ts`](typescript/04-goldenpipe-orchestration.ts).
+- **Working in SQL / a warehouse?** → [`sql/duckdb_core_apis.sql`](sql/duckdb_core_apis.sql) or [`sql/postgres_core_apis.sql`](sql/postgres_core_apis.sql) for the SQL-native core API + GoldenFlow transforms.
 
 ## Convention
 

--- a/examples/sql/README.md
+++ b/examples/sql/README.md
@@ -1,0 +1,52 @@
+# SQL usage examples
+
+Run GoldenMatch entity resolution directly from SQL. Both backends expose the
+same surface: **13 core-API functions** (`goldenmatch_*`) plus **8 GoldenFlow
+transforms** (`goldenflow_*`), on top of the pre-existing dedupe / match /
+score / identity functions.
+
+| File | Backend | Demonstrates |
+|---|---|---|
+| `duckdb_core_apis.sql` | DuckDB | `goldenmatch_profile_table`, `goldenmatch_suggest_threshold`, `goldenflow_*` transforms, `goldenmatch_evaluate` |
+| `postgres_core_apis.sql` | PostgreSQL | the same four, qualified to the `goldenmatch` schema |
+
+## DuckDB
+
+The UDFs are registered from Python, then you run SQL on the connection:
+
+```python
+import duckdb
+import goldenmatch_duckdb
+
+con = duckdb.connect()
+goldenmatch_duckdb.register(con)
+# now run any statement from duckdb_core_apis.sql, e.g.:
+con.sql("SELECT goldenmatch_profile_table('customers')").show()
+```
+
+Install: `pip install goldenmatch-duckdb` (and `pip install goldenflow` to make
+the `goldenflow_*` UDFs actually transform -- they fail open as pass-throughs
+otherwise). See
+[`packages/rust/extensions/duckdb/README.md`](../../packages/rust/extensions/duckdb/README.md).
+
+## PostgreSQL
+
+```sql
+CREATE EXTENSION goldenmatch_pg;
+\i postgres_core_apis.sql
+```
+
+All functions live in the `goldenmatch` schema. See
+[`packages/rust/extensions/postgres/README.md`](../../packages/rust/extensions/postgres/README.md)
+for build / install steps and the full function catalog.
+
+## Notes
+
+- `goldenmatch_*` core-API functions return JSON text. The one exception is
+  `goldenmatch_suggest_threshold`, which returns `DOUBLE` / SQL `NULL`.
+- `goldenflow_*` transforms are scalar `text -> text` and `STRICT` (NULL in ->
+  NULL out). They pass the input through unchanged if `goldenflow` is not
+  installed.
+- The JSON in / JSON out contract is **identical across both backends**, so a
+  call written for DuckDB ports to Postgres by qualifying the schema, and vice
+  versa.

--- a/examples/sql/duckdb_core_apis.sql
+++ b/examples/sql/duckdb_core_apis.sql
@@ -1,0 +1,39 @@
+-- GoldenMatch DuckDB extension: core-API + goldenflow demo.
+--
+-- The DuckDB UDFs are registered from Python:
+--
+--   import duckdb, goldenmatch_duckdb
+--   con = duckdb.connect()
+--   goldenmatch_duckdb.register(con)
+--
+-- Then run any of the SQL below on `con`. All `goldenmatch_*` core-API UDFs
+-- return JSON strings (except goldenmatch_suggest_threshold, which returns a
+-- DOUBLE / SQL NULL). `goldenflow_*` UDFs are scalar text -> text.
+
+-- A toy table to profile / dedupe.
+CREATE TABLE customers AS SELECT * FROM (VALUES
+    ('John Smith',  'JOHN@example.com ', '212-555-0100'),
+    ('Jon Smyth',   'john@example.com',  '(212) 555-0100'),
+    ('Jane Doe',    'jane@example.com',  '415-555-0199')
+) AS t(name, email, phone);
+
+-- 1) Profile a table -- column stats, types, quality signals (JSON).
+SELECT goldenmatch_profile_table('customers');
+
+-- 2) Suggest a threshold from a score distribution (Otsu).
+--    Returns SQL NULL when the distribution is unimodal / too few scores.
+SELECT goldenmatch_suggest_threshold('[0.10, 0.12, 0.11, 0.90, 0.92, 0.91]');
+
+-- 3) GoldenFlow transforms -- normalize a column before matching.
+SELECT
+    goldenflow_normalize_email(email)  AS email_norm,
+    goldenflow_normalize_phone(phone)  AS phone_e164,
+    goldenflow_whitespace_normalize(name) AS name_clean
+FROM customers;
+
+-- 4) Evaluate predicted pairs against ground truth (precision / recall / F1).
+--    pairs: [[id_a, id_b, score], ...]   ground truth: [[id_a, id_b], ...]
+SELECT goldenmatch_evaluate(
+    '[[0, 1, 0.95], [0, 2, 0.40]]',
+    '[[0, 1]]'
+);

--- a/examples/sql/postgres_core_apis.sql
+++ b/examples/sql/postgres_core_apis.sql
@@ -1,0 +1,41 @@
+-- GoldenMatch Postgres extension: core-API + goldenflow demo.
+--
+-- Install once per database:
+--
+--   CREATE EXTENSION goldenmatch_pg;
+--
+-- All functions live in the `goldenmatch` schema, so either qualify each call
+-- (`goldenmatch.fn(...)`) or `SET search_path = goldenmatch, public;` first.
+-- The `goldenmatch_*` core-API functions return JSON text (except
+-- goldenmatch_suggest_threshold, which returns DOUBLE PRECISION / NULL).
+-- The `goldenflow_*` functions are scalar text -> text.
+
+SET search_path = goldenmatch, public;
+
+-- A toy table to profile / dedupe.
+CREATE TABLE customers (name TEXT, email TEXT, phone TEXT);
+INSERT INTO customers (name, email, phone) VALUES
+    ('John Smith', 'JOHN@example.com ', '212-555-0100'),
+    ('Jon Smyth',  'john@example.com',  '(212) 555-0100'),
+    ('Jane Doe',   'jane@example.com',  '415-555-0199');
+
+-- 1) Profile a table -- column stats, types, quality signals (JSON).
+SELECT goldenmatch_profile_table('customers');
+
+-- 2) Suggest a threshold from a score distribution (Otsu).
+--    Returns SQL NULL when the distribution is unimodal / too few scores.
+SELECT goldenmatch_suggest_threshold('[0.10, 0.12, 0.11, 0.90, 0.92, 0.91]');
+
+-- 3) GoldenFlow transforms -- normalize a column before matching.
+SELECT
+    goldenflow_normalize_email(email)     AS email_norm,
+    goldenflow_normalize_phone(phone)     AS phone_e164,
+    goldenflow_whitespace_normalize(name) AS name_clean
+FROM customers;
+
+-- 4) Evaluate predicted pairs against ground truth (precision / recall / F1).
+--    pairs: [[id_a, id_b, score], ...]   ground truth: [[id_a, id_b], ...]
+SELECT goldenmatch_evaluate(
+    '[[0, 1, 0.95], [0, 2, 0.40]]',
+    '[[0, 1]]'
+);

--- a/examples/typescript/04-goldenpipe-orchestration.ts
+++ b/examples/typescript/04-goldenpipe-orchestration.ts
@@ -1,0 +1,52 @@
+/**
+ * 04 — GoldenPipe orchestration, TypeScript edition.
+ *
+ * Chains GoldenCheck (scan) -> GoldenFlow (transform) -> GoldenMatch (dedupe)
+ * through one adaptive pipeline. The whole runner is async because
+ * GoldenMatch's `dedupe` is async, so `runDf` returns a promise.
+ *
+ * Run:
+ *     npm install goldenpipe   # pulls goldencheck/goldenflow/goldenmatch
+ *     npx tsx 04-goldenpipe-orchestration.ts
+ */
+import {
+  runDf,
+  makePipelineConfig,
+  makeStageSpec,
+  PipeStatus,
+} from "goldenpipe";
+
+const rows = [
+  { first_name: "John", last_name: "Smith", email: "JOHN@example.com  " },
+  { first_name: "Jon",  last_name: "Smith", email: "john@example.com" },
+  { first_name: "Jane", last_name: "Doe",   email: "jane@example.com" },
+];
+
+// ── Zero-config chain: goldencheck.scan -> goldenflow.transform -> goldenmatch.dedupe
+const result = await runDf(rows);
+
+console.log("status:", result.status);          // "success"
+console.log("input rows:", result.inputRows);    // 3
+console.log("golden:", result.artifacts.golden); // canonical records
+console.log("unique:", result.artifacts.unique); // distinct records
+
+// Per-stage status sequence + any decisions the pipeline made.
+for (const [name, stage] of Object.entries(result.stages)) {
+  console.log(`  stage ${name}: ${stage.status}`);
+}
+if (result.status !== PipeStatus.SUCCESS) {
+  console.error("errors:", result.errors);
+}
+
+// ── Custom config: tighten the dedupe threshold, skip the transform stage.
+const config = makePipelineConfig({
+  pipeline: "check-and-dedupe",
+  stages: [
+    "goldencheck.scan",
+    makeStageSpec({ use: "goldenmatch.dedupe", config: { threshold: 0.9 } }),
+  ],
+});
+
+const tuned = await runDf(rows, config);
+console.log("\ntuned status:", tuned.status);
+console.log("tuned clusters:", tuned.artifacts.clusters);

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -5,12 +5,20 @@
 | `01-quickstart.ts` | 30-second dedupe of a record array | `goldenmatch` |
 | `02-edge-runtime.ts` | Vercel Edge / Cloudflare Workers route. Uses `goldenmatch/core` (no `node:*` imports). | `goldenmatch/core` |
 | `03-mcp-client.ts` | Connect to the `goldensuite-mcp` container from a TS MCP client. | `@modelcontextprotocol/sdk` |
+| `04-goldenpipe-orchestration.ts` | Chain check -> flow -> dedupe through the `goldenpipe` orchestrator via `runDf` (zero-config + custom config). | `goldenpipe` |
 
 ## Run
 
 ```bash
 npm install goldenmatch
 npx tsx examples/typescript/01-quickstart.ts
+```
+
+For 04, install the orchestrator (it pulls the three siblings as deps):
+
+```bash
+npm install goldenpipe
+npx tsx examples/typescript/04-goldenpipe-orchestration.ts
 ```
 
 For 03, spin up the master MCP server first:

--- a/packages/python/goldenmatch/docs/wiki/Home.md
+++ b/packages/python/goldenmatch/docs/wiki/Home.md
@@ -33,6 +33,7 @@ goldenmatch setup
 | [LLM Boost](LLM-Boost.md) | Claude/GPT-4 labeling + fine-tuning |
 | [Learning Memory](Learning-Memory) | Persistent corrections + threshold learning (v1.6.0) |
 | [dbt Integration](dbt-Integration.md) | Post-hooks, Postgres sync, Snowflake/BigQuery recipes |
+| [SQL Extensions](SQL-Extensions.md) | SQL-native ER for Postgres + DuckDB: 13 core-API functions + 8 GoldenFlow transforms at parity |
 
 ## Reference
 

--- a/packages/python/goldenmatch/docs/wiki/SQL-Extensions.md
+++ b/packages/python/goldenmatch/docs/wiki/SQL-Extensions.md
@@ -1,0 +1,144 @@
+# SQL Extensions
+
+Run GoldenMatch entity resolution directly from SQL. Two backends -- PostgreSQL
+(via [pgrx](https://github.com/pgcentralfoundation/pgrx)) and DuckDB (Python
+UDFs) -- now expose the **same surface**, so a query written for one ports to
+the other.
+
+Both embed / call the `goldenmatch` Python package, so it must be installed into
+the same Python the database uses.
+
+## Install
+
+### PostgreSQL
+
+```sql
+CREATE EXTENSION goldenmatch_pg;
+SELECT goldenmatch.goldenmatch_score('John Smith', 'Jon Smyth', 'jaro_winkler');
+```
+
+All functions live in the `goldenmatch` schema -- qualify each call
+(`goldenmatch.fn(...)`) or `SET search_path = goldenmatch, public;`. Pre-built
+`.deb` / `.rpm` / `.tar.gz`, a Docker image, and a build-from-source recipe are
+in the extensions repo.
+
+### DuckDB
+
+```python
+import duckdb
+import goldenmatch_duckdb
+
+con = duckdb.connect()
+goldenmatch_duckdb.register(con)
+con.sql("SELECT goldenmatch_profile_table('customers')").show()
+```
+
+```bash
+pip install goldenmatch-duckdb
+pip install goldenflow   # optional, enables the goldenflow_* transforms
+```
+
+## Parity at a glance
+
+On top of the original dedupe / match / score / identity functions, both
+backends ship **13 core-API functions** and **8 GoldenFlow transforms**:
+
+| Surface | PostgreSQL | DuckDB | Contract |
+|---------|:---:|:---:|----------|
+| Dedupe / match / score | yes | yes | table + JSON |
+| Identity graph (read-only) | yes | yes | JSON |
+| Core-API (13 functions) | yes | yes | JSON in / JSON out (identical) |
+| GoldenFlow transforms (8) | yes | yes | scalar text -> text (byte-equivalent) |
+| Pipeline / job management | yes | (use dedupe/match) | -- |
+
+The core-API functions share an **identical JSON in / JSON out contract** across
+backends; the GoldenFlow transforms are byte-equivalent. Pipeline job-management
+functions (`gm_configure` / `gm_run` / ...) are Postgres-only -- DuckDB returns
+JSON via `dedupe` / `dedupe_table` instead. PPRL and file-path functions are
+deferred as not SQL-natural.
+
+## Core-API functions
+
+Thin wrappers over GoldenMatch's public core APIs. All return JSON text except
+`goldenmatch_suggest_threshold`, which returns a floating-point value / SQL
+`NULL` (unimodal or too-few-scores).
+
+| Function | Wraps | Description |
+|----------|-------|-------------|
+| `goldenmatch_profile_table(table)` | `profile_dataframe` | Full profile report for a table |
+| `goldenmatch_suggest_threshold(scores_json)` | `suggest_threshold` | Otsu threshold over a JSON score list |
+| `goldenmatch_detect_domain(columns_json)` | `detect_domain` | Detect data domain from column names |
+| `goldenmatch_extract_features(text, kind)` | `extract_*_features` | Structured features (`product`/`software`/`biblio`) |
+| `goldenmatch_evaluate(pairs_json, ground_truth_json)` | `evaluate_pairs` / `evaluate_clusters` | Precision/recall/F1 vs. ground truth |
+| `goldenmatch_compare_clusters(a_json, b_json)` | `compare_clusters` | CCMS / TWI comparison of two clusterings |
+| `goldenmatch_validate_table(table, rules_json)` | `validate_dataframe` | Run validation rules; report + quarantine |
+| `goldenmatch_autofix_table(table)` | `auto_fix_dataframe` | Common data fixes; fixes + fixed rows |
+| `goldenmatch_detect_anomalies(table, sensitivity)` | `detect_anomalies` | Flag suspicious records (low/medium/high) |
+| `goldenmatch_preflight(table, config_json)` | `preflight` | Pre-run config validation findings |
+| `goldenmatch_postflight(table, config_json)` | `postflight` | Post-run signal report |
+| `goldenmatch_train_em(rows_json, matchkey_json, params_json)` | `train_em` | Train Fellegi-Sunter m/u probabilities |
+| `goldenmatch_score_probabilistic(rows_json, matchkey_json, em_result_json)` | `score_probabilistic` | Score pairs with a trained EMResult |
+
+## GoldenFlow transforms
+
+Scalar `text -> text` UDFs wrapping GoldenFlow's transform registry -- normalize
+or canonicalize a column before matching. They fail open (pass the input through
+unchanged) when `goldenflow` isn't installed.
+
+| Function | GoldenFlow transform | Description |
+|----------|----------------------|-------------|
+| `goldenflow_normalize_email(value)` | `email_normalize` | Normalize an email address |
+| `goldenflow_normalize_phone(value)` | `phone_e164` | Normalize a phone number to E.164 |
+| `goldenflow_normalize_date(value)` | `date_iso8601` | Normalize a date to ISO-8601 |
+| `goldenflow_normalize_name_proper(value)` | `name_proper` | Proper-case a personal name |
+| `goldenflow_canonicalize_url(value)` | `url_normalize` | Canonicalize a URL |
+| `goldenflow_canonicalize_address(value)` | `address_standardize` | Standardize a postal address |
+| `goldenflow_strip(value)` | `strip` | Strip leading/trailing whitespace |
+| `goldenflow_whitespace_normalize(value)` | `collapse_whitespace` | Collapse internal whitespace runs |
+
+## Usage
+
+### PostgreSQL
+
+```sql
+SET search_path = goldenmatch, public;
+
+-- Profile a table (column stats, types, quality signals)
+SELECT goldenmatch_profile_table('customers');
+
+-- Otsu threshold suggestion (NULL when unimodal)
+SELECT goldenmatch_suggest_threshold('[0.10, 0.12, 0.90, 0.92]');
+
+-- Normalize columns inline before matching
+SELECT
+    goldenflow_normalize_email(email) AS email_norm,
+    goldenflow_normalize_phone(phone) AS phone_e164
+FROM customers;
+
+-- Deduplicate a table
+SELECT goldenmatch_dedupe_table('customers', '{"exact": ["email"]}');
+```
+
+### DuckDB
+
+```python
+con.sql("SELECT goldenmatch_profile_table('customers')").show()
+con.sql("SELECT goldenmatch_suggest_threshold('[0.10, 0.12, 0.90, 0.92]')").show()
+con.sql("""
+    SELECT goldenflow_normalize_email(email) AS email_norm
+    FROM customers
+""").show()
+con.sql("SELECT goldenmatch_dedupe_table('customers', '{\"exact\": [\"email\"]}')").show()
+```
+
+## Examples
+
+Runnable snippets live in the monorepo at `examples/sql/duckdb_core_apis.sql`
+and `examples/sql/postgres_core_apis.sql`. Per-backend function catalogs are in
+the extension READMEs (`packages/rust/extensions/{postgres,duckdb}/README.md`).
+
+## See also
+
+- [Database Integration](Database-Integration) -- live Postgres sync via the
+  CLI (`goldenmatch sync`), a different path from these in-database functions.
+- [dbt Integration](dbt-Integration) -- run GoldenMatch from dbt over DuckDB.

--- a/packages/rust/extensions/README.md
+++ b/packages/rust/extensions/README.md
@@ -34,11 +34,20 @@ SELECT goldenmatch_explain(
 ```
 goldenmatch-extensions/
 ├── bridge/     # Shared Rust crate: embeds Python via pyo3, calls goldenmatch
-├── postgres/   # PostgreSQL extension via pgrx
-└── duckdb/     # DuckDB extension (planned)
+├── postgres/   # PostgreSQL extension via pgrx  -> postgres/README.md
+└── duckdb/     # DuckDB Python UDF package      -> duckdb/README.md
 ```
 
-The extension embeds a CPython interpreter via [pyo3](https://pyo3.rs/) and calls the GoldenMatch Python package. Data flows through Apache Arrow for efficient interchange.
+The Postgres extension embeds a CPython interpreter via [pyo3](https://pyo3.rs/) and calls the GoldenMatch Python package; data flows through Apache Arrow for efficient interchange. The DuckDB layer is a Python UDF package (`pip install goldenmatch-duckdb`) that registers the same functions via `con.create_function()`.
+
+## Backend parity
+
+Both backends now expose the **same surface**. On top of the original dedupe / match / score / identity functions, each ships:
+
+- **13 core-API functions** (`goldenmatch_profile_table`, `_suggest_threshold`, `_detect_domain`, `_extract_features`, `_evaluate`, `_compare_clusters`, `_validate_table`, `_autofix_table`, `_detect_anomalies`, `_preflight`, `_postflight`, `_train_em`, `_score_probabilistic`) -- thin wrappers over GoldenMatch's public core APIs with an **identical JSON in / JSON out contract**, so a call written for one backend ports to the other.
+- **8 GoldenFlow transforms** (`goldenflow_normalize_email`/`_phone`/`_date`/`_name_proper`, `goldenflow_canonicalize_url`/`_address`, `goldenflow_strip`, `goldenflow_whitespace_normalize`) -- scalar text -> text, byte-equivalent across backends, fail-open when `goldenflow` isn't installed.
+
+See [`postgres/README.md`](postgres/README.md) and [`duckdb/README.md`](duckdb/README.md) for the full per-backend function catalogs and `examples/sql/` (in the monorepo root) for runnable snippets.
 
 ## Installation
 
@@ -147,10 +156,11 @@ Config is a JSON object with optional keys:
 
 ## Roadmap
 
-- **v0.1.0** -- PostgreSQL quick-start functions (current)
+- **v0.1.0** -- PostgreSQL quick-start functions
 - **v0.2.0** -- Pipeline schema (`goldenmatch.configure()`, `goldenmatch.run()`, job management)
-- **v0.3.0** -- DuckDB extension
-- **v0.4.0** -- Distribution: Trunk, Docker, pre-built binaries
+- **v0.3.0** -- DuckDB extension (shipped)
+- **v0.4.0** -- Distribution: Docker, pre-built binaries (`.deb` / `.rpm` / `.tar.gz`)
+- **Now** -- Postgres <-> DuckDB parity: 13 core-API functions + 8 GoldenFlow transforms on both backends
 
 ## License
 

--- a/packages/rust/extensions/duckdb/README.md
+++ b/packages/rust/extensions/duckdb/README.md
@@ -85,6 +85,35 @@ con.sql("""
 """)
 ```
 
+### GoldenFlow transforms
+
+8 scalar `VARCHAR -> VARCHAR` UDFs wrapping GoldenFlow's transform registry --
+normalize / canonicalize a column before matching. Byte-equivalent to the
+Postgres `goldenflow_*` functions, so a transform written for one backend
+ports to the other. They fail open (pass the input through unchanged) when
+`goldenflow` isn't installed -- `pip install goldenflow` to enable.
+
+| Function | GoldenFlow transform | Description |
+|----------|----------------------|-------------|
+| `goldenflow_normalize_email(value)` | `email_normalize` | Normalize an email address |
+| `goldenflow_normalize_phone(value)` | `phone_e164` | Normalize a phone number to E.164 |
+| `goldenflow_normalize_date(value)` | `date_iso8601` | Normalize a date to ISO-8601 |
+| `goldenflow_normalize_name_proper(value)` | `name_proper` | Proper-case a personal name |
+| `goldenflow_canonicalize_url(value)` | `url_normalize` | Canonicalize a URL |
+| `goldenflow_canonicalize_address(value)` | `address_standardize` | Standardize a postal address |
+| `goldenflow_strip(value)` | `strip` | Strip leading/trailing whitespace |
+| `goldenflow_whitespace_normalize(value)` | `collapse_whitespace` | Collapse internal whitespace runs |
+
+```python
+# Normalize columns inline before matching
+con.sql("""
+    SELECT
+        goldenflow_normalize_email(email)  AS email_norm,
+        goldenflow_normalize_phone(phone)  AS phone_e164
+    FROM customers
+""").show()
+```
+
 ## Requirements
 
 - Python 3.11+

--- a/packages/rust/extensions/postgres/README.md
+++ b/packages/rust/extensions/postgres/README.md
@@ -1,0 +1,190 @@
+# goldenmatch_pg
+
+GoldenMatch entity resolution functions for PostgreSQL, built with
+[pgrx](https://github.com/pgcentralfoundation/pgrx). The extension embeds a
+CPython interpreter and calls the [`goldenmatch`](https://pypi.org/project/goldenmatch/)
+Python package, so install that into the same Python the server uses.
+
+## Install
+
+```sql
+CREATE EXTENSION goldenmatch_pg;
+-- Verify:
+SELECT goldenmatch.goldenmatch_score('John Smith', 'Jon Smyth', 'jaro_winkler');
+```
+
+All functions live in the **`goldenmatch` schema**. Either qualify each call
+(`goldenmatch.fn(...)`) or `SET search_path = goldenmatch, public;` first.
+
+See the [extensions README](../README.md) for pre-built binaries (`.deb` /
+`.rpm` / `.tar.gz`), the Docker image, and the build-from-source recipe
+(`cargo pgrx install`, Python 3.11+, PG dev headers, libclang).
+
+## Usage
+
+```sql
+SET search_path = goldenmatch, public;
+
+-- Score two strings
+SELECT goldenmatch_score('John Smith', 'Jon Smyth', 'jaro_winkler');
+
+-- Deduplicate a table
+CREATE TABLE customers (name TEXT, email TEXT);
+INSERT INTO customers VALUES ('John', 'john@x.com'), ('JOHN', 'john@x.com'), ('Jane', 'jane@y.com');
+SELECT goldenmatch_dedupe_table('customers', '{"exact": ["email"]}');
+
+-- Match two tables
+SELECT goldenmatch_match_tables('prospects', 'customers', '{"fuzzy": {"name": 0.85}}');
+```
+
+## Functions
+
+### Table operations
+
+| Function | Description |
+|----------|-------------|
+| `goldenmatch_dedupe_table(table, config)` | Deduplicate a Postgres table |
+| `goldenmatch_match_tables(target, ref, config)` | Match two Postgres tables |
+| `goldenmatch_dedupe_pairs(table, config)` | Dedupe -> table of `(id_a, id_b, score)` |
+| `goldenmatch_dedupe_clusters(table, config)` | Dedupe -> table of `(cluster_id, record_id, cluster_size)` |
+
+### Scalar functions
+
+| Function | Description |
+|----------|-------------|
+| `goldenmatch_score(a, b, scorer)` | Score two strings (jaro_winkler, levenshtein, exact, ...) |
+| `goldenmatch_score_pair(rec_a, rec_b, config)` | Score two JSON records |
+| `goldenmatch_explain(rec_a, rec_b, config)` | Explain a match in natural language |
+
+### JSON functions
+
+| Function | Description |
+|----------|-------------|
+| `goldenmatch_dedupe(rows_json, config)` | Deduplicate JSON records directly |
+| `goldenmatch_match(target_json, ref_json, config)` | Match two JSON record sets |
+
+### Pipeline / job management
+
+| Function | Description |
+|----------|-------------|
+| `gm_configure(job, config)` | Store a named job config |
+| `gm_run(job, table)` | Run a stored job against a table |
+| `gm_jobs()` | List configured jobs |
+| `gm_golden(job)` | Golden records for a job |
+| `gm_drop(job)` | Drop a job + its results |
+| `gm_pairs(job)` | Table of `(id_a, id_b, score)` for a job |
+| `gm_clusters(job)` | Table of `(cluster_id, record_id)` for a job |
+| `gm_telemetry(job)` | Last run's AutoConfigController telemetry |
+
+### AutoConfig
+
+| Function | Description |
+|----------|-------------|
+| `goldenmatch_autoconfig(table)` | Run the controller, return the committed `GoldenMatchConfig` JSON |
+| `goldenmatch_autoconfig_telemetry(table)` | Same, but return the controller telemetry blob |
+| `goldenmatch_dedupe_full(table, config)` | Dedupe with a full `GoldenMatchConfig` (negative evidence, per-matchkey scorers, ...) |
+| `goldenmatch_dedupe_full_telemetry(table, config)` | Same, returning that run's telemetry |
+
+### Identity graph (read-only)
+
+| Function | Description |
+|----------|-------------|
+| `goldenmatch_identity_resolve(record_id, db_path)` | Resolve `{source}:{pk}` to its identity view |
+| `goldenmatch_identity_view(entity_id, db_path)` | Full identity view JSON |
+| `goldenmatch_identity_history(entity_id, db_path)` | Temporal event log (JSON array) |
+| `goldenmatch_identity_conflicts(dataset, db_path)` | `conflicts_with` evidence edges (JSON array) |
+| `goldenmatch_identity_list(dataset, status, db_path)` | List identities (empty filter = all) |
+
+### Corrections (Learning Memory)
+
+| Function | Description |
+|----------|-------------|
+| `correction_add(...)` | File a pair / field / cluster correction (REVOKEd from PUBLIC; grant `goldenmatch_correction_writer`) |
+| `correction_list(dataset, memory_path)` | List corrections (JSON) |
+| `goldenmatch.corrections` (view) | `SELECT * FROM goldenmatch.corrections WHERE dataset = '...'` |
+
+### Core-API functions
+
+Thin wrappers over GoldenMatch's public core APIs -- **identical JSON in / JSON
+out contract to the DuckDB `goldenmatch_*` core-API UDFs**, so the two backends
+are interchangeable. Table-input functions read the named table via SPI; all
+read-only. Every function returns JSON text except `goldenmatch_suggest_threshold`,
+which returns `DOUBLE PRECISION` / SQL `NULL`.
+
+| Function | Wraps | Description |
+|----------|-------|-------------|
+| `goldenmatch_profile_table(table)` | `profile_dataframe` | Full profile report for a table (JSON) |
+| `goldenmatch_suggest_threshold(scores_json)` | `suggest_threshold` | Otsu threshold over a JSON score list (NULL when unimodal) |
+| `goldenmatch_detect_domain(columns_json)` | `detect_domain` | Detect data domain from a JSON column-name list |
+| `goldenmatch_extract_features(text, kind)` | `extract_*_features` | Extract structured features; `kind` = `product`/`electronics`, `software`, or `biblio` |
+| `goldenmatch_evaluate(pairs_json, ground_truth_json)` | `evaluate_pairs` / `evaluate_clusters` | Precision/recall/F1 vs. ground truth (auto-selects by shape) |
+| `goldenmatch_compare_clusters(a_json, b_json)` | `compare_clusters` | CCMS / TWI comparison of two clusterings |
+| `goldenmatch_validate_table(table, rules_json)` | `validate_dataframe` | Apply validation rules; returns report + quarantined rows |
+| `goldenmatch_autofix_table(table)` | `auto_fix_dataframe` | Apply common data fixes; returns fixes + fixed rows |
+| `goldenmatch_detect_anomalies(table, sensitivity)` | `detect_anomalies` | Flag suspicious records (`low`/`medium`/`high`) |
+| `goldenmatch_preflight(table, config_json)` | `preflight` | Pre-run config validation findings |
+| `goldenmatch_postflight(table, config_json)` | `postflight` | Post-run signal report (runs dedupe to derive pair scores) |
+| `goldenmatch_train_em(rows_json, matchkey_json, params_json)` | `train_em` | Train Fellegi-Sunter m/u probabilities; returns EMResult JSON |
+| `goldenmatch_score_probabilistic(rows_json, matchkey_json, em_result_json)` | `score_probabilistic` | Score pairs with a trained EMResult |
+
+```sql
+-- Otsu threshold suggestion
+SELECT goldenmatch_suggest_threshold('[0.1, 0.12, 0.9, 0.92]');
+
+-- Profile a table
+SELECT goldenmatch_profile_table('customers');
+
+-- Detect domain from columns
+SELECT goldenmatch_detect_domain('["product_title", "brand", "sku"]');
+```
+
+### GoldenFlow transforms
+
+8 scalar `text -> text` functions wrapping GoldenFlow's transform registry --
+normalize / canonicalize a column before matching. Byte-equivalent to the
+DuckDB `goldenflow_*` UDFs. All `STRICT` (NULL in -> NULL out) and fail open
+(pass the input through unchanged) when `goldenflow` isn't installed, so they
+are read-only and safe for PUBLIC.
+
+| Function | GoldenFlow transform | Description |
+|----------|----------------------|-------------|
+| `goldenflow_normalize_email(value)` | `email_normalize` | Normalize an email address |
+| `goldenflow_normalize_phone(value)` | `phone_e164` | Normalize a phone number to E.164 |
+| `goldenflow_normalize_date(value)` | `date_iso8601` | Normalize a date to ISO-8601 |
+| `goldenflow_normalize_name_proper(value)` | `name_proper` | Proper-case a personal name |
+| `goldenflow_canonicalize_url(value)` | `url_normalize` | Canonicalize a URL |
+| `goldenflow_canonicalize_address(value)` | `address_standardize` | Standardize a postal address |
+| `goldenflow_strip(value)` | `strip` | Strip leading/trailing whitespace |
+| `goldenflow_whitespace_normalize(value)` | `collapse_whitespace` | Collapse internal whitespace runs |
+
+```sql
+-- Normalize columns inline before matching
+SELECT
+    goldenflow_normalize_email(email)     AS email_norm,
+    goldenflow_normalize_phone(phone)     AS phone_e164,
+    goldenflow_whitespace_normalize(name) AS name_clean
+FROM customers;
+```
+
+### Config format
+
+Config is a JSON object with optional keys:
+
+```json
+{
+    "exact": ["email", "phone"],
+    "fuzzy": {"name": 0.85, "address": 0.90},
+    "blocking": ["zip"],
+    "threshold": 0.85
+}
+```
+
+## Requirements
+
+- PostgreSQL 15, 16, or 17
+- Python 3.11+ with `goldenmatch >= 1.1.0` installed into the server's Python
+- `goldenflow` (optional) to enable the `goldenflow_*` transforms
+
+## License
+
+MIT


### PR DESCRIPTION
Documents the surface added today — the full TS suite on npm (incl. the new goldenpipe TS port) and the DuckDB↔Postgres SQL parity (13 core-API + 8 goldenflow functions).

## Changes (docs/examples only — no source/tests/versions touched)
- **README**: new "SQL-native, both engines at parity" bullet + updated "Polyglot parity" bullet (whole suite on npm incl. goldenpipe).
- **Extension docs**: new `packages/rust/extensions/postgres/README.md` (was missing); `duckdb/README.md` gains the 8 `goldenflow_*` transforms; `extensions/README.md` refreshed to note both backends at parity.
- **Examples**: `examples/typescript/04-goldenpipe-orchestration.ts` (verified against goldenpipe's real exports — `runDf`, `makePipelineConfig`, `makeStageSpec`, `PipeStatus`), and a new `examples/sql/` (DuckDB + Postgres core-API examples + README), linked from `examples/README.md`.
- **Wiki (staged)**: `packages/python/goldenmatch/docs/wiki/SQL-Extensions.md` + a `Home.md` nav link — staged in the repo's wiki-staging dir for manual sync to the live GitHub wiki (I can't push the wiki from here).

## Two manual hand-offs (env can't apply these directly)
**1. Wiki** — after merge, copy `packages/python/goldenmatch/docs/wiki/SQL-Extensions.md` into the GitHub wiki (and the `Home.md` nav link), same as the other staged wiki pages.

**2. About** (repo description + topics) — apply via `gh repo edit` or the GitHub UI:
- **Description** (347 chars):
  `Polyglot entity-resolution + data-quality suite. Python toolkit (fuzzy + exact + probabilistic dedupe, identity graph, PPRL, LLM boost) and a full TypeScript port on npm: goldenmatch, goldencheck, goldenflow, infermap, goldenpipe. SQL-native at parity in PostgreSQL and DuckDB. Zero-config auto-tuning, MCP/REST/A2A servers, dbt + Airflow recipes.`
- **Topics**: `entity-resolution, record-linkage, deduplication, data-matching, fuzzy-matching, data-quality, python, typescript, postgresql, duckdb, sql, dbt, mcp, fellegi-sunter, pprl, master-data-management, llm, edge-runtime`

Draft pending review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx)_