### PR TITLE
feat(native): surface Native Core in Python (re-export + string scorers)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -30,6 +30,12 @@ All features are accessible via `import goldenmatch as gm`.
 
 __version__ = "1.19.0"
 
+# ── Native Core surface ───────────────────────────────────────────────────
+# goldenmatch.native: graph/pair primitives + native string scorers, re-exported
+# for discoverability. Import-safe ahead of the rest — native.py only pulls in
+# leaf goldenmatch.core.* modules, so there's no cycle back through this package.
+from goldenmatch import native
+
 # ── High-level API (convenience functions) ────────────────────────────────
 from goldenmatch._api import (
     DedupeResult,
@@ -267,10 +273,6 @@ from goldenmatch.pprl.protocol import (
     link_trusted_third_party,
     run_pprl,
 )
-
-# Native Core surface (graph/pair primitives + native string scorers). Imported
-# last so the core modules it re-exports are already initialized.
-from goldenmatch import native
 
 # ── Shortcuts ────────────────────────────────────────────────────────────
 explain_pair = explain_pair_nl

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -268,6 +268,10 @@ from goldenmatch.pprl.protocol import (
     run_pprl,
 )
 
+# Native Core surface (graph/pair primitives + native string scorers). Imported
+# last so the core modules it re-exports are already initialized.
+from goldenmatch import native
+
 # ── Shortcuts ────────────────────────────────────────────────────────────
 explain_pair = explain_pair_nl
 explain_cluster = explain_cluster_nl
@@ -276,6 +280,8 @@ pprl_auto_config = auto_configure_pprl
 __all__ = [
     # Version
     "__version__",
+    # Native Core (goldenmatch.native: graph/pair primitives + string scorers)
+    "native",
     # High-level API
     "dedupe", "dedupe_df", "match", "match_df",
     "score_strings", "score_pair_df", "explain_pair_df",

--- a/packages/python/goldenmatch/goldenmatch/native.py
+++ b/packages/python/goldenmatch/goldenmatch/native.py
@@ -10,14 +10,19 @@ Stable import path for the native-runtime primitives::
         block_histogram,
     )
 
-Each function has a pure-Python implementation (in ``core/pairs.py``) that is the
-source of truth and an optional Rust kernel that accelerates it when the
-``goldenmatch._native`` extension is built. ``available()`` reports whether the
-compiled accelerator is importable; the primitives work either way.
+Each primitive has a pure-Python implementation (the source of truth) and an
+optional Rust kernel that accelerates it when the ``goldenmatch._native``
+extension is built. ``available()`` reports whether the compiled accelerator is
+importable; everything here works either way (it falls back to pure Python /
+rapidfuzz). ``string_similarity`` exposes the native string scorers directly::
+
+    from goldenmatch.native import string_similarity, string_similarity as sim
+    sim("John Smith", "Jon Smyth", "jaro_winkler")
 """
 from __future__ import annotations
 
 from goldenmatch.core._native_loader import native_available as available
+from goldenmatch.core._native_loader import native_enabled, native_module
 from goldenmatch.core.pairs import (
     block_histogram,
     candidate_pair_count,
@@ -26,11 +31,45 @@ from goldenmatch.core.pairs import (
     dedup_pairs_max_score,
 )
 
+STRING_SCORERS = ("jaro_winkler", "levenshtein", "token_sort")
+
+
+def string_similarity(a: str | None, b: str | None, scorer: str = "jaro_winkler") -> float:
+    """Native-accelerated string similarity in ``[0, 1]``.
+
+    ``scorer`` is one of :data:`STRING_SCORERS`. Uses the Rust kernel when the
+    ``goldenmatch._native`` extension is importable (bit-parity with rapidfuzz to
+    1e-9), else the pure-Python rapidfuzz reference. ``None`` is treated as the
+    empty string. The gate honours ``GOLDENMATCH_NATIVE`` like every other native
+    call (these are the kernels behind native block scoring)."""
+    if scorer not in STRING_SCORERS:
+        raise ValueError(f"scorer must be one of {STRING_SCORERS}, got {scorer!r}")
+    sa = "" if a is None else str(a)
+    sb = "" if b is None else str(b)
+    if native_enabled("block_scoring"):
+        mod = native_module()
+        if scorer == "jaro_winkler":
+            return float(mod.jaro_winkler_similarity(sa, sb))
+        if scorer == "levenshtein":
+            return float(mod.levenshtein_similarity(sa, sb))
+        return float(mod.token_sort_ratio(sa, sb)) / 100.0
+    # Pure-Python reference — exactly what the native kernels replicate.
+    from rapidfuzz.distance import JaroWinkler, Levenshtein
+    from rapidfuzz.fuzz import token_sort_ratio
+    if scorer == "jaro_winkler":
+        return float(JaroWinkler.similarity(sa, sb))
+    if scorer == "levenshtein":
+        return float(Levenshtein.normalized_similarity(sa, sb))
+    return float(token_sort_ratio(sa, sb)) / 100.0
+
+
 __all__ = [
+    "STRING_SCORERS",
     "available",
     "block_histogram",
     "candidate_pair_count",
     "canonicalize_pairs",
     "connected_components",
     "dedup_pairs_max_score",
+    "string_similarity",
 ]

--- a/packages/python/goldenmatch/tests/test_native_surface.py
+++ b/packages/python/goldenmatch/tests/test_native_surface.py
@@ -1,0 +1,68 @@
+"""Public ``goldenmatch.native`` surface.
+
+Covers the top-level re-export and the ``string_similarity`` wrapper. Runs with
+or without the compiled extension: both the native kernel and the rapidfuzz
+fallback match rapidfuzz, so the assertions hold either way (the native-vs-fallback
+bit-parity of the underlying kernels is locked separately in test_native_parity).
+"""
+from __future__ import annotations
+
+import goldenmatch
+import pytest
+from goldenmatch import native
+from rapidfuzz.distance import JaroWinkler, Levenshtein
+from rapidfuzz.fuzz import token_sort_ratio
+
+
+def test_native_is_reexported_at_top_level():
+    assert "native" in goldenmatch.__all__
+    assert goldenmatch.native is native
+
+
+def test_native_exports_primitives_and_scorers():
+    for name in ("canonicalize_pairs", "dedup_pairs_max_score", "connected_components",
+                 "candidate_pair_count", "block_histogram", "available",
+                 "string_similarity", "STRING_SCORERS"):
+        assert name in native.__all__
+        assert hasattr(native, name)
+
+
+@pytest.mark.parametrize("a,b", [
+    ("John Smith", "Jon Smyth"),
+    ("Acme Corp", "Acme Corporation"),
+    ("Smith John", "John Smith"),  # token reorder
+    ("", ""),
+    ("café", "cafe"),
+])
+def test_string_similarity_matches_rapidfuzz(a, b):
+    assert native.string_similarity(a, b, "jaro_winkler") == pytest.approx(
+        JaroWinkler.similarity(a, b), abs=1e-9)
+    assert native.string_similarity(a, b, "levenshtein") == pytest.approx(
+        Levenshtein.normalized_similarity(a, b), abs=1e-9)
+    assert native.string_similarity(a, b, "token_sort") == pytest.approx(
+        token_sort_ratio(a, b) / 100.0, abs=1e-9)
+
+
+def test_string_similarity_range_and_self():
+    for scorer in native.STRING_SCORERS:
+        s = native.string_similarity("hello world", "hello world", scorer)
+        assert s == pytest.approx(1.0, abs=1e-9)
+        assert 0.0 <= native.string_similarity("abc", "xyz", scorer) <= 1.0
+
+
+def test_string_similarity_handles_none():
+    assert native.string_similarity(None, "x", "jaro_winkler") == pytest.approx(
+        native.string_similarity("", "x", "jaro_winkler"))
+
+
+def test_string_similarity_rejects_unknown_scorer():
+    with pytest.raises(ValueError, match="scorer must be one of"):
+        native.string_similarity("a", "b", "cosine")
+
+
+def test_string_similarity_fallback_matches_native(monkeypatch):
+    # Force the pure-Python path; result must equal the default (native when built).
+    default = native.string_similarity("Margaret Chen", "Maggie Chen", "jaro_winkler")
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    forced_python = native.string_similarity("Margaret Chen", "Maggie Chen", "jaro_winkler")
+    assert forced_python == pytest.approx(default, abs=1e-9)


### PR DESCRIPTION
Closes the two gaps I flagged when you asked whether the native work is callable from Python.

## 1. `goldenmatch.native` re-exported at the top level
It was a stable submodule but absent from `goldenmatch.__all__`, so you had to know to `import goldenmatch.native`. Now `import goldenmatch; goldenmatch.native` resolves and it's in `__all__` (discoverable, documented). The graph/pair primitives (`canonicalize_pairs`, `dedup_pairs_max_score`, `connected_components`, `candidate_pair_count`, `block_histogram`, `available`) are first-class.

## 2. Native string scorers exposed: `goldenmatch.native.string_similarity`
Previously the native `jaro_winkler` / `levenshtein` / `token_sort` kernels were reachable only internally (block scoring) — no public Python path. New:
```python
from goldenmatch.native import string_similarity
string_similarity("John Smith", "Jon Smyth", "jaro_winkler")  # -> 0.917
```
- Returns `[0, 1]`; `scorer ∈ {jaro_winkler, levenshtein, token_sort}` (`native.STRING_SCORERS`).
- Uses the Rust kernel when the ext is built (bit-parity with rapidfuzz to 1e-9), else the rapidfuzz reference. Honours `GOLDENMATCH_NATIVE`. `None` → `""`. Unknown scorer → `ValueError`.
- No rebuild needed — the kernels already exist in the ext; this is a thin Python wrapper.

## Correctness / scope
- **Additive + import-safe.** `import goldenmatch` works with **or without** the compiled ext — verified both ways (the new top-level `from goldenmatch import native` is placed after the core modules it re-exports, no circular import; fallback path confirmed with the `.so` hidden).
- Verified `string_similarity` matches rapidfuzz exactly in **both** native and fallback modes across edge cases (reorder, empty, accents).
- Did **not** expose `char_ngram_project` (it needs the weights matrix — it's an `embed()` impl detail, surfaced via `GoldenEmbedModel.embed`).

## Test plan
- [x] `tests/test_native_surface.py` (11) — re-export, `string_similarity` parity vs rapidfuzz, range/self/None, unknown-scorer raises, fallback==native. Runs with or without the ext.
- [x] `tests/test_native_parity.py` still green (66 with surface tests); package collection clean (pre-existing web/mcp optional-dep collection errors unrelated).
- [x] ruff clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019TUwadtGy7dSNt1yTmBfoJ)_