### PR TITLE
refactor(bridge): drop dead clusters_json field + tuple-key JSON hazard (Phase 3)

### DIFF
--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -105,8 +105,6 @@ fn build_full_config<'py>(
 pub struct DedupeResult {
     /// Golden records as JSON array of objects
     pub golden_json: Option<String>,
-    /// Cluster assignments as JSON
-    pub clusters_json: String,
     /// Stats as JSON object
     pub stats_json: String,
     /// AutoConfigController telemetry (stop_reason, decisions, health verdict,
@@ -220,16 +218,10 @@ pub fn dedupe(rows_json: &str, config_json: &str) -> Result<DedupeResult, Bridge
         let stats = result.getattr("stats")?;
         let stats_json: String = json_mod.call_method1("dumps", (stats,))?.extract()?;
 
-        // Extract clusters -- convert to JSON-safe dict (pair_scores has tuple keys)
-        let clusters = result.getattr("clusters")?;
-        let clusters_json: String = {
-            let str_repr: String = clusters.call_method0("__str__")?.extract()?;
-            // Use str() representation as fallback since json.dumps fails on tuple keys
-            match json_mod.call_method1("dumps", (clusters,)) {
-                Ok(j) => j.extract()?,
-                Err(_) => str_repr,
-            }
-        };
+        // Structured cluster output is served via `dedupe_clusters` (and the
+        // pgrx `goldenmatch_dedupe_clusters` TableIterator); no JSON clusters
+        // blob is carried here — the prior `clusters_json` field fell back to a
+        // non-JSON `str()` repr whenever `pair_scores` had tuple keys.
 
         // If the slim-kwargs path ended up triggering auto-config (i.e. the
         // caller didn't pass enough kwargs to bypass it), `_LAST_CONTROLLER_RUN`
@@ -245,7 +237,6 @@ pub fn dedupe(rows_json: &str, config_json: &str) -> Result<DedupeResult, Bridge
 
         Ok(DedupeResult {
             golden_json,
-            clusters_json,
             stats_json,
             telemetry_json,
         })
@@ -289,14 +280,8 @@ pub fn dedupe_full(rows_json: &str, config_json: &str) -> Result<DedupeResult, B
         let stats = result.getattr("stats")?;
         let stats_json: String = json_mod.call_method1("dumps", (stats,))?.extract()?;
 
-        let clusters = result.getattr("clusters")?;
-        let clusters_json: String = {
-            let str_repr: String = clusters.call_method0("__str__")?.extract()?;
-            match json_mod.call_method1("dumps", (clusters,)) {
-                Ok(j) => j.extract()?,
-                Err(_) => str_repr,
-            }
-        };
+        // Structured clusters are served via `dedupe_clusters`; no tuple-keyed
+        // JSON clusters blob is carried here (see `dedupe`).
 
         // dedupe_full passes its own config in, so re-use it for NE display.
         // Re-fetch from result.config in case the engine swapped in an
@@ -311,7 +296,6 @@ pub fn dedupe_full(rows_json: &str, config_json: &str) -> Result<DedupeResult, B
 
         Ok(DedupeResult {
             golden_json,
-            clusters_json,
             stats_json,
             telemetry_json,
         })
@@ -1791,8 +1775,8 @@ mod tests {
 
         match dedupe(rows, config) {
             Ok(result) => {
-                assert!(!result.clusters_json.is_empty());
                 assert!(!result.stats_json.is_empty());
+                // Structured clusters come from `dedupe_clusters`, not a JSON blob here.
             }
             Err(e) => eprintln!("Skipping: {}", e),
         }


### PR DESCRIPTION
## Summary

Phase 3 (Rust acceleration roadmap — Arrow bridge) first slice: removes the one concrete correctness hazard the spec calls out, after an investigation that found the broader Arrow-IPC marshaling has no payoff given the actual consumer architecture.

### What this changes
- Removes `DedupeResult.clusters_json` and its computation in `dedupe()` / `dedupe_full()`. That field did `json.dumps(clusters)`, which **fails** on the tuple-keyed `pair_scores` sub-dict and fell back to a non-JSON Python `str()` repr (`api.rs:225-232`, `:293-299`) — the exact tuple-key fallback the Phase 3 spec §4.3 says should be "gone."
- The field was **dead**: no pgrx function in `postgres/src` reads `result.clusters_json` (grep-verified), and structured clusters are already served via `dedupe_clusters` → the `goldenmatch_dedupe_clusters` TableIterator. Zero consumer impact.

### Why the rest of the Arrow work is deferred (finding)
The roadmap framed Phase 3 as "mostly wiring — the Arrow primitives already exist." Investigating the actual consumers shows the payoff isn't there:
- The bridge's **only** consumer is the pgrx `postgres` crate (the DuckDB layer is independent Python that bypasses the bridge entirely).
- Every data-carrying pgrx function returns **JSON `TEXT`** (`goldenmatch_dedupe` etc. are `-> String`). Routing `golden`/`matched` DataFrames through Arrow IPC would just be decoded back to JSON for the `TEXT` return — no benefit.
- `dedupe_pairs` / `dedupe_clusters` already return **structured** data (no JSON).
- An Arrow *input* path (replacing `row_to_json` SPI) requires real pgrx→Arrow array construction — substantial work, not "wiring" — and is **unmeasured**. The roadmap's own guardrail #1 is "measure before rewriting; do not proceed unless the candidate is the measured bottleneck."

Recommendation: treat the full Arrow marshaling as deferred pending (a) a measured per-call overhead bottleneck on a representative table and (b) a decision to change the pgrx SQL contract (e.g. `bytea`/Arrow returns). This PR lands the unambiguous correctness win now.

## Verification
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test --workspace` — 9/9 green (incl. updated `test_dedupe_basic` + convert Arrow round-trip tests)
- pgrx + DuckDB consumers unchanged; the `rust` and `rust_pgrx` CI lanes verify the postgres build against the changed bridge.

## Test plan
- [ ] `rust` lane green (`cargo test`/`clippy --workspace`)
- [ ] `rust_pgrx` lanes (PG 15/16/17) green — confirms `postgres` compiles against the bridge without `clusters_json`
- [ ] `duckdb_extensions` lane green (unaffected; sanity)

https://claude.ai/code/session_0112NiwW5pRMJKCNRoP9Xm1h

---
_Generated by [Claude Code](https://claude.ai/code/session_0112NiwW5pRMJKCNRoP9Xm1h)_