### PR TITLE
fix(bench): discriminative surnames so generate-bench-dataset validation passes

### DIFF
--- a/packages/python/goldenmatch/scripts/generate_bench_dataset.py
+++ b/packages/python/goldenmatch/scripts/generate_bench_dataset.py
@@ -39,18 +39,6 @@ import polars as pl
 # ── Fixture construction ────────────────────────────────────────────
 
 
-_BASE_FIRSTS = [
-    "Alice", "Bob", "Charlie", "Dana", "Eve", "Frank",
-    "Grace", "Henry", "Iris", "Jack",
-]
-_BASE_LASTS = [
-    "Smith", "Johnson", "Williams", "Brown", "Jones",
-    "Garcia", "Miller", "Davis", "Rodriguez", "Martinez",
-    "Hernandez", "Lopez", "Gonzalez", "Wilson", "Anderson",
-    "Thomas", "Taylor", "Moore", "Jackson", "Martin",
-]
-
-
 def _variant(s: str, kind: int) -> str:
     """Three typo variants per (first, last) base identity.
 
@@ -78,13 +66,35 @@ def build_df(n: int) -> pl.DataFrame:
 
     Yields ~n/3 multi-member clusters at the dedupe stage. Each cluster
     has size 3.
+
+    Each group draws its surname from the **rank-ordered** census pool by
+    `last[g % L]`. Rank-adjacent surnames are dissimilar (jaro(Smith,
+    Johnson) ~= 0.45), and the pool has 10k entries, so co-blocked groups
+    (e.g. a `zip = g % 100` block) get distinct, dissimilar last names. That
+    keeps the fuzzy name matchkey discriminative — it links only the 3
+    intra-group typo-variants, never unrelated groups. (The earlier tiny
+    10/20-name pools correlated with `zip = g % 100`, so every row in a zip
+    block shared a name base and a zip-blocked dedup collapsed the whole
+    block into one cluster — see the e2e validation gate below. The given-name
+    pool is kept on a separate cycle; the surname alone carries the
+    discriminating signal because adjacent given names ("Abbie"/"Abby") are
+    similar.)
     """
+    from goldenmatch.refdata import given_names, surnames
+
+    surnames._load()
+    given_names._load()
+    first_pool = [g.title() for g in sorted(given_names._state.canonicals)]
+    last_pool = [s.title() for s in surnames._state.ranks.keys()]
+    n_first = len(first_pool)
+    n_last = len(last_pool)
+
     rows = []
     for i in range(n):
         group_id = i // 3
         within = i % 3
-        first_base = _BASE_FIRSTS[group_id % len(_BASE_FIRSTS)]
-        last_base = _BASE_LASTS[group_id % len(_BASE_LASTS)]
+        first_base = first_pool[group_id % n_first]
+        last_base = last_pool[group_id % n_last]
         rows.append({
             "first_name": _variant(first_base, within),
             "last_name":  _variant(last_base, within),


### PR DESCRIPTION
## Summary

`generate-bench-dataset` (rows=5000000) failed its e2e validation gate: the 10k-row dedupe slice found only **100 multi-member clusters** vs the ~3,333 designed, and refused to publish.

**Root cause (a fixture-design bug, not a regression):** `build_df` used 10 first / 20 last hard-coded names indexed by `group_id % len`, while `zip = group_id % 100`. Since 100 is a multiple of 10 and 20, **every row sharing a zip also shared a name base**. Auto-config blocks on `zip`, so within each ~100-row zip block all rows fuzzy-matched on name and Union-Find collapsed the **whole zip block into one cluster** → 100 giant clusters instead of 3,333 small ones. (The exact-email matchkey would have formed the right 3-row groups, but the over-broad name matches unioned right over them.)

## Fix

Draw each group's surname from the **rank-ordered census pool** (`last[g % 10000]`). Rank-adjacent surnames are dissimilar (`jaro(Smith, Johnson) ≈ 0.45`), so co-blocked groups get distinct names and the fuzzy matchkey links only the 3 intra-group typo-variants — never unrelated groups. (Surname carries the discriminating signal because adjacent *given* names like "Abbie"/"Abby" are too similar.)

## Verification (10k validation slice, local)

| | before | after |
|---|---|---|
| multi-member clusters | 100 | **3,278** |
| n_unique_last_names | (degenerate) | 9,794 |
| validation floor (70% of 3,333) | 2,333 | 2,333 → **PASS** |

## Note on the release tag

Regenerating the **existing** 50M/100M assets with this change alters their contents — bump to **`bench-dataset-v2`** when doing so (bench workflows pin to a tag). The net-new 5M asset can go on `bench-dataset-v1`.

## Test plan

- [ ] CI green (script-only change; no tests reference the fixture)
- [ ] After merge: re-run `generate-bench-dataset` (rows=5000000) → validation passes → asset published


---
_Generated by [Claude Code](https://claude.ai/code/session_01BmPB23AtPux2HwnFccEchQ)_