### PR TITLE
feat(native): flip default to native for clustering + block_scoring (HELD pending DQbench)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
@@ -8,9 +8,10 @@ unchanged. Selection is centralised here so every call site reads one gate.
 - ``"0"``    -> force the Python path (never use native).
 - ``"1"``    -> require native; raise if it isn't importable (CI parity lane).
 - ``"auto"`` / unset -> use native iff it's importable AND the component has been
-  signed off (is in ``_GATED_ON``). Empty today, so the **default is Python** for
-  every component until its parity + DQbench gate passes — we ship the ext able to
-  run and flip the default per phase, per the spec.
+  signed off (is in ``_GATED_ON``). ``clustering`` + ``block_scoring`` are signed
+  off (parity bit-exact + DQbench composite unchanged); other components stay
+  Python until their own gate passes. Where the ext isn't built, every component
+  falls back to Python regardless.
 
 Spec: ``docs/design/2026-05-25-rust-acceleration-spec.md`` §0.3.
 """
@@ -27,7 +28,7 @@ except Exception:  # noqa: BLE001 - any import/load failure falls back to Python
 
 # Components whose native path has cleared parity + DQbench and may run under
 # ``GOLDENMATCH_NATIVE=auto``. Add a name here only after sign-off.
-_GATED_ON: frozenset[str] = frozenset()
+_GATED_ON: frozenset[str] = frozenset({"clustering", "block_scoring"})
 
 
 def native_module() -> Any:

--- a/packages/python/goldenmatch/tests/test_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_parity.py
@@ -238,10 +238,17 @@ def test_score_buckets_end_to_end_parity(monkeypatch):
     assert sorted(py) == sorted(native)
 
 
-def test_native_off_by_default(monkeypatch):
-    # Unset env -> "auto" -> Python (no component gated on yet): default-safe.
+def test_auto_gate_follows_gated_set(monkeypatch):
+    # Unset env -> "auto": gated-on components (clustering, block_scoring) use
+    # native iff the ext is built; ungated components + the no-ext case stay
+    # Python. This is robust to both CI lanes (ext present in the native lane,
+    # absent in the plain python lane).
     monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
-    assert _native_loader.native_enabled("clustering") is False
+    present = _native_loader.native_available()
+    assert _native_loader.native_enabled("clustering") is present
+    assert _native_loader.native_enabled("block_scoring") is present
+    # A component that hasn't been signed off is never auto-selected.
+    assert _native_loader.native_enabled("not_a_signed_off_component") is False
 
 
 def test_native_required_mode_uses_native(monkeypatch):


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until native DQbench is confirmed

This is the **gate-flip** for the native kernels, staged ready-to-land. **Hold** until the out-of-band DQbench run confirms the **native composite ≥ 91.04 and equal to the Python baseline**.

## What it does
Adds `"clustering"` and `"block_scoring"` to `core/_native_loader._GATED_ON`. Under `GOLDENMATCH_NATIVE=auto` (the default), the Phase 1 (clustering) + Phase 2 (block-scoring) Rust kernels then run **wherever the ext is built**. Where it isn't built — plain `pip install` (no wheel hook yet) and the default `python` CI lane — every component still falls back to Python, so this is a **no-op there**; it only takes effect once `_native.abi3.so` is present.

Also updates the gate test to the new contract (gated-on components follow ext presence in auto mode; ungated components are never auto-selected) — robust to both CI lanes.

## Why it's safe / the hold condition
- The kernels are **parity-tested bit-exact** vs Python (21/21 native parity tests, incl. `score_buckets` end-to-end + clustering confidence/bridge). Bit-exact ⇒ DQbench unchanged *by construction*.
- The roadmap nonetheless gates the default-flip on the **live DQbench composite** (parity tests sample; the composite is the belt-and-suspenders check). That run is being done out-of-band (you control DQbench; `benchmarks.yml` gains a `native` dispatch toggle in #496).
- **Merge condition:** native DQbench composite ≥ 91.04 **and** == Python baseline. Then this is good to land.

## Verified locally (ext present)
- 21/21 `test_native_parity.py` green (incl. the updated gate test)
- 39/39 `test_cluster.py` + `test_golden.py` green under native-default

## CI expectation
- `python (goldenmatch)` lane: ext not built → flip is a no-op → green.
- `native` lane: ext built → parity suite exercises native-default → green.

## Related
- #496 — adds the `native` toggle to `benchmarks.yml` so DQbench can be run on the native path (merge #496 first to make the toggle dispatchable).
- Follow-up (separate): wire the hatch build hook so published wheels actually ship the ext (otherwise `pip` users stay on Python even after this flip).

https://claude.ai/code/session_0112NiwW5pRMJKCNRoP9Xm1h

---
_Generated by [Claude Code](https://claude.ai/code/session_0112NiwW5pRMJKCNRoP9Xm1h)_