### PR TITLE
ci(benchmarks): add native toggle to run DQbench on the native kernels (Phase 2 gate)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,6 +29,10 @@ on:
         description: "Run DQbench with LLM scorer (requires OPENAI_API_KEY)"
         type: boolean
         default: false
+      native:
+        description: "Build + run with native kernels (GOLDENMATCH_NATIVE=1) for the Phase 1/2 gate sign-off"
+        type: boolean
+        default: false
 
 # Locked-down by default; benchmarks job stays read-only.
 permissions:
@@ -49,6 +53,9 @@ jobs:
     env:
       DATASETS: ${{ inputs.datasets || 'all' }}
       WITH_LLM: ${{ inputs.with_llm || false }}
+      # "1" forces ALL native kernels (clustering + block_scoring) on; "0" pins
+      # Python. Scheduled runs (no inputs.native) stay Python.
+      NATIVE: ${{ inputs.native && '1' || '0' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
@@ -76,12 +83,27 @@ jobs:
         if: steps.prereqs.outputs.configured == 'true'
         run: uv sync --all-packages
 
+      # Native kernels ship gated OFF by default; build them so a `native=true`
+      # dispatch measures DQbench on the native path (the parity + composite
+      # >= 91.04 sign-off gate for flipping core/_native_loader._GATED_ON).
+      # Mirrors the ci.yml `native` lane's toolchain + build steps.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        if: steps.prereqs.outputs.configured == 'true' && inputs.native
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        if: steps.prereqs.outputs.configured == 'true' && inputs.native
+        with:
+          workspaces: packages/rust/extensions/native
+      - name: Build native extension
+        if: steps.prereqs.outputs.configured == 'true' && inputs.native
+        run: uv run python scripts/build_native.py
+
       - name: Run real benchmarks (DBLP-ACM/Febrl3/NCVR)
         if: steps.prereqs.outputs.configured == 'true' && (env.DATASETS == 'all' || env.DATASETS != 'dqbench')
         shell: bash
         env:
           # Memory disabled so cross-run state doesn't leak between scheduled runs.
           GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+          GOLDENMATCH_NATIVE: ${{ env.NATIVE }}
         run: |
           set -euo pipefail
           # The runner script (committed in this PR — see scripts/run_benchmarks.py)
@@ -97,6 +119,7 @@ jobs:
         shell: bash
         env:
           GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+          GOLDENMATCH_NATIVE: ${{ env.NATIVE }}
         run: |
           set -euo pipefail
           uv run python scripts/run_benchmarks.py \
@@ -110,6 +133,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+          GOLDENMATCH_NATIVE: ${{ env.NATIVE }}
         run: |
           if [ -z "$OPENAI_API_KEY" ]; then
             echo "::error::OPENAI_API_KEY secret not set; cannot run with-LLM benchmarks"


### PR DESCRIPTION
## Summary

The native acceleration kernels — **Phase 1 (clustering)** and **Phase 2 (block-scoring)**, both already merged in #486 — ship **gated OFF**: `core/_native_loader._GATED_ON` is empty, so `native_enabled(...)` is `False` unless `GOLDENMATCH_NATIVE=1`. The roadmap holds the default at Python until the **parity + DQbench ≥ 91.04** gates pass.

`benchmarks.yml` is where real DQbench runs (workflow_dispatch + Monday cron), but it only ever ran the **Python default** — it never built the native ext and had no `GOLDENMATCH_NATIVE` toggle, so it couldn't produce the native composite the sign-off needs.

This adds a **`native` workflow_dispatch boolean**. When `true` (and benchmarks are configured via `vars.RUN_BENCHMARKS=true`), the job:
- sets up the pinned Rust toolchain + rust-cache,
- builds `_native.abi3.so` via `scripts/build_native.py` (mirrors the `ci.yml` `native` lane),
- exports `GOLDENMATCH_NATIVE=1` on the benchmark steps, so DQbench exercises the native path (all kernels: clustering + block_scoring).

Default `false`; scheduled runs stay Python. The workflow has **no `pull_request` trigger**, so this is dispatch/cron-only — zero blast radius on PR CI and no change to default runtime behavior.

## The sign-off path this unblocks
1. Dispatch `benchmarks` with `datasets=dqbench`, `native=true`.
2. Confirm the native composite is **≥ 91.04** and matches the Python baseline (the kernels are parity-tested as bit-exact; locally I verified 21/21 native parity tests green and ~1.9× kernel speedup).
3. Follow-up PR flips `_GATED_ON` to `{"clustering", "block_scoring"}` to make native the default.

## Notes / caveats
- `workflow_dispatch` inputs are validated against the **default branch**, so the `native` input only becomes dispatchable **after this merges to `main`**.
- Requires `vars.RUN_BENCHMARKS=true` + the `dqbench` CLI/datasets on the runner; otherwise the job exits 0 with the existing "not configured" notice and the native steps are skipped.

## Test plan
- [ ] `yamllint`/parse OK (validated locally)
- [ ] After merge: dispatch `benchmarks` (`datasets=dqbench`, `native=true`) and inspect the composite vs the Python baseline

https://claude.ai/code/session_0112NiwW5pRMJKCNRoP9Xm1h

---
_Generated by [Claude Code](https://claude.ai/code/session_0112NiwW5pRMJKCNRoP9Xm1h)_