### PR TITLE
fix(cluster): terminating auto-split for dense clusters + de-flake the materialization test

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 from collections import defaultdict
 from datetime import datetime
@@ -17,6 +18,27 @@ if TYPE_CHECKING:
     from goldenmatch.core.memory.store import MemoryStore
 
 _log = logging.getLogger("goldenmatch.memory")
+_clog = logging.getLogger("goldenmatch.cluster")
+
+# Auto-split work budget (cumulative edges processed across the split loop).
+# split_oversized_cluster removes the single weakest MST edge per pass, which is
+# O(edges); a large DENSE cluster with no clean weak bridge peels ~1 node per
+# pass and degrades to O(nodes * edges) -- effectively non-terminating. Legitimate
+# weak-bridge splits finish far under this budget; a dense peel trips it and the
+# remaining oversized clusters are left intact (excluded from golden downstream,
+# matching auto_split=False). Env-overridable for testing.
+_DEFAULT_SPLIT_EDGE_WORK_BUDGET = 5_000_000
+
+
+def _split_edge_work_budget() -> int:
+    """Cumulative-edge-work cap for the auto-split loop (env-overridable)."""
+    raw = os.environ.get("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET")
+    if raw is None:
+        return _DEFAULT_SPLIT_EDGE_WORK_BUDGET
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_SPLIT_EDGE_WORK_BUDGET
 
 
 def _record_unmerge_corrections(
@@ -374,12 +396,36 @@ def build_clusters(
         cinfo["confidence"] = conf["confidence"]
         cinfo["bottleneck_pair"] = conf["bottleneck_pair"]
 
-    # Auto-split oversized clusters (when enabled)
+    # Auto-split oversized clusters (when enabled). See _split_edge_work_budget:
+    # the per-pass single-weakest-edge split degrades to O(nodes * edges) on a
+    # large dense cluster, so two guards keep the loop terminating without
+    # changing behavior for normal weak-bridge clusters:
+    #   1. no-progress: if a split can't break the cluster (returns it unchanged),
+    #      leave it oversized instead of re-enqueueing the same cluster forever.
+    #   2. work budget: cap cumulative edge-work; once tripped, leave the current
+    #      and any still-queued clusters oversized.
+    # Oversized clusters left un-split are excluded from golden downstream, the
+    # same as auto_split=False -- a giant cohesive blob of near-identical records
+    # is legitimately one quarantined cluster, not N arbitrary cuts.
     to_split = [cid for cid, c in result.items() if c["oversized"]] if auto_split else []
+    edge_work = 0
+    edge_budget = _split_edge_work_budget()
+    budget_tripped = False
     while to_split:
         cid = to_split.pop()
         cinfo = result.pop(cid)
+        edge_work += len(cinfo["pair_scores"])
+        if edge_work > edge_budget:
+            cinfo["oversized"] = True
+            result[cid] = cinfo  # leave oversized; queued cids stay in result too
+            budget_tripped = True
+            break
         sub_clusters = split_oversized_cluster(cinfo["members"], cinfo["pair_scores"])
+        if len(sub_clusters) <= 1:
+            # Couldn't split (no edges / no MST): leave it as-is, don't re-enqueue.
+            cinfo["oversized"] = cinfo["size"] > max_cluster_size
+            result[cid] = cinfo
+            continue
         next_cid = max(result.keys(), default=0) + 1
         for sc in sub_clusters:
             sc["oversized"] = sc["size"] > max_cluster_size
@@ -388,6 +434,14 @@ def build_clusters(
             if sc["oversized"]:
                 to_split.append(next_cid)
             next_cid += 1
+    if budget_tripped:
+        n_oversized = sum(1 for c in result.values() if c.get("oversized"))
+        _clog.warning(
+            "build_clusters: auto-split edge-work budget (%d) exhausted; %d "
+            "cluster(s) left oversized (dense, no clean weak-bridge split). "
+            "Oversized clusters are excluded from golden downstream.",
+            edge_budget, n_oversized,
+        )
 
     # Assign cluster_quality and apply confidence downgrade
     for cid, cinfo in result.items():

--- a/packages/python/goldenmatch/tests/test_cluster.py
+++ b/packages/python/goldenmatch/tests/test_cluster.py
@@ -197,6 +197,44 @@ def test_was_split_not_in_output():
         assert "_was_split" not in cinfo
 
 
+def test_dense_cluster_split_is_bounded(monkeypatch):
+    """A large DENSE cluster has no clean weak bridge, so the single-weakest-edge
+    split peels ~1 node per O(edges) pass -- O(nodes*edges), effectively a hang.
+    The work budget must bound the loop and leave the blob oversized rather than
+    peeling it into arbitrary pieces. Regression for the build_clusters
+    dense-cluster split-loop pathology (found greening the ray lane, 2026-05-26)."""
+    import time
+
+    # Tiny budget so the guard trips deterministically on the first dense pass.
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET", "1000")
+    n = 60
+    all_ids = list(range(n))
+    # Complete graph: every pair a strong match -> one dense cohesive cluster.
+    pairs = [(i, j, 0.95) for i in range(n) for j in range(i + 1, n)]
+
+    t0 = time.time()
+    clusters = build_clusters(pairs, all_ids, max_cluster_size=10)
+    elapsed = time.time() - t0
+
+    assert elapsed < 5.0, f"auto-split loop not bounded: {elapsed:.1f}s"
+    # The dense blob is left oversized (not peeled into arbitrary sub-clusters).
+    assert any(c["size"] > 10 for c in clusters.values())
+    # Membership is conserved exactly -- no lost or duplicated records.
+    members = sorted(m for c in clusters.values() for m in c["members"])
+    assert members == all_ids
+
+
+def test_sparse_oversized_still_splits_under_default_budget():
+    """The budget must not change behavior for normal (sparse) weak-bridge
+    clusters: a chain well under the default budget still splits fully."""
+    # Chain of 8, max_cluster_size=2 -> must split so no cluster exceeds 2.
+    pairs = [(i, i + 1, 0.9 - i * 0.05) for i in range(7)]
+    clusters = build_clusters(pairs, list(range(8)), max_cluster_size=2)
+    assert all(c["size"] <= 2 for c in clusters.values())
+    members = sorted(m for c in clusters.values() for m in c["members"])
+    assert members == list(range(8))
+
+
 def test_union_find_nodes_returns_added_members():
     from goldenmatch.core.cluster import UnionFind
 

--- a/packages/python/goldenmatch/tests/test_distributed_controller.py
+++ b/packages/python/goldenmatch/tests/test_distributed_controller.py
@@ -60,10 +60,10 @@ def test_controller_distributed_path_does_not_materialize_full_df(tmp_path, monk
     400 MB, so the check only ever measured Ray's variable runtime overhead
     (it grew 703 MB on one shared-runner run, 18 MB on another). A non-degenerate
     surname pool also avoids the soundex-collapse pair explosion."""
+    import goldenmatch.distributed.sample as sample_mod
     import polars as pl
     from goldenmatch import auto_configure_df
     from goldenmatch.distributed import read_csv_partitioned
-    import goldenmatch.distributed.sample as sample_mod
 
     n = 100_000
     csv = tmp_path / "big.csv"

--- a/packages/python/goldenmatch/tests/test_distributed_controller.py
+++ b/packages/python/goldenmatch/tests/test_distributed_controller.py
@@ -50,28 +50,47 @@ def test_controller_accepts_ray_dataset_input(tmp_path):
     assert config.get_matchkeys() is not None
 
 
-def test_controller_distributed_path_does_not_materialize_full_df(tmp_path):
-    """The full df should never be collected to the driver during run()."""
+def test_controller_distributed_path_does_not_materialize_full_df(tmp_path, monkeypatch):
+    """The controller must sample the Ray Dataset, never collect the full df to
+    the driver.
+
+    Asserts directly on the max rows pulled to the driver via the bounded-sample
+    helper -- not on process RSS. The old RSS-growth proxy was meaningless and
+    flaky: a materialized 100K-row frame is only ~30 MB, but the threshold was
+    400 MB, so the check only ever measured Ray's variable runtime overhead
+    (it grew 703 MB on one shared-runner run, 18 MB on another). A non-degenerate
+    surname pool also avoids the soundex-collapse pair explosion."""
     import polars as pl
-    import psutil
     from goldenmatch import auto_configure_df
     from goldenmatch.distributed import read_csv_partitioned
+    import goldenmatch.distributed.sample as sample_mod
 
+    n = 100_000
     csv = tmp_path / "big.csv"
     pl.DataFrame({
-        "first_name": ["Alice"] * 100_000,
-        "last_name": ["Smith"] * 100_000,
-        "email": [f"u{i}@example.com" for i in range(100_000)],
+        "first_name": [_FIRSTNAMES[i % len(_FIRSTNAMES)] for i in range(n)],
+        "last_name": [_SURNAMES[i % len(_SURNAMES)] for i in range(n)],
+        "email": [f"u{i}@example.com" for i in range(n)],
     }).write_csv(csv)
 
-    proc = psutil.Process()
-    baseline = proc.memory_info().rss
+    # Spy on the controller's only driver-side collection point. controller.run()
+    # does a late `from goldenmatch.distributed.sample import take_sample_distributed`,
+    # so patching the module attribute binds the spy at call time.
+    collected_heights: list[int] = []
+    real_tsd = sample_mod.take_sample_distributed
+
+    def _spy(ds, sample_cap=20_000):
+        out = real_tsd(ds, sample_cap=sample_cap)
+        collected_heights.append(out.height)
+        return out
+
+    monkeypatch.setattr(sample_mod, "take_sample_distributed", _spy)
 
     ds = read_csv_partitioned(str(csv), n_partitions=8)
-    _ = auto_configure_df(ds, confidence_required=False)
-    after = proc.memory_info().rss
+    config = auto_configure_df(ds, confidence_required=False)
+    assert config is not None
 
-    growth_mb = (after - baseline) / 1024 / 1024
-    # 100K-row Polars frame is ~30 MB; if it materialized on driver we'd
-    # see at least that much growth. Budget 400 MB for sample collections.
-    assert growth_mb < 400, f"driver RSS grew {growth_mb:.0f} MB"
+    assert collected_heights, "controller pulled no distributed sample"
+    # Every driver-side sample is bounded by the cap, far below the full df.
+    assert max(collected_heights) <= 20_000, collected_heights
+    assert max(collected_heights) < n


### PR DESCRIPTION
Two follow-ups from greening PR #514's distributed lane.

## 1. `build_clusters` dense-cluster split-loop hang (the real fix)
`build_clusters` auto-splits oversized clusters by removing the single weakest MST edge per pass (`split_oversized_cluster`, O(edges)). On a large **dense** cluster with no clean weak bridge, each pass peels ~1 node -> O(nodes*edges), effectively non-terminating (a 1000-node / ~500k-edge blob hung >300s). Pre-existing and ray-independent (reproduces with a plain Polars df).

Two guards bound the loop without changing behavior for normal weak-bridge clusters:
- **no-progress**: a split that can't break the cluster leaves it oversized instead of re-enqueueing forever (also fixes a latent infinite loop when there's no MST to cut).
- **work budget**: cap cumulative edge-work (`GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET`, default 5M). Once tripped, remaining clusters are left oversized.

Oversized-and-unsplit clusters are excluded from golden downstream, same as `auto_split=False` (`test_oversized_clusters_excluded`). `split_oversized_cluster`'s single-cut contract is unchanged. New tests: `test_dense_cluster_split_is_bounded`, `test_sparse_oversized_still_splits_under_default_budget`. The original degenerate-fixture repro now terminates (budget warning fires) instead of hanging.

## 2. De-flake the controller materialization test
`test_controller_distributed_path_does_not_materialize_full_df` used an RSS-growth proxy that was meaningless and flaky (a 100K-row frame is ~30 MB but the threshold was 400 MB, so it only measured Ray's variable runtime overhead -- 703 MB one run, 18 MB another). Replaced with a direct assertion that the controller's driver-side samples stay bounded by the cap, plus a non-degenerate surname pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)