### PR TITLE
chore(bench): sweep N for bucket-cutover decision + cluster parity

### DIFF
--- a/.github/workflows/bench-fs-stages.yml
+++ b/.github/workflows/bench-fs-stages.yml
@@ -7,9 +7,9 @@ name: bench-fs-stages
 on:
   workflow_dispatch:
     inputs:
-      rows:
-        description: "End-to-end dedupe row count"
-        default: "50000"
+      ns:
+        description: "Row counts to sweep (comma-separated)"
+        default: "1000,5000,10000,30000,60000"
       fs_pairs:
         description: "FS comparison-loop pair counts (comma-separated)"
         default: "50000,200000"
@@ -42,7 +42,7 @@ jobs:
         run: |
           set -o pipefail
           uv run python packages/python/goldenmatch/scripts/bench_fs_and_stages.py \
-            --rows "${{ inputs.rows }}" \
+            --ns "${{ inputs.ns }}" \
             --fs-pairs "${{ inputs.fs_pairs }}" \
             --runs "${{ inputs.runs }}" | tee /tmp/bench.txt
           {

--- a/packages/python/goldenmatch/scripts/bench_fs_and_stages.py
+++ b/packages/python/goldenmatch/scripts/bench_fs_and_stages.py
@@ -1,19 +1,23 @@
-"""Measure-first profiler: dedupe pipeline stage timings + the Fellegi-Sunter
-comparison-vector loop, to decide whether either is worth a native kernel.
+"""Measure-first profiler for the bucket+native vs polars-direct decision.
 
-Run on a clean box (locally or the bench CI lane); the goldenmatch import +
-dedupe are heavy. Prints a per-stage wall breakdown (where the time actually
-goes) and the cost of `_build_comparison_matrix` (the per-pair Python loop that
-is the FS native-kernel candidate). 3-run medians per the decision-matrix gate
-("trust 3-run medians, not single runs").
+The native Arrow block-scorer (~5x scoring) only runs on the `bucket` backend,
+which the controller's v3 planner picks at ~100K rows. Below that, dedupes use
+polars-direct and get no native scoring. This sweeps row counts comparing
+bucket+native vs polars-direct head-to-head, reporting the speedup AND whether
+the two backends produce identical clusters (parity gate) at each N -- the data
+needed to safely lower the bucket cutover.
+
+Also times the Fellegi-Sunter comparison-vector loop (a separate opt-in
+native-kernel candidate). 3-run medians per the decision-matrix gate.
 
 Usage:
     uv run python packages/python/goldenmatch/scripts/bench_fs_and_stages.py \
-        [--rows N] [--fs-pairs N1,N2] [--runs K]
+        [--ns 1000,5000,10000,30000,60000] [--fs-pairs 50000,200000] [--runs 3]
 """
 from __future__ import annotations
 
 import argparse
+import os
 import random
 import statistics
 import time
@@ -42,18 +46,17 @@ def _typo(s: str, rng: random.Random) -> str:
 
 
 def gen(n: int, dup_frac: float = 0.2, seed: int = 7) -> pl.DataFrame:
-    """Synthetic person data with distributed surnames (avoids the soundex
-    collapse) + injected near-duplicates (typo'd name, shared block key) so
-    blocking + scoring + clustering all do real work. Block key `zip` has
-    ~n/40 distinct values -> ~40 rows/block."""
+    """Synthetic person data: distributed surnames (no soundex collapse) +
+    injected near-duplicates (typo'd name, shared block key) so blocking +
+    scoring + clustering all do real work. Block key `zip` ~ n/40 distinct."""
     rng = random.Random(seed)
     n_zip = max(1, n // 40)
     rows = []
     for i in range(n):
         f, l = rng.choice(_FIRST), rng.choice(_SURN)
-        z = f"{rng.randrange(n_zip):05d}"
         rows.append({"first_name": f, "last_name": l,
-                     "email": f"{f}.{l}.{i}@x.com".lower(), "zip": z})
+                     "email": f"{f}.{l}.{i}@x.com".lower(),
+                     "zip": f"{rng.randrange(n_zip):05d}"})
     for _ in range(int(n * dup_frac)):
         src = rng.choice(rows)
         rows.append({"first_name": _typo(src["first_name"], rng),
@@ -63,69 +66,7 @@ def gen(n: int, dup_frac: float = 0.2, seed: int = 7) -> pl.DataFrame:
     return pl.DataFrame(rows)
 
 
-def _median(fn, runs: int):
-    ts = []
-    for _ in range(runs):
-        t0 = time.perf_counter()
-        fn()
-        ts.append(time.perf_counter() - t0)
-    return statistics.median(ts), ts
-
-
-def _run_pipeline(df: pl.DataFrame, native_mode: str) -> tuple[float, dict]:
-    """One dedupe_df under bench_capture with GOLDENMATCH_NATIVE=native_mode.
-    Returns (wall, stage_timings). native_enabled() reads the env each call, so
-    toggling it per-run flips the block-scoring + clustering kernels."""
-    import os
-
-    from goldenmatch import dedupe_df
-    from goldenmatch.core.bench import bench_capture
-
-    os.environ["GOLDENMATCH_NATIVE"] = native_mode
-    t0 = time.perf_counter()
-    with bench_capture() as b:
-        dedupe_df(df, fuzzy={"first_name": 0.85, "last_name": 0.85}, blocking=["zip"])
-    return time.perf_counter() - t0, dict(b.timings)
-
-
-def profile_pipeline(df: pl.DataFrame, runs: int) -> None:
-    from goldenmatch.core._native_loader import native_available
-
-    print(f"\n=== END-TO-END dedupe_df  (rows={df.height}) ===", flush=True)
-    print(f"native ext importable: {native_available()}", flush=True)
-    if not native_available():
-        print("   WARNING: native ext not built -> only the pure-Python path is "
-              "measurable; build it (scripts/build_native.py) to see the kernel.",
-              flush=True)
-
-    score_times: dict[str, float] = {}
-    for mode in ("0", "auto"):
-        timings_last: dict = {}
-        walls = []
-        for _ in range(runs):
-            w, t = _run_pipeline(df, mode)
-            walls.append(w)
-            timings_last = t
-        med = statistics.median(walls)
-        label = "python (NATIVE=0)" if mode == "0" else "native (NATIVE=auto)"
-        total = sum(timings_last.values()) or 1.0
-        print(f"\n-- {label}: total wall ({runs}-run median) {med:.2f}s "
-              f"runs={[round(x, 2) for x in walls]}", flush=True)
-        for k, v in sorted(timings_last.items(), key=lambda kv: -kv[1])[:8]:
-            print(f"   {v:8.3f}s  {100 * v / total:5.1f}%  {k}", flush=True)
-        # Track the scoring stage for the native-vs-python comparison.
-        score_times[mode] = timings_last.get("fuzzy_score_blocks") or \
-            timings_last.get("fuzzy_scoring") or 0.0
-
-    py, nat = score_times.get("0", 0.0), score_times.get("auto", 0.0)
-    if py > 0 and nat > 0:
-        ratio = py / nat
-        engaged = "ENGAGED" if ratio >= 1.3 else "NOT engaging (routing gap?)"
-        print(f"\nscoring stage: python {py:.3f}s vs native {nat:.3f}s "
-              f"-> {ratio:.2f}x  [native fast-path {engaged}]", flush=True)
-
-
-def _mk_weighted_cfg(backend):
+def _mk_cfg(backend):
     from goldenmatch.config.schemas import (
         BlockingConfig,
         BlockingKeyConfig,
@@ -146,56 +87,48 @@ def _mk_weighted_cfg(backend):
     )
 
 
-def _run_cfg(df: pl.DataFrame, cfg, native_mode: str) -> tuple[float, dict]:
-    import os
+def _partition(result) -> set:
+    """Non-singleton cluster membership as a set of frozensets (cluster ids +
+    order don't matter) -- the backend-agnostic identity of the clustering."""
+    return {
+        frozenset(c["members"]) for c in result.clusters.values()
+        if len(c.get("members", [])) > 1
+    }
 
+
+def sweep(ns: list[int], runs: int) -> None:
     from goldenmatch import dedupe_df
-    from goldenmatch.core.bench import bench_capture
+    from goldenmatch.core._native_loader import native_available
 
-    os.environ["GOLDENMATCH_NATIVE"] = native_mode
-    t0 = time.perf_counter()
-    with bench_capture() as b:
-        dedupe_df(df, config=cfg)
-    return time.perf_counter() - t0, dict(b.timings)
+    print("\n=== bucket+native vs polars-direct: speedup + cluster parity ===", flush=True)
+    print(f"native ext importable: {native_available()}", flush=True)
+    print(f"{'N':>7}  {'polars':>8}  {'bucket+nat':>10}  {'speedup':>7}  clusters_identical",
+          flush=True)
 
+    def run(df, backend):
+        os.environ["GOLDENMATCH_NATIVE"] = "auto"
+        walls, last = [], None
+        for _ in range(runs):
+            t0 = time.perf_counter()
+            last = dedupe_df(df, config=_mk_cfg(backend))
+            walls.append(time.perf_counter() - t0)
+        return statistics.median(walls), last
 
-def profile_backends(df: pl.DataFrame, runs: int) -> None:
-    """Head-to-head: does the bucket backend + native Arrow kernel beat the
-    default polars-direct path at mid scale? Explicit config bypasses the
-    controller so we pin the backend. Decides whether lowering the bucket
-    threshold (or wiring the kernel into the default scorer) would unlock the
-    ~5x scoring win below the controller's current ~100K cutover."""
-    print(f"\n=== BACKEND HEAD-TO-HEAD  (rows={df.height}, explicit config) ===", flush=True)
-    configs = [
-        ("polars-direct  native=auto", None, "auto"),
-        ("bucket         native=0   ", "bucket", "0"),
-        ("bucket         native=auto", "bucket", "auto"),
-    ]
-    res: dict[str, float] = {}
-    for label, backend, native in configs:
-        walls, last = [], {}
+    for n in ns:
+        df = gen(n)
         try:
-            for _ in range(runs):
-                w, t = _run_cfg(df, _mk_weighted_cfg(backend), native)
-                walls.append(w)
-                last = t
-        except Exception as exc:  # noqa: BLE001 - report, don't abort the bench
-            print(f"-- {label}: ERROR {type(exc).__name__}: {exc}", flush=True)
+            pd_t, pd_r = run(df, None)            # polars-direct (default)
+            bn_t, bn_r = run(df, "bucket")        # bucket + native
+        except Exception as exc:  # noqa: BLE001
+            print(f"  {n:>7}  ERROR {type(exc).__name__}: {exc}", flush=True)
             continue
-        med = statistics.median(walls)
-        res[label.strip()] = med
-        top = ", ".join(f"{k}={v:.2f}s" for k, v in
-                        sorted(last.items(), key=lambda kv: -kv[1])[:3])
-        print(f"-- {label}: total {med:.2f}s   [{top}]", flush=True)
-    pd_ = res.get("polars-direct  native=auto")
-    bn = res.get("bucket         native=auto")
-    bp = res.get("bucket         native=0")
-    if pd_ and bn:
-        print(f"\nbucket+native vs polars-direct: {bn:.2f}s vs {pd_:.2f}s "
-              f"-> {pd_ / bn:.2f}x  (>1 = bucket+native wins at this scale)", flush=True)
-    if bp and bn:
-        print(f"native kernel within bucket: {bp:.2f}s -> {bn:.2f}s = {bp / bn:.2f}x",
-              flush=True)
+        identical = _partition(pd_r) == _partition(bn_r)
+        speed = pd_t / bn_t if bn_t else float("nan")
+        print(f"  {n:>7}  {pd_t:7.2f}s  {bn_t:9.2f}s  {speed:6.2f}x  {identical}", flush=True)
+        if not identical:
+            a, b = _partition(pd_r), _partition(bn_r)
+            print(f"           PARITY MISMATCH: polars-only={len(a - b)} bucket-only={len(b - a)}",
+                  flush=True)
 
 
 def profile_fs(df: pl.DataFrame, fs_pairs: list[int], runs: int) -> None:
@@ -213,16 +146,17 @@ def profile_fs(df: pl.DataFrame, fs_pairs: list[int], runs: int) -> None:
     )
     dfid = df.with_row_index("__row_id__")
     row_lookup = {r["__row_id__"]: r for r in dfid.to_dicts()}
-    print("\n=== FS comparison-vector loop (_build_comparison_matrix, 2 fields) ===",
-          flush=True)
-    print("    (per-pair Python loop over native rapidfuzz scorers -- the kernel candidate)",
-          flush=True)
+    print("\n=== FS comparison-vector loop (_build_comparison_matrix, 2 fields) ===", flush=True)
     for npairs in fs_pairs:
         pairs = _sample_pairs(dfid, n_pairs=npairs)
         if not pairs:
-            print(f"   n_pairs={npairs}: no pairs sampled (dataset too small)", flush=True)
             continue
-        med, _ = _median(lambda: _build_comparison_matrix(pairs, row_lookup, mk), runs)
+        ts = []
+        for _ in range(runs):
+            t0 = time.perf_counter()
+            _build_comparison_matrix(pairs, row_lookup, mk)
+            ts.append(time.perf_counter() - t0)
+        med = statistics.median(ts)
         per_us = med / len(pairs) * 1e6
         print(f"   n_pairs={len(pairs):7d}: {med:7.3f}s  ({per_us:6.2f} us/pair)"
               f"  -> 1M ~ {per_us:.1f}s, 10M ~ {per_us * 10:.0f}s", flush=True)
@@ -230,17 +164,16 @@ def profile_fs(df: pl.DataFrame, fs_pairs: list[int], runs: int) -> None:
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--rows", type=int, default=50_000)
+    ap.add_argument("--ns", default="1000,5000,10000,30000,60000")
     ap.add_argument("--fs-pairs", default="50000,200000")
     ap.add_argument("--runs", type=int, default=3)
     args = ap.parse_args()
 
+    ns = [int(x) for x in args.ns.split(",") if x.strip()]
     fs_pairs = [int(x) for x in args.fs_pairs.split(",") if x.strip()]
-    print(f"rows={args.rows}  fs_pairs={fs_pairs}  runs={args.runs}", flush=True)
-    df = gen(args.rows)
-    profile_pipeline(df, args.runs)
-    profile_backends(df, args.runs)
-    profile_fs(df, fs_pairs, args.runs)
+    print(f"ns={ns}  fs_pairs={fs_pairs}  runs={args.runs}", flush=True)
+    sweep(ns, args.runs)
+    profile_fs(gen(max(ns)), fs_pairs, args.runs)
     return 0
 
 


### PR DESCRIPTION
Sweeps row counts (1k/5k/10k/30k/60k) comparing bucket+native vs polars-direct: total wall + speedup, and whether the two backends produce **identical clusters** (parity gate) at each N. Gives the crossover (where bucket+native starts winning) + the correctness check needed before lowering the controller's ~100K bucket cutover. Workflow input rows->ns. Merging so the updated script is on main for dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)