### PR TITLE
Wave 3: SQL surface — memory learn/stats + deferred-by-design docs

### DIFF
--- a/packages/rust/extensions/CLAUDE.md
+++ b/packages/rust/extensions/CLAUDE.md
@@ -40,6 +40,7 @@ Native SQL extensions for [GoldenMatch](https://github.com/benseverndev-oss/gold
 - `quick.rs` -- 11 SQL functions: table-based (SPI), table-returning (TableIterator), scalar, JSON-based
 - `pipeline.rs` -- 5 job management functions: gm_configure, gm_run, gm_jobs, gm_golden, gm_drop
 - `spi.rs` -- reads PG tables via `row_to_json()` SPI queries
+- `correction.rs` -- Learning Memory CRUD + tuning: `correction_add`, `correction_list`, plus `memory_learn` (force a MemoryLearner pass) and `memory_stats` (counts + learned adjustments). All wrap the bridge `goldenmatch_bridge::api::*`. `memory_learn` is REVOKEd from PUBLIC like `correction_add`; `memory_stats` is read-only status, left for PUBLIC.
 - SQL file at `sql/goldenmatch_pg--0.5.0.sql` -- handwritten (pgrx doesn't auto-generate)
 - .control file: `schema = goldenmatch` -- all functions in goldenmatch schema
 
@@ -51,7 +52,8 @@ Native SQL extensions for [GoldenMatch](https://github.com/benseverndev-oss/gold
 - Table-reading UDFs use `con.cursor()` to avoid deadlock (UDF can't query same connection)
 - `goldenmatch_suggest_threshold` registers with `null_handling="special"` because it legitimately returns SQL NULL (unimodal / too-few-scores). Other UDFs that may "fail" return a JSON `{"error": ...}` string instead.
 - `functions.py` also registers the `gm_configure`/`gm_run`/`gm_jobs`/`gm_golden`/`gm_drop` job-management UDFs (in-memory dict equivalent of the Postgres `pipeline.rs` set) -- both backends expose these. Only the table-returning `gm_pairs`/`gm_clusters` remain Postgres-only; DuckDB returns JSON via `dedupe`/`dedupe_table` instead.
-- `goldenmatch_postflight` derives `pair_scores` by running `dedupe_df` on the table (postflight needs scored pairs that aren't in the table). PPRL (`pprl_link`, file-path args) and `run_sensitivity` (file_specs) are deferred as not SQL-natural.
+- `goldenmatch_postflight` derives `pair_scores` by running `dedupe_df` on the table (postflight needs scored pairs that aren't in the table).
+- `functions.py` also registers Learning Memory UDFs: `goldenmatch_correction_add`/`_list` (CRUD) + `goldenmatch_memory_learn` (MemoryLearner pass) + `goldenmatch_memory_stats` (status). Both backends expose all four. Tests: `tests/test_memory_learn_stats.py`.
 - Requires `pyarrow` for DuckDB `.pl()` Polars conversion
 
 ## Testing
@@ -96,6 +98,33 @@ DuckDB UDFs + Postgres pg_extern functions implementing the contract at
   tmp_path-seeded SQLite identity DB. Postgres-side is CI-only.
 - **Version bumps**: `goldenmatch-duckdb` 0.2.0 -> 0.3.0; pgrx
   `goldenmatch_pg` 0.3.0 -> 0.4.0.
+
+## SQL surface coverage + deferred-by-design
+
+Both backends expose the same function set (DuckDB UDFs <-> Postgres
+`pg_extern`, JSON in/JSON out): core scoring/dedupe/match, the 13 core-API
+parity functions, 8 `goldenflow_*` transforms, 5 read-only identity functions,
+job-management (`gm_*`), and Learning Memory (`correction_add`/`_list` +
+`memory_learn`/`memory_stats`).
+
+A sizeable slice of the Python `goldenmatch.__all__` is **intentionally not**
+exposed in SQL. These are deferred by design, not gaps -- the rationale:
+
+| Python capability | Why not SQL |
+|---|---|
+| PPRL (`pprl_link`, `run_pprl`, ...) | File-path / multi-party protocol args; not a single-table JSON-in/out shape. |
+| `run_sensitivity` | Takes `file_specs` (sweep over multiple input files). |
+| Streaming (`match_one`, `StreamProcessor`) | Stateful / incremental; SQL UDFs are stateless per call. |
+| LLM family (`llm_score_pairs`, `llm_cluster_pairs`, `llm_extract_features`) | Needs network + API keys; not safe/deterministic inside a SQL engine. |
+| boost / rerank (`boost_accuracy`, `rerank_top_pairs`) | Bootstraps a HuggingFace cross-encoder (model download); too heavy for a UDF. |
+| `run_graph_er` | Multi-table + relationship config; not a single-table call. |
+| Identity **writes** (`manual_merge`, `manual_split`, `resolve_clusters`) | SQL identity surface is read-only by design; writes go through the Python CLI / REST `/api/v1/identities/...` / MCP `identity_merge`/`identity_split`. |
+| `auto_map_columns` | InferMap schema mapping -- a separate package, not goldenmatch core. |
+| lineage / output writers (`build_lineage`, `write_output`, `generate_dedupe_report`) | Run-coupled / file-emitting; SQL callers get the data back directly and persist it themselves. |
+
+If a user genuinely needs one of these in SQL, add it to BOTH backends in
+lockstep (bridge fn + pgrx wrapper + handwritten SQL on the Postgres side;
+`functions.py` UDF on the DuckDB side) so the two stay interchangeable.
 
 ## Gotchas
 - pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.5.0.sql` manually

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -991,6 +991,98 @@ pub fn correction_list(
     })
 }
 
+/// Force a MemoryLearner pass over accumulated corrections. Returns a JSON
+/// object `{ "count": N, "adjustments": [...] }`. Mirrors the Python MCP
+/// `learn_thresholds` tool: needs >= 10 corrections per matchkey before
+/// threshold tuning fires; otherwise returns an empty list.
+pub fn memory_learn(
+    matchkey_name: Option<&str>,
+    memory_path: Option<&str>,
+) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let store_mod = py.import("goldenmatch.core.memory.store")?;
+        let learner_mod = py.import("goldenmatch.core.memory.learner")?;
+        let json_mod = py.import("json")?;
+        let dataclasses = py.import("dataclasses")?;
+
+        let store_cls = store_mod.getattr("MemoryStore")?;
+        let store_kwargs = PyDict::new(py);
+        store_kwargs.set_item("backend", "sqlite")?;
+        store_kwargs.set_item("path", memory_path.unwrap_or(".goldenmatch/memory.db"))?;
+        let store = store_cls.call((), Some(&store_kwargs))?;
+
+        let learner_cls = learner_mod.getattr("MemoryLearner")?;
+        let learner = learner_cls.call1((store.clone(),))?;
+        let adjustments = learner.call_method1("learn", (matchkey_name,))?;
+
+        let items = pyo3::types::PyList::empty(py);
+        for a in adjustments.try_iter()? {
+            let d = dataclasses.call_method1("asdict", (a?,))?;
+            if let Ok(dt) = d.get_item("learned_at") {
+                if !dt.is_none() {
+                    let iso: String = dt.call_method0("isoformat")?.extract()?;
+                    d.set_item("learned_at", iso)?;
+                }
+            }
+            items.append(d)?;
+        }
+        let _ = store.call_method0("close");
+
+        let out = PyDict::new(py);
+        out.set_item("count", items.len())?;
+        out.set_item("adjustments", items)?;
+        let s: String = json_mod.call_method1("dumps", (out,))?.extract()?;
+        Ok(s)
+    })
+}
+
+/// Learning-memory status as a JSON object
+/// `{ "total_corrections": N, "last_learn_time": ISO|null, "adjustments": [...] }`.
+/// Cheap; safe for status checks. Mirrors the Python MCP `memory_stats` tool.
+pub fn memory_stats(memory_path: Option<&str>) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let store_mod = py.import("goldenmatch.core.memory.store")?;
+        let json_mod = py.import("json")?;
+        let dataclasses = py.import("dataclasses")?;
+
+        let store_cls = store_mod.getattr("MemoryStore")?;
+        let store_kwargs = PyDict::new(py);
+        store_kwargs.set_item("backend", "sqlite")?;
+        store_kwargs.set_item("path", memory_path.unwrap_or(".goldenmatch/memory.db"))?;
+        let store = store_cls.call((), Some(&store_kwargs))?;
+
+        let total: i64 = store.call_method0("count_corrections")?.extract()?;
+        let last = store.call_method0("last_learn_time")?;
+        let last_iso: Option<String> = if last.is_none() {
+            None
+        } else {
+            Some(last.call_method0("isoformat")?.extract()?)
+        };
+
+        let items = pyo3::types::PyList::empty(py);
+        for a in store.call_method0("get_all_adjustments")?.try_iter()? {
+            let d = dataclasses.call_method1("asdict", (a?,))?;
+            if let Ok(dt) = d.get_item("learned_at") {
+                if !dt.is_none() {
+                    let iso: String = dt.call_method0("isoformat")?.extract()?;
+                    d.set_item("learned_at", iso)?;
+                }
+            }
+            items.append(d)?;
+        }
+        let _ = store.call_method0("close");
+
+        let out = PyDict::new(py);
+        out.set_item("total_corrections", total)?;
+        out.set_item("last_learn_time", last_iso)?;
+        out.set_item("adjustments", items)?;
+        let s: String = json_mod.call_method1("dumps", (out,))?.extract()?;
+        Ok(s)
+    })
+}
+
 // ─── Core-API parity (mirrors duckdb/core_apis.py) ───────────────────────
 //
 // Wrappers over goldenmatch's function-shaped core APIs so the Postgres
@@ -1630,6 +1722,41 @@ pub fn goldenflow_transform(transform_name: &str, value: &str) -> Result<String,
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_memory_stats_empty_store() {
+        // Exercises the full pyo3 path: MemoryStore open, count_corrections,
+        // last_learn_time, get_all_adjustments, JSON serialize. A fresh path
+        // yields zero counts.
+        let dir = std::env::temp_dir().join(format!("gm-mem-{}", std::process::id()));
+        let path = dir.join("memory.db");
+        let path_s = path.to_string_lossy();
+        match memory_stats(Some(&path_s)) {
+            Ok(json) => {
+                assert!(json.contains("\"total_corrections\": 0"), "got: {}", json);
+                assert!(json.contains("\"adjustments\": []"), "got: {}", json);
+                assert!(json.contains("\"last_learn_time\": null"), "got: {}", json);
+            }
+            Err(e) => eprintln!("Skipping (goldenmatch not installed): {}", e),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_memory_learn_below_threshold() {
+        // No corrections -> learner emits an empty adjustments list.
+        let dir = std::env::temp_dir().join(format!("gm-learn-{}", std::process::id()));
+        let path = dir.join("memory.db");
+        let path_s = path.to_string_lossy();
+        match memory_learn(None, Some(&path_s)) {
+            Ok(json) => {
+                assert!(json.contains("\"count\": 0"), "got: {}", json);
+                assert!(json.contains("\"adjustments\": []"), "got: {}", json);
+            }
+            Err(e) => eprintln!("Skipping (goldenmatch not installed): {}", e),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn test_score_strings() {

--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
@@ -149,6 +149,18 @@ def register(con: duckdb.DuckDBPyConnection) -> None:
         # dataset, memory_path
         ["VARCHAR", "VARCHAR"], "VARCHAR",
     )
+    # Learning Memory: learn (threshold tuning) + status. Read-mostly
+    # companions to correction_add/list, completing the memory SQL surface.
+    con.create_function(
+        "goldenmatch_memory_learn", _memory_learn,
+        # matchkey_name, memory_path
+        ["VARCHAR", "VARCHAR"], "VARCHAR",
+    )
+    con.create_function(
+        "goldenmatch_memory_stats", _memory_stats,
+        # memory_path
+        ["VARCHAR"], "VARCHAR",
+    )
 
     # ── GoldenFlow transforms (v0.5 of dbt-goldensuite, #465 Tier 1.1) ──
     # 8 UDFs wrapping goldenflow's series-level transforms. Safe to
@@ -705,3 +717,63 @@ def _correction_list(dataset: str, memory_path: str) -> str:
             "created_at": c.created_at.isoformat() if c.created_at else None,
         })
     return json.dumps(out)
+
+
+def _adjustment_to_dict(a: object) -> dict:
+    """Serialize a LearnedAdjustment to a JSON-friendly dict (snake_case)."""
+    learned_at = getattr(a, "learned_at", None)
+    return {
+        "matchkey_name": getattr(a, "matchkey_name", None),
+        "threshold": getattr(a, "threshold", None),
+        "field_weights": getattr(a, "field_weights", None),
+        "sample_size": getattr(a, "sample_size", None),
+        "learned_at": learned_at.isoformat() if learned_at else None,
+    }
+
+
+def _memory_learn(matchkey_name: str, memory_path: str) -> str:
+    """Force a MemoryLearner pass over accumulated corrections.
+
+    Returns JSON ``{"count": N, "adjustments": [...]}``. Needs >= 10
+    corrections per matchkey before threshold tuning fires; otherwise the
+    adjustments list is empty. Mirrors the bridge ``memory_learn``.
+    """
+    try:
+        from goldenmatch.core.memory.learner import MemoryLearner
+        from goldenmatch.core.memory.store import MemoryStore
+    except ImportError as exc:  # pragma: no cover
+        return json.dumps({"error": f"goldenmatch import failed: {exc}"})
+    path = memory_path or ".goldenmatch/memory.db"
+    mk = matchkey_name or None
+    try:
+        with MemoryStore(backend="sqlite", path=path) as store:
+            adjustments = list(MemoryLearner(store).learn(mk))
+    except Exception as exc:
+        return json.dumps({"error": f"MemoryLearner failed: {exc}"})
+    out = [_adjustment_to_dict(a) for a in adjustments]
+    return json.dumps({"count": len(out), "adjustments": out})
+
+
+def _memory_stats(memory_path: str) -> str:
+    """Learning Memory status: total corrections, last learn time, adjustments.
+
+    Returns JSON ``{"total_corrections": N, "last_learn_time": ISO|null,
+    "adjustments": [...]}``. Cheap; safe for status checks.
+    """
+    try:
+        from goldenmatch.core.memory.store import MemoryStore
+    except ImportError as exc:  # pragma: no cover
+        return json.dumps({"error": f"goldenmatch import failed: {exc}"})
+    path = memory_path or ".goldenmatch/memory.db"
+    try:
+        with MemoryStore(backend="sqlite", path=path) as store:
+            total = store.count_corrections()
+            last = store.last_learn_time()
+            adjustments = list(store.get_all_adjustments())
+    except Exception as exc:
+        return json.dumps({"error": f"MemoryStore read failed: {exc}"})
+    return json.dumps({
+        "total_corrections": total,
+        "last_learn_time": last.isoformat() if last else None,
+        "adjustments": [_adjustment_to_dict(a) for a in adjustments],
+    })

--- a/packages/rust/extensions/duckdb/tests/test_memory_learn_stats.py
+++ b/packages/rust/extensions/duckdb/tests/test_memory_learn_stats.py
@@ -1,0 +1,90 @@
+"""Tests for the DuckDB Learning Memory UDFs (Wave 3 SQL-surface expansion).
+
+Exercises:
+- goldenmatch_memory_stats on an empty store and after corrections
+- goldenmatch_memory_learn structure (count + adjustments) and the
+  >= 10-corrections threshold-tuning gate
+- Round-trip on the same SQLite file the correction_add UDF writes
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import duckdb
+import pytest
+
+pytest.importorskip("goldenmatch")
+
+from goldenmatch_duckdb.functions import register
+
+
+@pytest.fixture
+def con():
+    c = duckdb.connect(":memory:")
+    register(c)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def _add(con, memory_path: str, id_a: int, id_b: int) -> None:
+    args = json.dumps({"id_a": id_a, "id_b": id_b, "matchkey_name": "mk"})
+    con.execute(
+        "SELECT goldenmatch_correction_add(?, ?, ?, ?)",
+        ["approve", "ds", memory_path, args],
+    ).fetchone()
+
+
+def test_memory_stats_empty(con, tmp_path: Path):
+    memory_path = str(tmp_path / "memory.db")
+    result = json.loads(
+        con.sql(f"SELECT goldenmatch_memory_stats('{memory_path}')").fetchone()[0]
+    )
+    assert result["total_corrections"] == 0
+    assert result["last_learn_time"] is None
+    assert result["adjustments"] == []
+
+
+def test_memory_stats_counts_corrections(con, tmp_path: Path):
+    memory_path = str(tmp_path / "memory.db")
+    for i in range(3):
+        _add(con, memory_path, i, i + 100)
+    result = json.loads(
+        con.sql(f"SELECT goldenmatch_memory_stats('{memory_path}')").fetchone()[0]
+    )
+    assert result["total_corrections"] == 3
+
+
+def test_memory_learn_below_threshold_returns_empty(con, tmp_path: Path):
+    memory_path = str(tmp_path / "memory.db")
+    for i in range(3):  # < 10 corrections -> no threshold tuning
+        _add(con, memory_path, i, i + 100)
+    result = json.loads(
+        con.sql(f"SELECT goldenmatch_memory_learn('', '{memory_path}')").fetchone()[0]
+    )
+    assert result["count"] == 0
+    assert result["adjustments"] == []
+
+
+def test_memory_learn_returns_structured_result(con, tmp_path: Path):
+    memory_path = str(tmp_path / "memory.db")
+    for i in range(12):  # >= 10 -> learner may emit an adjustment
+        _add(con, memory_path, i, i + 100)
+    result = json.loads(
+        con.sql(f"SELECT goldenmatch_memory_learn('mk', '{memory_path}')").fetchone()[0]
+    )
+    assert isinstance(result["count"], int)
+    assert isinstance(result["adjustments"], list)
+    assert result["count"] == len(result["adjustments"])
+
+
+def test_memory_stats_missing_path_is_soft(con, tmp_path: Path):
+    # Empty memory_path defaults to .goldenmatch/memory.db; a fresh/missing
+    # store must not raise — it returns zeroed stats or a soft {"error": ...}.
+    out = con.sql(
+        f"SELECT goldenmatch_memory_stats('{tmp_path / 'nope.db'}')"
+    ).fetchone()[0]
+    parsed = json.loads(out)
+    assert "total_corrections" in parsed or "error" in parsed

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.5.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.5.0.sql
@@ -462,6 +462,23 @@ CREATE FUNCTION "correction_list"(
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'correction_list_wrapper';
 
+-- Learning Memory: force a MemoryLearner pass; returns JSON
+-- { "count": N, "adjustments": [...] }. Needs >= 10 corrections per matchkey.
+CREATE FUNCTION "memory_learn"(
+    "matchkey_name" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_learn_wrapper';
+
+-- Learning Memory status: JSON
+-- { "total_corrections": N, "last_learn_time": ISO|null, "adjustments": [...] }.
+CREATE FUNCTION "memory_stats"(
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_stats_wrapper';
+
 -- Read-only view over the correction store. Wraps `correction_list`
 -- with `json_array_elements` so callers can write SQL like
 -- `SELECT * FROM goldenmatch.corrections WHERE dataset = 'customers'`.
@@ -514,6 +531,12 @@ GRANT EXECUTE ON FUNCTION goldenmatch.correction_add(
 
 REVOKE EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) TO goldenmatch_correction_writer;
+
+-- memory_learn mutates the store (writes learned adjustments); gate it like
+-- correction_add. memory_stats is read-only status (counts + thresholds, no
+-- correction contents) and stays available to PUBLIC.
+REVOKE EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) TO goldenmatch_correction_writer;
 GRANT SELECT ON goldenmatch.corrections TO goldenmatch_correction_writer;
 
 -- ─── GoldenFlow transforms (src/goldenflow.rs) ────────────────────────────

--- a/packages/rust/extensions/postgres/src/correction.rs
+++ b/packages/rust/extensions/postgres/src/correction.rs
@@ -144,3 +144,31 @@ pub fn correction_list(
         Err(e) => pgrx::error!("goldenmatch correction_list: {}", e),
     }
 }
+
+/// Force a MemoryLearner pass over accumulated corrections. Returns a JSON
+/// object `{ "count": N, "adjustments": [...] }`. Needs >= 10 corrections per
+/// matchkey before threshold tuning fires; otherwise the list is empty.
+/// Read-mostly (writes learned adjustments back to the MemoryStore).
+#[pg_extern]
+pub fn memory_learn(
+    matchkey_name: pgrx::default!(Option<String>, "NULL"),
+    memory_path: pgrx::default!(Option<String>, "NULL"),
+) -> String {
+    let matchkey_name_s = matchkey_name.as_deref();
+    let memory_path_s = memory_path.as_deref();
+    match goldenmatch_bridge::api::memory_learn(matchkey_name_s, memory_path_s) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch memory_learn: {}", e),
+    }
+}
+
+/// Learning-memory status: total correction count, last learn time, and the
+/// current learned adjustments, as a JSON object. Cheap; safe for status checks.
+#[pg_extern]
+pub fn memory_stats(memory_path: pgrx::default!(Option<String>, "NULL")) -> String {
+    let memory_path_s = memory_path.as_deref();
+    match goldenmatch_bridge::api::memory_stats(memory_path_s) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch memory_stats: {}", e),
+    }
+}


### PR DESCRIPTION
## Summary

Wave 3 of the cross-surface parity roadmap (follow-up to #482/#483). The SQL extensions audit found a slice of the Python core absent from both SQL backends. This wave does two things:

### 1. Expand the SQL-natural surface — Learning Memory `learn` + `stats`
`correction_add`/`correction_list` already existed in both backends; this completes the memory surface with the two read-mostly companions, in **lockstep across DuckDB and Postgres**:
- **bridge** (`api.rs`): `memory_learn` (force a `MemoryLearner` pass) + `memory_stats` (counts + last-learn-time + learned adjustments), mirroring the `correction_list` pyo3 pattern.
- **Postgres** (`correction.rs` + handwritten SQL): thin `#[pg_extern]` wrappers; `memory_learn` REVOKEd from PUBLIC (mutates), `memory_stats` stays PUBLIC (read-only status).
- **DuckDB** (`functions.py`): `goldenmatch_memory_learn` + `goldenmatch_memory_stats` UDFs (fail-soft).

### 2. Document the deferred-by-design SQL boundary
New "SQL surface coverage + deferred-by-design" section in `extensions/CLAUDE.md` — a table stating exactly which Python-core capabilities are *intentionally* not in SQL (PPRL, streaming, LLM, boost/rerank, graph-ER, identity writes, lineage/output writers, infermap `auto_map_columns`) with the rationale for each. These are deliberate, not gaps.

## Verification
- **bridge**: `cargo check` + `cargo clippy` clean; `cargo test` green incl. 2 new runtime tests (`memory_stats`/`memory_learn` against real goldenmatch Python via pyo3).
- **DuckDB**: `tests/test_memory_learn_stats.py` (5 cases) + full extension suite (55) pass locally.
- **Postgres**: pgrx builds only in CI (no local libclang/PG headers); the wrappers are thin mirrors of `correction_list`, and CI's `CREATE EXTENSION` step validates the SQL↔symbol wiring.

## Roadmap position
Wave 3 done. Remaining: **Wave 5** (peripheral breadth — GitHub Actions for goldenmatch/goldenflow; dbt macros for goldenpipe + infermap). **Wave 4** (Ray/web-UI) stays decision-gated / likely Python-only.

https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx)_