### PR TITLE
feat: surface record_fingerprint in Python public API + TypeScript

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -76,6 +76,9 @@ from goldenmatch.config.schemas import (
     ValidationConfig,
 )
 
+# ── Canonical record fingerprint (cross-surface stable record-id hash) ─────
+from goldenmatch.core._hashing import record_fingerprint
+
 # ── Agent ────────────────────────────────────────────────────────────────
 from goldenmatch.core.agent import AgentSession
 from goldenmatch.core.anomaly import detect_anomalies
@@ -289,6 +292,9 @@ __all__ = [
     "score_strings", "score_pair_df", "explain_pair_df",
     "pprl_link", "evaluate", "load_config",
     "DedupeResult", "MatchResult",
+    # Canonical record fingerprint (stable record-id hash; same value as the
+    # native C ABI + DuckDB/Postgres goldenmatch_record_fingerprint).
+    "record_fingerprint",
     # Agent
     "AgentSession", "ReviewQueue", "gate_pairs",
     # Config

--- a/packages/typescript/goldenmatch/src/core/index.ts
+++ b/packages/typescript/goldenmatch/src/core/index.ts
@@ -84,6 +84,9 @@ export { TabularData, isNullish, toColumnValue } from "./data.js";
 // ---------------------------------------------------------------------------
 
 export { applyTransform, applyTransforms, soundex, metaphone } from "./transforms.js";
+// Canonical record fingerprint — cross-surface stable record-id hash (byte
+// parity with Python record_fingerprint + the native C ABI + the SQL UDFs).
+export { recordFingerprint } from "./record-fingerprint.js";
 
 // ---------------------------------------------------------------------------
 // Scoring

--- a/packages/typescript/goldenmatch/src/core/record-fingerprint.ts
+++ b/packages/typescript/goldenmatch/src/core/record-fingerprint.ts
@@ -1,0 +1,80 @@
+/**
+ * Canonical record fingerprint — the cross-surface stable record-id hash.
+ *
+ * Byte-parity with the Python reference
+ * (`goldenmatch.core._hashing.record_fingerprint`), the native C ABI
+ * (`gm_record_fingerprint`), and the DuckDB / Postgres
+ * `goldenmatch_record_fingerprint` SQL functions. Spec:
+ * `docs/design/2026-05-26-stable-record-hash-cabi-plan.md`.
+ *
+ * Edge-safe: uses the global Web Crypto API (`crypto.subtle.digest`); MUST NOT
+ * import `node:*`. SHA-256 is async, so this returns a Promise.
+ *
+ * Canonicalization v1: drop `__`-prefixed fields; sort by name; for each append
+ * `name 0x1f TAG value 0x1e`; type-tagged values (so int 1 != str "1" != true):
+ *   null -> 'n' | bool -> 'b' + '1'/'0' | int -> 'i' + decimal |
+ *   float -> 'f' + 16 hex of IEEE-754 big-endian bits (-0 -> 0; NaN/Inf reject) |
+ *   string -> 's' + UTF-8 | bytes (Uint8Array) -> 'y' + raw.
+ *
+ * JS-number caveats (documented divergences from Python's int/float type model):
+ *   - A whole-number `number` is treated as an int, so `1.0` hashes like Python
+ *     int `1`, NOT Python float `1.0`. Pass a non-integer for float semantics.
+ *   - `number` integers above 2^53 lose precision; use `bigint` for exact large
+ *     ints (bigint -> int tag).
+ *   - Field-name sort is the default UTF-16 order (== code-point order for the
+ *     BMP; field names are normally ASCII).
+ */
+
+const US = 0x1f; // unit separator: between a field name and its value
+const RS = 0x1e; // record separator: end of one field
+const _enc = new TextEncoder();
+
+function _hex(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) out += bytes[i]!.toString(16).padStart(2, "0");
+  return out;
+}
+
+function _valueBytes(name: string, v: unknown): number[] {
+  if (v === null || v === undefined) return [0x6e]; // 'n'
+  if (typeof v === "boolean") return [0x62, v ? 0x31 : 0x30]; // 'b' '1'/'0'
+  if (typeof v === "bigint") return [0x69, ..._enc.encode(v.toString())]; // 'i'
+  if (typeof v === "number") {
+    if (Number.isInteger(v) && !Object.is(v, -0)) {
+      return [0x69, ..._enc.encode(String(v))]; // 'i' + decimal
+    }
+    if (!Number.isFinite(v)) {
+      throw new RangeError(`field ${JSON.stringify(name)}: non-finite float is not canonicalizable`);
+    }
+    const norm = v === 0 ? 0 : v; // collapse -0 -> 0 (matches Python -0.0 -> 0.0)
+    const buf = new ArrayBuffer(8);
+    new DataView(buf).setFloat64(0, norm, false); // big-endian IEEE-754
+    return [0x66, ..._enc.encode(_hex(new Uint8Array(buf)))]; // 'f' + 16 hex
+  }
+  if (typeof v === "string") return [0x73, ..._enc.encode(v)]; // 's'
+  if (v instanceof Uint8Array) return [0x79, ...v]; // 'y'
+  throw new TypeError(
+    `field ${JSON.stringify(name)}: unsupported value type ${typeof v} ` +
+      "(v1 record fingerprint is primitive-only: null/boolean/number/bigint/string/Uint8Array)",
+  );
+}
+
+/**
+ * Canonical SHA-256 fingerprint (64 lowercase hex) of a record's content
+ * fields. `__`-prefixed keys are dropped. Returns the same value the Python,
+ * native C ABI, and SQL surfaces produce for the same record.
+ */
+export async function recordFingerprint(record: Record<string, unknown>): Promise<string> {
+  const names = Object.keys(record)
+    .filter((k) => !k.startsWith("__"))
+    .sort();
+  const bytes: number[] = [];
+  for (const name of names) {
+    for (const b of _enc.encode(name)) bytes.push(b);
+    bytes.push(US);
+    for (const b of _valueBytes(name, record[name])) bytes.push(b);
+    bytes.push(RS);
+  }
+  const digest = await crypto.subtle.digest("SHA-256", new Uint8Array(bytes));
+  return _hex(new Uint8Array(digest));
+}

--- a/packages/typescript/goldenmatch/tests/parity/record-fingerprint.parity.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/record-fingerprint.parity.test.ts
@@ -1,0 +1,63 @@
+/**
+ * record-fingerprint.parity.test.ts — TS recordFingerprint vs the canonical spec.
+ *
+ * The pinned vectors are computed from the canonical bytes (independent of any
+ * implementation) and are identical to the Python
+ * tests/test_record_fingerprint.py::_PINNED + the fingerprint-core Rust unit
+ * tests + the pgrx pg_test. If these hold, the TS surface mints the same
+ * cross-surface stable record id as Python / native C ABI / DuckDB / Postgres.
+ */
+import { describe, it, expect } from "vitest";
+import { recordFingerprint } from "../../src/core/record-fingerprint.js";
+
+// {}        -> sha256("")
+// {"a":"x"} -> sha256("a" 1f "s" "x" 1e)
+// {"a":1}   -> sha256("a" 1f "i" "1" 1e)
+// {"n":1.5} -> sha256("n" 1f "f" "3ff8000000000000" 1e)
+const PINNED: ReadonlyArray<[Record<string, unknown>, string]> = [
+  [{}, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"],
+  [{ a: "x" }, "7381d5ba2dac5be0af49232a3209ab8d0dc2e4ed804a60ce533fdfe5254307e3"],
+  [{ a: 1 }, "b42e38730ddd9a099426dffa93926c03258ee2cd93f75204daa6f989af628206"],
+  [{ n: 1.5 }, "241b8cd11b575fd2b21e90b490f57fac54930f9a12124f23e284caa200c403a9"],
+];
+
+describe("recordFingerprint cross-surface parity", () => {
+  it.each(PINNED)("matches the pinned vector for %o", async (record, expected) => {
+    expect(await recordFingerprint(record)).toBe(expected);
+  });
+
+  it("is 64 lowercase hex", async () => {
+    const fp = await recordFingerprint({ a: "x", b: 2 });
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is key-order independent", async () => {
+    expect(await recordFingerprint({ a: 1, b: 2 })).toBe(
+      await recordFingerprint({ b: 2, a: 1 }),
+    );
+  });
+
+  it("drops __-prefixed fields", async () => {
+    expect(await recordFingerprint({ a: 1, __row_id__: 9 })).toBe(
+      await recordFingerprint({ a: 1 }),
+    );
+  });
+
+  it("type-tags distinguish int / string / bool", async () => {
+    const fps = new Set([
+      await recordFingerprint({ a: 1 }),
+      await recordFingerprint({ a: "1" }),
+      await recordFingerprint({ a: true }),
+    ]);
+    expect(fps.size).toBe(3);
+  });
+
+  it("rejects non-finite floats", async () => {
+    await expect(recordFingerprint({ a: NaN })).rejects.toThrow();
+    await expect(recordFingerprint({ a: Infinity })).rejects.toThrow();
+  });
+
+  it("rejects unsupported value types", async () => {
+    await expect(recordFingerprint({ a: [1, 2, 3] })).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
The canonical record fingerprint (cross-surface stable record-id hash) was exposed in **SQL** (DuckDB/Postgres) + the **C ABI**, but not the Python *public* API (only the private `_hashing` module) or **TS**. This adds both, completing the surface set.

- **Python:** re-export `goldenmatch.record_fingerprint` from the top level + `__all__`. The function already exists (native-accelerated); parity with the SQL surfaces.
- **TypeScript:** new `core/record-fingerprint.ts` (edge-safe — `crypto.subtle`, no `node:*`), exported from `core/index.ts`. **Byte-parity** with Python/native/SQL: the 4 pinned golden vectors + properties pass (`tests/parity/record-fingerprint.parity.test.ts`, 10 tests). Documents the JS-number caveats (whole-number `Number` → int tag; `bigint` for >2^53; non-finite floats rejected; UTF-16 key sort == code-point for BMP).

## Validation
- **TS:** vitest 10/10 + `tsc --noEmit` clean (locally).
- **Python:** ruff-clean re-export, no import cycle (`_hashing` → `_native_loader` → leaves). The full local import is currently too slow to run (box saturated), so the public attribute is confirmed by the python lane importing `goldenmatch` for the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)