### PR TITLE
feat(native): Phase 3a — gm_record_fingerprint C ABI + cross-language proof

### DIFF
--- a/packages/python/goldenmatch/tests/test_record_fingerprint.py
+++ b/packages/python/goldenmatch/tests/test_record_fingerprint.py
@@ -144,3 +144,77 @@ def test_public_uses_native_when_on(monkeypatch):
     assert _hashing.record_fingerprint(rec) == _native_loader.native_module().record_fingerprint(
         rec
     )
+
+
+# ── C ABI cross-language determinism (Phase 3) ──
+# gm_record_fingerprint is the C symbol non-Python surfaces (pgrx/DuckDB/Node)
+# call. Loaded via ctypes from the same shared object, it must produce the same
+# hex as the PyO3 function + the pure-Python reference + the pinned vectors.
+def _load_native_cdll():
+    import ctypes
+
+    mod = _native_loader.native_module()
+    path = getattr(mod, "__file__", None)
+    if not path:
+        return None
+    try:
+        return ctypes.CDLL(path)
+    except OSError:
+        return None
+
+
+# JSON can't carry bytes; exclude any bytes-valued records from the C-ABI battery.
+_JSON_BATTERY = [
+    r for r in _BATTERY if not any(isinstance(v, bytes) for v in r.values())
+]
+
+
+@pytestmark_native
+@pytest.mark.parametrize("record", _JSON_BATTERY)
+def test_c_abi_matches_pyo3_and_reference(record):
+    import ctypes
+    import json
+
+    lib = _load_native_cdll()
+    if lib is None or not hasattr(lib, "gm_record_fingerprint"):
+        pytest.skip("gm_record_fingerprint C symbol not loadable in this build")
+    lib.gm_record_fingerprint.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib.gm_record_fingerprint.restype = ctypes.c_int
+    out = ctypes.create_string_buffer(65)
+    rc = lib.gm_record_fingerprint(json.dumps(record).encode("utf-8"), out)
+    assert rc == 0, (rc, record)
+    hex_c = out.value.decode("ascii")
+    assert hex_c == _hashing._fingerprint_py(record)
+    assert hex_c == _native_loader.native_module().record_fingerprint(record)
+
+
+@pytestmark_native
+@pytest.mark.parametrize("record,expected", _PINNED)
+def test_c_abi_matches_pinned(record, expected):
+    import ctypes
+    import json
+
+    lib = _load_native_cdll()
+    if lib is None or not hasattr(lib, "gm_record_fingerprint"):
+        pytest.skip("gm_record_fingerprint C symbol not loadable in this build")
+    lib.gm_record_fingerprint.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib.gm_record_fingerprint.restype = ctypes.c_int
+    out = ctypes.create_string_buffer(65)
+    rc = lib.gm_record_fingerprint(json.dumps(record).encode("utf-8"), out)
+    assert rc == 0
+    assert out.value.decode("ascii") == expected
+
+
+@pytestmark_native
+def test_c_abi_rejects_bad_input():
+    import ctypes
+
+    lib = _load_native_cdll()
+    if lib is None or not hasattr(lib, "gm_record_fingerprint"):
+        pytest.skip("gm_record_fingerprint C symbol not loadable in this build")
+    lib.gm_record_fingerprint.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib.gm_record_fingerprint.restype = ctypes.c_int
+    out = ctypes.create_string_buffer(65)
+    assert lib.gm_record_fingerprint(b"not json", out) == 1          # invalid JSON
+    assert lib.gm_record_fingerprint(b"[1,2,3]", out) == 1           # not an object
+    assert lib.gm_record_fingerprint(b'{"a":[1]}', out) == 1         # nested array

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -28,6 +28,10 @@ blake2 = "0.10"
 # SHA-256 for the canonical record fingerprint kernel — must match Python
 # hashlib.sha256 byte-for-byte (see hash.rs + core/_hashing.py).
 sha2 = "0.10"
+# JSON parsing for the gm_record_fingerprint C ABI (non-Python callers pass a
+# JSON object). arbitrary_precision preserves integer literals exactly so big
+# ints match the pyo3 path's Python-str() ints.
+serde_json = { version = "1", features = ["arbitrary_precision"] }
 rapidfuzz = "0.5.0"
 rayon = "1.12.0"
 # Arrow C Data Interface for zero-copy kernel input (see score.rs

--- a/packages/rust/extensions/native/src/hash.rs
+++ b/packages/rust/extensions/native/src/hash.rs
@@ -8,6 +8,13 @@
 //! `json.dumps(..., sort_keys=True, default=str)` does NOT reproduce across
 //! languages (separators, `ensure_ascii`, float repr, `default=str`).
 //!
+//! Two entry points share one canonicalizer (`fingerprint_fields`):
+//! - `record_fingerprint` (PyO3) — takes a Python `dict`;
+//! - `gm_record_fingerprint` (C ABI) — takes a JSON object string, for
+//!   non-Python callers (pgrx / DuckDB / a future Node/C# SDK). Both map their
+//!   input to the same `FpValue` intermediate, so the same logical record
+//!   yields the same hash on every surface.
+//!
 //! Canonicalization v1 — MUST match `goldenmatch.core._hashing._fingerprint_py`
 //! byte-for-byte:
 //! - drop fields whose name starts with `__`;
@@ -15,19 +22,21 @@
 //!   which for valid UTF-8 equals Unicode code-point order == Python `sorted`);
 //! - for each field append `name 0x1f TAG value 0x1e` to a byte buffer;
 //! - per-type TAG + value bytes (type-tagged, so int `1` != str `"1"` != `True`),
-//!   any other type raising (v1 is primitive-only; datetime/UUID/Decimal
-//!   canonicalization is a documented follow-up):
+//!   any other type raising (v1 is primitive-only):
 //!
 //! ```text
 //! null  -> b'n'   (no value bytes)
 //! bool  -> b'b' + b'1' / b'0'
-//! int   -> b'i' + base-10 ASCII via Python str()  (arbitrary precision)
+//! int   -> b'i' + base-10 ASCII  (arbitrary precision)
 //! float -> b'f' + 16 hex of IEEE-754 big-endian bits; -0.0 -> 0.0; NaN/Inf rejected
 //! str   -> b's' + raw UTF-8 bytes
-//! bytes -> b'y' + raw bytes
+//! bytes -> b'y' + raw bytes  (PyO3 path only; JSON can't carry bytes)
 //! ```
 //!
 //! - SHA-256 the buffer; return 64 lowercase hex chars.
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyString};
@@ -35,6 +44,17 @@ use sha2::{Digest, Sha256};
 
 const US: u8 = 0x1f; // unit separator: between a field name and its value
 const RS: u8 = 0x1e; // record separator: end of one field
+
+/// Type-tagged value the canonicalizer accepts. `Int` keeps the decimal string
+/// (arbitrary precision); `Float` keeps the f64 (canonicalized via IEEE bits).
+enum FpValue {
+    Null,
+    Bool(bool),
+    Int(String),
+    Float(f64),
+    Str(String),
+    Bytes(Vec<u8>),
+}
 
 fn to_hex(bytes: &[u8]) -> String {
     let mut s = String::with_capacity(bytes.len() * 2);
@@ -44,24 +64,62 @@ fn to_hex(bytes: &[u8]) -> String {
     s
 }
 
-/// Append `TAG + value-bytes` for one value. `name` is only used for error text.
-fn append_value(buf: &mut Vec<u8>, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+/// The canonicalization spec, shared by every surface. The caller has already
+/// dropped `__`-prefixed fields. Returns 64 lowercase hex chars, or an error
+/// string for a non-finite float.
+fn fingerprint_fields(mut fields: Vec<(String, FpValue)>) -> Result<String, String> {
+    fields.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut buf: Vec<u8> = Vec::new();
+    for (name, value) in &fields {
+        buf.extend_from_slice(name.as_bytes());
+        buf.push(US);
+        match value {
+            FpValue::Null => buf.push(b'n'),
+            FpValue::Bool(b) => {
+                buf.push(b'b');
+                buf.push(if *b { b'1' } else { b'0' });
+            }
+            FpValue::Int(s) => {
+                buf.push(b'i');
+                buf.extend_from_slice(s.as_bytes());
+            }
+            FpValue::Float(x) => {
+                if !x.is_finite() {
+                    return Err(format!(
+                        "field {name:?}: non-finite float is not canonicalizable"
+                    ));
+                }
+                let norm = if *x == 0.0 { 0.0_f64 } else { *x }; // collapse -0.0
+                buf.push(b'f');
+                buf.extend_from_slice(to_hex(&norm.to_bits().to_be_bytes()).as_bytes());
+            }
+            FpValue::Str(s) => {
+                buf.push(b's');
+                buf.extend_from_slice(s.as_bytes());
+            }
+            FpValue::Bytes(b) => {
+                buf.push(b'y');
+                buf.extend_from_slice(b);
+            }
+        }
+        buf.push(RS);
+    }
+    Ok(to_hex(&Sha256::digest(&buf)))
+}
+
+// ── PyO3 entry point ─────────────────────────────────────────────────────
+
+fn py_to_fpvalue(name: &str, value: &Bound<'_, PyAny>) -> PyResult<FpValue> {
     if value.is_none() {
-        buf.push(b'n');
-        return Ok(());
+        return Ok(FpValue::Null);
     }
     // bool MUST precede int: in Python `bool` is a subclass of `int`.
     if value.is_instance_of::<PyBool>() {
-        buf.push(b'b');
-        buf.push(if value.extract::<bool>()? { b'1' } else { b'0' });
-        return Ok(());
+        return Ok(FpValue::Bool(value.extract()?));
     }
     if value.is_instance_of::<PyInt>() {
         // Via Python str() so arbitrary-precision ints match the reference.
-        buf.push(b'i');
-        let s: String = value.str()?.extract()?;
-        buf.extend_from_slice(s.as_bytes());
-        return Ok(());
+        return Ok(FpValue::Int(value.str()?.extract()?));
     }
     if value.is_instance_of::<PyFloat>() {
         let x: f64 = value.extract()?;
@@ -70,22 +128,15 @@ fn append_value(buf: &mut Vec<u8>, name: &str, value: &Bound<'_, PyAny>) -> PyRe
                 "field {name:?}: non-finite float {x} is not canonicalizable"
             )));
         }
-        let norm = if x == 0.0 { 0.0_f64 } else { x }; // collapse -0.0 -> 0.0
-        buf.push(b'f');
-        buf.extend_from_slice(to_hex(&norm.to_bits().to_be_bytes()).as_bytes());
-        return Ok(());
+        return Ok(FpValue::Float(x));
     }
     if value.is_instance_of::<PyString>() {
-        buf.push(b's');
-        let s: String = value.extract()?;
-        buf.extend_from_slice(s.as_bytes());
-        return Ok(());
+        return Ok(FpValue::Str(value.extract()?));
     }
     if value.is_instance_of::<PyBytes>() {
-        buf.push(b'y');
-        let b = value.downcast::<PyBytes>()?;
-        buf.extend_from_slice(b.as_bytes());
-        return Ok(());
+        return Ok(FpValue::Bytes(
+            value.downcast::<PyBytes>()?.as_bytes().to_vec(),
+        ));
     }
     Err(PyTypeError::new_err(format!(
         "field {name:?}: unsupported value type (v1 record fingerprint is \
@@ -100,7 +151,7 @@ fn append_value(buf: &mut Vec<u8>, name: &str, value: &Bound<'_, PyAny>) -> PyRe
 /// non-primitive values, `ValueError` for NaN/Inf floats.
 #[pyfunction]
 pub fn record_fingerprint(record: &Bound<'_, PyDict>) -> PyResult<String> {
-    let mut fields: Vec<(String, Bound<'_, PyAny>)> = Vec::with_capacity(record.len());
+    let mut fields: Vec<(String, FpValue)> = Vec::with_capacity(record.len());
     for (k, v) in record.iter() {
         let name: String = k
             .extract()
@@ -108,16 +159,82 @@ pub fn record_fingerprint(record: &Bound<'_, PyDict>) -> PyResult<String> {
         if name.starts_with("__") {
             continue;
         }
-        fields.push((name, v));
+        let fv = py_to_fpvalue(&name, &v)?;
+        fields.push((name, fv));
     }
-    fields.sort_by(|a, b| a.0.cmp(&b.0));
+    fingerprint_fields(fields).map_err(PyValueError::new_err)
+}
 
-    let mut buf: Vec<u8> = Vec::new();
-    for (name, value) in &fields {
-        buf.extend_from_slice(name.as_bytes());
-        buf.push(US);
-        append_value(&mut buf, name, value)?;
-        buf.push(RS);
+// ── C ABI entry point ────────────────────────────────────────────────────
+
+fn json_to_fpvalue(v: &serde_json::Value) -> Result<FpValue, String> {
+    use serde_json::Value as J;
+    match v {
+        J::Null => Ok(FpValue::Null),
+        J::Bool(b) => Ok(FpValue::Bool(*b)),
+        J::String(s) => Ok(FpValue::Str(s.clone())),
+        J::Number(n) => {
+            // arbitrary_precision keeps the literal; an int has no '.'/'e'.
+            let lit = n.to_string();
+            if lit.contains('.') || lit.contains('e') || lit.contains('E') {
+                lit.parse::<f64>()
+                    .map(FpValue::Float)
+                    .map_err(|_| format!("unparseable number {lit}"))
+            } else {
+                Ok(FpValue::Int(lit))
+            }
+        }
+        J::Array(_) | J::Object(_) => {
+            Err("nested arrays/objects are not supported (v1 is primitive-only)".into())
+        }
     }
-    Ok(to_hex(&Sha256::digest(&buf)))
+}
+
+fn fingerprint_json(s: &str) -> Result<String, String> {
+    let v: serde_json::Value = serde_json::from_str(s).map_err(|e| e.to_string())?;
+    let obj = v.as_object().ok_or("top-level JSON must be an object")?;
+    let mut fields: Vec<(String, FpValue)> = Vec::with_capacity(obj.len());
+    for (k, val) in obj {
+        if k.starts_with("__") {
+            continue;
+        }
+        fields.push((k.clone(), json_to_fpvalue(val)?));
+    }
+    fingerprint_fields(fields)
+}
+
+/// C ABI: canonical record fingerprint over a JSON object string.
+///
+/// - `json_utf8`: NUL-terminated UTF-8 JSON object (`{"field": scalar, ...}`).
+/// - `out_hex`: caller-provided buffer of **>= 65 bytes**; on success it
+///   receives the 64 lowercase hex chars plus a trailing NUL. The output size
+///   is fixed (SHA-256), so nothing is allocated across the boundary.
+///
+/// Returns `0` on success, `1` on any error (null pointer, bad UTF-8, invalid
+/// JSON, non-object, unsupported value, non-finite float). Panic-safe.
+///
+/// # Safety
+/// `json_utf8` must point to a valid NUL-terminated C string and `out_hex` to a
+/// writable buffer of at least 65 bytes.
+#[no_mangle]
+pub extern "C" fn gm_record_fingerprint(json_utf8: *const c_char, out_hex: *mut c_char) -> c_int {
+    let result = std::panic::catch_unwind(|| {
+        if json_utf8.is_null() || out_hex.is_null() {
+            return Err(());
+        }
+        let s = unsafe { CStr::from_ptr(json_utf8) }
+            .to_str()
+            .map_err(|_| ())?;
+        let hex = fingerprint_json(s).map_err(|_| ())?;
+        debug_assert_eq!(hex.len(), 64);
+        unsafe {
+            std::ptr::copy_nonoverlapping(hex.as_ptr(), out_hex as *mut u8, 64);
+            *out_hex.add(64) = 0; // NUL terminator
+        }
+        Ok(())
+    });
+    match result {
+        Ok(Ok(())) => 0,
+        _ => 1,
+    }
 }


### PR DESCRIPTION
Phase 3a of the stable record-hash plan: export the canonical fingerprint as a **C ABI** so non-Python surfaces (pgrx / DuckDB / a future Node/C# SDK) can mint the same record id without embedding CPython. First concrete slice of "decouple SQL extensions from embedded CPython".

## What
- `hash.rs` refactored so the PyO3 function and the C ABI share **one** canonicalizer (`fingerprint_fields` over an `FpValue` intermediate). Both map their input to the same typed values, so the same logical record hashes identically on every surface. Canonical bytes unchanged — the pinned golden vectors still hold.
- `gm_record_fingerprint(json_utf8, out_hex) -> c_int`: parses a JSON object (`serde_json`, `arbitrary_precision` so big ints match the Python-`str()` path), writes 64 hex + NUL into a caller-provided 65-byte buffer (fixed output size → nothing allocated across the boundary), returns 0/1. Panic-safe (`catch_unwind` at the FFI edge).
- Tests: `ctypes` loads the built `.so` and asserts **C ABI == PyO3 == Python reference == pinned vectors** across the battery, plus bad-input rejection (invalid JSON / non-object / nested array). Runs in the native CI lane.

## Scope
No Python behavior change (the C symbol is additive; the PyO3 surface and canonical bytes are identical). **Phase 3b** — wiring the pgrx + DuckDB identity functions to call this symbol + a dedicated cross-language determinism CI lane — is a separate, CI-only follow-up (pgrx builds only in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)