### PR TITLE
feat(native): Phase 4 — pyo3-free fingerprint-core; pgrx computes in pure Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -874,6 +874,18 @@ jobs:
           # Confirm new v1.7-v1.12 functions registered alongside the originals.
           sudo -u postgres psql -p "${PGPORT}" -c "SELECT proname FROM pg_proc WHERE proname LIKE 'goldenmatch%' OR proname LIKE 'gm_%' ORDER BY proname;"
           sudo -u postgres psql -p "${PGPORT}" -v ON_ERROR_STOP=1 -c "SELECT goldenmatch.goldenmatch_score('John Smith'::TEXT, 'Jon Smyth'::TEXT, 'jaro_winkler'::TEXT);"
+          # Cross-language determinism: the pure-Rust record fingerprint must
+          # equal the pinned vector shared with Python / native C ABI / DuckDB.
+          # (RAISE under ON_ERROR_STOP fails the lane on any mismatch.)
+          sudo -u postgres psql -p "${PGPORT}" -v ON_ERROR_STOP=1 <<'EOSQL'
+            DO $$
+            DECLARE fp TEXT := goldenmatch.goldenmatch_record_fingerprint('{"a":"x"}');
+            BEGIN
+              IF fp <> '7381d5ba2dac5be0af49232a3209ab8d0dc2e4ed804a60ce533fdfe5254307e3' THEN
+                RAISE EXCEPTION 'goldenmatch_record_fingerprint mismatch: %', fp;
+              END IF;
+            END $$;
+          EOSQL
           # goldenflow_* transforms (fail-open: pass input through if goldenflow absent).
           sudo -u postgres psql -p "${PGPORT}" -v ON_ERROR_STOP=1 -c "SELECT goldenmatch.goldenflow_normalize_email('  John@Example.COM '::TEXT), goldenmatch.goldenflow_whitespace_normalize('a   b'::TEXT);"
           sudo -u postgres psql -p "${PGPORT}" -v ON_ERROR_STOP=1 <<'EOSQL'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
               # (which SKIPS when the ext is absent). Trigger on the crate plus
               # the Python files it's wired into + the build script.
               - 'packages/rust/extensions/native/**'
+              - 'packages/rust/extensions/fingerprint-core/**'
               - 'packages/python/goldenmatch/goldenmatch/core/_native_loader.py'
               - 'packages/python/goldenmatch/goldenmatch/core/_hashing.py'
               - 'packages/python/goldenmatch/goldenmatch/core/cluster.py'
@@ -658,6 +659,14 @@ jobs:
       - name: clippy (native crate)
         working-directory: packages/rust/extensions/native
         run: cargo clippy --release -- -D warnings
+      - name: clippy + test (fingerprint-core crate)
+        # Shared pyo3-free canonicalizer (also a dep of the pgrx crate). Its own
+        # unit tests pin the canonical vectors; the native parity + pgrx pg_test
+        # exercise it through each surface.
+        working-directory: packages/rust/extensions/fingerprint-core
+        run: |
+          cargo clippy -- -D warnings
+          cargo test
       - name: Build native extension into the package
         # No --offline: CI has network + a cold cache on first run.
         run: uv run python scripts/build_native.py

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -1726,30 +1726,6 @@ pub fn connected_components(pairs_json: &str) -> Result<String, BridgeError> {
     })
 }
 
-/// Canonical record fingerprint (64 lowercase hex) of a JSON record object via
-/// `goldenmatch.core._hashing.record_fingerprint`. The cross-surface stable
-/// record-id hash — same value the DuckDB UDF and the Python identity path
-/// produce. `__`-prefixed keys are dropped. Fail-soft to `{"error": ...}`.
-pub fn record_fingerprint(record_json: &str) -> Result<String, BridgeError> {
-    crate::init()?;
-    Python::with_gil(|py| {
-        let result: Result<String, BridgeError> = (|| {
-            let hashing = py.import("goldenmatch.core._hashing")?;
-            let json_mod = py.import("json")?;
-            let builtins = py.import("builtins")?;
-            let record = if record_json.is_empty() {
-                builtins.call_method0("dict")?
-            } else {
-                json_mod.call_method1("loads", (record_json,))?
-            };
-            let fp = hashing.call_method1("record_fingerprint", (record,))?;
-            let s: String = fp.extract()?;
-            Ok(s)
-        })();
-        Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
-    })
-}
-
 /// Canonicalize + keep max score per pair over JSON `[[a, b, score], ...]` via
 /// `goldenmatch.native.dedup_pairs_max_score`. Returns a JSON array of
 /// `[a, b, score]`. Fail-soft to `{"error": ...}`.

--- a/packages/rust/extensions/fingerprint-core/Cargo.toml
+++ b/packages/rust/extensions/fingerprint-core/Cargo.toml
@@ -1,0 +1,23 @@
+# Standalone workspace so this pyo3-free / pgrx-free core can be a path
+# dependency of BOTH the `native` crate (its own workspace, extension-module)
+# and the `postgres` crate (excluded from the bridge workspace, pgrx) without
+# either workspace claiming it.
+[workspace]
+
+[package]
+name = "goldenmatch-fingerprint-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "Canonical record-fingerprint canonicalization (no pyo3, no pgrx) shared across surfaces"
+
+[lib]
+name = "goldenmatch_fingerprint_core"
+
+[dependencies]
+# Must match Python hashlib.sha256 byte-for-byte (see core/_hashing.py).
+sha2 = "0.10"
+# JSON parsing for non-Python callers (pgrx / DuckDB / C ABI). arbitrary_precision
+# preserves integer literals exactly so big ints match the Python-str() path.
+serde_json = { version = "1", features = ["arbitrary_precision"] }

--- a/packages/rust/extensions/fingerprint-core/src/lib.rs
+++ b/packages/rust/extensions/fingerprint-core/src/lib.rs
@@ -1,0 +1,178 @@
+//! Canonical record fingerprint — the cross-surface stable record-id hash.
+//!
+//! Pure Rust (no pyo3, no pgrx) so every surface can share ONE canonicalizer:
+//! the `native` PyO3 extension wraps it for Python, the C ABI exposes it, and
+//! the `postgres` pgrx extension calls it **directly** (no embedded CPython).
+//!
+//! The digest is SHA-256 (portable + fast everywhere; a hand-rolled hash would
+//! just reimplement a tuned lib). The value of this crate is the
+//! canonicalization, which CPython's `json.dumps(..., sort_keys=True,
+//! default=str)` does NOT reproduce across languages.
+//!
+//! Spec — MUST match `goldenmatch.core._hashing._fingerprint_py` byte-for-byte:
+//! drop `__`-prefixed fields; sort by name (UTF-8 byte order == code-point
+//! order == Python `sorted`); append `name 0x1f TAG value 0x1e`; type-tagged
+//! values (so int `1` != str `"1"` != `True`):
+//!
+//! ```text
+//! null  -> b'n'   (no value bytes)
+//! bool  -> b'b' + b'1' / b'0'
+//! int   -> b'i' + base-10 ASCII  (arbitrary precision)
+//! float -> b'f' + 16 hex of IEEE-754 big-endian bits; -0.0 -> 0.0; NaN/Inf rejected
+//! str   -> b's' + raw UTF-8 bytes
+//! bytes -> b'y' + raw bytes
+//! ```
+//!
+//! then SHA-256 the buffer and return 64 lowercase hex chars.
+use sha2::{Digest, Sha256};
+
+const US: u8 = 0x1f; // unit separator: between a field name and its value
+const RS: u8 = 0x1e; // record separator: end of one field
+
+/// Type-tagged value the canonicalizer accepts. `Int` keeps the decimal string
+/// (arbitrary precision); `Float` keeps the f64 (canonicalized via IEEE bits).
+pub enum FpValue {
+    Null,
+    Bool(bool),
+    Int(String),
+    Float(f64),
+    Str(String),
+    Bytes(Vec<u8>),
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// The canonicalization spec. The caller has already dropped `__`-prefixed
+/// fields. Returns 64 lowercase hex chars, or an error string for a non-finite
+/// float.
+pub fn fingerprint_fields(mut fields: Vec<(String, FpValue)>) -> Result<String, String> {
+    fields.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut buf: Vec<u8> = Vec::new();
+    for (name, value) in &fields {
+        buf.extend_from_slice(name.as_bytes());
+        buf.push(US);
+        match value {
+            FpValue::Null => buf.push(b'n'),
+            FpValue::Bool(b) => {
+                buf.push(b'b');
+                buf.push(if *b { b'1' } else { b'0' });
+            }
+            FpValue::Int(s) => {
+                buf.push(b'i');
+                buf.extend_from_slice(s.as_bytes());
+            }
+            FpValue::Float(x) => {
+                if !x.is_finite() {
+                    return Err(format!(
+                        "field {name:?}: non-finite float is not canonicalizable"
+                    ));
+                }
+                let norm = if *x == 0.0 { 0.0_f64 } else { *x }; // collapse -0.0
+                buf.push(b'f');
+                buf.extend_from_slice(to_hex(&norm.to_bits().to_be_bytes()).as_bytes());
+            }
+            FpValue::Str(s) => {
+                buf.push(b's');
+                buf.extend_from_slice(s.as_bytes());
+            }
+            FpValue::Bytes(b) => {
+                buf.push(b'y');
+                buf.extend_from_slice(b);
+            }
+        }
+        buf.push(RS);
+    }
+    Ok(to_hex(&Sha256::digest(&buf)))
+}
+
+fn json_to_fpvalue(v: &serde_json::Value) -> Result<FpValue, String> {
+    use serde_json::Value as J;
+    match v {
+        J::Null => Ok(FpValue::Null),
+        J::Bool(b) => Ok(FpValue::Bool(*b)),
+        J::String(s) => Ok(FpValue::Str(s.clone())),
+        J::Number(n) => {
+            // arbitrary_precision keeps the literal; an int has no '.'/'e'.
+            let lit = n.to_string();
+            if lit.contains('.') || lit.contains('e') || lit.contains('E') {
+                lit.parse::<f64>()
+                    .map(FpValue::Float)
+                    .map_err(|_| format!("unparseable number {lit}"))
+            } else {
+                Ok(FpValue::Int(lit))
+            }
+        }
+        J::Array(_) | J::Object(_) => {
+            Err("nested arrays/objects are not supported (v1 is primitive-only)".into())
+        }
+    }
+}
+
+/// Canonical fingerprint of a record given as a JSON object string. Drops
+/// `__`-prefixed keys. Returns 64 lowercase hex chars, or an error string for
+/// invalid JSON, a non-object, an unsupported value, or a non-finite float.
+pub fn fingerprint_json(s: &str) -> Result<String, String> {
+    let v: serde_json::Value = serde_json::from_str(s).map_err(|e| e.to_string())?;
+    let obj = v.as_object().ok_or("top-level JSON must be an object")?;
+    let mut fields: Vec<(String, FpValue)> = Vec::with_capacity(obj.len());
+    for (k, val) in obj {
+        if k.starts_with("__") {
+            continue;
+        }
+        fields.push((k.clone(), json_to_fpvalue(val)?));
+    }
+    fingerprint_fields(fields)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pinned vectors computed from the canonical bytes (independent of impl),
+    // identical to tests/test_record_fingerprint.py::_PINNED.
+    #[test]
+    fn pinned_vectors() {
+        assert_eq!(
+            fingerprint_json("{}").unwrap(),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            fingerprint_json(r#"{"a":"x"}"#).unwrap(),
+            "7381d5ba2dac5be0af49232a3209ab8d0dc2e4ed804a60ce533fdfe5254307e3"
+        );
+        assert_eq!(
+            fingerprint_json(r#"{"a":1}"#).unwrap(),
+            "b42e38730ddd9a099426dffa93926c03258ee2cd93f75204daa6f989af628206"
+        );
+        assert_eq!(
+            fingerprint_json(r#"{"n":1.5}"#).unwrap(),
+            "241b8cd11b575fd2b21e90b490f57fac54930f9a12124f23e284caa200c403a9"
+        );
+    }
+
+    #[test]
+    fn drops_underscore_and_is_type_tagged() {
+        assert_eq!(
+            fingerprint_json(r#"{"a":1,"__row_id__":9}"#).unwrap(),
+            fingerprint_json(r#"{"a":1}"#).unwrap()
+        );
+        // int 1 != str "1"
+        assert_ne!(
+            fingerprint_json(r#"{"a":1}"#).unwrap(),
+            fingerprint_json(r#"{"a":"1"}"#).unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_bad_input() {
+        assert!(fingerprint_json("not json").is_err());
+        assert!(fingerprint_json("[1,2,3]").is_err());
+        assert!(fingerprint_json(r#"{"a":[1]}"#).is_err());
+    }
+}

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -25,13 +25,9 @@ pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py31
 # BLAKE2b for the char-n-gram feature hashing kernel — must match Python
 # hashlib.blake2b(digest_size=8) byte-for-byte (see featurize.rs).
 blake2 = "0.10"
-# SHA-256 for the canonical record fingerprint kernel — must match Python
-# hashlib.sha256 byte-for-byte (see hash.rs + core/_hashing.py).
-sha2 = "0.10"
-# JSON parsing for the gm_record_fingerprint C ABI (non-Python callers pass a
-# JSON object). arbitrary_precision preserves integer literals exactly so big
-# ints match the pyo3 path's Python-str() ints.
-serde_json = { version = "1", features = ["arbitrary_precision"] }
+# Canonical record fingerprint canonicalizer (sha256 + JSON parsing live here),
+# shared pyo3-free with the pgrx `postgres` crate so both compute the same id.
+goldenmatch-fingerprint-core = { path = "../fingerprint-core" }
 rapidfuzz = "0.5.0"
 rayon = "1.12.0"
 # Arrow C Data Interface for zero-copy kernel input (see score.rs

--- a/packages/rust/extensions/native/src/hash.rs
+++ b/packages/rust/extensions/native/src/hash.rs
@@ -1,113 +1,20 @@
-//! Canonical record fingerprint kernel — see
-//! `packages/python/goldenmatch/docs/design/2026-05-26-stable-record-hash-cabi-plan.md`.
+//! Canonical record fingerprint — PyO3 + C ABI surfaces over the shared
+//! pyo3-free canonicalizer in `goldenmatch-fingerprint-core`.
 //!
-//! Produces a deterministic, language-agnostic SHA-256 fingerprint of a
-//! record's content fields. The digest is SHA-256 (portable + fast everywhere;
-//! a hand-rolled hash would just reimplement a tuned lib and violate Gate 1).
-//! The *value* of this kernel is the canonicalization, which CPython's
-//! `json.dumps(..., sort_keys=True, default=str)` does NOT reproduce across
-//! languages (separators, `ensure_ascii`, float repr, `default=str`).
+//! - `record_fingerprint` (PyO3) — maps a Python `dict` to `core::FpValue` and
+//!   calls `core::fingerprint_fields`.
+//! - `gm_record_fingerprint` (C ABI) — parses a JSON object via
+//!   `core::fingerprint_json`, for non-Python callers.
 //!
-//! Two entry points share one canonicalizer (`fingerprint_fields`):
-//! - `record_fingerprint` (PyO3) — takes a Python `dict`;
-//! - `gm_record_fingerprint` (C ABI) — takes a JSON object string, for
-//!   non-Python callers (pgrx / DuckDB / a future Node/C# SDK). Both map their
-//!   input to the same `FpValue` intermediate, so the same logical record
-//!   yields the same hash on every surface.
-//!
-//! Canonicalization v1 — MUST match `goldenmatch.core._hashing._fingerprint_py`
-//! byte-for-byte:
-//! - drop fields whose name starts with `__`;
-//! - sort fields by name (Rust `str` ordering is UTF-8 byte-lexicographic,
-//!   which for valid UTF-8 equals Unicode code-point order == Python `sorted`);
-//! - for each field append `name 0x1f TAG value 0x1e` to a byte buffer;
-//! - per-type TAG + value bytes (type-tagged, so int `1` != str `"1"` != `True`),
-//!   any other type raising (v1 is primitive-only):
-//!
-//! ```text
-//! null  -> b'n'   (no value bytes)
-//! bool  -> b'b' + b'1' / b'0'
-//! int   -> b'i' + base-10 ASCII  (arbitrary precision)
-//! float -> b'f' + 16 hex of IEEE-754 big-endian bits; -0.0 -> 0.0; NaN/Inf rejected
-//! str   -> b's' + raw UTF-8 bytes
-//! bytes -> b'y' + raw bytes  (PyO3 path only; JSON can't carry bytes)
-//! ```
-//!
-//! - SHA-256 the buffer; return 64 lowercase hex chars.
+//! The canonicalization spec + the byte-for-byte parity contract with
+//! `goldenmatch.core._hashing._fingerprint_py` live in the core crate.
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int};
 
+use goldenmatch_fingerprint_core::{fingerprint_fields, fingerprint_json, FpValue};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyString};
-use sha2::{Digest, Sha256};
-
-const US: u8 = 0x1f; // unit separator: between a field name and its value
-const RS: u8 = 0x1e; // record separator: end of one field
-
-/// Type-tagged value the canonicalizer accepts. `Int` keeps the decimal string
-/// (arbitrary precision); `Float` keeps the f64 (canonicalized via IEEE bits).
-enum FpValue {
-    Null,
-    Bool(bool),
-    Int(String),
-    Float(f64),
-    Str(String),
-    Bytes(Vec<u8>),
-}
-
-fn to_hex(bytes: &[u8]) -> String {
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        s.push_str(&format!("{b:02x}"));
-    }
-    s
-}
-
-/// The canonicalization spec, shared by every surface. The caller has already
-/// dropped `__`-prefixed fields. Returns 64 lowercase hex chars, or an error
-/// string for a non-finite float.
-fn fingerprint_fields(mut fields: Vec<(String, FpValue)>) -> Result<String, String> {
-    fields.sort_by(|a, b| a.0.cmp(&b.0));
-    let mut buf: Vec<u8> = Vec::new();
-    for (name, value) in &fields {
-        buf.extend_from_slice(name.as_bytes());
-        buf.push(US);
-        match value {
-            FpValue::Null => buf.push(b'n'),
-            FpValue::Bool(b) => {
-                buf.push(b'b');
-                buf.push(if *b { b'1' } else { b'0' });
-            }
-            FpValue::Int(s) => {
-                buf.push(b'i');
-                buf.extend_from_slice(s.as_bytes());
-            }
-            FpValue::Float(x) => {
-                if !x.is_finite() {
-                    return Err(format!(
-                        "field {name:?}: non-finite float is not canonicalizable"
-                    ));
-                }
-                let norm = if *x == 0.0 { 0.0_f64 } else { *x }; // collapse -0.0
-                buf.push(b'f');
-                buf.extend_from_slice(to_hex(&norm.to_bits().to_be_bytes()).as_bytes());
-            }
-            FpValue::Str(s) => {
-                buf.push(b's');
-                buf.extend_from_slice(s.as_bytes());
-            }
-            FpValue::Bytes(b) => {
-                buf.push(b'y');
-                buf.extend_from_slice(b);
-            }
-        }
-        buf.push(RS);
-    }
-    Ok(to_hex(&Sha256::digest(&buf)))
-}
-
-// ── PyO3 entry point ─────────────────────────────────────────────────────
 
 fn py_to_fpvalue(name: &str, value: &Bound<'_, PyAny>) -> PyResult<FpValue> {
     if value.is_none() {
@@ -134,9 +41,7 @@ fn py_to_fpvalue(name: &str, value: &Bound<'_, PyAny>) -> PyResult<FpValue> {
         return Ok(FpValue::Str(value.extract()?));
     }
     if value.is_instance_of::<PyBytes>() {
-        return Ok(FpValue::Bytes(
-            value.downcast::<PyBytes>()?.as_bytes().to_vec(),
-        ));
+        return Ok(FpValue::Bytes(value.downcast::<PyBytes>()?.as_bytes().to_vec()));
     }
     Err(PyTypeError::new_err(format!(
         "field {name:?}: unsupported value type (v1 record fingerprint is \
@@ -165,44 +70,6 @@ pub fn record_fingerprint(record: &Bound<'_, PyDict>) -> PyResult<String> {
     fingerprint_fields(fields).map_err(PyValueError::new_err)
 }
 
-// ── C ABI entry point ────────────────────────────────────────────────────
-
-fn json_to_fpvalue(v: &serde_json::Value) -> Result<FpValue, String> {
-    use serde_json::Value as J;
-    match v {
-        J::Null => Ok(FpValue::Null),
-        J::Bool(b) => Ok(FpValue::Bool(*b)),
-        J::String(s) => Ok(FpValue::Str(s.clone())),
-        J::Number(n) => {
-            // arbitrary_precision keeps the literal; an int has no '.'/'e'.
-            let lit = n.to_string();
-            if lit.contains('.') || lit.contains('e') || lit.contains('E') {
-                lit.parse::<f64>()
-                    .map(FpValue::Float)
-                    .map_err(|_| format!("unparseable number {lit}"))
-            } else {
-                Ok(FpValue::Int(lit))
-            }
-        }
-        J::Array(_) | J::Object(_) => {
-            Err("nested arrays/objects are not supported (v1 is primitive-only)".into())
-        }
-    }
-}
-
-fn fingerprint_json(s: &str) -> Result<String, String> {
-    let v: serde_json::Value = serde_json::from_str(s).map_err(|e| e.to_string())?;
-    let obj = v.as_object().ok_or("top-level JSON must be an object")?;
-    let mut fields: Vec<(String, FpValue)> = Vec::with_capacity(obj.len());
-    for (k, val) in obj {
-        if k.starts_with("__") {
-            continue;
-        }
-        fields.push((k.clone(), json_to_fpvalue(val)?));
-    }
-    fingerprint_fields(fields)
-}
-
 /// C ABI: canonical record fingerprint over a JSON object string.
 ///
 /// - `json_utf8`: NUL-terminated UTF-8 JSON object (`{"field": scalar, ...}`).
@@ -222,9 +89,7 @@ pub extern "C" fn gm_record_fingerprint(json_utf8: *const c_char, out_hex: *mut 
         if json_utf8.is_null() || out_hex.is_null() {
             return Err(());
         }
-        let s = unsafe { CStr::from_ptr(json_utf8) }
-            .to_str()
-            .map_err(|_| ())?;
+        let s = unsafe { CStr::from_ptr(json_utf8) }.to_str().map_err(|_| ())?;
         let hex = fingerprint_json(s).map_err(|_| ())?;
         debug_assert_eq!(hex.len(), 64);
         unsafe {

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -21,6 +21,9 @@ pg_test = []
 [dependencies]
 pgrx = "0.12.9"
 goldenmatch-bridge = { path = "../bridge" }
+# Pure-Rust canonical fingerprint — computed in-process, NOT through the
+# embedded-CPython bridge (the decoupling lever; see kernels.rs).
+goldenmatch-fingerprint-core = { path = "../fingerprint-core" }
 serde_json = "1"
 
 [[bin]]

--- a/packages/rust/extensions/postgres/src/kernels.rs
+++ b/packages/rust/extensions/postgres/src/kernels.rs
@@ -47,16 +47,37 @@ pub fn goldenmatch_embed_local(text: String, model_path: String) -> String {
 
 /// Canonical record fingerprint (64 lowercase hex) of a JSON record object.
 /// The cross-surface stable record-id hash — same value the DuckDB
-/// `goldenmatch_record_fingerprint` UDF and the Python identity path produce.
-/// `__`-prefixed keys are dropped.
+/// `goldenmatch_record_fingerprint` UDF, the native C ABI, and the Python
+/// identity path produce. `__`-prefixed keys are dropped.
+///
+/// Computed **in pure Rust** via `goldenmatch-fingerprint-core` — NOT through
+/// the embedded-CPython bridge. This is the first SQL function that needs no
+/// interpreter for its work (the decoupling lever).
 ///
 /// ```sql
 /// SELECT goldenmatch.goldenmatch_record_fingerprint('{"first":"Alex","last":"Smith"}');
 /// ```
 #[pg_extern]
 pub fn goldenmatch_record_fingerprint(record_json: String) -> String {
-    match goldenmatch_bridge::api::record_fingerprint(&record_json) {
+    match goldenmatch_fingerprint_core::fingerprint_json(&record_json) {
         Ok(hex) => hex,
         Err(e) => pgrx::error!("goldenmatch_record_fingerprint: {}", e),
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    /// pgrx computes the canonical fingerprint in pure Rust; assert it matches
+    /// the pinned vector shared with the Python + native + DuckDB surfaces.
+    #[pg_test]
+    fn record_fingerprint_matches_pinned() {
+        let got = crate::kernels::goldenmatch_record_fingerprint(r#"{"a":"x"}"#.to_string());
+        assert_eq!(
+            got,
+            "7381d5ba2dac5be0af49232a3209ab8d0dc2e4ed804a60ce533fdfe5254307e3"
+        );
     }
 }


### PR DESCRIPTION
Phase 4 of the stable record-hash plan: extract the canonicalizer into a pyo3-free / pgrx-free crate and make the **Postgres** extension compute the fingerprint **in pure Rust** instead of through the embedded-CPython bridge — the first SQL function that needs no interpreter for its work. The long-game "decouple SQL extensions from embedded CPython" lever, applied to one well-defined function.

## What
- **`goldenmatch-fingerprint-core`** (new): `FpValue` + `fingerprint_fields` + `fingerprint_json` + sha2/serde, with unit tests pinning the canonical vectors. Standalone workspace so both the `native` (own workspace) and `postgres` (excluded) crates path-dep it cleanly.
- **native**: `hash.rs` maps `PyDict -> core::FpValue` (pyo3 wrapper) and the C ABI calls `core::fingerprint_json`; the duplicated logic + `sha2`/`serde_json` deps moved to core. Canonical bytes unchanged (pinned golden vectors still hold).
- **postgres**: `goldenmatch_record_fingerprint` now calls `goldenmatch_fingerprint_core::fingerprint_json` directly — no bridge, no GIL — with a `#[pg_test]` asserting the shared pinned vector.
- **bridge**: dropped the now-unused `record_fingerprint` (added in #520; pgrx no longer routes through CPython for it).
- **ci**: native lane gains the `fingerprint-core` filter + a clippy+test step; the pgrx `pg_test` validates the pure-Rust path in the `rust_pgrx` lanes.

## Validation
Locally: core clippy + 3 unit tests pass; native clippy clean (uses core); bridge builds clean. The native parity suite (pyo3 + C ABI vs Python + pinned) runs in the native lane; the pgrx pure-Rust path is validated by `rust_pgrx` (PG 15/16/17). No behavior change — the fingerprint value is identical across Python, the C ABI, DuckDB, and Postgres; pgrx just stops embedding an interpreter to get it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)