### PR TITLE
feat(sql): Phase 3b — goldenmatch_record_fingerprint in both SQL backends

### DIFF
--- a/packages/python/goldenmatch/tests/test_record_fingerprint.py
+++ b/packages/python/goldenmatch/tests/test_record_fingerprint.py
@@ -144,3 +144,77 @@ def test_public_uses_native_when_on(monkeypatch):
     assert _hashing.record_fingerprint(rec) == _native_loader.native_module().record_fingerprint(
         rec
     )
+
+
+# ── C ABI cross-language determinism (Phase 3) ──
+# gm_record_fingerprint is the C symbol non-Python surfaces (pgrx/DuckDB/Node)
+# call. Loaded via ctypes from the same shared object, it must produce the same
+# hex as the PyO3 function + the pure-Python reference + the pinned vectors.
+def _load_native_cdll():
+    import ctypes
+
+    mod = _native_loader.native_module()
+    path = getattr(mod, "__file__", None)
+    if not path:
+        return None
+    try:
+        return ctypes.CDLL(path)
+    except OSError:
+        return None
+
+
+# JSON can't carry bytes; exclude any bytes-valued records from the C-ABI battery.
+_JSON_BATTERY = [
+    r for r in _BATTERY if not any(isinstance(v, bytes) for v in r.values())
+]
+
+
+@pytestmark_native
+@pytest.mark.parametrize("record", _JSON_BATTERY)
+def test_c_abi_matches_pyo3_and_reference(record):
+    import ctypes
+    import json
+
+    lib = _load_native_cdll()
+    if lib is None or not hasattr(lib, "gm_record_fingerprint"):
+        pytest.skip("gm_record_fingerprint C symbol not loadable in this build")
+    lib.gm_record_fingerprint.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib.gm_record_fingerprint.restype = ctypes.c_int
+    out = ctypes.create_string_buffer(65)
+    rc = lib.gm_record_fingerprint(json.dumps(record).encode("utf-8"), out)
+    assert rc == 0, (rc, record)
+    hex_c = out.value.decode("ascii")
+    assert hex_c == _hashing._fingerprint_py(record)
+    assert hex_c == _native_loader.native_module().record_fingerprint(record)
+
+
+@pytestmark_native
+@pytest.mark.parametrize("record,expected", _PINNED)
+def test_c_abi_matches_pinned(record, expected):
+    import ctypes
+    import json
+
+    lib = _load_native_cdll()
+    if lib is None or not hasattr(lib, "gm_record_fingerprint"):
+        pytest.skip("gm_record_fingerprint C symbol not loadable in this build")
+    lib.gm_record_fingerprint.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib.gm_record_fingerprint.restype = ctypes.c_int
+    out = ctypes.create_string_buffer(65)
+    rc = lib.gm_record_fingerprint(json.dumps(record).encode("utf-8"), out)
+    assert rc == 0
+    assert out.value.decode("ascii") == expected
+
+
+@pytestmark_native
+def test_c_abi_rejects_bad_input():
+    import ctypes
+
+    lib = _load_native_cdll()
+    if lib is None or not hasattr(lib, "gm_record_fingerprint"):
+        pytest.skip("gm_record_fingerprint C symbol not loadable in this build")
+    lib.gm_record_fingerprint.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    lib.gm_record_fingerprint.restype = ctypes.c_int
+    out = ctypes.create_string_buffer(65)
+    assert lib.gm_record_fingerprint(b"not json", out) == 1          # invalid JSON
+    assert lib.gm_record_fingerprint(b"[1,2,3]", out) == 1           # not an object
+    assert lib.gm_record_fingerprint(b'{"a":[1]}', out) == 1         # nested array

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -1726,6 +1726,30 @@ pub fn connected_components(pairs_json: &str) -> Result<String, BridgeError> {
     })
 }
 
+/// Canonical record fingerprint (64 lowercase hex) of a JSON record object via
+/// `goldenmatch.core._hashing.record_fingerprint`. The cross-surface stable
+/// record-id hash — same value the DuckDB UDF and the Python identity path
+/// produce. `__`-prefixed keys are dropped. Fail-soft to `{"error": ...}`.
+pub fn record_fingerprint(record_json: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let result: Result<String, BridgeError> = (|| {
+            let hashing = py.import("goldenmatch.core._hashing")?;
+            let json_mod = py.import("json")?;
+            let builtins = py.import("builtins")?;
+            let record = if record_json.is_empty() {
+                builtins.call_method0("dict")?
+            } else {
+                json_mod.call_method1("loads", (record_json,))?
+            };
+            let fp = hashing.call_method1("record_fingerprint", (record,))?;
+            let s: String = fp.extract()?;
+            Ok(s)
+        })();
+        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
+    })
+}
+
 /// Canonicalize + keep max score per pair over JSON `[[a, b, score], ...]` via
 /// `goldenmatch.native.dedup_pairs_max_score`. Returns a JSON array of
 /// `[a, b, score]`. Fail-soft to `{"error": ...}`.

--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/core_apis.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/core_apis.py
@@ -29,7 +29,6 @@ import duckdb
 
 from goldenmatch_duckdb.functions import _validate_table_name
 
-
 # ── Registration ─────────────────────────────────────────────────────────
 
 
@@ -111,6 +110,13 @@ def register_core_api_functions(con: duckdb.DuckDBPyConnection) -> None:
         ["VARCHAR", "VARCHAR", "VARCHAR"], "VARCHAR",
     )
 
+    # Canonical record fingerprint -- the cross-surface stable record-id hash
+    # (same value the Python identity path + the native C ABI produce).
+    con.create_function(
+        "goldenmatch_record_fingerprint", _record_fingerprint,
+        ["VARCHAR"], "VARCHAR",
+    )
+
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -174,6 +180,21 @@ def _detect_domain(columns_json: str) -> str:
     except Exception as exc:  # noqa: BLE001
         return json.dumps({"error": str(exc)})
     return json.dumps(dataclasses.asdict(profile), default=str)
+
+
+def _record_fingerprint(record_json: str) -> str:
+    """Wrap ``record_fingerprint`` -- the canonical, cross-surface-stable
+    SHA-256 fingerprint (64 hex) of a JSON record object. ``__``-prefixed keys
+    are dropped. Returns the same value the Python identity path and the native
+    C ABI produce for the same record. Fail-soft to ``{"error": ...}``."""
+    from goldenmatch.core._hashing import record_fingerprint
+    try:
+        record = _parse_json(record_json, {})
+        if not isinstance(record, dict):
+            return json.dumps({"error": "record must be a JSON object"})
+        return record_fingerprint(record)
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"error": str(exc)})
 
 
 def _extract_features(text: str, kind: str) -> str:

--- a/packages/rust/extensions/duckdb/tests/test_core_apis.py
+++ b/packages/rust/extensions/duckdb/tests/test_core_apis.py
@@ -388,3 +388,44 @@ class TestProbabilistic:
         }
         # Reconstructed EMResult round-trips.
         EMResult(**json.loads(em_json))
+
+
+# ── record fingerprint (Phase 3b: canonical cross-surface id hash) ──────────
+
+
+class TestRecordFingerprint:
+    def test_matches_core(self, con):
+        record = {"first": "Alex", "last": "Smith", "email": "a@x.com"}
+        udf = con.sql(
+            "SELECT goldenmatch_record_fingerprint(?)",
+            params=[json.dumps(record)],
+        ).fetchone()[0]
+        # Parity against the core fingerprint on the same record.
+        from goldenmatch.core._hashing import record_fingerprint
+        assert udf == record_fingerprint(record)
+        assert len(udf) == 64
+
+    def test_matches_pinned_vector(self, con):
+        # {"a": "x"} -> sha256(b"a" 0x1f b"s" b"x" 0x1e), independent of impl.
+        udf = con.sql(
+            "SELECT goldenmatch_record_fingerprint(?)",
+            params=[json.dumps({"a": "x"})],
+        ).fetchone()[0]
+        assert udf == "7381d5ba2dac5be0af49232a3209ab8d0dc2e4ed804a60ce533fdfe5254307e3"
+
+    def test_drops_underscore_fields(self, con):
+        with_meta = con.sql(
+            "SELECT goldenmatch_record_fingerprint(?)",
+            params=[json.dumps({"a": 1, "__row_id__": 9})],
+        ).fetchone()[0]
+        without = con.sql(
+            "SELECT goldenmatch_record_fingerprint(?)",
+            params=[json.dumps({"a": 1})],
+        ).fetchone()[0]
+        assert with_meta == without
+
+    def test_non_object_is_fail_soft(self, con):
+        out = con.sql(
+            "SELECT goldenmatch_record_fingerprint(?)", params=["[1,2,3]"]
+        ).fetchone()[0]
+        assert json.loads(out)["error"]

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -28,6 +28,10 @@ blake2 = "0.10"
 # SHA-256 for the canonical record fingerprint kernel — must match Python
 # hashlib.sha256 byte-for-byte (see hash.rs + core/_hashing.py).
 sha2 = "0.10"
+# JSON parsing for the gm_record_fingerprint C ABI (non-Python callers pass a
+# JSON object). arbitrary_precision preserves integer literals exactly so big
+# ints match the pyo3 path's Python-str() ints.
+serde_json = { version = "1", features = ["arbitrary_precision"] }
 rapidfuzz = "0.5.0"
 rayon = "1.12.0"
 # Arrow C Data Interface for zero-copy kernel input (see score.rs

--- a/packages/rust/extensions/native/src/hash.rs
+++ b/packages/rust/extensions/native/src/hash.rs
@@ -8,6 +8,13 @@
 //! `json.dumps(..., sort_keys=True, default=str)` does NOT reproduce across
 //! languages (separators, `ensure_ascii`, float repr, `default=str`).
 //!
+//! Two entry points share one canonicalizer (`fingerprint_fields`):
+//! - `record_fingerprint` (PyO3) — takes a Python `dict`;
+//! - `gm_record_fingerprint` (C ABI) — takes a JSON object string, for
+//!   non-Python callers (pgrx / DuckDB / a future Node/C# SDK). Both map their
+//!   input to the same `FpValue` intermediate, so the same logical record
+//!   yields the same hash on every surface.
+//!
 //! Canonicalization v1 — MUST match `goldenmatch.core._hashing._fingerprint_py`
 //! byte-for-byte:
 //! - drop fields whose name starts with `__`;
@@ -15,19 +22,21 @@
 //!   which for valid UTF-8 equals Unicode code-point order == Python `sorted`);
 //! - for each field append `name 0x1f TAG value 0x1e` to a byte buffer;
 //! - per-type TAG + value bytes (type-tagged, so int `1` != str `"1"` != `True`),
-//!   any other type raising (v1 is primitive-only; datetime/UUID/Decimal
-//!   canonicalization is a documented follow-up):
+//!   any other type raising (v1 is primitive-only):
 //!
 //! ```text
 //! null  -> b'n'   (no value bytes)
 //! bool  -> b'b' + b'1' / b'0'
-//! int   -> b'i' + base-10 ASCII via Python str()  (arbitrary precision)
+//! int   -> b'i' + base-10 ASCII  (arbitrary precision)
 //! float -> b'f' + 16 hex of IEEE-754 big-endian bits; -0.0 -> 0.0; NaN/Inf rejected
 //! str   -> b's' + raw UTF-8 bytes
-//! bytes -> b'y' + raw bytes
+//! bytes -> b'y' + raw bytes  (PyO3 path only; JSON can't carry bytes)
 //! ```
 //!
 //! - SHA-256 the buffer; return 64 lowercase hex chars.
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyString};
@@ -35,6 +44,17 @@ use sha2::{Digest, Sha256};
 
 const US: u8 = 0x1f; // unit separator: between a field name and its value
 const RS: u8 = 0x1e; // record separator: end of one field
+
+/// Type-tagged value the canonicalizer accepts. `Int` keeps the decimal string
+/// (arbitrary precision); `Float` keeps the f64 (canonicalized via IEEE bits).
+enum FpValue {
+    Null,
+    Bool(bool),
+    Int(String),
+    Float(f64),
+    Str(String),
+    Bytes(Vec<u8>),
+}
 
 fn to_hex(bytes: &[u8]) -> String {
     let mut s = String::with_capacity(bytes.len() * 2);
@@ -44,24 +64,62 @@ fn to_hex(bytes: &[u8]) -> String {
     s
 }
 
-/// Append `TAG + value-bytes` for one value. `name` is only used for error text.
-fn append_value(buf: &mut Vec<u8>, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+/// The canonicalization spec, shared by every surface. The caller has already
+/// dropped `__`-prefixed fields. Returns 64 lowercase hex chars, or an error
+/// string for a non-finite float.
+fn fingerprint_fields(mut fields: Vec<(String, FpValue)>) -> Result<String, String> {
+    fields.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut buf: Vec<u8> = Vec::new();
+    for (name, value) in &fields {
+        buf.extend_from_slice(name.as_bytes());
+        buf.push(US);
+        match value {
+            FpValue::Null => buf.push(b'n'),
+            FpValue::Bool(b) => {
+                buf.push(b'b');
+                buf.push(if *b { b'1' } else { b'0' });
+            }
+            FpValue::Int(s) => {
+                buf.push(b'i');
+                buf.extend_from_slice(s.as_bytes());
+            }
+            FpValue::Float(x) => {
+                if !x.is_finite() {
+                    return Err(format!(
+                        "field {name:?}: non-finite float is not canonicalizable"
+                    ));
+                }
+                let norm = if *x == 0.0 { 0.0_f64 } else { *x }; // collapse -0.0
+                buf.push(b'f');
+                buf.extend_from_slice(to_hex(&norm.to_bits().to_be_bytes()).as_bytes());
+            }
+            FpValue::Str(s) => {
+                buf.push(b's');
+                buf.extend_from_slice(s.as_bytes());
+            }
+            FpValue::Bytes(b) => {
+                buf.push(b'y');
+                buf.extend_from_slice(b);
+            }
+        }
+        buf.push(RS);
+    }
+    Ok(to_hex(&Sha256::digest(&buf)))
+}
+
+// ── PyO3 entry point ─────────────────────────────────────────────────────
+
+fn py_to_fpvalue(name: &str, value: &Bound<'_, PyAny>) -> PyResult<FpValue> {
     if value.is_none() {
-        buf.push(b'n');
-        return Ok(());
+        return Ok(FpValue::Null);
     }
     // bool MUST precede int: in Python `bool` is a subclass of `int`.
     if value.is_instance_of::<PyBool>() {
-        buf.push(b'b');
-        buf.push(if value.extract::<bool>()? { b'1' } else { b'0' });
-        return Ok(());
+        return Ok(FpValue::Bool(value.extract()?));
     }
     if value.is_instance_of::<PyInt>() {
         // Via Python str() so arbitrary-precision ints match the reference.
-        buf.push(b'i');
-        let s: String = value.str()?.extract()?;
-        buf.extend_from_slice(s.as_bytes());
-        return Ok(());
+        return Ok(FpValue::Int(value.str()?.extract()?));
     }
     if value.is_instance_of::<PyFloat>() {
         let x: f64 = value.extract()?;
@@ -70,22 +128,15 @@ fn append_value(buf: &mut Vec<u8>, name: &str, value: &Bound<'_, PyAny>) -> PyRe
                 "field {name:?}: non-finite float {x} is not canonicalizable"
             )));
         }
-        let norm = if x == 0.0 { 0.0_f64 } else { x }; // collapse -0.0 -> 0.0
-        buf.push(b'f');
-        buf.extend_from_slice(to_hex(&norm.to_bits().to_be_bytes()).as_bytes());
-        return Ok(());
+        return Ok(FpValue::Float(x));
     }
     if value.is_instance_of::<PyString>() {
-        buf.push(b's');
-        let s: String = value.extract()?;
-        buf.extend_from_slice(s.as_bytes());
-        return Ok(());
+        return Ok(FpValue::Str(value.extract()?));
     }
     if value.is_instance_of::<PyBytes>() {
-        buf.push(b'y');
-        let b = value.downcast::<PyBytes>()?;
-        buf.extend_from_slice(b.as_bytes());
-        return Ok(());
+        return Ok(FpValue::Bytes(
+            value.downcast::<PyBytes>()?.as_bytes().to_vec(),
+        ));
     }
     Err(PyTypeError::new_err(format!(
         "field {name:?}: unsupported value type (v1 record fingerprint is \
@@ -100,7 +151,7 @@ fn append_value(buf: &mut Vec<u8>, name: &str, value: &Bound<'_, PyAny>) -> PyRe
 /// non-primitive values, `ValueError` for NaN/Inf floats.
 #[pyfunction]
 pub fn record_fingerprint(record: &Bound<'_, PyDict>) -> PyResult<String> {
-    let mut fields: Vec<(String, Bound<'_, PyAny>)> = Vec::with_capacity(record.len());
+    let mut fields: Vec<(String, FpValue)> = Vec::with_capacity(record.len());
     for (k, v) in record.iter() {
         let name: String = k
             .extract()
@@ -108,16 +159,82 @@ pub fn record_fingerprint(record: &Bound<'_, PyDict>) -> PyResult<String> {
         if name.starts_with("__") {
             continue;
         }
-        fields.push((name, v));
+        let fv = py_to_fpvalue(&name, &v)?;
+        fields.push((name, fv));
     }
-    fields.sort_by(|a, b| a.0.cmp(&b.0));
+    fingerprint_fields(fields).map_err(PyValueError::new_err)
+}
 
-    let mut buf: Vec<u8> = Vec::new();
-    for (name, value) in &fields {
-        buf.extend_from_slice(name.as_bytes());
-        buf.push(US);
-        append_value(&mut buf, name, value)?;
-        buf.push(RS);
+// ── C ABI entry point ────────────────────────────────────────────────────
+
+fn json_to_fpvalue(v: &serde_json::Value) -> Result<FpValue, String> {
+    use serde_json::Value as J;
+    match v {
+        J::Null => Ok(FpValue::Null),
+        J::Bool(b) => Ok(FpValue::Bool(*b)),
+        J::String(s) => Ok(FpValue::Str(s.clone())),
+        J::Number(n) => {
+            // arbitrary_precision keeps the literal; an int has no '.'/'e'.
+            let lit = n.to_string();
+            if lit.contains('.') || lit.contains('e') || lit.contains('E') {
+                lit.parse::<f64>()
+                    .map(FpValue::Float)
+                    .map_err(|_| format!("unparseable number {lit}"))
+            } else {
+                Ok(FpValue::Int(lit))
+            }
+        }
+        J::Array(_) | J::Object(_) => {
+            Err("nested arrays/objects are not supported (v1 is primitive-only)".into())
+        }
     }
-    Ok(to_hex(&Sha256::digest(&buf)))
+}
+
+fn fingerprint_json(s: &str) -> Result<String, String> {
+    let v: serde_json::Value = serde_json::from_str(s).map_err(|e| e.to_string())?;
+    let obj = v.as_object().ok_or("top-level JSON must be an object")?;
+    let mut fields: Vec<(String, FpValue)> = Vec::with_capacity(obj.len());
+    for (k, val) in obj {
+        if k.starts_with("__") {
+            continue;
+        }
+        fields.push((k.clone(), json_to_fpvalue(val)?));
+    }
+    fingerprint_fields(fields)
+}
+
+/// C ABI: canonical record fingerprint over a JSON object string.
+///
+/// - `json_utf8`: NUL-terminated UTF-8 JSON object (`{"field": scalar, ...}`).
+/// - `out_hex`: caller-provided buffer of **>= 65 bytes**; on success it
+///   receives the 64 lowercase hex chars plus a trailing NUL. The output size
+///   is fixed (SHA-256), so nothing is allocated across the boundary.
+///
+/// Returns `0` on success, `1` on any error (null pointer, bad UTF-8, invalid
+/// JSON, non-object, unsupported value, non-finite float). Panic-safe.
+///
+/// # Safety
+/// `json_utf8` must point to a valid NUL-terminated C string and `out_hex` to a
+/// writable buffer of at least 65 bytes.
+#[no_mangle]
+pub extern "C" fn gm_record_fingerprint(json_utf8: *const c_char, out_hex: *mut c_char) -> c_int {
+    let result = std::panic::catch_unwind(|| {
+        if json_utf8.is_null() || out_hex.is_null() {
+            return Err(());
+        }
+        let s = unsafe { CStr::from_ptr(json_utf8) }
+            .to_str()
+            .map_err(|_| ())?;
+        let hex = fingerprint_json(s).map_err(|_| ())?;
+        debug_assert_eq!(hex.len(), 64);
+        unsafe {
+            std::ptr::copy_nonoverlapping(hex.as_ptr(), out_hex as *mut u8, 64);
+            *out_hex.add(64) = 0; // NUL terminator
+        }
+        Ok(())
+    });
+    match result {
+        Ok(Ok(())) => 0,
+        _ => 1,
+    }
 }

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.5.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.5.0.sql
@@ -641,3 +641,13 @@ CREATE FUNCTION "goldenmatch_embed_local"(
 STRICT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'goldenmatch_embed_local_wrapper';
+
+-- Canonical record fingerprint (64 hex) of a JSON record object. The
+-- cross-surface stable record-id hash; matches the DuckDB
+-- goldenmatch_record_fingerprint UDF + the Python identity path.
+CREATE FUNCTION "goldenmatch_record_fingerprint"(
+    "record_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_record_fingerprint_wrapper';

--- a/packages/rust/extensions/postgres/src/kernels.rs
+++ b/packages/rust/extensions/postgres/src/kernels.rs
@@ -44,3 +44,19 @@ pub fn goldenmatch_embed_local(text: String, model_path: String) -> String {
         Err(e) => pgrx::error!("goldenmatch_embed_local: {}", e),
     }
 }
+
+/// Canonical record fingerprint (64 lowercase hex) of a JSON record object.
+/// The cross-surface stable record-id hash — same value the DuckDB
+/// `goldenmatch_record_fingerprint` UDF and the Python identity path produce.
+/// `__`-prefixed keys are dropped.
+///
+/// ```sql
+/// SELECT goldenmatch.goldenmatch_record_fingerprint('{"first":"Alex","last":"Smith"}');
+/// ```
+#[pg_extern]
+pub fn goldenmatch_record_fingerprint(record_json: String) -> String {
+    match goldenmatch_bridge::api::record_fingerprint(&record_json) {
+        Ok(hex) => hex,
+        Err(e) => pgrx::error!("goldenmatch_record_fingerprint: {}", e),
+    }
+}


### PR DESCRIPTION
Phase 3b of the stable record-hash plan: expose the canonical record fingerprint (the cross-surface stable record-id hash) at the **SQL boundary** in both backends, in lockstep.

## What
- **DuckDB**: `goldenmatch_record_fingerprint(json)` UDF (`core_apis.py`) → calls `goldenmatch.core._hashing.record_fingerprint`. JSON-in / 64-hex-out, fail-soft. Tested against the core function + a pinned vector.
- **Postgres**: `goldenmatch.goldenmatch_record_fingerprint(text)` `pg_extern` (`kernels.rs`) + handwritten SQL, wrapping a new `goldenmatch_bridge::api::record_fingerprint`. Same contract.

Both return the **exact same hash** the Python identity path and the native C ABI (#519) produce — so a record's stable id is now computable identically from Python, DuckDB SQL, and Postgres SQL.

## Validation
- DuckDB UDF + tests run locally (duckdb 1.5.2): full `test_core_apis.py` 23 passed (incl. 4 new). Bridge crate compiles + clippy-clean locally. pgrx wrapper + SQL validated by the `rust_pgrx` CI lanes (no local libclang).

## Scope
The pgrx path still routes through the embedded-CPython bridge (the existing `kernels.rs` pattern). Converting it to call a pyo3-free `fingerprint-core` crate **directly** (true CPython decoupling) is the Phase 4 "native ER core" follow-up; this PR delivers the cross-surface SQL parity + lockstep first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)