### PR TITLE
chore(deps): bump pyo3 0.23.5 -> 0.24.1 in native crate (security)

### DIFF
--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "unicode-ident"

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13.
 # extension-module: don't link libpython (this .so is imported BY CPython).
-pyo3 = { version = ">=0.23.3, <0.24", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py311"] }
 rapidfuzz = "0.5.0"
 rayon = "1.12.0"
 


### PR DESCRIPTION
## Summary

PyO3 **0.24.1** is a security fix for `PyString::from_object` (out-of-bounds read with non-nul-terminated `encoding`/`errors` args; RUSTSEC advisory). Bumps the `goldenmatch._native` crate from 0.23.5 → 0.24.1.

Supersedes dependabot **#493**, whose branch predates #498 and now conflicts with the post-#498 `Cargo.toml` (which added `rapidfuzz` + `rayon`). This PR carries the same bump on top of current `main` and — crucially — **build-verifies it against the new rapidfuzz-rs + rayon block-scoring kernel**, which is the only code here that touches the PyO3 surface (`Python<'_>` arg, `py.allow_threads`, `#[pyfunction]`/`#[pymodule]`).

## Verification (pyo3 0.24.1, local)

- `cargo build --release` (via `scripts/build_native.py`): clean, no API breaks
- `cargo clippy --release -- -D warnings`: clean (matches the `native` CI lane gate)
- `pytest tests/test_native_parity.py`: **22/22 pass**
- gate sane: `GOLDENMATCH_NATIVE=1` → ext imports, `block True cluster True`

## Notes

- Pin widened to `>=0.23.3,<0.25` (accepts 0.24.x patches).
- 0.24 pulled a transitive `target-lexicon` 0.12 → 0.13 bump (build-only).

## Test plan

- [ ] `native` CI lane green (builds ext + parity suite under 0.24.1)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BmPB23AtPux2HwnFccEchQ)_