### PR TITLE
perf(planner): bucket+native scorer for simple/fast-box plans (4x at mid scale)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
@@ -10,11 +10,18 @@ rules that mutate the GoldenMatchConfig during controller iteration.
 """
 from __future__ import annotations
 
+import os
+
 from goldenmatch.core._native_loader import native_enabled
 from goldenmatch.core.autoconfig_planner import PlannerRule
 from goldenmatch.core.complexity_profile import ComplexityProfile
 from goldenmatch.core.execution_plan import BackendName, ExecutionPlan
 from goldenmatch.core.runtime_profile import RuntimeProfile
+
+# Opt-out kill-switch: set to 0/off/false/no to force polars-direct even when
+# the native bucket scorer is available (operability lever if a bucket-path
+# issue ever surfaces in production).
+_BUCKET_OPT_OUT = frozenset({"0", "off", "false", "no"})
 
 
 def _scoring_backend() -> BackendName:
@@ -25,7 +32,12 @@ def _scoring_backend() -> BackendName:
     rows with BYTE-IDENTICAL clusters, and the win grows with N. The native
     scorer only runs on the bucket backend, so prefer it whenever the kernel is
     actually enabled; fall back to polars-direct otherwise (bucket + the Python
-    scorer is ~on par / slightly slower, so the win requires the kernel)."""
+    scorer is ~on par / slightly slower, so the win requires the kernel).
+
+    Default-on where the kernel is present; ``GOLDENMATCH_PLANNER_BUCKET=0``
+    forces polars-direct (opt-out)."""
+    if os.environ.get("GOLDENMATCH_PLANNER_BUCKET", "1").strip().lower() in _BUCKET_OPT_OUT:
+        return "polars-direct"
     return "bucket" if native_enabled("block_scoring") else "polars-direct"
 
 # ── Rule 1: pathological inputs (spec §Rule 1) ──────────────────────────────

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py
@@ -10,10 +10,23 @@ rules that mutate the GoldenMatchConfig during controller iteration.
 """
 from __future__ import annotations
 
+from goldenmatch.core._native_loader import native_enabled
 from goldenmatch.core.autoconfig_planner import PlannerRule
 from goldenmatch.core.complexity_profile import ComplexityProfile
-from goldenmatch.core.execution_plan import ExecutionPlan
+from goldenmatch.core.execution_plan import BackendName, ExecutionPlan
 from goldenmatch.core.runtime_profile import RuntimeProfile
+
+
+def _scoring_backend() -> BackendName:
+    """In-memory scoring backend for the simple / fast-box plans.
+
+    Measured 2026-05-26 (scripts/bench_fs_and_stages.py): the bucket backend +
+    native Arrow block-scorer is 1.7-3.7x faster than polars-direct from 1K-60K
+    rows with BYTE-IDENTICAL clusters, and the win grows with N. The native
+    scorer only runs on the bucket backend, so prefer it whenever the kernel is
+    actually enabled; fall back to polars-direct otherwise (bucket + the Python
+    scorer is ~on par / slightly slower, so the win requires the kernel)."""
+    return "bucket" if native_enabled("block_scoring") else "polars-direct"
 
 # ── Rule 1: pathological inputs (spec §Rule 1) ──────────────────────────────
 
@@ -74,7 +87,7 @@ def _simple_plan(
     n_rows_full: int,
 ) -> ExecutionPlan:
     return ExecutionPlan(
-        backend="polars-direct",
+        backend=_scoring_backend(),
         chunk_size=None,
         max_workers=min(4, runtime.cpu_count),
         pair_spill_threshold=None,
@@ -118,7 +131,7 @@ def _fast_box_plan(
     n_rows_full: int,
 ) -> ExecutionPlan:
     return ExecutionPlan(
-        backend="polars-direct",
+        backend=_scoring_backend(),
         max_workers=min(16, runtime.cpu_count),
         clustering_strategy="in_memory",
         rule_name="plan_selected_fast_box",

--- a/packages/python/goldenmatch/goldenmatch/core/execution_plan.py
+++ b/packages/python/goldenmatch/goldenmatch/core/execution_plan.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Literal
 if TYPE_CHECKING:
     from goldenmatch.config.schemas import GoldenMatchConfig
 
-BackendName = Literal["polars-direct", "chunked", "duckdb", "ray"]
+BackendName = Literal["polars-direct", "chunked", "duckdb", "ray", "bucket"]
 ClusteringStrategy = Literal["in_memory", "partitioned_union_find", "streaming_cc"]
 SpillThreshold = Literal["ram", "duckdb", "disk_per_worker"] | None
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_backend_routing.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_backend_routing.py
@@ -37,6 +37,17 @@ from goldenmatch.core.complexity_profile import (
 from goldenmatch.core.runtime_profile import RuntimeProfile
 
 
+@pytest.fixture(autouse=True)
+def _native_off(monkeypatch):
+    """Backend selection for the simple / fast-box rules is now native-conditional
+    (bucket when the native block-scorer is enabled, else polars-direct). Pin it
+    OFF so these routing assertions are deterministic regardless of whether the
+    native ext is built in the test env. Bucket-branch coverage lives in
+    test_autoconfig_planner_rules.py."""
+    import goldenmatch.core.autoconfig_planner_rules as pr
+    monkeypatch.setattr(pr, "native_enabled", lambda component: False)
+
+
 def _profile(n_rows: int = 1000, total_comparisons: int = 100) -> ComplexityProfile:
     return ComplexityProfile(
         data=DataProfile(n_rows=n_rows, n_cols=3),

--- a/packages/python/goldenmatch/tests/test_autoconfig_planner_rules.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_planner_rules.py
@@ -121,6 +121,15 @@ def test_fast_box_plan_uses_bucket_when_native_enabled(monkeypatch):
     assert plan.rule_name == "plan_selected_fast_box"
 
 
+def test_bucket_opt_out_forces_polars_direct(monkeypatch):
+    """GOLDENMATCH_PLANNER_BUCKET=0 forces polars-direct even with native on."""
+    import goldenmatch.core.autoconfig_planner_rules as pr
+    monkeypatch.setattr(pr, "native_enabled", lambda component: True)
+    monkeypatch.setenv("GOLDENMATCH_PLANNER_BUCKET", "0")
+    p = _profile(n_rows=50_000, total_comparisons=1_000_000)
+    assert rule_simple_plan.action(p, _runtime(), 50_000).backend == "polars-direct"
+
+
 def test_rule_simple_plan_fires_under_50m_pairs_at_99k_rows():
     """Even near the upper-bound row count, low pair count keeps simple plan eligible."""
     p = _profile(n_rows=99_000, total_comparisons=49_000_000)

--- a/packages/python/goldenmatch/tests/test_autoconfig_planner_rules.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_planner_rules.py
@@ -65,6 +65,16 @@ def _runtime(ram_gb: float = 16.0, cpus: int = 4) -> RuntimeProfile:
     return RuntimeProfile(available_ram_gb=ram_gb, cpu_count=cpus, disk_free_gb=100.0)
 
 
+@pytest.fixture(autouse=True)
+def _native_off(monkeypatch):
+    """The simple / fast-box rules pick the bucket backend when the native
+    block-scorer is enabled, else polars-direct. Pin it OFF by default so the
+    backend assertions below are deterministic regardless of whether the native
+    ext happens to be built in the test env. The bucket-branch tests re-enable it."""
+    import goldenmatch.core.autoconfig_planner_rules as pr
+    monkeypatch.setattr(pr, "native_enabled", lambda component: False)
+
+
 def test_rule_pathological_fires_at_one_row():
     """Single-row inputs trigger the pathological rule. Defensive -- the
     controller already short-circuits these earlier; the rule exists so
@@ -89,6 +99,26 @@ def test_rule_simple_plan_fires_under_100k_rows():
     assert plan.max_workers == 4
     assert plan.clustering_strategy == "in_memory"
     assert plan.rule_name == "plan_selected_simple"
+
+
+def test_simple_plan_uses_bucket_when_native_enabled(monkeypatch):
+    """With the native block-scorer enabled, the simple plan selects the bucket
+    backend (measured 1.7-3.7x faster than polars-direct, identical clusters)."""
+    import goldenmatch.core.autoconfig_planner_rules as pr
+    monkeypatch.setattr(pr, "native_enabled", lambda component: True)
+    p = _profile(n_rows=50_000, total_comparisons=1_000_000)
+    plan = rule_simple_plan.action(p, _runtime(), 50_000)
+    assert plan.backend == "bucket"
+    assert plan.rule_name == "plan_selected_simple"
+
+
+def test_fast_box_plan_uses_bucket_when_native_enabled(monkeypatch):
+    import goldenmatch.core.autoconfig_planner_rules as pr
+    monkeypatch.setattr(pr, "native_enabled", lambda component: True)
+    p = _profile(n_rows=200_000, total_comparisons=1_000_000)
+    plan = rule_fast_box.action(p, _runtime(ram_gb=64.0), 200_000)
+    assert plan.backend == "bucket"
+    assert plan.rule_name == "plan_selected_fast_box"
 
 
 def test_rule_simple_plan_fires_under_50m_pairs_at_99k_rows():


### PR DESCRIPTION
Acts on the measured finding: bucket+native is **1.7-3.7x faster** than polars-direct from 1K-60K rows with **byte-identical clusters** (sweep on the 64GB bench lane), but the v3 planner never emitted `backend="bucket"` at mid scale.

## Change
`simple` + `fast-box` planner rules now pick `_scoring_backend()` = `"bucket"` when `native_enabled("block_scoring")`, else `"polars-direct"`:
- **with the native ext** (production wheels) -> bucket+native, the ~4x;
- **without it** (or `GOLDENMATCH_NATIVE=0`) -> polars-direct, unchanged (bucket+Python is ~on par / slower, so the win requires the kernel — the gate conditions on it).

`plan.apply_to()` already wires `plan.backend -> config.backend`; added `"bucket"` to `BackendName`.

## Safety / validation
- PR-gating lanes don't build the native ext, so `native_enabled` is False there -> polars-direct -> **existing planner/routing tests unchanged** (made deterministic via an autouse native-off fixture). New tests cover the bucket branch (native forced on). Both planner test files pass locally (48 passed).
- **Quality gate (do before relying on this in prod):** the `benchmarks` workflow builds the native ext + runs DQbench. Dispatch it to confirm the composite holds at 92.03 on the bucket+native path. Clusters are measured-identical, so it should hold — but DQbench tiers exercise configs the sweep didn't, so this is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)