### PR TITLE
Wave 2: TS MCP tool-depth (goldenmatch identity + goldencheck agent tools)

### DIFF
--- a/packages/python/goldencheck/CLAUDE.md
+++ b/packages/python/goldencheck/CLAUDE.md
@@ -214,6 +214,7 @@ npm run dev                      # tsup --watch
 - Profiler interface: `profile(data: TabularData, column: string, context?: Record<string, unknown>): Finding[]`
 - Findings are immutable — use `replaceFinding()` (spread), never mutate
 - Mulberry32 PRNG (not Mersenne Twister) — deterministic but NOT matching Python's `random.Random(seed)`
+- **MCP tools (v0.4.0): 17 = 7 core + 10 agent.** `src/node/mcp/agent-tools.ts` ports `goldencheck/mcp/agent_tools.py` (analyze_data, auto_configure, explain_finding, explain_column, review_queue, approve_reject, compare_domains, suggest_fix, pipeline_handoff, review_stats), wiring the existing TS agent + engine primitives. Composed into `TOOL_DEFINITIONS` (`CORE_TOOL_DEFINITIONS` + `AGENT_TOOLS`) and routed via `AGENT_TOOL_NAMES` in the server. Handlers are synchronous and return plain objects (the server's `handleTool` convention). `auto_configure` hand-emits the small `goldencheck.yml` (no runtime `yaml` dep). Shared `ReviewQueue` singleton with `__resetReviewQueueForTests`.
 
 ### Publishing
 - npm publish: push tag `goldencheck-js-v*` triggers `.github/workflows/npm-publish.yml`

--- a/packages/typescript/goldencheck/package.json
+++ b/packages/typescript/goldencheck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldencheck",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Data validation that discovers rules from your data. TypeScript port of the goldencheck Python library.",
   "keywords": [
     "data-validation",

--- a/packages/typescript/goldencheck/src/node/mcp/agent-tools.ts
+++ b/packages/typescript/goldencheck/src/node/mcp/agent-tools.ts
@@ -1,0 +1,443 @@
+/**
+ * mcp/agent-tools.ts -- 10 agent-level MCP tools for GoldenCheck.
+ *
+ * Parity with goldencheck/mcp/agent_tools.py: strategy analysis, auto-config,
+ * finding/column explanation, review queue, domain comparison, fix preview, and
+ * pipeline handoff. Wires the existing TS agent + engine primitives.
+ *
+ * Node-only: reads files via ../reader.js. Handlers are synchronous and return
+ * plain objects (matching the GoldenCheck MCP server convention); errors are
+ * trapped and returned as `{ error }` rather than thrown.
+ */
+
+import { existsSync } from "node:fs";
+
+import { readFile } from "../reader.js";
+import { scanData } from "../../core/engine/scanner.js";
+import { applyConfidenceDowngrade } from "../../core/engine/confidence.js";
+import { autoTriage } from "../../core/engine/triage.js";
+import { applyFixes } from "../../core/engine/fixer.js";
+import {
+  selectStrategy,
+  buildAlternatives,
+  explainFinding,
+  explainColumn,
+  compareDomains,
+  generateHandoff,
+  ReviewQueue,
+} from "../../core/agent/index.js";
+import { Severity, severityLabel, type Finding } from "../../core/types.js";
+
+export interface Tool {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Readonly<Record<string, unknown>>;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions (mirror Python agent_tools.py)
+// ---------------------------------------------------------------------------
+
+export const AGENT_TOOLS: readonly Tool[] = [
+  {
+    name: "analyze_data",
+    description:
+      "Analyze a data file to detect its domain, profile columns, and recommend a " +
+      "scanning strategy. Returns domain detection, column/row counts, strategy " +
+      "decisions, and alternative approaches.",
+    inputSchema: {
+      type: "object",
+      properties: { file_path: { type: "string", description: "Path to the data file (CSV, Parquet)" } },
+      required: ["file_path"],
+    },
+  },
+  {
+    name: "auto_configure",
+    description:
+      "Scan a data file, triage findings by confidence, and generate goldencheck.yml " +
+      "content from the pinned findings. Optionally accepts constraints to filter the config.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        file_path: { type: "string", description: "Path to the data file" },
+        constraints: {
+          type: "object",
+          description: "Optional: { min_confidence, severity_filter, include_columns, exclude_columns }",
+        },
+      },
+      required: ["file_path"],
+    },
+  },
+  {
+    name: "explain_finding",
+    description:
+      "Explain a single finding in natural language. Requires the finding as a JSON " +
+      "dict and the file_path to load a profile for context.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        file_path: { type: "string", description: "Path to the data file (for profile context)" },
+        finding: {
+          type: "object",
+          description: "Finding dict: severity, column, check, message, affected_rows, confidence, sample_values",
+        },
+      },
+      required: ["file_path", "finding"],
+    },
+  },
+  {
+    name: "explain_column",
+    description:
+      "Get a natural-language health narrative for a specific column. Scans the file, " +
+      "profiles the column, and explains all findings.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        file_path: { type: "string", description: "Path to the data file" },
+        column: { type: "string", description: "Column name to explain" },
+      },
+      required: ["file_path", "column"],
+    },
+  },
+  {
+    name: "review_queue",
+    description: "List all pending review items for a given job (medium-confidence findings needing a decision).",
+    inputSchema: {
+      type: "object",
+      properties: { job_name: { type: "string", description: "Job name to filter review items" } },
+      required: ["job_name"],
+    },
+  },
+  {
+    name: "approve_reject",
+    description: "Approve (pin) or reject (dismiss) a review queue item. Decision must be 'pin' or 'dismiss'.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        item_id: { type: "string", description: "Review item ID to update" },
+        decision: { type: "string", description: "'pin' (approve) or 'dismiss' (reject)", enum: ["pin", "dismiss"] },
+        reason: { type: "string", description: "Optional reason for the decision" },
+      },
+      required: ["item_id", "decision"],
+    },
+  },
+  {
+    name: "compare_domains",
+    description:
+      "Scan a file with every available domain pack (plus base/no-domain) and compare " +
+      "health scores. Recommends the best-fitting domain.",
+    inputSchema: {
+      type: "object",
+      properties: { file_path: { type: "string", description: "Path to the data file" } },
+      required: ["file_path"],
+    },
+  },
+  {
+    name: "suggest_fix",
+    description:
+      "Preview fixes for a data file without applying them. Shows what would change " +
+      "(columns, fix types, rows affected, before/after samples).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        file_path: { type: "string", description: "Path to the data file" },
+        mode: { type: "string", description: "'safe' (default) or 'aggressive'", default: "safe", enum: ["safe", "aggressive"] },
+      },
+      required: ["file_path"],
+    },
+  },
+  {
+    name: "pipeline_handoff",
+    description:
+      "Generate a structured quality attestation for a data file: health score, findings " +
+      "summary, pinned rules, and attestation status (PASS / PASS_WITH_WARNINGS / REVIEW_REQUIRED / FAIL).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        file_path: { type: "string", description: "Path to the data file" },
+        job_name: { type: "string", description: "Job name for the handoff record" },
+      },
+      required: ["file_path", "job_name"],
+    },
+  },
+  {
+    name: "review_stats",
+    description: "Get review queue statistics for a job — counts of pending, pinned, and dismissed items.",
+    inputSchema: {
+      type: "object",
+      properties: { job_name: { type: "string", description: "Job name to get stats for" } },
+      required: ["job_name"],
+    },
+  },
+];
+
+export const AGENT_TOOL_NAMES: ReadonlySet<string> = new Set(AGENT_TOOLS.map((t) => t.name));
+
+// ---------------------------------------------------------------------------
+// Shared review queue (created on first use, mirrors Python's module singleton)
+// ---------------------------------------------------------------------------
+
+let _reviewQueue: ReviewQueue | null = null;
+function getReviewQueue(): ReviewQueue {
+  if (_reviewQueue === null) _reviewQueue = new ReviewQueue();
+  return _reviewQueue;
+}
+
+/** Test seam: reset the shared review queue between tests. */
+export function __resetReviewQueueForTests(): void {
+  _reviewQueue = null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function severityFromName(name: unknown): Severity {
+  switch (String(name).toUpperCase()) {
+    case "ERROR":
+      return Severity.ERROR;
+    case "WARNING":
+      return Severity.WARNING;
+    default:
+      return Severity.INFO;
+  }
+}
+
+function findingFromDict(d: Record<string, unknown>): Finding {
+  return {
+    severity: severityFromName(d["severity"]),
+    column: typeof d["column"] === "string" ? (d["column"] as string) : "",
+    check: typeof d["check"] === "string" ? (d["check"] as string) : "",
+    message: typeof d["message"] === "string" ? (d["message"] as string) : "",
+    affectedRows: typeof d["affected_rows"] === "number" ? (d["affected_rows"] as number) : 0,
+    sampleValues: Array.isArray(d["sample_values"]) ? (d["sample_values"] as string[]).map(String) : [],
+    suggestion: typeof d["suggestion"] === "string" ? (d["suggestion"] as string) : null,
+    pinned: d["pinned"] === true,
+    source: typeof d["source"] === "string" ? (d["source"] as string) : null,
+    confidence: typeof d["confidence"] === "number" ? (d["confidence"] as number) : 1.0,
+    metadata: (d["metadata"] as Record<string, unknown>) ?? {},
+  };
+}
+
+/** Minimal YAML emitter for the fixed goldencheck.yml config shape. */
+function rulesToYaml(
+  rules: ReadonlyArray<Record<string, unknown>>,
+  rowCount: number,
+  columnCount: number,
+): string {
+  const q = (v: unknown): string => JSON.stringify(v ?? null);
+  const lines: string[] = [
+    "version: 1",
+    "dataset:",
+    `  row_count: ${rowCount}`,
+    `  column_count: ${columnCount}`,
+    "rules:",
+  ];
+  for (const r of rules) {
+    lines.push(`  - column: ${q(r["column"])}`);
+    lines.push(`    check: ${q(r["check"])}`);
+    lines.push(`    severity: ${String(r["severity"])}`);
+    lines.push(`    message: ${q(r["message"])}`);
+    if (r["suggestion"]) lines.push(`    suggestion: ${q(r["suggestion"])}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+export function handleAgentTool(name: string, args: Record<string, unknown>): object {
+  try {
+    return dispatch(name, args ?? {});
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function dispatch(name: string, args: Record<string, unknown>): object {
+  // Tools that read a file share the existence guard.
+  const filePath = typeof args["file_path"] === "string" ? (args["file_path"] as string) : "";
+  const needsFile = name !== "review_queue" && name !== "approve_reject" && name !== "review_stats";
+  if (needsFile) {
+    if (!filePath) return { error: "Missing required parameter: file_path" };
+    if (!existsSync(filePath)) return { error: `File not found: ${filePath}` };
+  }
+
+  if (name === "analyze_data") {
+    const data = readFile(filePath);
+    const decision = selectStrategy(data);
+    const scores = (decision.why["domain_scores"] as Record<string, number>) ?? {};
+    return {
+      file: filePath,
+      rows: data.rowCount,
+      columns: data.columns.length,
+      column_names: data.columns,
+      strategy: {
+        domain: decision.domain,
+        domain_confidence: Math.round(decision.domainConfidence * 1000) / 1000,
+        sample_strategy: decision.sampleStrategy,
+        profiler_strategy: decision.profilerStrategy,
+        llm_boost: decision.llmBoost,
+      },
+      reasoning: decision.why,
+      alternatives: buildAlternatives(decision, scores),
+    };
+  }
+
+  if (name === "auto_configure") {
+    const constraints = (args["constraints"] as Record<string, unknown>) ?? {};
+    const data = readFile(filePath);
+    const result = scanData(data);
+    const findings = applyConfidenceDowngrade(result.findings, false);
+    const triage = autoTriage(findings);
+
+    let pinned: Finding[] = [...triage.pin];
+    const minConf = typeof constraints["min_confidence"] === "number" ? (constraints["min_confidence"] as number) : 0;
+    if (minConf > 0) pinned = pinned.filter((f) => f.confidence >= minConf);
+    const sevFilter = constraints["severity_filter"];
+    if (typeof sevFilter === "string") {
+      const target = severityFromName(sevFilter);
+      pinned = pinned.filter((f) => f.severity >= target);
+    }
+    const include = constraints["include_columns"];
+    if (Array.isArray(include)) pinned = pinned.filter((f) => (include as unknown[]).includes(f.column));
+    const exclude = constraints["exclude_columns"];
+    if (Array.isArray(exclude)) pinned = pinned.filter((f) => !(exclude as unknown[]).includes(f.column));
+
+    const rules = pinned.map((f) => {
+      const rule: Record<string, unknown> = {
+        column: f.column,
+        check: f.check,
+        severity: severityLabel(f.severity),
+        message: f.message,
+      };
+      if (f.suggestion) rule["suggestion"] = f.suggestion;
+      if (f.metadata && Object.keys(f.metadata).length > 0) rule["metadata"] = f.metadata;
+      return rule;
+    });
+
+    return {
+      file: filePath,
+      pinned_count: pinned.length,
+      review_count: triage.review.length,
+      dismissed_count: triage.dismiss.length,
+      rules,
+      yaml_content: rulesToYaml(rules, result.profile.rowCount, result.profile.columnCount),
+    };
+  }
+
+  if (name === "explain_finding") {
+    const findingDict = args["finding"];
+    if (typeof findingDict !== "object" || findingDict === null) {
+      return { error: "Missing or invalid required parameter: finding" };
+    }
+    const data = readFile(filePath);
+    const result = scanData(data);
+    return explainFinding(findingFromDict(findingDict as Record<string, unknown>), result.profile);
+  }
+
+  if (name === "explain_column") {
+    const column = typeof args["column"] === "string" ? (args["column"] as string) : "";
+    if (!column) return { error: "Missing required parameter: column" };
+    const data = readFile(filePath);
+    const result = scanData(data);
+    return explainColumn(data, column, result.findings, result.profile);
+  }
+
+  if (name === "review_queue") {
+    const jobName = typeof args["job_name"] === "string" ? (args["job_name"] as string) : "";
+    if (!jobName) return { error: "Missing required parameter: job_name" };
+    const items = getReviewQueue()
+      .pending(jobName)
+      .map((it) => ({
+        item_id: it.itemId,
+        column: it.column,
+        check: it.check,
+        severity: it.severity,
+        confidence: it.confidence,
+        message: it.message,
+        explanation: it.explanation,
+        sample_values: it.sampleValues,
+      }));
+    return { job_name: jobName, pending_count: items.length, items };
+  }
+
+  if (name === "approve_reject") {
+    const itemId = typeof args["item_id"] === "string" ? (args["item_id"] as string) : "";
+    const decision = args["decision"];
+    if (!itemId) return { error: "Missing required parameter: item_id" };
+    if (decision !== "pin" && decision !== "dismiss") {
+      return { error: "decision must be 'pin' or 'dismiss'" };
+    }
+    const reason = typeof args["reason"] === "string" ? (args["reason"] as string) : "";
+    const queue = getReviewQueue();
+    try {
+      if (decision === "pin") queue.approve(itemId, "mcp_agent", reason);
+      else queue.reject(itemId, "mcp_agent", reason);
+    } catch {
+      return { error: `Review item not found: ${itemId}` };
+    }
+    return { item_id: itemId, decision, reason, status: "updated" };
+  }
+
+  if (name === "compare_domains") {
+    const data = readFile(filePath);
+    return compareDomains(data);
+  }
+
+  if (name === "suggest_fix") {
+    const mode = args["mode"] === "aggressive" ? "aggressive" : "safe";
+    const data = readFile(filePath);
+    const result = scanData(data);
+    const findings = applyConfidenceDowngrade(result.findings, false);
+    const { report } = applyFixes(data, findings, mode, mode === "aggressive");
+    const fixes = report.entries.map((e) => ({
+      column: e.column,
+      fix_type: e.fixType,
+      rows_affected: e.rowsAffected,
+      sample_before: e.sampleBefore.slice(0, 5),
+      sample_after: e.sampleAfter.slice(0, 5),
+    }));
+    return {
+      file: filePath,
+      mode,
+      total_fixes: fixes.length,
+      total_rows_fixed: report.totalRowsFixed,
+      fixes,
+    };
+  }
+
+  if (name === "pipeline_handoff") {
+    const jobName = typeof args["job_name"] === "string" ? (args["job_name"] as string) : "";
+    if (!jobName) return { error: "Missing required parameter: job_name" };
+    const data = readFile(filePath);
+    const result = scanData(data);
+    const findings = applyConfidenceDowngrade(result.findings, false);
+    const triage = autoTriage(findings);
+    const pinnedRules = triage.pin.map((f) => ({
+      column: f.column,
+      check: f.check,
+      severity: severityLabel(f.severity),
+      message: f.message,
+    }));
+    return generateHandoff({
+      filePath,
+      findings,
+      profile: result.profile,
+      pinnedRules,
+      reviewPending: triage.review.length,
+      dismissed: triage.dismiss.length,
+      jobName,
+    });
+  }
+
+  if (name === "review_stats") {
+    const jobName = typeof args["job_name"] === "string" ? (args["job_name"] as string) : "";
+    if (!jobName) return { error: "Missing required parameter: job_name" };
+    const stats = getReviewQueue().stats(jobName);
+    return { job_name: jobName, ...stats };
+  }
+
+  return { error: `Unknown agent tool: ${name}` };
+}

--- a/packages/typescript/goldencheck/src/node/mcp/server.ts
+++ b/packages/typescript/goldencheck/src/node/mcp/server.ts
@@ -11,9 +11,10 @@ import { scanData, type ScanOptions } from "../../core/engine/scanner.js";
 import { applyConfidenceDowngrade } from "../../core/engine/confidence.js";
 import { Severity, type Finding, type DatasetProfile, healthScore } from "../../core/types.js";
 import { listAvailableDomains, getDomainTypes } from "../../core/semantic/domains/index.js";
+import { AGENT_TOOLS, AGENT_TOOL_NAMES, handleAgentTool } from "./agent-tools.js";
 
 // Tool definitions for MCP registration
-export const TOOL_DEFINITIONS = [
+const CORE_TOOL_DEFINITIONS = [
   {
     name: "scan",
     description: "Scan a data file (CSV, Parquet) for data quality issues. Returns findings with severity, confidence, affected rows.",
@@ -84,6 +85,10 @@ export const TOOL_DEFINITIONS = [
   },
 ];
 
+// The full surface = 7 core tools + 10 agent tools (parity with the Python
+// goldencheck MCP server, which merges agent_tools.py into the core server).
+export const TOOL_DEFINITIONS = [...CORE_TOOL_DEFINITIONS, ...AGENT_TOOLS];
+
 // --- Tool handlers ---
 
 function findingsByColumn(findings: readonly Finding[]): Record<string, { errors: number; warnings: number }> {
@@ -112,6 +117,9 @@ function serializeFindings(findings: readonly Finding[]): object[] {
 }
 
 export function handleTool(name: string, args: Record<string, unknown>): object {
+  if (AGENT_TOOL_NAMES.has(name)) {
+    return handleAgentTool(name, args);
+  }
   switch (name) {
     case "scan":
       return toolScan(args);

--- a/packages/typescript/goldencheck/src/node/mcp/server.ts
+++ b/packages/typescript/goldencheck/src/node/mcp/server.ts
@@ -13,8 +13,17 @@ import { Severity, type Finding, type DatasetProfile, healthScore } from "../../
 import { listAvailableDomains, getDomainTypes } from "../../core/semantic/domains/index.js";
 import { AGENT_TOOLS, AGENT_TOOL_NAMES, handleAgentTool } from "./agent-tools.js";
 
+// Local Tool shape. Annotating the arrays with this (rather than letting the
+// type flow in from agent-tools) keeps the dts bundler from namespace-importing
+// agent-tools above the shebang (rollup-plugin-dts: "Syntax not yet supported").
+interface Tool {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Readonly<Record<string, unknown>>;
+}
+
 // Tool definitions for MCP registration
-const CORE_TOOL_DEFINITIONS = [
+const CORE_TOOL_DEFINITIONS: readonly Tool[] = [
   {
     name: "scan",
     description: "Scan a data file (CSV, Parquet) for data quality issues. Returns findings with severity, confidence, affected rows.",
@@ -87,7 +96,7 @@ const CORE_TOOL_DEFINITIONS = [
 
 // The full surface = 7 core tools + 10 agent tools (parity with the Python
 // goldencheck MCP server, which merges agent_tools.py into the core server).
-export const TOOL_DEFINITIONS = [...CORE_TOOL_DEFINITIONS, ...AGENT_TOOLS];
+export const TOOL_DEFINITIONS: readonly Tool[] = [...CORE_TOOL_DEFINITIONS, ...AGENT_TOOLS];
 
 // --- Tool handlers ---
 

--- a/packages/typescript/goldencheck/tests/unit/mcp-agent-tools.test.ts
+++ b/packages/typescript/goldencheck/tests/unit/mcp-agent-tools.test.ts
@@ -1,0 +1,135 @@
+/**
+ * MCP agent-tools tests. Parity with the Python
+ * tests/test_mcp_agent_tools.py surface (analyze/auto_configure/explain/
+ * review/compare/fix/handoff). File-based tools run against the committed
+ * tests/fixtures/simple.csv.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  AGENT_TOOLS,
+  AGENT_TOOL_NAMES,
+  handleAgentTool,
+  __resetReviewQueueForTests,
+} from "../../src/node/mcp/agent-tools.js";
+import { TOOL_DEFINITIONS, handleTool } from "../../src/node/mcp/server.js";
+
+const __dirnameLocal = dirname(fileURLToPath(import.meta.url));
+const SIMPLE_CSV = join(__dirnameLocal, "..", "fixtures", "simple.csv");
+
+beforeEach(() => __resetReviewQueueForTests());
+
+describe("AGENT_TOOLS metadata", () => {
+  it("exports the 10 agent tools matching the Python sibling", () => {
+    expect(AGENT_TOOLS.map((t) => t.name)).toEqual([
+      "analyze_data",
+      "auto_configure",
+      "explain_finding",
+      "explain_column",
+      "review_queue",
+      "approve_reject",
+      "compare_domains",
+      "suggest_fix",
+      "pipeline_handoff",
+      "review_stats",
+    ]);
+    expect(AGENT_TOOL_NAMES.size).toBe(10);
+  });
+
+  it("are merged into the server's TOOL_DEFINITIONS (7 core + 10 agent = 17)", () => {
+    expect(TOOL_DEFINITIONS.length).toBe(17);
+    expect(TOOL_DEFINITIONS.map((t) => t.name)).toContain("analyze_data");
+    expect(TOOL_DEFINITIONS.map((t) => t.name)).toContain("scan");
+  });
+});
+
+describe("agent tool dispatch (file-based)", () => {
+  it("analyze_data returns strategy + counts", () => {
+    const r = handleAgentTool("analyze_data", { file_path: SIMPLE_CSV }) as Record<string, unknown>;
+    expect(r["rows"]).toBeGreaterThan(0);
+    expect(Array.isArray(r["column_names"])).toBe(true);
+    expect((r["strategy"] as Record<string, unknown>)["profiler_strategy"]).toBeTypeOf("string");
+  });
+
+  it("auto_configure returns rules + goldencheck.yml content", () => {
+    const r = handleAgentTool("auto_configure", { file_path: SIMPLE_CSV }) as Record<string, unknown>;
+    expect(Array.isArray(r["rules"])).toBe(true);
+    expect(r["yaml_content"]).toBeTypeOf("string");
+    expect(String(r["yaml_content"])).toContain("version: 1");
+    expect(r["pinned_count"]).toBeTypeOf("number");
+  });
+
+  it("auto_configure honors exclude_columns constraint", () => {
+    const r = handleAgentTool("auto_configure", {
+      file_path: SIMPLE_CSV,
+      constraints: { exclude_columns: ["email", "name", "age", "status", "id"] },
+    }) as Record<string, unknown>;
+    expect(r["pinned_count"]).toBe(0);
+  });
+
+  it("explain_column returns a narrative object", () => {
+    const r = handleAgentTool("explain_column", { file_path: SIMPLE_CSV, column: "email" }) as Record<string, unknown>;
+    expect(typeof r).toBe("object");
+    expect(Object.keys(r).length).toBeGreaterThan(0);
+  });
+
+  it("compare_domains returns a comparison object", () => {
+    const r = handleAgentTool("compare_domains", { file_path: SIMPLE_CSV }) as Record<string, unknown>;
+    expect(typeof r).toBe("object");
+  });
+
+  it("suggest_fix previews fixes without applying", () => {
+    const r = handleAgentTool("suggest_fix", { file_path: SIMPLE_CSV }) as Record<string, unknown>;
+    expect(r["mode"]).toBe("safe");
+    expect(Array.isArray(r["fixes"])).toBe(true);
+    expect(r["total_rows_fixed"]).toBeTypeOf("number");
+  });
+
+  it("pipeline_handoff returns a quality attestation", () => {
+    const r = handleAgentTool("pipeline_handoff", { file_path: SIMPLE_CSV, job_name: "job1" }) as Record<string, unknown>;
+    expect(r["source_tool"]).toBe("goldencheck");
+    expect(r["job_name"]).toBe("job1");
+    expect(r["health"]).toBeTypeOf("object");
+  });
+
+  it("returns File not found for a missing path", () => {
+    const r = handleAgentTool("analyze_data", { file_path: "does-not-exist.csv" }) as Record<string, unknown>;
+    expect(String(r["error"])).toContain("File not found");
+  });
+});
+
+describe("agent tool dispatch (review queue)", () => {
+  it("review_queue is empty for a fresh job", () => {
+    const r = handleAgentTool("review_queue", { job_name: "job1" }) as Record<string, unknown>;
+    expect(r["pending_count"]).toBe(0);
+    expect(r["items"]).toEqual([]);
+  });
+
+  it("review_stats returns zeroed counts for a fresh job", () => {
+    const r = handleAgentTool("review_stats", { job_name: "job1" }) as Record<string, unknown>;
+    expect(r["pending"]).toBe(0);
+    expect(r["approved"]).toBe(0);
+    expect(r["rejected"]).toBe(0);
+  });
+
+  it("approve_reject errors on an unknown item", () => {
+    const r = handleAgentTool("approve_reject", { item_id: "nope", decision: "pin" }) as Record<string, unknown>;
+    expect(String(r["error"])).toContain("not found");
+  });
+
+  it("approve_reject validates the decision value", () => {
+    const r = handleAgentTool("approve_reject", { item_id: "x", decision: "maybe" }) as Record<string, unknown>;
+    expect(String(r["error"])).toContain("pin");
+  });
+});
+
+describe("server routes agent tools through handleTool", () => {
+  it("handleTool dispatches review_stats to the agent handler", () => {
+    const r = handleTool("review_stats", { job_name: "jobX" }) as Record<string, unknown>;
+    expect(r["job_name"]).toBe("jobX");
+    expect(r["pending"]).toBe(0);
+  });
+});

--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -56,8 +56,9 @@ npx vitest run tests/parity/        # parity-only suite
 - Memory mirror: `getMemory`, `addCorrection`, `learn`, `memoryStats`.
 - **Identity Graph (v0.8.0, edge-safe core):** `InMemoryIdentityStore`, `newEntityId`, `findByRecord`, `getEntity`, `listEntities`, `manualMerge`, `manualSplit`, `IdentityView`, types (`IdentityNode`, `SourceRecord`, `EvidenceEdge`, `IdentityEvent`, `IdentityAlias`, `IdentityStatus`, `EventKind`, `EdgeKind`, `IdentityStore`).
 - **Identity Graph (v0.9.0, persistent backend):** `SqliteIdentityStore` in `src/node/identity/`. Implements every `IdentityStore` method (19 total) against an SQLite file at `.goldenmatch/identity.db` (configurable). `better-sqlite3` is an optional peer dep. Schema is byte-identical to Python so cross-toolkit DBs round-trip.
-- MCP tool count: 24 (19 base + 5 memory). Description literal at `src/node/mcp/server.ts:7` — keep in sync via the existing regex test. Identity MCP tools will be added in v0.10 alongside the pipeline-driven `resolveClusters` hook.
+- MCP tool count: 30 (19 base + 5 memory + 6 identity). Description literal at `src/node/mcp/server.ts:7`. `tool_count` is derived from `TOOLS.length`, asserted dynamically in `tests/unit/mcp-server.test.ts` (no hardcoded count).
 - **MCP bin (v0.12.0):** `src/node/mcp/server.ts` is exposed as the `goldenmatch-mcp` bin (tsup entry `node/mcp/server`); it already had the JSON-RPC stdio loop (`startMcpServer`) — v0.12.0 added the shebang + `require.main` guard + bin wiring so it's directly runnable.
+- **Identity MCP tools (v0.13.0):** `src/node/mcp/identity-tools.ts` exposes the 6 identity tools (`identity_resolve`/`identity_list`/`identity_history`/`identity_conflicts`/`identity_merge`/`identity_split`) at parity with `goldenmatch/mcp/identity_tools.py`, composed into `TOOLS` and routed via `IDENTITY_TOOL_NAMES` in the server. snake_case wire format; backed by `SqliteIdentityStore` (test seam `__setIdentityStoreFactoryForTests` injects `InMemoryIdentityStore` so tests skip the better-sqlite3 peer dep).
 
 ## Build outputs
 - tsup with 5 entry points: `index`, `core/index`, `node/index`, `cli`, `node/backends/score-worker` (piscina worker).

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/typescript/goldenmatch/src/node/mcp/identity-tools.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/identity-tools.ts
@@ -1,0 +1,334 @@
+/**
+ * mcp/identity-tools.ts -- Six MCP tools for the Identity Graph.
+ *
+ * Mirrors goldenmatch/mcp/identity_tools.py:
+ *   identity_resolve, identity_list, identity_history,
+ *   identity_conflicts, identity_merge, identity_split.
+ *
+ * Each handler opens its own SqliteIdentityStore, traps errors and returns
+ * structured TextContent rather than crashing the JSON-RPC loop. Wire format
+ * is snake_case to match the Python sibling.
+ *
+ * Node-only: depends on SqliteIdentityStore (better-sqlite3 optional peer dep).
+ */
+
+import { SqliteIdentityStore } from "../identity/sqlite-store.js";
+import {
+  findByRecord,
+  listEntities,
+  manualMerge,
+  manualSplit,
+  type IdentityView,
+} from "../../core/identity/query.js";
+import type {
+  EvidenceEdge,
+  IdentityEvent,
+  IdentityNode,
+  IdentityStatus,
+  IdentityStore,
+  SourceRecord,
+} from "../../core/identity/types.js";
+
+export interface Tool {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Readonly<Record<string, unknown>>;
+}
+
+export interface TextContent {
+  readonly type: "text";
+  readonly text: string;
+}
+
+const DEFAULT_PATH = ".goldenmatch/identity.db";
+
+// ---------------------------------------------------------------------------
+// Tool definitions (mirror Python identity_tools.py)
+// ---------------------------------------------------------------------------
+
+export const IDENTITY_TOOLS: readonly Tool[] = [
+  {
+    name: "identity_resolve",
+    description:
+      "Resolve a record_id to its durable identity. Returns the full identity " +
+      "view (members, evidence edges, recent events) or { found: false } when " +
+      "no identity exists for that record.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        record_id: {
+          type: "string",
+          description: "record id in `{source}:{source_pk}` form",
+        },
+        path: { type: "string", description: "Identity DB path. Default: .goldenmatch/identity.db" },
+      },
+      required: ["record_id"],
+    },
+  },
+  {
+    name: "identity_list",
+    description: "List identities, optionally filtered by dataset/status.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        dataset: { type: "string" },
+        status: { type: "string", description: "active | merged_into | split | retired" },
+        limit: { type: "integer", default: 50 },
+        offset: { type: "integer", default: 0 },
+        path: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "identity_history",
+    description: "Return the temporal event log for an identity.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entity_id: { type: "string" },
+        limit: { type: "integer", default: 100 },
+        path: { type: "string" },
+      },
+      required: ["entity_id"],
+    },
+  },
+  {
+    name: "identity_conflicts",
+    description: "List evidence edges marked `conflicts_with`.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        dataset: { type: "string" },
+        path: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "identity_merge",
+    description:
+      "Manually merge two identities. All records from `absorb_entity_id` are " +
+      "reassigned to `keep_entity_id`.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        keep_entity_id: { type: "string" },
+        absorb_entity_id: { type: "string" },
+        reason: { type: "string" },
+        path: { type: "string" },
+      },
+      required: ["keep_entity_id", "absorb_entity_id"],
+    },
+  },
+  {
+    name: "identity_split",
+    description:
+      "Split a subset of records off an identity into a brand-new identity. " +
+      "The original keeps the remaining records.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        entity_id: { type: "string" },
+        record_ids: { type: "array", items: { type: "string" } },
+        reason: { type: "string" },
+        path: { type: "string" },
+      },
+      required: ["entity_id", "record_ids"],
+    },
+  },
+];
+
+export const IDENTITY_TOOL_NAMES: ReadonlySet<string> = new Set(
+  IDENTITY_TOOLS.map((t) => t.name),
+);
+
+// ---------------------------------------------------------------------------
+// snake_case serializers (match the Python wire format)
+// ---------------------------------------------------------------------------
+
+function nodeToDict(n: IdentityNode): Record<string, unknown> {
+  return {
+    entity_id: n.entityId,
+    status: n.status,
+    merged_into: n.mergedInto,
+    golden_record: n.goldenRecord,
+    confidence: n.confidence,
+    dataset: n.dataset,
+    created_at: n.createdAt.toISOString(),
+    updated_at: n.updatedAt.toISOString(),
+  };
+}
+
+function recordToDict(r: SourceRecord): Record<string, unknown> {
+  return {
+    record_id: r.recordId,
+    source: r.source,
+    source_pk: r.sourcePk,
+    record_hash: r.recordHash,
+    entity_id: r.entityId,
+    payload: r.payload,
+    dataset: r.dataset,
+    first_seen_at: r.firstSeenAt.toISOString(),
+    last_seen_at: r.lastSeenAt.toISOString(),
+  };
+}
+
+function edgeToDict(e: EvidenceEdge): Record<string, unknown> {
+  return {
+    edge_id: e.edgeId,
+    entity_id: e.entityId,
+    record_a_id: e.recordAId,
+    record_b_id: e.recordBId,
+    kind: e.kind,
+    score: e.score,
+    matchkey_name: e.matchkeyName,
+    field_scores: e.fieldScores,
+    negative_evidence: e.negativeEvidence,
+    controller_snapshot: e.controllerSnapshot,
+    run_name: e.runName,
+    dataset: e.dataset,
+    recorded_at: e.recordedAt.toISOString(),
+  };
+}
+
+function eventToDict(ev: IdentityEvent): Record<string, unknown> {
+  return {
+    event_id: ev.eventId,
+    entity_id: ev.entityId,
+    kind: ev.kind,
+    payload: ev.payload,
+    run_name: ev.runName,
+    dataset: ev.dataset,
+    recorded_at: ev.recordedAt.toISOString(),
+  };
+}
+
+function viewToDict(v: IdentityView): Record<string, unknown> {
+  return {
+    node: nodeToDict(v.node),
+    records: v.records.map(recordToDict),
+    edges: v.edges.map(edgeToDict),
+    events: v.events.map(eventToDict),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store factory (overridable in tests)
+// ---------------------------------------------------------------------------
+
+let _storeFactory: (path: string) => Promise<IdentityStore> = (path) =>
+  SqliteIdentityStore.open({ path });
+
+/** Test seam: override how the identity store is opened (e.g. inject an
+ *  InMemoryIdentityStore so tests don't need the better-sqlite3 peer dep). */
+export function __setIdentityStoreFactoryForTests(
+  factory: ((path: string) => Promise<IdentityStore>) | null,
+): void {
+  _storeFactory = factory ?? ((path) => SqliteIdentityStore.open({ path }));
+}
+
+async function openStore(path: string): Promise<IdentityStore> {
+  return _storeFactory(path);
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+export async function handleIdentityTool(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<TextContent[]> {
+  let result: Record<string, unknown>;
+  try {
+    result = await dispatch(name, args ?? {});
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    result = { error: msg };
+  }
+  return [{ type: "text", text: JSON.stringify(result, null, 2) }];
+}
+
+function strArg(args: Record<string, unknown>, key: string): string | undefined {
+  return typeof args[key] === "string" && args[key] ? (args[key] as string) : undefined;
+}
+
+function intArg(args: Record<string, unknown>, key: string, dflt: number): number {
+  const raw = args[key];
+  const n = typeof raw === "number" ? raw : parseInt(String(raw), 10);
+  return Number.isFinite(n) ? n : dflt;
+}
+
+async function dispatch(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const path = strArg(args, "path") ?? DEFAULT_PATH;
+  const store = await openStore(path);
+  try {
+    if (name === "identity_resolve") {
+      const recordId = strArg(args, "record_id");
+      if (!recordId) return { error: "Missing required parameter: record_id" };
+      const view = await findByRecord(store, recordId);
+      return view ? viewToDict(view) : { found: false };
+    }
+
+    if (name === "identity_list") {
+      const opts: { dataset?: string; status?: IdentityStatus; limit?: number; offset?: number } = {
+        limit: intArg(args, "limit", 50),
+        offset: intArg(args, "offset", 0),
+      };
+      const dataset = strArg(args, "dataset");
+      if (dataset) opts.dataset = dataset;
+      const status = strArg(args, "status");
+      if (status) opts.status = status as IdentityStatus;
+      const nodes = await listEntities(store, opts);
+      return { items: nodes.map(nodeToDict) };
+    }
+
+    if (name === "identity_history") {
+      const entityId = strArg(args, "entity_id");
+      if (!entityId) return { error: "Missing required parameter: entity_id" };
+      const events = await store.history(entityId, intArg(args, "limit", 100));
+      return { items: events.map(eventToDict) };
+    }
+
+    if (name === "identity_conflicts") {
+      const dataset = strArg(args, "dataset");
+      const edges = await store.findConflicts(dataset);
+      return { items: edges.map(edgeToDict) };
+    }
+
+    if (name === "identity_merge") {
+      const keep = strArg(args, "keep_entity_id");
+      const absorb = strArg(args, "absorb_entity_id");
+      if (!keep || !absorb) {
+        return { error: "Missing required parameters: keep_entity_id, absorb_entity_id" };
+      }
+      const reason = strArg(args, "reason");
+      const res = await manualMerge(store, keep, absorb, {
+        ...(reason !== undefined ? { reason } : {}),
+        runName: "mcp",
+      });
+      return { keep: res.keep, absorbed: res.absorbed, at: res.at };
+    }
+
+    if (name === "identity_split") {
+      const entityId = strArg(args, "entity_id");
+      const recordIdsRaw = args["record_ids"];
+      if (!entityId || !Array.isArray(recordIdsRaw)) {
+        return { error: "Missing required parameters: entity_id, record_ids" };
+      }
+      const recordIds = recordIdsRaw.map((r) => String(r));
+      const reason = strArg(args, "reason");
+      const res = await manualSplit(store, entityId, recordIds, {
+        ...(reason !== undefined ? { reason } : {}),
+        runName: "mcp",
+      });
+      return { new_entity_id: res.newEntityId, moved: res.moved, at: res.at };
+    }
+
+    return { error: `Unknown identity tool: ${name}` };
+  } finally {
+    await store.close();
+  }
+}

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -4,9 +4,10 @@
  *
  * Node-only: uses node:fs, node:path, node:readline. NOT edge-safe.
  *
- * Exposes 24 tools covering dedupe, match, scoring, explanation,
- * profiling, auto-config (shorthand), evaluation, listings, and Learning
- * Memory (5 memory tools wired in via MEMORY_TOOLS).
+ * Exposes 30 tools covering dedupe, match, scoring, explanation,
+ * profiling, auto-config (shorthand), evaluation, listings, Learning
+ * Memory (5 memory tools via MEMORY_TOOLS), and the Identity Graph
+ * (6 identity tools via IDENTITY_TOOLS).
  *
  * Every tool dispatch is wrapped in try/catch so a single failure never
  * crashes the JSON-RPC loop; errors come back as `{ error: "<msg>" }`.
@@ -45,6 +46,11 @@ import {
   MEMORY_TOOL_NAMES,
   handleMemoryTool,
 } from "./memory-tools.js";
+import {
+  IDENTITY_TOOLS,
+  IDENTITY_TOOL_NAMES,
+  handleIdentityTool,
+} from "./identity-tools.js";
 
 // ---------------------------------------------------------------------------
 // Tool definitions
@@ -354,7 +360,7 @@ const EXISTING_TOOLS: readonly Tool[] = [
   },
 ];
 
-export const TOOLS: readonly Tool[] = [...EXISTING_TOOLS, ...MEMORY_TOOLS];
+export const TOOLS: readonly Tool[] = [...EXISTING_TOOLS, ...MEMORY_TOOLS, ...IDENTITY_TOOLS];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -473,6 +479,15 @@ export async function handleTool(
         return JSON.parse(text);
       } catch {
         return { error: "memory tool returned non-JSON" };
+      }
+    }
+    if (IDENTITY_TOOL_NAMES.has(name)) {
+      const content = await handleIdentityTool(name, args);
+      const text = content[0]?.text ?? "{}";
+      try {
+        return JSON.parse(text);
+      } catch {
+        return { error: "identity tool returned non-JSON" };
       }
     }
     switch (name) {

--- a/packages/typescript/goldenmatch/tests/unit/mcp-identity-tools.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/mcp-identity-tools.test.ts
@@ -1,0 +1,181 @@
+/**
+ * MCP identity-tools tests. Mirrors the Python
+ * tests/test_mcp_identity_tools.py surface (resolve/list/history/conflicts/
+ * merge/split) but injects an InMemoryIdentityStore via the test seam so it
+ * runs without the better-sqlite3 peer dep.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import {
+  IDENTITY_TOOLS,
+  IDENTITY_TOOL_NAMES,
+  handleIdentityTool,
+  __setIdentityStoreFactoryForTests,
+} from "../../src/node/mcp/identity-tools.js";
+import { InMemoryIdentityStore } from "../../src/core/identity/in-memory-store.js";
+import type { IdentityStore } from "../../src/core/identity/types.js";
+
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+async function seed(): Promise<IdentityStore> {
+  const store = new InMemoryIdentityStore();
+  for (const entityId of ["E1", "E2"]) {
+    await store.upsertIdentity({
+      entityId,
+      status: "active",
+      mergedInto: null,
+      goldenRecord: { name: entityId },
+      confidence: 0.9,
+      dataset: "d",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+  }
+  await store.upsertRecord({
+    recordId: "src:1",
+    source: "src",
+    sourcePk: "1",
+    recordHash: "h1",
+    entityId: "E1",
+    payload: { name: "Alice" },
+    dataset: "d",
+    firstSeenAt: NOW,
+    lastSeenAt: NOW,
+  });
+  await store.upsertRecord({
+    recordId: "src:2",
+    source: "src",
+    sourcePk: "2",
+    recordHash: "h2",
+    entityId: "E2",
+    payload: { name: "Alicia" },
+    dataset: "d",
+    firstSeenAt: NOW,
+    lastSeenAt: NOW,
+  });
+  await store.emitEvent({
+    eventId: null,
+    entityId: "E1",
+    kind: "created",
+    payload: {},
+    runName: "r",
+    dataset: "d",
+    recordedAt: NOW,
+  });
+  await store.addEdge({
+    edgeId: null,
+    entityId: "E1",
+    recordAId: "src:1",
+    recordBId: "src:2",
+    kind: "conflicts_with",
+    score: 0.4,
+    matchkeyName: "name",
+    fieldScores: null,
+    negativeEvidence: null,
+    controllerSnapshot: null,
+    runName: "r",
+    dataset: "d",
+    recordedAt: NOW,
+  });
+  return store;
+}
+
+async function call(name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const content = await handleIdentityTool(name, args);
+  return JSON.parse(content[0]!.text) as Record<string, unknown>;
+}
+
+let store: IdentityStore;
+
+beforeEach(async () => {
+  store = await seed();
+  __setIdentityStoreFactoryForTests(async () => store);
+});
+
+afterEach(() => {
+  __setIdentityStoreFactoryForTests(null);
+});
+
+describe("IDENTITY_TOOLS metadata", () => {
+  it("exports the 6 identity tools matching the Python sibling", () => {
+    expect(IDENTITY_TOOLS.map((t) => t.name)).toEqual([
+      "identity_resolve",
+      "identity_list",
+      "identity_history",
+      "identity_conflicts",
+      "identity_merge",
+      "identity_split",
+    ]);
+    expect(IDENTITY_TOOL_NAMES.size).toBe(6);
+    for (const t of IDENTITY_TOOLS) {
+      expect(t.description.length).toBeGreaterThan(0);
+      expect(t.inputSchema).toBeTypeOf("object");
+    }
+  });
+});
+
+describe("identity tool dispatch", () => {
+  it("identity_resolve returns the full snake_case view", async () => {
+    const r = await call("identity_resolve", { record_id: "src:1" });
+    const node = r["node"] as Record<string, unknown>;
+    expect(node["entity_id"]).toBe("E1");
+    expect((r["records"] as unknown[]).length).toBe(1);
+    expect((r["records"] as Record<string, unknown>[])[0]!["record_id"]).toBe("src:1");
+  });
+
+  it("identity_resolve returns { found: false } for an unknown record", async () => {
+    const r = await call("identity_resolve", { record_id: "nope:0" });
+    expect(r["found"]).toBe(false);
+  });
+
+  it("identity_resolve errors without record_id", async () => {
+    const r = await call("identity_resolve", {});
+    expect(r["error"]).toBeTypeOf("string");
+  });
+
+  it("identity_list returns snake_case nodes", async () => {
+    const r = await call("identity_list", {});
+    const items = r["items"] as Record<string, unknown>[];
+    expect(items.map((i) => i["entity_id"]).sort()).toEqual(["E1", "E2"]);
+  });
+
+  it("identity_history returns the event log", async () => {
+    const r = await call("identity_history", { entity_id: "E1" });
+    const items = r["items"] as Record<string, unknown>[];
+    expect(items.some((e) => e["kind"] === "created")).toBe(true);
+  });
+
+  it("identity_conflicts returns conflicts_with edges", async () => {
+    const r = await call("identity_conflicts", {});
+    const items = r["items"] as Record<string, unknown>[];
+    expect(items.length).toBe(1);
+    expect(items[0]!["kind"]).toBe("conflicts_with");
+    expect(items[0]!["record_a_id"]).toBe("src:1");
+  });
+
+  it("identity_merge reassigns the absorbed entity's records", async () => {
+    const r = await call("identity_merge", {
+      keep_entity_id: "E1",
+      absorb_entity_id: "E2",
+      reason: "dupe",
+    });
+    expect(r["keep"]).toBe("E1");
+    expect(r["absorbed"]).toBe("E2");
+    // src:2 now resolves to E1.
+    const resolved = await call("identity_resolve", { record_id: "src:2" });
+    expect((resolved["node"] as Record<string, unknown>)["entity_id"]).toBe("E1");
+  });
+
+  it("identity_split moves records to a fresh identity", async () => {
+    const r = await call("identity_split", {
+      entity_id: "E1",
+      record_ids: ["src:1"],
+      reason: "wrong merge",
+    });
+    expect(r["new_entity_id"]).toBeTypeOf("string");
+    expect(r["moved"]).toEqual(["src:1"]);
+    const resolved = await call("identity_resolve", { record_id: "src:1" });
+    expect((resolved["node"] as Record<string, unknown>)["entity_id"]).toBe(r["new_entity_id"]);
+  });
+});


### PR DESCRIPTION
## Summary

Wave 2 of the cross-surface parity roadmap (follow-up to #482, which landed Waves 0–1). Closes the TS MCP **tool-depth** gaps the audit flagged — the TS MCP servers exposed fewer tools than their Python siblings. Both packages already had the underlying primitives, so this is wiring, not new capability.

### goldenmatch (0.12.0 → 0.13.0) — 6 Identity Graph tools
`src/node/mcp/identity-tools.ts`: `identity_resolve`, `identity_list`, `identity_history`, `identity_conflicts`, `identity_merge`, `identity_split` — parity with `goldenmatch/mcp/identity_tools.py`. snake_case wire format, backed by the existing `SqliteIdentityStore` + `query.ts`. Server now exposes **30 tools** (was 24). Test seam injects an `InMemoryIdentityStore` so tests skip the `better-sqlite3` peer dep.

### goldencheck (0.3.0 → 0.4.0) — 10 agent tools
`src/node/mcp/agent-tools.ts`: `analyze_data`, `auto_configure`, `explain_finding`, `explain_column`, `review_queue`, `approve_reject`, `compare_domains`, `suggest_fix`, `pipeline_handoff`, `review_stats` — parity with `goldencheck/mcp/agent_tools.py`, wiring the existing `core/agent/*` + engine triage/fixer/confidence primitives. Server now exposes **17 tools** (was 7). `auto_configure` hand-emits `goldencheck.yml` (no runtime `yaml` dep).

## Verification
- `tsc --noEmit` clean for both packages.
- goldenmatch identity + MCP tests (27); goldencheck full suite **214** (+15 agent-tools); stdio smoke tests confirm 30 / 17 tools incl. the new ones.

## Roadmap position
Wave 2 complete. Remaining: **Wave 3** (SQL surface expansion + document deferred-by-design set), **Wave 5** (peripheral breadth — GitHub Actions for gm/gf, dbt macros for goldenpipe/infermap). **Wave 4** (Ray/web-UI) stays decision-gated.

https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx