### PR TITLE
release(goldenmatch): v1.20.0 - cluster-decision tuner

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-05-26
+
 ### Added — cluster-decision tuner (RFC from MJH Print Modernization)
 
 Third tuner in the Learning Memory family, paralleling the

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.19.0"
+__version__ = "1.20.0"
 
 # ── High-level API (convenience functions) ────────────────────────────────
 from goldenmatch._api import (

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.19.0"
+version = "1.20.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts **goldenmatch v1.20.0** to PyPI — the cluster-decision tuner (PR #451, `c6b3149c`) shipped in the TS package but was left uncut on PyPI in the same wave, blocking the Python consumer.

## Changes
- `pyproject.toml` + `goldenmatch/__init__.py`: `1.19.0` -> `1.20.0`
- `CHANGELOG.md`: finalize `[Unreleased]` -> `[1.20.0] - 2026-05-26`

Tuner-only minor bump; no other unreleased changes. No code changes — version + changelog only.

## Release flow
On merge to `main`, tag `v1.20.0` -> `publish-goldenmatch.yml` -> PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)