### PR TITLE
Wave 5 + roadmap close: gm/gf Actions, infermap dbt macro, Wave 4 Python-only declaration

### DIFF
--- a/packages/actions/goldenflow/README.md
+++ b/packages/actions/goldenflow/README.md
@@ -1,0 +1,37 @@
+# GoldenFlow Action
+
+Run [GoldenFlow](https://github.com/benseverndev-oss/goldenmatch) data
+transformations on your data files in CI, report what changed, and post a PR
+comment. Companion to the GoldenCheck action.
+
+## Usage
+
+```yaml
+- uses: benseverndev-oss/goldenmatch/packages/actions/goldenflow@main
+  with:
+    files: "data/*.csv"
+    config: goldenflow.yml   # optional; zero-config when omitted
+    strict: "false"          # set "true" to fail on transform errors
+```
+
+## Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `files` | (required) | Glob pattern for data files to transform |
+| `config` | `""` | Path to a goldenflow YAML config |
+| `domain` | `""` | Domain pack (e.g. `people_hr`, `healthcare`) |
+| `strict` | `false` | Fail the check if any transform errors occur |
+| `python-version` | `3.12` | Python version |
+| `version` | latest | GoldenFlow version to install |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `transforms-applied` | Total transforms applied across all files |
+| `files-processed` | Number of files transformed |
+| `errors` | Total transform errors |
+
+On pull requests the action posts (and updates) a comment summarizing the
+transforms applied per file.

--- a/packages/actions/goldenflow/action.yml
+++ b/packages/actions/goldenflow/action.yml
@@ -1,0 +1,89 @@
+name: "GoldenFlow"
+description: "Data transformation — standardize, clean, and normalize data files. Reports transforms applied and posts PR comments."
+author: "Ben Severn"
+
+branding:
+  icon: "shuffle"
+  color: "blue"
+
+inputs:
+  files:
+    description: "Glob pattern for data files to transform"
+    required: true
+  config:
+    description: "Path to a goldenflow YAML config (zero-config when omitted)"
+    required: false
+    default: ""
+  domain:
+    description: "Domain pack to use (e.g. people_hr, healthcare)"
+    required: false
+    default: ""
+  strict:
+    description: "Fail the check if any transform errors occur"
+    required: false
+    default: "false"
+  python-version:
+    description: "Python version to use"
+    required: false
+    default: "3.12"
+  version:
+    description: "GoldenFlow version to install (default: latest)"
+    required: false
+    default: ""
+
+outputs:
+  transforms-applied:
+    description: "Total transforms applied across all files"
+    value: ${{ steps.run.outputs.transforms_applied }}
+  files-processed:
+    description: "Number of files transformed"
+    value: ${{ steps.run.outputs.files_processed }}
+  errors:
+    description: "Total transform errors across all files"
+    value: ${{ steps.run.outputs.errors }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache pip
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: goldenflow-pip-${{ inputs.python-version }}-${{ inputs.version || 'latest' }}
+
+    - name: Install GoldenFlow
+      shell: bash
+      env:
+        GF_VERSION: ${{ inputs.version }}
+      run: |
+        if [ -n "$GF_VERSION" ]; then
+          pip install -q "goldenflow==${GF_VERSION}"
+        else
+          pip install -q "goldenflow"
+        fi
+
+    - name: Run transforms
+      id: run
+      shell: bash
+      env:
+        GF_FILES: ${{ inputs.files }}
+        GF_CONFIG: ${{ inputs.config }}
+        GF_DOMAIN: ${{ inputs.domain }}
+        GF_STRICT: ${{ inputs.strict }}
+      run: |
+        python "${{ github.action_path }}/scripts/run.py"
+
+    - name: Post PR comment
+      if: github.event_name == 'pull_request'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        python "${{ github.action_path }}/scripts/comment.py"

--- a/packages/actions/goldenflow/scripts/comment.py
+++ b/packages/actions/goldenflow/scripts/comment.py
@@ -1,0 +1,96 @@
+"""Post or update a PR comment with GoldenFlow transform results."""
+import glob
+import json
+import os
+import subprocess
+
+RESULTS_DIR = "/tmp/goldenflow-results"
+MARKER = "<!-- goldenflow -->"
+
+
+def load_results() -> list[dict]:
+    results = []
+    for path in sorted(glob.glob(os.path.join(RESULTS_DIR, "*.json"))):
+        try:
+            with open(path) as f:
+                results.append(json.load(f))
+        except (json.JSONDecodeError, OSError):
+            pass
+    return results
+
+
+def format_comment(results: list[dict]) -> str:
+    lines = [MARKER, "## GoldenFlow Results", ""]
+    if not results:
+        lines.append("No data files transformed.")
+        return "\n".join(lines)
+
+    lines.append("| File | Rows | Transforms | Errors |")
+    lines.append("|------|------|------------|--------|")
+    total_transforms = 0
+    total_errors = 0
+    for r in results:
+        if "error" in r:
+            lines.append(f"| {r.get('file', '?')} | - | - | {r['error'][:60]} |")
+            total_errors += 1
+            continue
+        total_transforms += r.get("transforms_applied", 0)
+        total_errors += r.get("errors", 0)
+        lines.append(
+            f"| {r['file']} | {r.get('rows', 0)} | "
+            f"{r.get('transforms_applied', 0)} | {r.get('errors', 0)} |"
+        )
+    lines.append("")
+    lines.append(
+        f"**{len(results)} file(s) transformed, {total_transforms} transforms applied, "
+        f"{total_errors} error(s)**"
+    )
+    return "\n".join(lines)
+
+
+def find_existing_comment() -> int | None:
+    repo = os.environ.get("GH_REPO", "")
+    pr = os.environ.get("PR_NUMBER", "")
+    if not repo or not pr:
+        return None
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/issues/{pr}/comments", "--jq",
+             f'[.[] | select(.body | contains("{MARKER}"))][0].id'],
+            capture_output=True, text=True, check=True,
+        )
+        cid = result.stdout.strip()
+        return int(cid) if cid else None
+    except (subprocess.CalledProcessError, ValueError):
+        return None
+
+
+def post_comment(body: str) -> None:
+    repo = os.environ.get("GH_REPO", "")
+    pr = os.environ.get("PR_NUMBER", "")
+    if not repo or not pr:
+        print("Not a PR context — skipping comment.")
+        return
+    existing = find_existing_comment()
+    if existing:
+        subprocess.run(
+            ["gh", "api", f"repos/{repo}/issues/comments/{existing}",
+             "-X", "PATCH", "-f", f"body={body}"],
+            check=True, capture_output=True,
+        )
+        print(f"Updated existing comment #{existing}")
+    else:
+        subprocess.run(
+            ["gh", "api", f"repos/{repo}/issues/{pr}/comments",
+             "-f", f"body={body}"],
+            check=True, capture_output=True,
+        )
+        print("Posted new comment")
+
+
+def main() -> None:
+    post_comment(format_comment(load_results()))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/actions/goldenflow/scripts/run.py
+++ b/packages/actions/goldenflow/scripts/run.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Run GoldenFlow transforms on matching files; emit per-file JSON results.
+
+Mirrors the GoldenCheck action's run step but uses the GoldenFlow Python API
+(the CLI emits files, not a JSON summary). Writes one JSON file per input to
+RESULTS_DIR, sets the composite-action outputs on GITHUB_OUTPUT, and exits
+non-zero when `strict` is set and any transform errored.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import sys
+
+RESULTS_DIR = "/tmp/goldenflow-results"
+
+
+def _set_output(name: str, value: object) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as f:
+            f.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    files_glob = os.environ.get("GF_FILES", "")
+    config_path = os.environ.get("GF_CONFIG", "")
+    domain = os.environ.get("GF_DOMAIN", "")
+    strict = os.environ.get("GF_STRICT", "false").lower() == "true"
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+
+    import polars as pl
+    import goldenflow
+
+    config = None
+    if config_path:
+        config = goldenflow.load_config(config_path)
+
+    matched = [f for f in sorted(glob.glob(files_glob)) if os.path.isfile(f)]
+    if not matched:
+        print(f"::error::No files matched pattern: {files_glob}")
+        return 1
+
+    total_transforms = 0
+    total_errors = 0
+    for path in matched:
+        name = os.path.basename(path)
+        try:
+            df = pl.read_csv(path, infer_schema_length=0)
+            kwargs = {}
+            if config is not None:
+                kwargs["config"] = config
+            if domain:
+                kwargs["domain"] = domain
+            result = goldenflow.transform_df(df, **kwargs)
+            records = list(result.manifest.records)
+            errors = list(getattr(result.manifest, "errors", []) or [])
+            entry = {
+                "file": name,
+                "rows": df.height,
+                "transforms_applied": len(records),
+                "errors": len(errors),
+            }
+            total_transforms += len(records)
+            total_errors += len(errors)
+        except Exception as exc:  # noqa: BLE001 - surface as a per-file error
+            entry = {"file": name, "error": str(exc)}
+            total_errors += 1
+        with open(os.path.join(RESULTS_DIR, f"{name}.json"), "w") as f:
+            json.dump(entry, f)
+
+    _set_output("transforms_applied", total_transforms)
+    _set_output("files_processed", len(matched))
+    _set_output("errors", total_errors)
+
+    print(
+        f"Transformed {len(matched)} file(s): "
+        f"{total_transforms} transforms applied, {total_errors} errors"
+    )
+    if strict and total_errors > 0:
+        print(f"::error::GoldenFlow transforms reported {total_errors} error(s)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/actions/goldenmatch/README.md
+++ b/packages/actions/goldenmatch/README.md
@@ -1,0 +1,50 @@
+# GoldenMatch Action
+
+Deduplicate data files in CI with [GoldenMatch](https://github.com/benseverndev-oss/goldenmatch),
+report cluster/duplicate counts, gate on a duplicate threshold, and post a PR
+comment. Companion to the GoldenCheck and GoldenFlow actions.
+
+## Usage
+
+```yaml
+# With explicit match keys:
+- uses: benseverndev-oss/goldenmatch/packages/actions/goldenmatch@main
+  with:
+    files: "data/*.csv"
+    exact: "email"
+    fuzzy: "name:0.85,address:0.8"
+    max-duplicates: "0"     # fail if any duplicate rows are found
+
+# Or with a config file:
+- uses: benseverndev-oss/goldenmatch/packages/actions/goldenmatch@main
+  with:
+    files: "data/*.csv"
+    config: goldenmatch.yml
+```
+
+> A `config`, `exact`, or `fuzzy` input is **required** — zero-config dedupe is
+> disabled in the action so CI never reaches the network for cross-encoder
+> rerank (the local controller can enable it on 3+ field weighted matchkeys).
+
+## Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `files` | (required) | Glob pattern for data files to deduplicate |
+| `config` | `""` | Path to a goldenmatch YAML config (recommended) |
+| `exact` | `""` | Comma-separated exact-match key columns |
+| `fuzzy` | `""` | Comma-separated `field:threshold` fuzzy keys |
+| `max-duplicates` | `-1` | Fail if duplicate rows exceed this (`-1` disables the gate) |
+| `python-version` | `3.12` | Python version |
+| `version` | latest | GoldenMatch version to install |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `clusters` | Total clusters across all files |
+| `duplicates` | Total duplicate rows across all files |
+| `files-processed` | Number of files deduped |
+
+On pull requests the action posts (and updates) a comment summarizing the
+clusters and duplicates found per file.

--- a/packages/actions/goldenmatch/action.yml
+++ b/packages/actions/goldenmatch/action.yml
@@ -1,0 +1,94 @@
+name: "GoldenMatch"
+description: "Entity resolution — deduplicate data files in CI, report duplicate/cluster counts, and gate on a duplicate threshold."
+author: "Ben Severn"
+
+branding:
+  icon: "layers"
+  color: "yellow"
+
+inputs:
+  files:
+    description: "Glob pattern for data files to deduplicate"
+    required: true
+  config:
+    description: "Path to a goldenmatch YAML config (recommended)"
+    required: false
+    default: ""
+  exact:
+    description: "Comma-separated columns for exact-match keys (when no config)"
+    required: false
+    default: ""
+  fuzzy:
+    description: "Comma-separated field:threshold pairs for fuzzy keys, e.g. 'name:0.85,address:0.8'"
+    required: false
+    default: ""
+  max-duplicates:
+    description: "Fail if total duplicate rows exceed this (-1 disables the gate)"
+    required: false
+    default: "-1"
+  python-version:
+    description: "Python version to use"
+    required: false
+    default: "3.12"
+  version:
+    description: "GoldenMatch version to install (default: latest)"
+    required: false
+    default: ""
+
+outputs:
+  clusters:
+    description: "Total clusters across all files"
+    value: ${{ steps.run.outputs.clusters }}
+  duplicates:
+    description: "Total duplicate rows across all files"
+    value: ${{ steps.run.outputs.duplicates }}
+  files-processed:
+    description: "Number of files deduped"
+    value: ${{ steps.run.outputs.files_processed }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache pip
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: goldenmatch-pip-${{ inputs.python-version }}-${{ inputs.version || 'latest' }}
+
+    - name: Install GoldenMatch
+      shell: bash
+      env:
+        GM_VERSION: ${{ inputs.version }}
+      run: |
+        if [ -n "$GM_VERSION" ]; then
+          pip install -q "goldenmatch==${GM_VERSION}"
+        else
+          pip install -q "goldenmatch"
+        fi
+
+    - name: Run dedupe
+      id: run
+      shell: bash
+      env:
+        GM_FILES: ${{ inputs.files }}
+        GM_CONFIG: ${{ inputs.config }}
+        GM_EXACT: ${{ inputs.exact }}
+        GM_FUZZY: ${{ inputs.fuzzy }}
+        GM_MAX_DUPLICATES: ${{ inputs.max-duplicates }}
+      run: |
+        python "${{ github.action_path }}/scripts/run.py"
+
+    - name: Post PR comment
+      if: github.event_name == 'pull_request'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        python "${{ github.action_path }}/scripts/comment.py"

--- a/packages/actions/goldenmatch/scripts/comment.py
+++ b/packages/actions/goldenmatch/scripts/comment.py
@@ -1,0 +1,90 @@
+"""Post or update a PR comment with GoldenMatch dedupe results."""
+import glob
+import json
+import os
+import subprocess
+
+RESULTS_DIR = "/tmp/goldenmatch-results"
+MARKER = "<!-- goldenmatch -->"
+
+
+def load_results() -> list[dict]:
+    results = []
+    for path in sorted(glob.glob(os.path.join(RESULTS_DIR, "*.json"))):
+        try:
+            with open(path) as f:
+                results.append(json.load(f))
+        except (json.JSONDecodeError, OSError):
+            pass
+    return results
+
+
+def format_comment(results: list[dict]) -> str:
+    lines = [MARKER, "## GoldenMatch Results", ""]
+    if not results:
+        lines.append("No data files deduped.")
+        return "\n".join(lines)
+
+    lines.append("| File | Rows | Clusters | Duplicates | Unique |")
+    lines.append("|------|------|----------|------------|--------|")
+    total_dupes = 0
+    for r in results:
+        if "error" in r:
+            lines.append(f"| {r.get('file', '?')} | - | - | - | {r['error'][:50]} |")
+            continue
+        total_dupes += r.get("duplicates", 0)
+        lines.append(
+            f"| {r['file']} | {r.get('rows', 0)} | {r.get('clusters', 0)} | "
+            f"{r.get('duplicates', 0)} | {r.get('unique', 0)} |"
+        )
+    lines.append("")
+    lines.append(f"**{len(results)} file(s) deduped, {total_dupes} duplicate row(s) found**")
+    return "\n".join(lines)
+
+
+def find_existing_comment() -> int | None:
+    repo = os.environ.get("GH_REPO", "")
+    pr = os.environ.get("PR_NUMBER", "")
+    if not repo or not pr:
+        return None
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/issues/{pr}/comments", "--jq",
+             f'[.[] | select(.body | contains("{MARKER}"))][0].id'],
+            capture_output=True, text=True, check=True,
+        )
+        cid = result.stdout.strip()
+        return int(cid) if cid else None
+    except (subprocess.CalledProcessError, ValueError):
+        return None
+
+
+def post_comment(body: str) -> None:
+    repo = os.environ.get("GH_REPO", "")
+    pr = os.environ.get("PR_NUMBER", "")
+    if not repo or not pr:
+        print("Not a PR context — skipping comment.")
+        return
+    existing = find_existing_comment()
+    if existing:
+        subprocess.run(
+            ["gh", "api", f"repos/{repo}/issues/comments/{existing}",
+             "-X", "PATCH", "-f", f"body={body}"],
+            check=True, capture_output=True,
+        )
+        print(f"Updated existing comment #{existing}")
+    else:
+        subprocess.run(
+            ["gh", "api", f"repos/{repo}/issues/{pr}/comments",
+             "-f", f"body={body}"],
+            check=True, capture_output=True,
+        )
+        print("Posted new comment")
+
+
+def main() -> None:
+    post_comment(format_comment(load_results()))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/actions/goldenmatch/scripts/run.py
+++ b/packages/actions/goldenmatch/scripts/run.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Run GoldenMatch dedupe on matching files; emit per-file JSON results.
+
+Uses the GoldenMatch Python API (the CLI emits output files, not a JSON
+summary). Each file is deduped with either an explicit YAML config or the
+`exact` / `fuzzy` keys supplied as inputs — an explicit key/config is required
+so CI never triggers the zero-config controller (which can reach the network
+for cross-encoder rerank). Writes one JSON file per input to RESULTS_DIR, sets
+the composite-action outputs, and fails when duplicates exceed `max-duplicates`.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import sys
+
+RESULTS_DIR = "/tmp/goldenmatch-results"
+
+
+def _set_output(name: str, value: object) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a") as f:
+            f.write(f"{name}={value}\n")
+
+
+def _parse_fields(raw: str) -> list[str]:
+    return [c.strip() for c in raw.split(",") if c.strip()]
+
+
+def main() -> int:
+    files_glob = os.environ.get("GM_FILES", "")
+    config_path = os.environ.get("GM_CONFIG", "")
+    exact = _parse_fields(os.environ.get("GM_EXACT", ""))
+    fuzzy_raw = os.environ.get("GM_FUZZY", "")
+    max_dupes = int(os.environ.get("GM_MAX_DUPLICATES", "-1"))
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+
+    import polars as pl
+    import goldenmatch
+
+    config = goldenmatch.load_config(config_path) if config_path else None
+    # fuzzy input is a comma list of `field:threshold` pairs.
+    fuzzy: dict[str, float] = {}
+    for pair in _parse_fields(fuzzy_raw):
+        field, _, thr = pair.partition(":")
+        fuzzy[field.strip()] = float(thr) if thr else 0.85
+
+    if config is None and not exact and not fuzzy:
+        print("::error::Provide a `config`, `exact`, or `fuzzy` input — "
+              "zero-config dedupe is disabled in CI to avoid network calls.")
+        return 1
+
+    matched = [f for f in sorted(glob.glob(files_glob)) if os.path.isfile(f)]
+    if not matched:
+        print(f"::error::No files matched pattern: {files_glob}")
+        return 1
+
+    total_dupes = 0
+    total_clusters = 0
+    for path in matched:
+        name = os.path.basename(path)
+        try:
+            df = pl.read_csv(path, infer_schema_length=0)
+            if config is not None:
+                result = goldenmatch.dedupe_df(df, config=config)
+            else:
+                kwargs: dict = {}
+                if exact:
+                    kwargs["exact"] = exact
+                if fuzzy:
+                    kwargs["fuzzy"] = fuzzy
+                result = goldenmatch.dedupe_df(df, **kwargs)
+            dupes = result.dupes.height
+            clusters = len(result.clusters)
+            entry = {
+                "file": name,
+                "rows": df.height,
+                "clusters": clusters,
+                "duplicates": dupes,
+                "unique": result.unique.height,
+            }
+            total_dupes += dupes
+            total_clusters += clusters
+        except Exception as exc:  # noqa: BLE001 - surface as a per-file error
+            entry = {"file": name, "error": str(exc)}
+        with open(os.path.join(RESULTS_DIR, f"{name}.json"), "w") as f:
+            json.dump(entry, f)
+
+    _set_output("clusters", total_clusters)
+    _set_output("duplicates", total_dupes)
+    _set_output("files_processed", len(matched))
+
+    print(
+        f"Deduped {len(matched)} file(s): "
+        f"{total_clusters} clusters, {total_dupes} duplicate rows"
+    )
+    if 0 <= max_dupes < total_dupes:
+        print(f"::error::Found {total_dupes} duplicate rows (max allowed: {max_dupes})")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/python/goldenmatch/dbt-goldensuite/README.md
+++ b/packages/python/goldenmatch/dbt-goldensuite/README.md
@@ -26,17 +26,31 @@ print(f"Deduped {result['input_rows']} -> {result['clusters']} clusters")
 
 ## Macros
 
-This package ships macros only (no models/seeds/snapshots). They `adapter.dispatch()`
-between the Postgres and DuckDB extension function shapes:
+This package ships macros only (no models/seeds/snapshots). The
+goldenmatch/goldencheck/goldenflow macros `adapter.dispatch()` between the
+Postgres and DuckDB extension function shapes; `infermap_apply` is pure SQL
+(works on every adapter):
 
 - **Dedupe materialization** -- `goldenmatch_dedupe` (`macros/materializations/`)
 - **Identity graph** -- `identity_resolve`, `identity_list`, `identity_view`, `identity_history`, `identity_conflicts`
 - **Learning memory** -- `file_field_correction`, `file_pair_correction`
 - **Quality gates (GoldenCheck)** -- `quality_assert`, `quality_health_gate`, `quality_not_empty`
 - **Transforms (GoldenFlow)** -- `transforms.sql`
+- **Schema mapping (InferMap)** -- `infermap_apply(relation, column_map)` applies a
+  Python-computed `infermap` column mapping as a plain projecting SELECT.
+
+### GoldenPipe orchestration in dbt
+
+GoldenPipe's value is *adaptive* orchestration (profile the data, then decide
+whether to clean / dedupe) — that decisioning is Python-side and not
+SQL-expressible, so there is no `goldenpipe` dispatch macro. The explicit
+pipeline composes the macros above: apply `transforms.sql` in one model, then
+materialize the result with `goldenmatch_dedupe`. Run the adaptive pipeline via
+the `goldenpipe` Python package / CLI / MCP when you need the decisioning.
 
 ## Status
 
 Early stage -- API may change. Covers GoldenMatch (dedupe + identity), GoldenCheck
-(quality gates), and GoldenFlow (transforms); goldenpipe orchestration and infermap
-mapping are not yet exposed as dbt macros.
+(quality gates), GoldenFlow (transforms), and InferMap (`infermap_apply`).
+GoldenPipe's adaptive orchestration stays Python-side (compose the macros above
+for the explicit pipeline).

--- a/packages/python/goldenmatch/dbt-goldensuite/macros/infermap_apply.sql
+++ b/packages/python/goldenmatch/dbt-goldensuite/macros/infermap_apply.sql
@@ -1,0 +1,39 @@
+{#-
+  infermap_apply -- apply a saved InferMap column mapping to a relation.
+
+  InferMap computes a source->target column mapping in Python (the `infermap`
+  package / CLI / MCP server). This macro APPLIES a pre-computed mapping inside
+  a dbt model as a plain SELECT. Unlike the goldenmatch_*/goldenflow_* dispatch
+  macros it needs NO SQL extension function, so it works on every adapter --
+  the mapping itself is the (Python-computed) intelligence; applying it is just
+  column projection + aliasing.
+
+  Args:
+    relation   -- the source relation, e.g. ref('raw_customers')
+    column_map -- a dict { target_column: source_column }, typically the
+                  `mappings` output of `infermap map` (load it from a dbt var
+                  or a seeded JSON in your project).
+
+  Usage in a model:
+
+      {{ dbt_goldensuite.infermap_apply(
+            ref('raw_customers'),
+            {'customer_id': 'cust_no', 'email': 'email_addr'}
+      ) }}
+-#}
+
+{% macro infermap_apply(relation, column_map) %}
+    {%- if column_map is not mapping -%}
+        {{ exceptions.raise_compiler_error(
+            "infermap_apply: `column_map` must be a dict { target: source }") }}
+    {%- endif -%}
+    {%- if column_map | length == 0 -%}
+        {{ exceptions.raise_compiler_error(
+            "infermap_apply: `column_map` must not be empty") }}
+    {%- endif -%}
+    SELECT
+    {% for target, source in column_map.items() -%}
+        {{ adapter.quote(source) }} AS {{ adapter.quote(target) }}{{ "," if not loop.last }}
+    {% endfor -%}
+    FROM {{ relation }}
+{% endmacro %}

--- a/packages/python/goldenmatch/dbt-goldensuite/tests/test_infermap_macro.py
+++ b/packages/python/goldenmatch/dbt-goldensuite/tests/test_infermap_macro.py
@@ -1,0 +1,60 @@
+"""Tests for the infermap_apply dbt macro (Wave 5 peripheral-breadth sync)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+jinja2 = pytest.importorskip("jinja2")
+
+_MACROS_DIR = Path(__file__).resolve().parents[1] / "macros"
+
+
+class _ExceptionsStub:
+    @staticmethod
+    def raise_compiler_error(msg):  # noqa: ANN001
+        raise RuntimeError(msg)
+
+
+class _AdapterStub:
+    @staticmethod
+    def quote(name):  # noqa: ANN001
+        return '"' + str(name) + '"'
+
+
+def _render(column_map, relation="my_source"):
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(_MACROS_DIR)),
+        autoescape=False,
+    )
+    env.globals["exceptions"] = _ExceptionsStub()
+    env.globals["adapter"] = _AdapterStub()
+    template = env.get_template("infermap_apply.sql")
+    fn = template.module.infermap_apply
+    return " ".join(fn(relation, column_map).split())
+
+
+def test_renders_select_with_aliases():
+    sql = _render({"customer_id": "cust_no", "email": "email_addr"})
+    assert '"cust_no" AS "customer_id"' in sql
+    assert '"email_addr" AS "email"' in sql
+    assert "FROM my_source" in sql
+    # exactly one comma between the two projected columns
+    assert sql.count(" AS ") == 2
+
+
+def test_single_column_has_no_trailing_comma():
+    sql = _render({"id": "raw_id"})
+    assert '"raw_id" AS "id"' in sql
+    # no dangling comma before FROM
+    assert ", FROM" not in sql.replace("  ", " ")
+
+
+def test_empty_map_raises():
+    with pytest.raises(RuntimeError, match="must not be empty"):
+        _render({})
+
+
+def test_non_dict_raises():
+    with pytest.raises(RuntimeError, match="must be a dict"):
+        _render(["not", "a", "dict"])

--- a/packages/typescript/goldenmatch/CLAUDE.md
+++ b/packages/typescript/goldenmatch/CLAUDE.md
@@ -23,6 +23,29 @@ Each wave's spec/plan: `docs/superpowers/specs/2026-05-10-ts-parity-arc-design.m
 - **Python v1.14 (controller surface-parity arc).** Threaded telemetry through TUI / CLI / Postgres / DuckDB surfaces that TS doesn't expose. TS already surfaces telemetry on its MCP server via the same `serialize_telemetry` JSON shape.
 - **Python v1.16 (`backend="bucket"` 5M-on-one-node).** Polars-only Python path. TS runs edge-safe in Web Crypto and doesn't ship Polars — no TS analogue planned.
 
+### Python-only by design (cross-surface parity audit, Wave 4 — declared, not a gap)
+The 2026-05 parity audit flagged two large goldenmatch subsystems absent from the
+TS port. After review these are **intentionally Python-only** — the cleaner close
+than a multi-month port, mirroring the SQL "deferred-by-design" boundary in
+`packages/rust/extensions/CLAUDE.md`:
+
+- **Distributed engine / Ray / GPU** — the entire `goldenmatch/distributed/`
+  (Ray-based loader, controller, clustering, golden, identity), `backends/ray_backend.py`,
+  `core/gpu.py`, and `core/vertex_embedder.py`. No JS-ecosystem equivalent for Ray,
+  Vertex embeddings, or GPU; the whole stack also assumes Polars. The TS package is
+  edge-safe (Web Crypto, no Polars/Ray) and targets single-node / library / Workers
+  use. **No TS port planned.** Users needing distributed ER use the Python package.
+- **REST API + React web UI** — `goldenmatch/web/` (20 FastAPI routers + a React/Vite
+  SPA) and the standalone `api/server.py`. The web UI is a full single-page app whose
+  natural home is the Python package. TS already ships a thin programmatic
+  `node/api/server.ts` for embedding in a Node service; the full browser UI is **not**
+  ported and not planned. Run `goldenmatch serve-ui` (Python) for the UI.
+
+Everything else (core scoring/blocking/clustering/golden, auto-config controller,
+identity graph, PPRL, memory, MCP/A2A, CLI, connectors) IS ported — see the wave
+history above. This closes the cross-surface parity roadmap (Waves 0–3, 5 shipped;
+Wave 4 = this declaration).
+
 ## Commands
 ```bash
 cd packages/typescript/goldenmatch


### PR DESCRIPTION
## Summary

Final PR of the cross-surface parity roadmap — Wave 5 (peripheral breadth) **plus** the Wave 4 "Python-only by design" declaration that closes the roadmap.

### Wave 5 — peripheral breadth
**GitHub composite Actions** (only goldencheck had one), mirroring `packages/actions/goldencheck`:
- **`packages/actions/goldenflow`** — transform data files, report transforms-applied, post a PR comment; `strict` fails on errors.
- **`packages/actions/goldenmatch`** — dedupe data files, report cluster/duplicate counts, gate on `max-duplicates`. Requires `config` or `exact`/`fuzzy` keys so CI never triggers zero-config auto-config (which can fetch a cross-encoder).
- Both source data via the Python API in `scripts/run.py`.

**dbt-goldensuite**:
- **`macros/infermap_apply.sql`** — applies a Python-computed InferMap column mapping as pure-SQL projection (all adapters; no extension function). 4 render tests.
- **GoldenPipe** — documented why its *adaptive* orchestration stays Python-side (compose `transforms.sql` + `goldenmatch_dedupe`) rather than a forced dispatch macro.

### Wave 4 — Python-only by design (declaration, closes roadmap)
Recorded in the goldenmatch TS `CLAUDE.md` "Deliberately not ported" section that two large subsystems are intentionally Python-only (not a porting gap), mirroring the SQL deferred-by-design boundary:
- **Distributed engine / Ray / GPU / Vertex embeddings** — no JS-ecosystem equivalent; assumes Polars. TS stays edge-safe / single-node.
- **REST API + React web UI** — a full SPA whose home is the Python package; TS ships only a thin programmatic `node/api` server.

## Verification
- `run.py` logic verified locally (counts + guard/threshold exit codes); composite `action.yml` only runs in the Actions runtime.
- `infermap_apply` — 4 jinja-render tests pass.

## Roadmap status — complete
Waves 0–3 merged (#482–#484); Wave 5 + the Wave 4 declaration here. The suite's cross-surface parity is now either shipped or explicitly declared deferred/Python-only by design.

https://claude.ai/code/session_01UPTahJFz5knwVqoBAjUBAx