### PR TITLE
Close cross-surface parity lag (audit follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,7 +666,7 @@ jobs:
           # handwritten one into PG's extension dir so `CREATE EXTENSION`
           # finds it. The schema file is the canonical declaration of
           # public function signatures.
-          cp sql/goldenmatch_pg--0.1.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
+          cp sql/goldenmatch_pg--0.5.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
 
       - name: Expose goldenmatch to Postgres' Python interpreter
         # Postgres runs as user `postgres` under a different Python than the

--- a/.github/workflows/publish-goldenmatch-pg.yml
+++ b/.github/workflows/publish-goldenmatch-pg.yml
@@ -101,7 +101,7 @@ jobs:
           # canonical SQL file there. Path layout: <PKG_DIR>/usr/share/postgresql/<N>/extension/
           EXT_DIR="${PKG_DIR}/usr/share/postgresql/${PG_VERSION}/extension"
           mkdir -p "${EXT_DIR}"
-          cp sql/goldenmatch_pg--0.1.0.sql "${EXT_DIR}/"
+          cp sql/goldenmatch_pg--0.5.0.sql "${EXT_DIR}/"
           echo "PKG_DIR=${PKG_DIR}" >> "$GITHUB_ENV"
 
       - name: Tar artifact

--- a/packages/python/goldenmatch/.github/copilot-instructions.md
+++ b/packages/python/goldenmatch/.github/copilot-instructions.md
@@ -212,7 +212,7 @@ Hosted on Railway, registered on Smithery:
 - Unicode box drawing chars (pipe/dash) crash on Windows cp1252 terminal -- use ASCII in benchmark scripts
 - GitHub release triggers publish workflow -- `twine upload --skip-existing` avoids double-publish errors
 - `discover_rulebooks()` returns all 7 packs -- domain match tests must accept retail alongside electronics (overlapping signals like "brand", "sku")
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must provide handwritten `sql/goldenmatch_pg--0.1.0.sql` manually
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must provide handwritten `sql/goldenmatch_pg--0.5.0.sql` manually
 - pgrx in workspace mode is broken -- postgres crate must be excluded from workspace (`exclude = ["postgres"]` in root Cargo.toml)
 - pgrx extension functions live in `goldenmatch` schema (per .control file) -- must use `goldenmatch.function_name()` or explicit `::TEXT` casts in psql
 - DuckDB UDFs cannot query the same connection they're called on (deadlock) -- use `con.cursor()` for table reads inside UDFs

--- a/packages/python/goldenmatch/AGENTS.md
+++ b/packages/python/goldenmatch/AGENTS.md
@@ -212,7 +212,7 @@ Hosted on Railway, registered on Smithery:
 - Unicode box drawing chars (pipe/dash) crash on Windows cp1252 terminal -- use ASCII in benchmark scripts
 - GitHub release triggers publish workflow -- `twine upload --skip-existing` avoids double-publish errors
 - `discover_rulebooks()` returns all 7 packs -- domain match tests must accept retail alongside electronics (overlapping signals like "brand", "sku")
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must provide handwritten `sql/goldenmatch_pg--0.1.0.sql` manually
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must provide handwritten `sql/goldenmatch_pg--0.5.0.sql` manually
 - pgrx in workspace mode is broken -- postgres crate must be excluded from workspace (`exclude = ["postgres"]` in root Cargo.toml)
 - pgrx extension functions live in `goldenmatch` schema (per .control file) -- must use `goldenmatch.function_name()` or explicit `::TEXT` casts in psql
 - DuckDB UDFs cannot query the same connection they're called on (deadlock) -- use `con.cursor()` for table reads inside UDFs

--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -312,7 +312,7 @@ Hosted on Railway, registered on Smithery:
 - Unicode box drawing chars (pipe/dash) crash on Windows cp1252 terminal -- use ASCII in benchmark scripts
 - GitHub release triggers publish workflow -- `twine upload --skip-existing` avoids double-publish errors
 - `discover_rulebooks()` returns all 7 packs -- domain match tests must accept retail alongside electronics (overlapping signals like "brand", "sku")
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must provide handwritten `sql/goldenmatch_pg--0.1.0.sql` manually
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must provide handwritten `sql/goldenmatch_pg--0.5.0.sql` manually
 - pgrx in workspace mode is broken -- postgres crate must be excluded from workspace (`exclude = ["postgres"]` in root Cargo.toml)
 - pgrx extension functions live in `goldenmatch` schema (per .control file) -- must use `goldenmatch.function_name()` or explicit `::TEXT` casts in psql
 - DuckDB UDFs cannot query the same connection they're called on (deadlock) -- use `con.cursor()` for table reads inside UDFs

--- a/packages/python/goldenmatch/dbt-goldensuite/README.md
+++ b/packages/python/goldenmatch/dbt-goldensuite/README.md
@@ -24,6 +24,19 @@ result = run_goldenmatch_dedupe(
 print(f"Deduped {result['input_rows']} -> {result['clusters']} clusters")
 ```
 
+## Macros
+
+This package ships macros only (no models/seeds/snapshots). They `adapter.dispatch()`
+between the Postgres and DuckDB extension function shapes:
+
+- **Dedupe materialization** -- `goldenmatch_dedupe` (`macros/materializations/`)
+- **Identity graph** -- `identity_resolve`, `identity_list`, `identity_view`, `identity_history`, `identity_conflicts`
+- **Learning memory** -- `file_field_correction`, `file_pair_correction`
+- **Quality gates (GoldenCheck)** -- `quality_assert`, `quality_health_gate`, `quality_not_empty`
+- **Transforms (GoldenFlow)** -- `transforms.sql`
+
 ## Status
 
-Early stage -- API may change. Full dbt materialization plugin coming soon.
+Early stage -- API may change. Covers GoldenMatch (dedupe + identity), GoldenCheck
+(quality gates), and GoldenFlow (transforms); goldenpipe orchestration and infermap
+mapping are not yet exposed as dbt macros.

--- a/packages/python/goldenmatch/docs/sql-postgres.md
+++ b/packages/python/goldenmatch/docs/sql-postgres.md
@@ -256,5 +256,5 @@ WHERE a.id < b.id
 
 - Extension functions live in the `goldenmatch` schema -- use `goldenmatch.function_name()` or set `search_path`
 - Explicit `::TEXT` casts may be needed for some argument types in psql
-- pgrx does not auto-generate SQL files -- the extension uses handwritten SQL at `sql/goldenmatch_pg--0.1.0.sql`
+- pgrx does not auto-generate SQL files -- the extension uses handwritten SQL at `sql/goldenmatch_pg--0.5.0.sql`
 - See [goldenmatch-extensions](https://github.com/benseverndev-oss/goldenmatch-extensions) for full documentation and CI details

--- a/packages/rust/extensions/.clinerules
+++ b/packages/rust/extensions/.clinerules
@@ -40,7 +40,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benzsevern/goldenmatc
 - `quick.rs` -- 11 SQL functions: table-based (SPI), table-returning (TableIterator), scalar, JSON-based
 - `pipeline.rs` -- 5 job management functions: gm_configure, gm_run, gm_jobs, gm_golden, gm_drop
 - `spi.rs` -- reads PG tables via `row_to_json()` SPI queries
-- SQL file at `sql/goldenmatch_pg--0.1.0.sql` -- handwritten (pgrx doesn't auto-generate)
+- SQL file at `sql/goldenmatch_pg--0.5.0.sql` -- handwritten (pgrx doesn't auto-generate)
 - .control file: `schema = goldenmatch` -- all functions in goldenmatch schema
 
 ### duckdb/ (goldenmatch-duckdb)
@@ -65,7 +65,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benzsevern/goldenmatc
 - Release workflow: builds .tar.gz + .deb + .rpm for PG 15/16/17, pushes Docker to ghcr.io + Docker Hub
 
 ## Gotchas
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.1.0.sql` manually
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.5.0.sql` manually
 - pgrx extension functions are in `goldenmatch` schema -- use `goldenmatch.function_name()` in psql, or explicit `::TEXT` casts
 - `cargo` defaults CARGO_HOME to drive root on Windows when CWD is D: -- always set explicitly
 - DuckDB UDFs cannot query same connection (deadlock) -- use `con.cursor()` for table reads

--- a/packages/rust/extensions/.cursorrules
+++ b/packages/rust/extensions/.cursorrules
@@ -40,7 +40,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benzsevern/goldenmatc
 - `quick.rs` -- 11 SQL functions: table-based (SPI), table-returning (TableIterator), scalar, JSON-based
 - `pipeline.rs` -- 5 job management functions: gm_configure, gm_run, gm_jobs, gm_golden, gm_drop
 - `spi.rs` -- reads PG tables via `row_to_json()` SPI queries
-- SQL file at `sql/goldenmatch_pg--0.1.0.sql` -- handwritten (pgrx doesn't auto-generate)
+- SQL file at `sql/goldenmatch_pg--0.5.0.sql` -- handwritten (pgrx doesn't auto-generate)
 - .control file: `schema = goldenmatch` -- all functions in goldenmatch schema
 
 ### duckdb/ (goldenmatch-duckdb)
@@ -65,7 +65,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benzsevern/goldenmatc
 - Release workflow: builds .tar.gz + .deb + .rpm for PG 15/16/17, pushes Docker to ghcr.io + Docker Hub
 
 ## Gotchas
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.1.0.sql` manually
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.5.0.sql` manually
 - pgrx extension functions are in `goldenmatch` schema -- use `goldenmatch.function_name()` in psql, or explicit `::TEXT` casts
 - `cargo` defaults CARGO_HOME to drive root on Windows when CWD is D: -- always set explicitly
 - DuckDB UDFs cannot query same connection (deadlock) -- use `con.cursor()` for table reads

--- a/packages/rust/extensions/.github/copilot-instructions.md
+++ b/packages/rust/extensions/.github/copilot-instructions.md
@@ -40,7 +40,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benseverndev-oss/gold
 - `quick.rs` -- 11 SQL functions: table-based (SPI), table-returning (TableIterator), scalar, JSON-based
 - `pipeline.rs` -- 5 job management functions: gm_configure, gm_run, gm_jobs, gm_golden, gm_drop
 - `spi.rs` -- reads PG tables via `row_to_json()` SPI queries
-- SQL file at `sql/goldenmatch_pg--0.1.0.sql` -- handwritten (pgrx doesn't auto-generate)
+- SQL file at `sql/goldenmatch_pg--0.5.0.sql` -- handwritten (pgrx doesn't auto-generate)
 - .control file: `schema = goldenmatch` -- all functions in goldenmatch schema
 
 ### duckdb/ (goldenmatch-duckdb)
@@ -65,7 +65,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benseverndev-oss/gold
 - Release workflow: builds .tar.gz + .deb + .rpm for PG 15/16/17, pushes Docker to ghcr.io + Docker Hub
 
 ## Gotchas
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.1.0.sql` manually
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.5.0.sql` manually
 - pgrx extension functions are in `goldenmatch` schema -- use `goldenmatch.function_name()` in psql, or explicit `::TEXT` casts
 - `cargo` defaults CARGO_HOME to drive root on Windows when CWD is D: -- always set explicitly
 - DuckDB UDFs cannot query same connection (deadlock) -- use `con.cursor()` for table reads

--- a/packages/rust/extensions/.github/workflows/ci.yml
+++ b/packages/rust/extensions/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         working-directory: postgres
         run: |
           cargo pgrx install "--pg-config=/usr/lib/postgresql/${PG_VERSION}/bin/pg_config" --release --features "pg${PG_VERSION}" --no-default-features
-          cp sql/goldenmatch_pg--0.1.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
+          cp sql/goldenmatch_pg--0.5.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
 
       - name: Install goldenmatch for Postgres Python
         run: |

--- a/packages/rust/extensions/.github/workflows/release.yml
+++ b/packages/rust/extensions/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           mkdir -p "${PKG_NAME}"
           cp "/usr/lib/postgresql/${PG_VERSION}/lib/goldenmatch_pg.so" "${PKG_NAME}/"
           cp "/usr/share/postgresql/${PG_VERSION}/extension/goldenmatch_pg.control" "${PKG_NAME}/"
-          cp postgres/sql/goldenmatch_pg--0.1.0.sql "${PKG_NAME}/"
+          cp postgres/sql/goldenmatch_pg--0.5.0.sql "${PKG_NAME}/"
           cp README.md "${PKG_NAME}/"
           tar czf "${PKG_NAME}.tar.gz" "${PKG_NAME}"
           echo "PKG_NAME=${PKG_NAME}" >> "$GITHUB_ENV"
@@ -90,8 +90,8 @@ jobs:
               dst: /usr/lib/postgresql/${PG_VERSION}/lib/goldenmatch_pg.so
             - src: ${PKG_NAME}/goldenmatch_pg.control
               dst: /usr/share/postgresql/${PG_VERSION}/extension/goldenmatch_pg.control
-            - src: ${PKG_NAME}/goldenmatch_pg--0.1.0.sql
-              dst: /usr/share/postgresql/${PG_VERSION}/extension/goldenmatch_pg--0.1.0.sql
+            - src: ${PKG_NAME}/goldenmatch_pg--0.5.0.sql
+              dst: /usr/share/postgresql/${PG_VERSION}/extension/goldenmatch_pg--0.5.0.sql
           EOF
 
           /tmp/nfpm package --config /tmp/nfpm.yaml --packager deb

--- a/packages/rust/extensions/.windsurfrules
+++ b/packages/rust/extensions/.windsurfrules
@@ -40,7 +40,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benzsevern/goldenmatc
 - `quick.rs` -- 11 SQL functions: table-based (SPI), table-returning (TableIterator), scalar, JSON-based
 - `pipeline.rs` -- 5 job management functions: gm_configure, gm_run, gm_jobs, gm_golden, gm_drop
 - `spi.rs` -- reads PG tables via `row_to_json()` SPI queries
-- SQL file at `sql/goldenmatch_pg--0.1.0.sql` -- handwritten (pgrx doesn't auto-generate)
+- SQL file at `sql/goldenmatch_pg--0.5.0.sql` -- handwritten (pgrx doesn't auto-generate)
 - .control file: `schema = goldenmatch` -- all functions in goldenmatch schema
 
 ### duckdb/ (goldenmatch-duckdb)
@@ -65,7 +65,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benzsevern/goldenmatc
 - Release workflow: builds .tar.gz + .deb + .rpm for PG 15/16/17, pushes Docker to ghcr.io + Docker Hub
 
 ## Gotchas
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.1.0.sql` manually
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.5.0.sql` manually
 - pgrx extension functions are in `goldenmatch` schema -- use `goldenmatch.function_name()` in psql, or explicit `::TEXT` casts
 - `cargo` defaults CARGO_HOME to drive root on Windows when CWD is D: -- always set explicitly
 - DuckDB UDFs cannot query same connection (deadlock) -- use `con.cursor()` for table reads

--- a/packages/rust/extensions/AGENTS.md
+++ b/packages/rust/extensions/AGENTS.md
@@ -40,7 +40,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benseverndev-oss/gold
 - `quick.rs` -- 11 SQL functions: table-based (SPI), table-returning (TableIterator), scalar, JSON-based
 - `pipeline.rs` -- 5 job management functions: gm_configure, gm_run, gm_jobs, gm_golden, gm_drop
 - `spi.rs` -- reads PG tables via `row_to_json()` SPI queries
-- SQL file at `sql/goldenmatch_pg--0.1.0.sql` -- handwritten (pgrx doesn't auto-generate)
+- SQL file at `sql/goldenmatch_pg--0.5.0.sql` -- handwritten (pgrx doesn't auto-generate)
 - .control file: `schema = goldenmatch` -- all functions in goldenmatch schema
 
 ### duckdb/ (goldenmatch-duckdb)
@@ -65,7 +65,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benseverndev-oss/gold
 - Release workflow: builds .tar.gz + .deb + .rpm for PG 15/16/17, pushes Docker to ghcr.io + Docker Hub
 
 ## Gotchas
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.1.0.sql` manually
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.5.0.sql` manually
 - pgrx extension functions are in `goldenmatch` schema -- use `goldenmatch.function_name()` in psql, or explicit `::TEXT` casts
 - `cargo` defaults CARGO_HOME to drive root on Windows when CWD is D: -- always set explicitly
 - DuckDB UDFs cannot query same connection (deadlock) -- use `con.cursor()` for table reads

--- a/packages/rust/extensions/CLAUDE.md
+++ b/packages/rust/extensions/CLAUDE.md
@@ -40,7 +40,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benseverndev-oss/gold
 - `quick.rs` -- 11 SQL functions: table-based (SPI), table-returning (TableIterator), scalar, JSON-based
 - `pipeline.rs` -- 5 job management functions: gm_configure, gm_run, gm_jobs, gm_golden, gm_drop
 - `spi.rs` -- reads PG tables via `row_to_json()` SPI queries
-- SQL file at `sql/goldenmatch_pg--0.1.0.sql` -- handwritten (pgrx doesn't auto-generate)
+- SQL file at `sql/goldenmatch_pg--0.5.0.sql` -- handwritten (pgrx doesn't auto-generate)
 - .control file: `schema = goldenmatch` -- all functions in goldenmatch schema
 
 ### duckdb/ (goldenmatch-duckdb)
@@ -50,7 +50,8 @@ Native SQL extensions for [GoldenMatch](https://github.com/benseverndev-oss/gold
 - `core_apis.py` -- 13 parity UDFs wrapping goldenmatch's function-shaped core APIs (`goldenmatch_profile_table`, `goldenmatch_suggest_threshold`, `goldenmatch_detect_domain`, `goldenmatch_extract_features`, `goldenmatch_evaluate`, `goldenmatch_compare_clusters`, `goldenmatch_validate_table`, `goldenmatch_autofix_table`, `goldenmatch_detect_anomalies`, `goldenmatch_preflight`, `goldenmatch_postflight`, `goldenmatch_train_em`, `goldenmatch_score_probabilistic`). Pure-Python wrappers (import `goldenmatch` directly), JSON in/JSON out, fail-soft to `{"error": ...}`. Tests: `tests/test_core_apis.py`
 - Table-reading UDFs use `con.cursor()` to avoid deadlock (UDF can't query same connection)
 - `goldenmatch_suggest_threshold` registers with `null_handling="special"` because it legitimately returns SQL NULL (unimodal / too-few-scores). Other UDFs that may "fail" return a JSON `{"error": ...}` string instead.
-- `goldenmatch_postflight` derives `pair_scores` by running `dedupe_df` on the table (postflight needs scored pairs that aren't in the table). The Postgres-only table-returning `gm_pairs`/`gm_clusters` are NOT ported -- DuckDB returns JSON via `dedupe`/`dedupe_table` instead. PPRL (`pprl_link`, file-path args) and `run_sensitivity` (file_specs) are deferred as not SQL-natural.
+- `functions.py` also registers the `gm_configure`/`gm_run`/`gm_jobs`/`gm_golden`/`gm_drop` job-management UDFs (in-memory dict equivalent of the Postgres `pipeline.rs` set) -- both backends expose these. Only the table-returning `gm_pairs`/`gm_clusters` remain Postgres-only; DuckDB returns JSON via `dedupe`/`dedupe_table` instead.
+- `goldenmatch_postflight` derives `pair_scores` by running `dedupe_df` on the table (postflight needs scored pairs that aren't in the table). PPRL (`pprl_link`, file-path args) and `run_sensitivity` (file_specs) are deferred as not SQL-natural.
 - Requires `pyarrow` for DuckDB `.pl()` Polars conversion
 
 ## Testing
@@ -97,7 +98,7 @@ DuckDB UDFs + Postgres pg_extern functions implementing the contract at
   `goldenmatch_pg` 0.3.0 -> 0.4.0.
 
 ## Gotchas
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.1.0.sql` manually
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.5.0.sql` manually
 - pgrx extension functions are in `goldenmatch` schema -- use `goldenmatch.function_name()` in psql, or explicit `::TEXT` casts
 - `cargo` defaults CARGO_HOME to drive root on Windows when CWD is D: -- always set explicitly
 - DuckDB UDFs cannot query same connection (deadlock) -- use `con.cursor()` for table reads

--- a/packages/rust/extensions/Dockerfile
+++ b/packages/rust/extensions/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /build
 COPY . .
 WORKDIR /build/postgres
 RUN cargo pgrx install --pg-config=/usr/lib/postgresql/16/bin/pg_config --release
-RUN cp sql/goldenmatch_pg--0.1.0.sql /usr/share/postgresql/16/extension/
+RUN cp sql/goldenmatch_pg--0.5.0.sql /usr/share/postgresql/16/extension/
 
 # ── Final image ──
 FROM postgres:16-bookworm

--- a/packages/rust/extensions/README.md
+++ b/packages/rust/extensions/README.md
@@ -107,7 +107,7 @@ cargo pgrx init --pg16=$(which pg_config)
 # Build and install
 cd goldenmatch-extensions/postgres
 cargo pgrx install --pg-config=$(which pg_config) --release
-cp sql/goldenmatch_pg--0.1.0.sql $(pg_config --sharedir)/extension/
+cp sql/goldenmatch_pg--0.5.0.sql $(pg_config --sharedir)/extension/
 ```
 
 ### After Installation

--- a/packages/rust/extensions/install.sh
+++ b/packages/rust/extensions/install.sh
@@ -68,7 +68,7 @@ fi
 
 ${NEED_SUDO} cp "${TMPDIR}/${PKG_NAME}/goldenmatch_pg.so" "${LIBDIR}/"
 ${NEED_SUDO} cp "${TMPDIR}/${PKG_NAME}/goldenmatch_pg.control" "${SHAREDIR}/"
-${NEED_SUDO} cp "${TMPDIR}/${PKG_NAME}/goldenmatch_pg--0.1.0.sql" "${SHAREDIR}/"
+${NEED_SUDO} cp "${TMPDIR}/${PKG_NAME}/goldenmatch_pg--0.5.0.sql" "${SHAREDIR}/"
 
 echo ""
 echo "=== Installation complete ==="

--- a/packages/rust/extensions/postgres/goldenmatch_pg.control
+++ b/packages/rust/extensions/postgres/goldenmatch_pg.control
@@ -1,5 +1,5 @@
 comment = 'Entity resolution toolkit -- deduplicate, match, and maintain golden records'
-default_version = '0.1.0'
+default_version = '0.5.0'
 module_pathname = '$libdir/goldenmatch_pg'
 relocatable = false
 schema = goldenmatch

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.5.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.5.0.sql
@@ -1,4 +1,4 @@
--- goldenmatch_pg SQL extension schema v0.1.0
+-- goldenmatch_pg SQL extension schema v0.5.0
 
 -- ══════════════════════════════════════════════════════════════════════
 -- Pipeline tables (job management)

--- a/packages/rust/extensions/postgres/src/correction.rs
+++ b/packages/rust/extensions/postgres/src/correction.rs
@@ -40,7 +40,7 @@
 //! ## Permissions
 //!
 //! `goldenmatch.correction_add` is REVOKEd from PUBLIC by default in
-//! `sql/goldenmatch_pg--0.1.0.sql`. Grant `goldenmatch_correction_writer`
+//! `sql/goldenmatch_pg--0.5.0.sql`. Grant `goldenmatch_correction_writer`
 //! (or any role you wire up) EXECUTE privilege before any caller can
 //! invoke it. The read-only `goldenmatch.correction_list` is also
 //! REVOKEd by default.

--- a/packages/typescript/goldencheck/package.json
+++ b/packages/typescript/goldencheck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldencheck",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Data validation that discovers rules from your data. TypeScript port of the goldencheck Python library.",
   "keywords": [
     "data-validation",
@@ -45,7 +45,8 @@
     }
   },
   "bin": {
-    "goldencheck-js": "./dist/cli.cjs"
+    "goldencheck-js": "./dist/cli.cjs",
+    "goldencheck-mcp": "./dist/node/mcp/server.cjs"
   },
   "files": [
     "dist",

--- a/packages/typescript/goldencheck/src/node/index.ts
+++ b/packages/typescript/goldencheck/src/node/index.ts
@@ -13,7 +13,7 @@ export { readFile, readCsv, type ReadOptions } from "./reader.js";
 export { watchDirectory, type WatchOptions } from "./watcher.js";
 
 // Node-only: MCP server
-export { TOOL_DEFINITIONS, handleTool } from "./mcp/server.js";
+export { TOOL_DEFINITIONS, handleTool, startMcpServer } from "./mcp/server.js";
 
 // Node-only: TUI renderer
 export { renderTui } from "./tui/app.js";

--- a/packages/typescript/goldencheck/src/node/mcp/server.ts
+++ b/packages/typescript/goldencheck/src/node/mcp/server.ts
@@ -1,8 +1,11 @@
+#!/usr/bin/env node
 /**
  * MCP server — exposes GoldenCheck tools for Claude Desktop and other MCP clients.
- * Port of goldencheck/mcp/server.py. Node-only (uses MCP SDK).
+ * Port of goldencheck/mcp/server.py. Node-only: hand-rolled JSON-RPC 2.0 over
+ * stdio (node:readline; no MCP SDK dep), mirroring the sibling TS servers.
  */
 
+import { createInterface } from "node:readline";
 import { readFile } from "../reader.js";
 import { scanData, type ScanOptions } from "../../core/engine/scanner.js";
 import { applyConfidenceDowngrade } from "../../core/engine/confidence.js";
@@ -251,4 +254,106 @@ function toolGetDomainInfo(args: Record<string, unknown>): object {
     typesInfo[name] = { name_hints: def.nameHints, suppress: def.suppress };
   }
   return { name: domain, types: typesInfo };
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC over stdio
+// ---------------------------------------------------------------------------
+
+interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: number | string | null;
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+function writeMessage(msg: Record<string, unknown>): void {
+  process.stdout.write(JSON.stringify(msg) + "\n");
+}
+
+/**
+ * Start the MCP server reading JSON-RPC messages one per line from stdin and
+ * writing responses to stdout (stdio transport for Claude Desktop / any MCP
+ * client). `handleTool` returns an object, serialized as the text content.
+ */
+export function startMcpServer(): void {
+  const rl = createInterface({ input: process.stdin, terminal: false });
+
+  rl.on("line", (line: string) => {
+    if (line.trim() === "") return;
+    let req: JsonRpcRequest;
+    try {
+      req = JSON.parse(line) as JsonRpcRequest;
+    } catch (err) {
+      console.warn("MCP parse error:", err instanceof Error ? err.message : String(err));
+      return;
+    }
+
+    const id = req.id ?? null;
+    try {
+      if (req.method === "initialize") {
+        writeMessage({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            protocolVersion: "2024-11-05",
+            serverInfo: { name: "goldencheck", version: "0.3.0" },
+            capabilities: { tools: {} },
+          },
+        });
+        return;
+      }
+
+      if (req.method === "tools/list") {
+        writeMessage({ jsonrpc: "2.0", id, result: { tools: TOOL_DEFINITIONS } });
+        return;
+      }
+
+      if (req.method === "tools/call") {
+        const params = req.params ?? {};
+        const toolName = String(params["name"] ?? "");
+        const toolArgs = (params["arguments"] as Record<string, unknown> | undefined) ?? {};
+        const result = handleTool(toolName, toolArgs);
+        writeMessage({
+          jsonrpc: "2.0",
+          id,
+          result: { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] },
+        });
+        return;
+      }
+
+      if (
+        req.method === "notifications/initialized" ||
+        req.method === "notifications/cancelled"
+      ) {
+        return;
+      }
+
+      writeMessage({
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32601, message: `Method not found: ${req.method}` },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      writeMessage({ jsonrpc: "2.0", id, error: { code: -32603, message: msg } });
+    }
+  });
+
+  rl.on("close", () => {
+    process.exit(0);
+  });
+}
+
+// Run as a bin when invoked directly (the `goldencheck-mcp` entry point).
+const isMain = (() => {
+  try {
+    return typeof require !== "undefined" && require.main === module;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  startMcpServer();
 }

--- a/packages/typescript/goldencheck/tsup.config.ts
+++ b/packages/typescript/goldencheck/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     index: "src/index.ts",
     "core/index": "src/core/index.ts",
     "node/index": "src/node/index.ts",
+    "node/mcp/server": "src/node/mcp/server.ts",
     cli: "src/cli.ts",
   },
   format: ["esm", "cjs"],

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",
@@ -45,7 +45,8 @@
     }
   },
   "bin": {
-    "goldenflow-js": "./dist/cli.cjs"
+    "goldenflow-js": "./dist/cli.cjs",
+    "goldenflow-mcp": "./dist/node/mcp/server.cjs"
   },
   "files": [
     "dist",

--- a/packages/typescript/goldenflow/src/node/index.ts
+++ b/packages/typescript/goldenflow/src/node/index.ts
@@ -11,7 +11,7 @@ export { readS3, writeS3, parseS3Uri } from "./connectors/s3.js";
 export { readGcs, writeGcs, parseGcsUri } from "./connectors/gcs.js";
 export { readTable, writeTable } from "./connectors/database.js";
 export { saveRun, listRuns, getRun, generateRunId } from "./history.js";
-export { TOOL_DEFINITIONS, handleTool } from "./mcp/server.js";
+export { TOOL_DEFINITIONS, handleTool, startMcpServer } from "./mcp/server.js";
 export { watchDirectory } from "./watch.js";
 export { runSchedule } from "./schedule.js";
 export { runWizard } from "./init-wizard.js";

--- a/packages/typescript/goldenflow/src/node/mcp/server.ts
+++ b/packages/typescript/goldenflow/src/node/mcp/server.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * GoldenFlow MCP Server — 10 tools for data transformation via stdio transport.
  * Node-only module.
@@ -5,6 +6,7 @@
 
 import { readFileSync } from "node:fs";
 import { resolve, isAbsolute } from "node:path";
+import { createInterface } from "node:readline";
 import { readFile } from "../connectors/file.js";
 
 /** Validate a file path to prevent path traversal. Resolves relative to cwd. */
@@ -302,4 +304,107 @@ function _handleToolInner(name: string, arguments_: Record<string, unknown>): st
     default:
       return JSON.stringify({ error: `Unknown tool: ${name}` });
   }
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC over stdio
+// ---------------------------------------------------------------------------
+
+interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: number | string | null;
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+function writeMessage(msg: Record<string, unknown>): void {
+  process.stdout.write(JSON.stringify(msg) + "\n");
+}
+
+/**
+ * Start the MCP server reading JSON-RPC messages one per line from stdin and
+ * writing responses to stdout (stdio transport for Claude Desktop / any MCP
+ * client). `handleTool` already returns a JSON string, so it's embedded as the
+ * text content directly.
+ */
+export function startMcpServer(): void {
+  const rl = createInterface({ input: process.stdin, terminal: false });
+
+  rl.on("line", (line: string) => {
+    if (line.trim() === "") return;
+    let req: JsonRpcRequest;
+    try {
+      req = JSON.parse(line) as JsonRpcRequest;
+    } catch (err) {
+      console.warn("MCP parse error:", err instanceof Error ? err.message : String(err));
+      return;
+    }
+
+    const id = req.id ?? null;
+    try {
+      if (req.method === "initialize") {
+        writeMessage({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            protocolVersion: "2024-11-05",
+            serverInfo: { name: "goldenflow", version: "0.3.0" },
+            capabilities: { tools: {} },
+          },
+        });
+        return;
+      }
+
+      if (req.method === "tools/list") {
+        writeMessage({ jsonrpc: "2.0", id, result: { tools: TOOL_DEFINITIONS } });
+        return;
+      }
+
+      if (req.method === "tools/call") {
+        const params = req.params ?? {};
+        const toolName = String(params["name"] ?? "");
+        const toolArgs = (params["arguments"] as Record<string, unknown> | undefined) ?? {};
+        const text = handleTool(toolName, toolArgs);
+        writeMessage({
+          jsonrpc: "2.0",
+          id,
+          result: { content: [{ type: "text", text }] },
+        });
+        return;
+      }
+
+      if (
+        req.method === "notifications/initialized" ||
+        req.method === "notifications/cancelled"
+      ) {
+        return;
+      }
+
+      writeMessage({
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32601, message: `Method not found: ${req.method}` },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      writeMessage({ jsonrpc: "2.0", id, error: { code: -32603, message: msg } });
+    }
+  });
+
+  rl.on("close", () => {
+    process.exit(0);
+  });
+}
+
+// Run as a bin when invoked directly (the `goldenflow-mcp` entry point).
+const isMain = (() => {
+  try {
+    return typeof require !== "undefined" && require.main === module;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  startMcpServer();
 }

--- a/packages/typescript/goldenflow/tsup.config.ts
+++ b/packages/typescript/goldenflow/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     index: "src/index.ts",
     "core/index": "src/core/index.ts",
     "node/index": "src/node/index.ts",
+    "node/mcp/server": "src/node/mcp/server.ts",
     cli: "src/cli.ts",
   },
   format: ["esm", "cjs"],

--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -56,7 +56,8 @@ npx vitest run tests/parity/        # parity-only suite
 - Memory mirror: `getMemory`, `addCorrection`, `learn`, `memoryStats`.
 - **Identity Graph (v0.8.0, edge-safe core):** `InMemoryIdentityStore`, `newEntityId`, `findByRecord`, `getEntity`, `listEntities`, `manualMerge`, `manualSplit`, `IdentityView`, types (`IdentityNode`, `SourceRecord`, `EvidenceEdge`, `IdentityEvent`, `IdentityAlias`, `IdentityStatus`, `EventKind`, `EdgeKind`, `IdentityStore`).
 - **Identity Graph (v0.9.0, persistent backend):** `SqliteIdentityStore` in `src/node/identity/`. Implements every `IdentityStore` method (19 total) against an SQLite file at `.goldenmatch/identity.db` (configurable). `better-sqlite3` is an optional peer dep. Schema is byte-identical to Python so cross-toolkit DBs round-trip.
-- MCP tool count: 24 (19 base + 5 memory). Description literal at `src/node/mcp/server.ts:6` — keep in sync via the existing regex test. Identity MCP tools will be added in v0.10 alongside the pipeline-driven `resolveClusters` hook.
+- MCP tool count: 24 (19 base + 5 memory). Description literal at `src/node/mcp/server.ts:7` — keep in sync via the existing regex test. Identity MCP tools will be added in v0.10 alongside the pipeline-driven `resolveClusters` hook.
+- **MCP bin (v0.12.0):** `src/node/mcp/server.ts` is exposed as the `goldenmatch-mcp` bin (tsup entry `node/mcp/server`); it already had the JSON-RPC stdio loop (`startMcpServer`) — v0.12.0 added the shebang + `require.main` guard + bin wiring so it's directly runnable.
 
 ## Build outputs
 - tsup with 5 entry points: `index`, `core/index`, `node/index`, `cli`, `node/backends/score-worker` (piscina worker).

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {
@@ -8,7 +8,7 @@
     "./core": { "types": "./dist/core/index.d.ts", "import": "./dist/core/index.js", "require": "./dist/core/index.cjs" },
     "./node": { "types": "./dist/node/index.d.ts", "import": "./dist/node/index.js", "require": "./dist/node/index.cjs" }
   },
-  "bin": { "goldenmatch-js": "./dist/cli.cjs" },
+  "bin": { "goldenmatch-js": "./dist/cli.cjs", "goldenmatch-mcp": "./dist/node/mcp/server.cjs" },
   "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "engines": { "node": ">=20" },
   "scripts": {

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * mcp/server.ts -- GoldenMatch MCP server (stdio transport, JSON-RPC).
  *
@@ -958,3 +959,17 @@ export function startMcpServer(): void {
 // Re-export for callers that want to pre-warm / test
 export { readFileSync, isAbsolute };
 export { writeJson };
+
+// Run as a bin when invoked directly (the `goldenmatch-mcp` entry point).
+// tsup compiles this to dist/node/mcp/server.{js,cjs}; the cjs build is the bin.
+const isMain = (() => {
+  try {
+    return typeof require !== "undefined" && require.main === module;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  startMcpServer();
+}

--- a/packages/typescript/goldenmatch/tsup.config.ts
+++ b/packages/typescript/goldenmatch/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     index: "src/index.ts",
     "core/index": "src/core/index.ts",
     "node/index": "src/node/index.ts",
+    "node/mcp/server": "src/node/mcp/server.ts",
     cli: "src/cli.ts",
     // Separate entry so piscina can load it at runtime from disk.
     "node/backends/score-worker": "src/node/backends/score-worker.ts",

--- a/packages/typescript/goldenpipe/CLAUDE.md
+++ b/packages/typescript/goldenpipe/CLAUDE.md
@@ -13,8 +13,8 @@ Reads the edge-safe cores of the three siblings (confirm exported shapes in thei
 ## Layout
 
 - `src/core/**` — edge-safe (NO `node:` imports): `models.ts`, `columnContext.ts`, `decisions.ts`, `engine/{registry,resolver,router,runner,reporter}.ts`, `adapters/{load,check,flow,match,index}.ts`, `pipeline.ts`.
-- `src/node/**` — Node-only: `csv.ts` (hand-rolled CSV reader), `run.ts` (`run(source)` file path), `loadConfig.ts` (YAML via optional `yaml` peer dep).
-- `src/cli.ts` — commander CLI (`run`, `stages`, `validate`, `init`).
+- `src/node/**` — Node-only: `csv.ts` (hand-rolled CSV reader), `run.ts` (`run(source)` file path), `loadConfig.ts` (YAML via optional `yaml` peer dep), `mcp/server.ts` (hand-rolled JSON-RPC 2.0 stdio MCP server, `goldenpipe-mcp` bin).
+- `src/cli.ts` — commander CLI (`run`, `stages`, `validate`, `init`, `mcp-serve`).
 
 ## Static registry, not entry points
 
@@ -23,7 +23,8 @@ Python discovers stages via importlib entry points. The TS port uses a STATIC re
 ## Deferred (document, don't silently drop)
 
 - `identity_resolve` stage (GoldenMatch Identity Graph pipeline population) and `infer_schema` stage (InferMap) — not ported.
-- FastAPI / A2A / MCP / TUI servers — not ported.
+- MCP server: PORTED (v0.2.0) — `src/node/mcp/server.ts` exposes the same 4 tools as the Python sibling (`list_stages`, `validate_pipeline`, `run_pipeline`, `explain_pipeline`) over hand-rolled JSON-RPC stdio (no MCP SDK dep), wired to a `goldenpipe-mcp` bin + `goldenpipe-js mcp-serve`. HTTP transport (Streamable HTTP) is not ported.
+- FastAPI / A2A / TUI servers — not ported.
 - `severityGate` / `piiRouter` are effectively no-ops vs current GoldenCheck-JS output (no `"critical"` severity, no `"pii_detection"` check). Ported for structural parity only. `rowCountGate` works but is not wired into the default chain.
 
 ## Sibling skew artifacts

--- a/packages/typescript/goldenpipe/CLAUDE.md
+++ b/packages/typescript/goldenpipe/CLAUDE.md
@@ -13,8 +13,8 @@ Reads the edge-safe cores of the three siblings (confirm exported shapes in thei
 ## Layout
 
 - `src/core/**` — edge-safe (NO `node:` imports): `models.ts`, `columnContext.ts`, `decisions.ts`, `engine/{registry,resolver,router,runner,reporter}.ts`, `adapters/{load,check,flow,match,index}.ts`, `pipeline.ts`.
-- `src/node/**` — Node-only: `csv.ts` (hand-rolled CSV reader), `run.ts` (`run(source)` file path), `loadConfig.ts` (YAML via optional `yaml` peer dep), `mcp/server.ts` (hand-rolled JSON-RPC 2.0 stdio MCP server, `goldenpipe-mcp` bin).
-- `src/cli.ts` — commander CLI (`run`, `stages`, `validate`, `init`, `mcp-serve`).
+- `src/node/**` — Node-only: `csv.ts` (hand-rolled CSV reader), `run.ts` (`run(source)` file path), `loadConfig.ts` (YAML via optional `yaml` peer dep), `mcp/server.ts` (hand-rolled JSON-RPC 2.0 stdio MCP server, `goldenpipe-mcp` bin), `a2a/server.ts` (node:http A2A agent, port 8250), `api/server.ts` (node:http REST API, port 8000).
+- `src/cli.ts` — commander CLI (`run`, `stages`, `validate`, `init`, `mcp-serve`, `agent-serve`, `serve`).
 
 ## Static registry, not entry points
 
@@ -23,8 +23,8 @@ Python discovers stages via importlib entry points. The TS port uses a STATIC re
 ## Deferred (document, don't silently drop)
 
 - `identity_resolve` stage (GoldenMatch Identity Graph pipeline population) and `infer_schema` stage (InferMap) — not ported.
-- MCP server: PORTED (v0.2.0) — `src/node/mcp/server.ts` exposes the same 4 tools as the Python sibling (`list_stages`, `validate_pipeline`, `run_pipeline`, `explain_pipeline`) over hand-rolled JSON-RPC stdio (no MCP SDK dep), wired to a `goldenpipe-mcp` bin + `goldenpipe-js mcp-serve`. HTTP transport (Streamable HTTP) is not ported.
-- FastAPI / A2A / TUI servers — not ported.
+- MCP / A2A / REST servers: PORTED (v0.2.0). `src/node/mcp/server.ts` exposes the same 4 tools as the Python sibling (`list_stages`, `validate_pipeline`, `run_pipeline`, `explain_pipeline`) over hand-rolled JSON-RPC stdio (no MCP SDK dep), wired to a `goldenpipe-mcp` bin + `goldenpipe-js mcp-serve`. `a2a/server.ts` (4 skills, `agent-serve`) and `api/server.ts` (`/health`, `/stages`, `/validate`, `/run`, `serve`) mirror the Python `a2a/server.py` + `api/server.py`. All three delegate to the MCP tool handler. MCP Streamable-HTTP transport is not ported (stdio only).
+- Textual TUI — not ported.
 - `severityGate` / `piiRouter` are effectively no-ops vs current GoldenCheck-JS output (no `"critical"` severity, no `"pii_detection"` check). Ported for structural parity only. `rowCountGate` works but is not wired into the default chain.
 
 ## Sibling skew artifacts

--- a/packages/typescript/goldenpipe/README.md
+++ b/packages/typescript/goldenpipe/README.md
@@ -94,6 +94,18 @@ goldenpipe-js run people.csv [-c pipeline.yml] [-v]   # run the chain on a CSV
 goldenpipe-js stages                                  # list registered stages
 goldenpipe-js validate -c pipeline.yml                # dry-run wiring validation
 goldenpipe-js init [-d .]                             # scaffold a goldenpipe.yml
+goldenpipe-js mcp-serve                               # run the MCP server (stdio)
+```
+
+## MCP server
+
+GoldenPipe ships an MCP server (stdio, JSON-RPC 2.0) exposing the same 4 tools as
+the Python sibling — `list_stages`, `validate_pipeline`, `run_pipeline`,
+`explain_pipeline`. Run it via `goldenpipe-js mcp-serve` or the `goldenpipe-mcp`
+bin. Wire it into an MCP client (e.g. Claude Desktop):
+
+```json
+{ "mcpServers": { "goldenpipe": { "command": "goldenpipe-mcp" } } }
 ```
 
 ## Architecture
@@ -132,7 +144,7 @@ A **column-context pipeline** carries semantic metadata across stages: GoldenChe
 
 - **`identity_resolve` stage** — GoldenMatch-JS Identity Graph wiring through the pipeline. The edge-safe `InMemoryIdentityStore` exists in `goldenmatch`, but the pipeline-driven `resolveClusters` population is not yet exposed.
 - **`infer_schema` stage** — InferMap-based schema inference is not ported.
-- **Servers/TUI** — the FastAPI REST API, A2A agent server, MCP server, and Textual TUI from the Python CLI are not ported.
+- **Servers/TUI** — the FastAPI REST API, A2A agent server, and Textual TUI from the Python CLI are not ported. (The MCP server **is** ported — see above.)
 
 ### Sibling version-skew artifacts
 

--- a/packages/typescript/goldenpipe/README.md
+++ b/packages/typescript/goldenpipe/README.md
@@ -95,14 +95,21 @@ goldenpipe-js stages                                  # list registered stages
 goldenpipe-js validate -c pipeline.yml                # dry-run wiring validation
 goldenpipe-js init [-d .]                             # scaffold a goldenpipe.yml
 goldenpipe-js mcp-serve                               # run the MCP server (stdio)
+goldenpipe-js agent-serve [-p 8250]                   # run the A2A agent server (HTTP)
+goldenpipe-js serve [-p 8000]                         # run the REST API server (HTTP)
 ```
 
-## MCP server
+## Servers (MCP / A2A / REST)
 
-GoldenPipe ships an MCP server (stdio, JSON-RPC 2.0) exposing the same 4 tools as
+GoldenPipe ships three server surfaces, each exposing the same 4 operations as
 the Python sibling — `list_stages`, `validate_pipeline`, `run_pipeline`,
-`explain_pipeline`. Run it via `goldenpipe-js mcp-serve` or the `goldenpipe-mcp`
-bin. Wire it into an MCP client (e.g. Claude Desktop):
+`explain_pipeline`:
+
+- **MCP** (stdio, JSON-RPC 2.0): `goldenpipe-js mcp-serve` or the `goldenpipe-mcp` bin.
+- **A2A** (HTTP, port 8250): `goldenpipe-js agent-serve` — agent card at `/.well-known/agent.json`, skill dispatch at `POST /tasks`.
+- **REST** (HTTP, port 8000): `goldenpipe-js serve` — `GET /stages`, `POST /validate`, `POST /run`.
+
+Wire the MCP server into a client (e.g. Claude Desktop):
 
 ```json
 { "mcpServers": { "goldenpipe": { "command": "goldenpipe-mcp" } } }
@@ -144,7 +151,7 @@ A **column-context pipeline** carries semantic metadata across stages: GoldenChe
 
 - **`identity_resolve` stage** — GoldenMatch-JS Identity Graph wiring through the pipeline. The edge-safe `InMemoryIdentityStore` exists in `goldenmatch`, but the pipeline-driven `resolveClusters` population is not yet exposed.
 - **`infer_schema` stage** — InferMap-based schema inference is not ported.
-- **Servers/TUI** — the FastAPI REST API, A2A agent server, and Textual TUI from the Python CLI are not ported. (The MCP server **is** ported — see above.)
+- **Textual TUI** — the Python Textual TUI is not ported. (The MCP, A2A, and REST servers **are** ported — see above.)
 
 ### Sibling version-skew artifacts
 

--- a/packages/typescript/goldenpipe/package.json
+++ b/packages/typescript/goldenpipe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenpipe",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Golden Suite orchestrator — chains GoldenCheck, GoldenFlow, and GoldenMatch into one adaptive pipeline. TypeScript port of the goldenpipe Python library.",
   "keywords": [
     "pipeline",
@@ -46,7 +46,8 @@
     }
   },
   "bin": {
-    "goldenpipe-js": "./dist/cli.cjs"
+    "goldenpipe-js": "./dist/cli.cjs",
+    "goldenpipe-mcp": "./dist/node/mcp/server.cjs"
   },
   "files": [
     "dist",

--- a/packages/typescript/goldenpipe/src/cli.ts
+++ b/packages/typescript/goldenpipe/src/cli.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
  * GoldenPipe JS CLI — Commander.js port of the Typer CLI.
- * Commands: run, stages, validate, init.
+ * Commands: run, stages, validate, init, mcp-serve.
  *
- * The FastAPI / A2A / MCP / TUI serve commands from the Python CLI are
+ * The FastAPI / A2A / TUI serve commands from the Python CLI are
  * deferred (see README + CLAUDE.md).
  */
 
@@ -18,8 +18,9 @@ import {
 } from "./core/index.js";
 import { run } from "./node/run.js";
 import { loadConfig } from "./node/loadConfig.js";
+import { startMcpServer } from "./node/mcp/server.js";
 
-const VERSION = "0.1.0";
+const VERSION = "0.2.0";
 
 function printResult(result: PipeResult, verbose: boolean): void {
   process.stdout.write(`GoldenPipe: ${result.source}\n`);
@@ -121,6 +122,13 @@ program
     const out = join(opts.dir, "goldenpipe.yml");
     writeFileSync(out, lines.join("\n") + "\n");
     process.stdout.write(`Created ${out}\n`);
+  });
+
+program
+  .command("mcp-serve")
+  .description("Run the GoldenPipe MCP server over stdio (JSON-RPC 2.0)")
+  .action(() => {
+    startMcpServer();
   });
 
 program.parseAsync(process.argv).catch((e: unknown) => {

--- a/packages/typescript/goldenpipe/src/cli.ts
+++ b/packages/typescript/goldenpipe/src/cli.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 /**
  * GoldenPipe JS CLI — Commander.js port of the Typer CLI.
- * Commands: run, stages, validate, init, mcp-serve.
+ * Commands: run, stages, validate, init, mcp-serve, agent-serve, serve.
  *
- * The FastAPI / A2A / TUI serve commands from the Python CLI are
- * deferred (see README + CLAUDE.md).
+ * The Textual TUI from the Python CLI is deferred (see README + CLAUDE.md).
  */
 
 import { writeFileSync } from "node:fs";
@@ -19,6 +18,8 @@ import {
 import { run } from "./node/run.js";
 import { loadConfig } from "./node/loadConfig.js";
 import { startMcpServer } from "./node/mcp/server.js";
+import { startA2aServer } from "./node/a2a/server.js";
+import { runServer as runApiServer } from "./node/api/server.js";
 
 const VERSION = "0.2.0";
 
@@ -129,6 +130,24 @@ program
   .description("Run the GoldenPipe MCP server over stdio (JSON-RPC 2.0)")
   .action(() => {
     startMcpServer();
+  });
+
+program
+  .command("agent-serve")
+  .description("Run the GoldenPipe A2A agent server (HTTP)")
+  .option("-p, --port <port>", "Port to listen on", "8250")
+  .option("--host <host>", "Host to bind", "127.0.0.1")
+  .action((opts: { port: string; host: string }) => {
+    startA2aServer({ port: Number(opts.port), host: opts.host });
+  });
+
+program
+  .command("serve")
+  .description("Run the GoldenPipe REST API server (HTTP)")
+  .option("-p, --port <port>", "Port to listen on", "8000")
+  .option("--host <host>", "Host to bind", "0.0.0.0")
+  .action((opts: { port: string; host: string }) => {
+    runApiServer(Number(opts.port), opts.host);
   });
 
 program.parseAsync(process.argv).catch((e: unknown) => {

--- a/packages/typescript/goldenpipe/src/node/a2a/server.ts
+++ b/packages/typescript/goldenpipe/src/node/a2a/server.ts
@@ -1,0 +1,245 @@
+/**
+ * a2a/server.ts -- GoldenPipe A2A (Agent-to-Agent) protocol server.
+ *
+ * Node-only: uses node:http, node:crypto. NOT edge-safe.
+ *
+ * Port of goldenpipe/a2a/server.py. Mirrors the sibling GoldenFlow / GoldenMatch
+ * TS A2A servers for structure (agent card at /.well-known/agent.json, skill
+ * dispatch, task lifecycle). Skills delegate to the GoldenPipe MCP tools via
+ * `handleTool`, exactly as the Python server delegates to its MCP tool functions.
+ *
+ * Endpoints:
+ *   GET  /.well-known/agent.json   - agent card (4 skills)
+ *   GET  /health                   - liveness probe
+ *   POST /tasks                    - create a task (skill + params)
+ *   GET  /tasks/{id}               - fetch task status/result
+ */
+
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { randomUUID } from "node:crypto";
+import { handleTool } from "../mcp/server.js";
+
+// ---------------------------------------------------------------------------
+// Agent card
+// ---------------------------------------------------------------------------
+
+export interface AgentSkill {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly inputModes: readonly string[];
+  readonly outputModes: readonly string[];
+}
+
+export const AGENT_CARD: {
+  readonly name: string;
+  readonly description: string;
+  readonly version: string;
+  readonly provider: { readonly organization: string };
+  readonly url: string;
+  readonly skills: readonly AgentSkill[];
+} = {
+  name: "GoldenPipe",
+  description: "Pluggable pipeline framework for data quality workflows",
+  version: "1.0.0",
+  provider: { organization: "Golden Suite" },
+  url: "http://localhost:8250",
+  skills: [
+    {
+      id: "run-pipeline",
+      name: "Run Pipeline",
+      description: "Execute a data quality pipeline on a CSV file",
+      inputModes: ["text"],
+      outputModes: ["text"],
+    },
+    {
+      id: "validate-pipeline",
+      name: "Validate Pipeline",
+      description: "Validate pipeline wiring without executing",
+      inputModes: ["text"],
+      outputModes: ["text"],
+    },
+    {
+      id: "list-stages",
+      name: "List Stages",
+      description: "List all registered pipeline stages",
+      inputModes: ["text"],
+      outputModes: ["text"],
+    },
+    {
+      id: "explain-pipeline",
+      name: "Explain Pipeline",
+      description: "Describe what a pipeline config will do",
+      inputModes: ["text"],
+      outputModes: ["text"],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Task store
+// ---------------------------------------------------------------------------
+
+interface Task {
+  readonly id: string;
+  readonly skill: string;
+  status: "pending" | "running" | "completed" | "failed";
+  readonly createdAt: string;
+  completedAt?: string;
+  result?: unknown;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Skill dispatch
+// ---------------------------------------------------------------------------
+
+/** A2A skill id (kebab-case) -> MCP tool name (snake_case). */
+const SKILL_TO_TOOL: Record<string, string> = {
+  "run-pipeline": "run_pipeline",
+  "validate-pipeline": "validate_pipeline",
+  "list-stages": "list_stages",
+  "explain-pipeline": "explain_pipeline",
+};
+
+async function dispatchSkill(
+  skill: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const tool = SKILL_TO_TOOL[skill];
+  if (tool === undefined) {
+    return { error: `Unknown skill: ${skill}` };
+  }
+  return handleTool(tool, params);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  let body = "";
+  for await (const chunk of req) {
+    body += typeof chunk === "string" ? chunk : (chunk as Buffer).toString("utf8");
+  }
+  if (!body) return {};
+  const parsed = JSON.parse(body);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("body must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function sendJson(res: ServerResponse, status: number, data: unknown): void {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(data));
+}
+
+// ---------------------------------------------------------------------------
+// Public: startA2aServer
+// ---------------------------------------------------------------------------
+
+export interface StartA2aOptions {
+  readonly port?: number;
+  readonly host?: string;
+}
+
+export function startA2aServer(
+  options: StartA2aOptions = {},
+): ReturnType<typeof createServer> {
+  const port = options.port ?? 8250;
+  const host = options.host ?? "127.0.0.1";
+  const tasks = new Map<string, Task>();
+
+  const server = createServer((req, res) => {
+    void (async () => {
+      const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+      const pathname = url.pathname;
+      const methodName = req.method ?? "GET";
+
+      try {
+        if (pathname === "/.well-known/agent.json" && methodName === "GET") {
+          sendJson(res, 200, AGENT_CARD);
+          return;
+        }
+
+        if (pathname === "/health" && methodName === "GET") {
+          sendJson(res, 200, { status: "ok", version: AGENT_CARD.version });
+          return;
+        }
+
+        if (pathname === "/tasks" && methodName === "POST") {
+          const body = await readJsonBody(req);
+          const skill = String(body["skill"] ?? "");
+          const params =
+            (body["params"] as Record<string, unknown> | undefined) ??
+            (body["input"] as Record<string, unknown> | undefined) ??
+            {};
+          if (!skill) {
+            sendJson(res, 400, { error: "skill is required" });
+            return;
+          }
+          const id = String(body["id"] ?? randomUUID());
+          const createdAt = new Date().toISOString();
+          const task: Task = { id, skill, status: "running", createdAt };
+          tasks.set(id, task);
+
+          try {
+            const result = await dispatchSkill(skill, params);
+            task.status = "completed";
+            task.completedAt = new Date().toISOString();
+            task.result = result;
+            sendJson(res, 200, { id, status: "completed", result });
+          } catch (err) {
+            // Log detail server-side; don't return exception/stack text to the
+            // client (CodeQL js/stack-trace-exposure).
+            console.error("[goldenpipe-a2a] skill failed:", err);
+            task.status = "failed";
+            task.completedAt = new Date().toISOString();
+            task.error = "skill execution failed";
+            sendJson(res, 200, { id, status: "failed", error: "skill execution failed" });
+          }
+          return;
+        }
+
+        if (pathname.startsWith("/tasks/") && methodName === "GET") {
+          const id = pathname.slice("/tasks/".length);
+          const task = tasks.get(id);
+          if (!task) {
+            sendJson(res, 404, { error: `Task not found: ${id}` });
+            return;
+          }
+          sendJson(res, 200, {
+            id: task.id,
+            skill: task.skill,
+            status: task.status,
+            created_at: task.createdAt,
+            completed_at: task.completedAt ?? null,
+            result: task.result ?? null,
+            error: task.error ?? null,
+          });
+          return;
+        }
+
+        sendJson(res, 404, { error: `Not found: ${methodName} ${pathname}` });
+      } catch (err) {
+        console.error("[goldenpipe-a2a] request error:", err);
+        sendJson(res, 500, { error: "internal server error" });
+      }
+    })();
+  });
+
+  server.listen(port, host, () => {
+    console.log(`GoldenPipe A2A agent listening on http://${host}:${port}`);
+  });
+  return server;
+}
+
+export function runServer(port: number = 8250): ReturnType<typeof createServer> {
+  return startA2aServer({ port });
+}

--- a/packages/typescript/goldenpipe/src/node/api/server.ts
+++ b/packages/typescript/goldenpipe/src/node/api/server.ts
@@ -1,0 +1,117 @@
+/**
+ * api/server.ts -- GoldenPipe REST API server.
+ *
+ * Node-only: uses node:http, node:path. NOT edge-safe.
+ *
+ * Port of goldenpipe/api/server.py (FastAPI). Mirrors the sibling GoldenFlow TS
+ * API server for structure. Endpoints:
+ *   GET  /health     - liveness probe
+ *   GET  /stages     - list registered stages with produces/consumes
+ *   POST /validate    - validate pipeline wiring ({ pipeline, stages })
+ *   POST /run         - run a pipeline on a CSV ({ source })
+ *
+ * /stages and /validate delegate to the MCP tool handler; /run calls the
+ * file-based `run` directly so the response can include per-stage timing
+ * (parity with the Python REST endpoint).
+ */
+
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { resolve, isAbsolute } from "node:path";
+import { handleTool } from "../mcp/server.js";
+import { run } from "../run.js";
+
+const VERSION = "1.0.0";
+
+/** Resolve a path relative to cwd and reject traversal outside it. */
+function sanitizePath(raw: string): string {
+  const resolved = isAbsolute(raw) ? resolve(raw) : resolve(process.cwd(), raw);
+  const cwd = resolve(process.cwd());
+  if (!resolved.startsWith(cwd)) {
+    throw new Error(`Path '${raw}' is outside the working directory`);
+  }
+  return resolved;
+}
+
+function jsonResponse(res: ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(data));
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export function createApp(): ReturnType<typeof createServer> {
+  return createServer((req, res) => {
+    void (async () => {
+      const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+      const pathname = url.pathname;
+      const methodName = req.method ?? "GET";
+
+      try {
+        if (pathname === "/health" && methodName === "GET") {
+          return jsonResponse(res, 200, { status: "ok", version: VERSION });
+        }
+
+        if (pathname === "/stages" && methodName === "GET") {
+          return jsonResponse(res, 200, await handleTool("list_stages", {}));
+        }
+
+        if (pathname === "/validate" && methodName === "POST") {
+          let data: { pipeline?: string; stages?: unknown[] };
+          try {
+            data = JSON.parse(await readBody(req));
+          } catch {
+            return jsonResponse(res, 400, { error: "Invalid JSON" });
+          }
+          const result = await handleTool("validate_pipeline", {
+            pipeline: data.pipeline ?? "",
+            stages: data.stages ?? [],
+          });
+          return jsonResponse(res, 200, result);
+        }
+
+        if (pathname === "/run" && methodName === "POST") {
+          let data: { source?: string };
+          try {
+            data = JSON.parse(await readBody(req));
+          } catch {
+            return jsonResponse(res, 400, { error: "Invalid JSON" });
+          }
+          if (!data.source) {
+            return jsonResponse(res, 400, { error: "'source' is required" });
+          }
+          const result = await run(sanitizePath(data.source));
+          return jsonResponse(res, 200, {
+            status: result.status,
+            source: result.source,
+            input_rows: result.inputRows,
+            errors: result.errors,
+            skipped: result.skipped,
+            timing: result.timing,
+          });
+        }
+
+        jsonResponse(res, 404, { error: "Not found" });
+      } catch (err) {
+        // Log server-side; return a generic message (CodeQL js/stack-trace-exposure).
+        console.error("[goldenpipe-api] request error:", err);
+        jsonResponse(res, 500, { error: "internal server error" });
+      }
+    })();
+  });
+}
+
+export function runServer(port = 8000, host = "0.0.0.0"): ReturnType<typeof createServer> {
+  const app = createApp();
+  app.listen(port, host, () => {
+    console.log(`GoldenPipe API server running at http://${host}:${port}`);
+  });
+  return app;
+}

--- a/packages/typescript/goldenpipe/src/node/index.ts
+++ b/packages/typescript/goldenpipe/src/node/index.ts
@@ -11,3 +11,10 @@ export type { RunOptions } from "./run.js";
 export { readCsv, parseCsv } from "./csv.js";
 export { loadConfig, normalizeConfig } from "./loadConfig.js";
 export { TOOLS as MCP_TOOLS, handleTool as mcpHandleTool, startMcpServer } from "./mcp/server.js";
+export {
+  AGENT_CARD,
+  startA2aServer,
+  runServer as runA2aServer,
+} from "./a2a/server.js";
+export type { AgentSkill, StartA2aOptions } from "./a2a/server.js";
+export { createApp as createApiApp, runServer as runApiServer } from "./api/server.js";

--- a/packages/typescript/goldenpipe/src/node/index.ts
+++ b/packages/typescript/goldenpipe/src/node/index.ts
@@ -10,3 +10,4 @@ export { run } from "./run.js";
 export type { RunOptions } from "./run.js";
 export { readCsv, parseCsv } from "./csv.js";
 export { loadConfig, normalizeConfig } from "./loadConfig.js";
+export { TOOLS as MCP_TOOLS, handleTool as mcpHandleTool, startMcpServer } from "./mcp/server.js";

--- a/packages/typescript/goldenpipe/src/node/mcp/server.ts
+++ b/packages/typescript/goldenpipe/src/node/mcp/server.ts
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+/**
+ * mcp/server.ts -- GoldenPipe MCP server (stdio transport, JSON-RPC 2.0).
+ *
+ * Node-only: uses node:path, node:readline. NOT edge-safe.
+ *
+ * Exposes 4 tools (`list_stages`, `validate_pipeline`, `run_pipeline`,
+ * `explain_pipeline`) wired to the GoldenPipe TS core/node APIs -- byte-parity
+ * with the Python sibling at `packages/python/goldenpipe/goldenpipe/mcp/server.py`.
+ *
+ * Every tool dispatch is wrapped in try/catch so a single failure never crashes
+ * the JSON-RPC loop; errors come back as `{ error: "<msg>" }`.
+ *
+ * Mirrors the hand-rolled JSON-RPC pattern in the sibling InferMap / GoldenFlow
+ * TS servers (no MCP SDK dep).
+ */
+
+import { resolve, isAbsolute } from "node:path";
+import { createInterface } from "node:readline";
+
+import {
+  buildDefaultRegistry,
+  Resolver,
+  WiringError,
+  makePipelineConfig,
+} from "../../core/index.js";
+import { run } from "../run.js";
+import { loadConfig } from "../loadConfig.js";
+
+// ---------------------------------------------------------------------------
+// Path safety
+// ---------------------------------------------------------------------------
+
+/** Resolve a path relative to cwd and reject traversal outside it. */
+function sanitizePath(raw: string): string {
+  const resolved = isAbsolute(raw) ? resolve(raw) : resolve(process.cwd(), raw);
+  const cwd = resolve(process.cwd());
+  if (!resolved.startsWith(cwd)) {
+    throw new Error(`Path '${raw}' is outside the working directory`);
+  }
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+interface Tool {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Readonly<Record<string, unknown>>;
+}
+
+export const TOOLS: readonly Tool[] = [
+  {
+    name: "list_stages",
+    description: "List all registered pipeline stages with their produces/consumes contracts.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "validate_pipeline",
+    description: "Validate pipeline wiring — every stage's consumes must be produced by an earlier stage.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        pipeline: { type: "string", description: "Pipeline name." },
+        stages: {
+          type: "array",
+          items: { type: "string" },
+          description: "Ordered list of stage names (e.g. ['goldencheck.scan', 'goldenflow.transform']).",
+        },
+      },
+      required: ["pipeline", "stages"],
+    },
+  },
+  {
+    name: "run_pipeline",
+    description: "Run a pipeline on a CSV file. Zero-config or from a YAML config path.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        source: { type: "string", description: "Path to the input CSV file." },
+        config_path: { type: "string", description: "Optional path to a YAML pipeline config." },
+      },
+      required: ["source"],
+    },
+  },
+  {
+    name: "explain_pipeline",
+    description: "Explain what a pipeline config will do — resolves it into an ordered stage plan.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        config_path: { type: "string", description: "Path to a YAML pipeline config." },
+      },
+      required: ["config_path"],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleTool(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  try {
+    switch (name) {
+      case "list_stages": {
+        const registry = buildDefaultRegistry();
+        const out: Record<string, { produces: string[]; consumes: string[] }> = {};
+        for (const [stageName, info] of Object.entries(registry.listAll())) {
+          out[stageName] = { produces: info.produces, consumes: info.consumes };
+        }
+        return out;
+      }
+
+      case "validate_pipeline": {
+        const pipeline = String(args["pipeline"] ?? "");
+        const stages = (args["stages"] as unknown[] | undefined ?? []).map((s) => String(s));
+        try {
+          const config = makePipelineConfig({ pipeline, stages });
+          const plan = Resolver.resolve(config, buildDefaultRegistry());
+          return { valid: true, stages: plan.stages.map((s) => s.name) };
+        } catch (e) {
+          if (e instanceof WiringError) {
+            return { valid: false, error: e.message };
+          }
+          throw e;
+        }
+      }
+
+      case "run_pipeline": {
+        const source = sanitizePath(String(args["source"]));
+        const configArg = args["config_path"];
+        const options =
+          configArg !== undefined && configArg !== null
+            ? { config: sanitizePath(String(configArg)) }
+            : undefined;
+        const result = await run(source, options);
+        return {
+          status: result.status,
+          source: result.source,
+          input_rows: result.inputRows,
+          errors: result.errors,
+          skipped: result.skipped,
+        };
+      }
+
+      case "explain_pipeline": {
+        const configPath = sanitizePath(String(args["config_path"]));
+        const config = await loadConfig(configPath);
+        const plan = Resolver.resolve(config, buildDefaultRegistry());
+        return {
+          pipeline: config.pipeline,
+          stages: plan.stages.map((s) => ({
+            name: s.name,
+            produces: s.stage.info.produces,
+            consumes: s.stage.info.consumes,
+          })),
+        };
+      }
+
+      default:
+        return { error: `Unknown tool: ${name}` };
+    }
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC over stdio
+// ---------------------------------------------------------------------------
+
+interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: number | string | null;
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+function writeMessage(msg: Record<string, unknown>): void {
+  process.stdout.write(JSON.stringify(msg) + "\n");
+}
+
+/**
+ * Start the MCP server reading JSON-RPC messages one per line from stdin and
+ * writing responses to stdout. Intended for Claude Desktop / any MCP client
+ * using stdio transport.
+ */
+export function startMcpServer(): void {
+  const rl = createInterface({ input: process.stdin, terminal: false });
+
+  rl.on("line", (line: string) => {
+    if (line.trim() === "") return;
+    let req: JsonRpcRequest;
+    try {
+      req = JSON.parse(line) as JsonRpcRequest;
+    } catch (err) {
+      console.warn("MCP parse error:", err instanceof Error ? err.message : String(err));
+      return;
+    }
+
+    const id = req.id ?? null;
+
+    void (async () => {
+      try {
+        if (req.method === "initialize") {
+          writeMessage({
+            jsonrpc: "2.0",
+            id,
+            result: {
+              protocolVersion: "2024-11-05",
+              serverInfo: { name: "goldenpipe", version: "0.2.0" },
+              capabilities: { tools: {}, resources: {}, prompts: {} },
+            },
+          });
+          return;
+        }
+
+        if (req.method === "tools/list") {
+          writeMessage({ jsonrpc: "2.0", id, result: { tools: TOOLS } });
+          return;
+        }
+
+        if (req.method === "tools/call") {
+          const params = req.params ?? {};
+          const toolName = String(params["name"] ?? "");
+          const toolArgs = (params["arguments"] as Record<string, unknown> | undefined) ?? {};
+          const result = await handleTool(toolName, toolArgs);
+          writeMessage({
+            jsonrpc: "2.0",
+            id,
+            result: { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] },
+          });
+          return;
+        }
+
+        if (req.method === "resources/list") {
+          writeMessage({ jsonrpc: "2.0", id, result: { resources: [] } });
+          return;
+        }
+
+        if (req.method === "prompts/list") {
+          writeMessage({ jsonrpc: "2.0", id, result: { prompts: [] } });
+          return;
+        }
+
+        if (
+          req.method === "notifications/initialized" ||
+          req.method === "notifications/cancelled"
+        ) {
+          return;
+        }
+
+        writeMessage({
+          jsonrpc: "2.0",
+          id,
+          error: { code: -32601, message: `Method not found: ${req.method}` },
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        writeMessage({ jsonrpc: "2.0", id, error: { code: -32603, message: msg } });
+      }
+    })();
+  });
+
+  rl.on("close", () => {
+    process.exit(0);
+  });
+}
+
+// Run as a bin when invoked directly (the `goldenpipe-mcp` entry point).
+// tsup compiles this to dist/node/mcp/server.{js,cjs}; the cjs build is the bin.
+const isMain = (() => {
+  try {
+    return typeof require !== "undefined" && require.main === module;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  startMcpServer();
+}

--- a/packages/typescript/goldenpipe/tests/unit/mcp.test.ts
+++ b/packages/typescript/goldenpipe/tests/unit/mcp.test.ts
@@ -1,0 +1,133 @@
+// GoldenPipe MCP server tests. Mirrors the sibling InferMap / GoldenMatch MCP
+// server test layout (TOOLS metadata + handleTool dispatcher) and matches the
+// Python sibling's 4-tool surface: list_stages, validate_pipeline, run_pipeline,
+// explain_pipeline.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { relative, join } from "node:path";
+
+import { TOOLS, handleTool } from "../../src/node/mcp/server.js";
+
+describe("MCP server — TOOLS metadata", () => {
+  it("exports the four GoldenPipe tools", () => {
+    const names = TOOLS.map((t) => t.name);
+    expect(names).toEqual([
+      "list_stages",
+      "validate_pipeline",
+      "run_pipeline",
+      "explain_pipeline",
+    ]);
+  });
+
+  it("each tool has a name, description, and inputSchema", () => {
+    for (const tool of TOOLS) {
+      expect(typeof tool.name).toBe("string");
+      expect(tool.name.length).toBeGreaterThan(0);
+      expect(typeof tool.description).toBe("string");
+      expect(tool.description.length).toBeGreaterThan(0);
+      expect(tool.inputSchema).toBeTypeOf("object");
+      expect(tool.inputSchema).not.toBeNull();
+    }
+  });
+
+  it("every tool name is unique", () => {
+    const names = TOOLS.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("declares required args matching the Python sibling", () => {
+    const validate = TOOLS.find((t) => t.name === "validate_pipeline")!;
+    expect(validate.inputSchema["required"]).toEqual(["pipeline", "stages"]);
+    const run = TOOLS.find((t) => t.name === "run_pipeline")!;
+    expect(run.inputSchema["required"]).toEqual(["source"]);
+    const explain = TOOLS.find((t) => t.name === "explain_pipeline")!;
+    expect(explain.inputSchema["required"]).toEqual(["config_path"]);
+  });
+});
+
+describe("MCP server — handleTool dispatcher", () => {
+  it("list_stages returns the built-in suite stages with contracts", async () => {
+    const result = (await handleTool("list_stages", {})) as Record<
+      string,
+      { produces: string[]; consumes: string[] }
+    >;
+    expect(Object.keys(result).sort()).toEqual([
+      "goldencheck.scan",
+      "goldenflow.transform",
+      "goldenmatch.dedupe",
+      "load",
+    ]);
+    expect(result["load"]!.produces).toContain("df");
+    expect(result["goldencheck.scan"]!.consumes).toContain("df");
+  });
+
+  it("validate_pipeline accepts a well-wired chain", async () => {
+    const result = (await handleTool("validate_pipeline", {
+      pipeline: "demo",
+      stages: ["goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe"],
+    })) as { valid: boolean; stages: string[] };
+    expect(result.valid).toBe(true);
+    // load is auto-prepended by the resolver.
+    expect(result.stages).toEqual([
+      "load",
+      "goldencheck.scan",
+      "goldenflow.transform",
+      "goldenmatch.dedupe",
+    ]);
+  });
+
+  it("validate_pipeline surfaces an error for an unknown stage", async () => {
+    const result = (await handleTool("validate_pipeline", {
+      pipeline: "demo",
+      stages: ["does.not.exist"],
+    })) as { error?: string; valid?: boolean };
+    expect(result.error).toBeTypeOf("string");
+  });
+
+  it("run_pipeline maps PipeResult to snake_case keys (failed read path)", async () => {
+    const result = (await handleTool("run_pipeline", {
+      source: "definitely-missing-file.csv",
+    })) as { status: string; input_rows: number; errors: string[] };
+    expect(result.status).toBe("failed");
+    expect(result.input_rows).toBe(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("explain_pipeline resolves a YAML config into an ordered plan", async () => {
+    const absDir = await mkdtemp("./goldenpipe-mcp-test-");
+    const dir = relative(process.cwd(), absDir);
+    const configPath = join(dir, "pipe.yml");
+    await writeFile(
+      configPath,
+      "pipeline: demo\nstages:\n  - goldencheck.scan\n  - goldenflow.transform\n",
+      "utf-8",
+    );
+    try {
+      const result = (await handleTool("explain_pipeline", {
+        config_path: configPath,
+      })) as { pipeline: string; stages: { name: string }[] };
+      expect(result.pipeline).toBe("demo");
+      expect(result.stages.map((s) => s.name)).toEqual([
+        "load",
+        "goldencheck.scan",
+        "goldenflow.transform",
+      ]);
+    } finally {
+      await rm(absDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects file paths outside the working directory", async () => {
+    const result = (await handleTool("run_pipeline", {
+      source: "/etc/passwd",
+    })) as { error?: string };
+    expect(result.error).toBeTypeOf("string");
+    expect(result.error).toContain("outside the working directory");
+  });
+
+  it("returns an error object for an unknown tool", async () => {
+    const result = (await handleTool("nonexistent_tool", {})) as { error: string };
+    expect(result.error).toContain("Unknown tool");
+  });
+});

--- a/packages/typescript/goldenpipe/tests/unit/servers.test.ts
+++ b/packages/typescript/goldenpipe/tests/unit/servers.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the GoldenPipe A2A + REST API servers.
+ * Mirrors the sibling GoldenFlow / GoldenMatch server tests and the Python
+ * packages/python/goldenpipe/tests cases. Both servers delegate to the same 4
+ * MCP tools, so these tests focus on the HTTP wiring + skill/endpoint dispatch.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { Server } from "node:http";
+import { startA2aServer, AGENT_CARD } from "../../src/node/a2a/server.js";
+import { createApp } from "../../src/node/api/server.js";
+
+function portOf(server: Server, fallback: number): number {
+  const addr = server.address();
+  return typeof addr === "object" && addr !== null && "port" in addr ? addr.port : fallback;
+}
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((res) => {
+    if (server.listening) return res();
+    server.once("listening", () => res());
+  });
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res())));
+}
+
+describe("A2A agent card", () => {
+  it("has name GoldenPipe and the 4 parity skills", () => {
+    expect(AGENT_CARD.name).toBe("GoldenPipe");
+    const ids = AGENT_CARD.skills.map((s) => s.id);
+    expect(ids).toEqual(["run-pipeline", "validate-pipeline", "list-stages", "explain-pipeline"]);
+    for (const skill of AGENT_CARD.skills) {
+      expect(skill.id.length).toBeGreaterThan(0);
+      expect(typeof skill.name).toBe("string");
+      expect(Array.isArray(skill.inputModes)).toBe(true);
+      expect(Array.isArray(skill.outputModes)).toBe(true);
+    }
+  });
+});
+
+describe("A2A server HTTP endpoints", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    server = startA2aServer({ port: 0, host: "127.0.0.1" });
+    await listen(server);
+    baseUrl = `http://127.0.0.1:${portOf(server, 8250)}`;
+  });
+  afterAll(async () => close(server));
+
+  it("GET /.well-known/agent.json returns the card", async () => {
+    const res = await fetch(baseUrl + "/.well-known/agent.json");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { name: string; skills: unknown[] };
+    expect(body.name).toBe("GoldenPipe");
+    expect(body.skills.length).toBe(4);
+  });
+
+  it("GET /health returns ok", async () => {
+    const res = await fetch(baseUrl + "/health");
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("ok");
+  });
+
+  it("POST /tasks list-stages returns the registered stages", async () => {
+    const res = await fetch(baseUrl + "/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "t1", skill: "list-stages", params: {} }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; result: Record<string, unknown> };
+    expect(body.status).toBe("completed");
+    expect(Object.keys(body.result)).toContain("goldenmatch.dedupe");
+  });
+
+  it("POST /tasks validate-pipeline returns valid:true", async () => {
+    const res = await fetch(baseUrl + "/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        skill: "validate-pipeline",
+        params: { pipeline: "demo", stages: ["goldencheck.scan", "goldenflow.transform"] },
+      }),
+    });
+    const body = (await res.json()) as { result: { valid: boolean } };
+    expect(body.result.valid).toBe(true);
+  });
+
+  it("POST /tasks rejects an unknown skill", async () => {
+    const res = await fetch(baseUrl + "/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ skill: "nope", params: {} }),
+    });
+    const body = (await res.json()) as { result: { error?: string } };
+    expect(body.result.error).toContain("Unknown skill");
+  });
+});
+
+describe("REST API server HTTP endpoints", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    server = createApp();
+    server.listen(0, "127.0.0.1");
+    await listen(server);
+    baseUrl = `http://127.0.0.1:${portOf(server, 8000)}`;
+  });
+  afterAll(async () => close(server));
+
+  it("GET /health returns ok", async () => {
+    const res = await fetch(baseUrl + "/health");
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("ok");
+  });
+
+  it("GET /stages lists the suite stages", async () => {
+    const res = await fetch(baseUrl + "/stages");
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(Object.keys(body)).toContain("goldencheck.scan");
+  });
+
+  it("POST /validate returns valid:true for a well-wired chain", async () => {
+    const res = await fetch(baseUrl + "/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pipeline: "demo", stages: ["goldencheck.scan"] }),
+    });
+    const body = (await res.json()) as { valid: boolean };
+    expect(body.valid).toBe(true);
+  });
+
+  it("POST /run requires a source", async () => {
+    const res = await fetch(baseUrl + "/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /run on a missing file returns a failed status with timing", async () => {
+    const res = await fetch(baseUrl + "/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source: "missing-pipe-input.csv" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; input_rows: number; timing: unknown };
+    expect(body.status).toBe("failed");
+    expect(body.input_rows).toBe(0);
+    expect(body.timing).toBeDefined();
+  });
+});

--- a/packages/typescript/goldenpipe/tsup.config.ts
+++ b/packages/typescript/goldenpipe/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     index: "src/index.ts",
     "core/index": "src/core/index.ts",
     "node/index": "src/node/index.ts",
+    "node/mcp/server": "src/node/mcp/server.ts",
     cli: "src/cli.ts",
   },
   format: ["esm", "cjs"],


### PR DESCRIPTION
## Summary

Executes the roadmap from the cross-surface parity audit. Incremental — landing in waves on this branch.

### Wave 0 — hygiene / doc-drift (this commit)
- **Postgres extension version realign:** the install SQL + `.control default_version` were frozen at `0.1.0` while the crate moved to `0.5.0`, so a fresh `CREATE EXTENSION goldenmatch_pg` reported the wrong surface version. Renamed `goldenmatch_pg--0.1.0.sql` → `--0.5.0.sql`, bumped `default_version`, and updated every active reference (root CI + publish workflow `cp` steps, Dockerfile, install.sh, READMEs, docs/AI-rules mirrors). Timely: the `v0.5.0` publish is pending, so it will now report 0.5.0.
- **extensions/CLAUDE.md:** documented that DuckDB also exposes the `gm_configure/gm_run/gm_jobs/gm_golden/gm_drop` job-management UDFs (both backends) — the doc previously implied these were Postgres-only. `gm_pairs`/`gm_clusters` remain Postgres-only table-returning by design.
- **dbt-goldensuite README:** replaced the stale "materialization coming soon" status with the actual macro inventory (dedupe materialization + identity/quality/transform macros already ship).

### Planned next waves
- **Wave 1** — goldenpipe TS interface parity (MCP, then A2A, REST) + wire TS MCP bins for gm/gc/gf.
- **Wave 2** — TS MCP tool-depth on goldenmatch/goldencheck.
- **Wave 3** — SQL surface expansion for SQL-natural Python APIs; document the deferred-by-design set.
- **Wave 4 (decision-gated)** — goldenmatch TS REST/web UI + distributed/Ray (likely declared Python-only by design).
- **Wave 5** — peripheral breadth (actions, dbt macros, infermap interfaces).

## Test plan
- [ ] CI postgres-build lane: `cp sql/goldenmatch_pg--0.5.0.sql` + `CREATE EXTENSION goldenmatch_pg;` succeeds (validates the rename + default_version).
- [ ] Full CI matrix re-runs (ci.yml touched).

https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx)_