### PR TITLE
feat(native): goldenmatch-native runtime package (maturin/abi3 split)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,6 +683,48 @@ jobs:
             packages/python/goldenmatch/tests/test_inhouse_embedder.py \
             -v
 
+  # goldenmatch-native distribution smoke: build the SEPARATE maturin/abi3
+  # wheel (the polars / polars-runtime split) and prove the runtime loads
+  # through the wheel path. Distinct from `native`, which builds the in-tree
+  # `goldenmatch._native` .so via build_native.py and runs the parity suite.
+  # Here we deliberately DON'T run build_native.py, so the loader must fall
+  # back to `goldenmatch_native._native` from the installed wheel.
+  native_wheel:
+    needs: changes
+    if: needs.changes.outputs.native == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/native
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      # Frontend only (pure-Python goldenmatch); NO build_native.py, so
+      # `goldenmatch._native` is absent and the loader must use the wheel.
+      - run: uv sync --all-packages
+      - name: Build the goldenmatch-native wheel (maturin, abi3)
+        run: uv run --with maturin maturin build --release --manifest-path packages/rust/extensions/native/Cargo.toml --out dist
+      - name: Install the wheel + smoke-test the split
+        run: |
+          uv pip install dist/goldenmatch_native-*.whl
+          uv run python - <<'PY'
+          import goldenmatch_native  # the separately-distributed runtime package
+          from goldenmatch.core import _native_loader
+          mod = _native_loader.native_module()
+          assert mod is not None, "loader did not discover goldenmatch_native"
+          assert mod.__name__ == "goldenmatch_native._native", mod.__name__
+          fp = mod.record_fingerprint({"a": "x"})
+          assert fp == "7381d5ba2dac5be0af49232a3209ab8d0dc2e4ed804a60ce533fdfe5254307e3", fp
+          assert _native_loader.native_enabled("hashing") is True
+          print("OK: goldenmatch-native wheel loads via the split path; fingerprint vector matches")
+          PY
+
   # Standalone Rust embedding runtime (goldenembed): builds the crate (which
   # links onnxruntime via the `ort` crate) and runs the featurizer unit tests.
   # The full ONNX-inference parity vs Python is validated out-of-CI against a
@@ -1004,6 +1046,7 @@ jobs:
       - rust_pgrx
       - duckdb_extensions
       - native
+      - native_wheel
       - goldenembed
       - distributed
       - pyright

--- a/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_native_loader.py
@@ -20,10 +20,19 @@ from __future__ import annotations
 import os
 from typing import Any
 
+# The kernel is reachable two ways, tried in order:
+#   1. ``goldenmatch._native`` — the in-tree build dropped by
+#      ``scripts/build_native.py`` for local dev / the CI parity lane.
+#   2. ``goldenmatch_native._native`` — the separately-distributed
+#      ``goldenmatch-native`` abi3 wheel (``pip install goldenmatch[native]``),
+#      the polars / polars-runtime split. Same ``_native`` pymodule either way.
 try:
     import goldenmatch._native as _native  # pyright: ignore[reportMissingImports]
-except Exception:  # noqa: BLE001 - any import/load failure falls back to Python
-    _native = None
+except Exception:  # noqa: BLE001 - any import/load failure falls back below
+    try:
+        from goldenmatch_native import _native  # pyright: ignore[reportMissingImports]
+    except Exception:  # noqa: BLE001 - neither path available -> pure Python
+        _native = None
 
 
 # Components whose native path has cleared parity + DQbench and may run under

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -111,6 +111,13 @@ quality = [
 transform = [
     "goldenflow>=1.0.0",
 ]
+# Optional native acceleration runtime (compiled Rust/PyO3 abi3 wheel, shipped
+# separately, polars / polars-runtime style). goldenmatch.core._native_loader
+# discovers it automatically; absent it, the pure-Python paths run unchanged.
+# Kept out of `all` (compiled, platform-specific — like `ray`/`duckdb`).
+native = [
+    "goldenmatch-native>=0.1.0",
+]
 web = [
     "fastapi>=0.110",
     "uvicorn[standard]>=0.29",

--- a/packages/rust/extensions/native/README.md
+++ b/packages/rust/extensions/native/README.md
@@ -1,0 +1,34 @@
+# goldenmatch-native
+
+Optional native (Rust/PyO3) acceleration kernels for
+[goldenmatch](https://github.com/benseverndev-oss/goldenmatch).
+
+This is **not** a standalone package — it ships only the compiled `abi3`
+extension that `goldenmatch` loads when present. Mirrors the
+`polars` / `polars-runtime` split: the `goldenmatch` frontend stays a
+pure-Python wheel, and the compiled runtime is distributed separately.
+
+## Install
+
+```bash
+pip install "goldenmatch[native]"   # frontend + this runtime
+```
+
+Installing `goldenmatch` alone keeps the pure-Python paths; adding the
+`native` extra pulls this package in and `goldenmatch` picks it up
+automatically — no code change required. With the runtime present, the
+auto-config planner routes simple/fast-box plans through the native Arrow
+block-scorer (measured 1.7–3.7x faster at 1k–60k rows, identical clusters).
+
+Set `GOLDENMATCH_PLANNER_BUCKET=0` to force the pure-Python scoring path even
+with the runtime installed.
+
+## What's inside
+
+A single abi3 extension (`goldenmatch_native._native`) covering the gated
+kernels: record fingerprinting, block scoring, pair generation, featurize, and
+connected-components clustering. CPython 3.11+ on a per-platform wheel.
+
+## License
+
+MIT.

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -1,0 +1,41 @@
+# goldenmatch-native — the optional native acceleration runtime, shipped as a
+# SEPARATE maturin/abi3 package (mirrors the polars / polars-runtime split).
+# `goldenmatch` stays a pure-Python wheel; `pip install goldenmatch[native]`
+# pulls this, and goldenmatch.core._native_loader discovers it.
+#
+# Build is intentionally maturin (this crate IS the package — no cross-tree
+# problem). The crate also still builds via scripts/build_native.py for in-tree
+# local dev (drops goldenmatch/_native.abi3.so); both paths share the same
+# `_native` pymodule, so the loader can import either.
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "goldenmatch-native"
+version = "0.1.0"
+description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Ben Severn", email = "ben@bensevern.dev" }]
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3 :: Only",
+    "License :: OSI Approved :: MIT License",
+    "Intended Audience :: Developers",
+    "Topic :: Scientific/Engineering",
+]
+
+[project.urls]
+Homepage = "https://github.com/benseverndev-oss/goldenmatch"
+
+[tool.maturin]
+# Mixed layout: the thin Python wrapper lives in python/goldenmatch_native/;
+# the compiled abi3 ext lands at goldenmatch_native/_native (pymodule `_native`,
+# so the last path component matches and no Rust rename is needed).
+python-source = "python"
+module-name = "goldenmatch_native._native"
+# One abi3 wheel per platform spans CPython 3.11-3.13 (pyo3 abi3-py311 in
+# Cargo.toml). extension-module (no libpython link) is already a default pyo3
+# feature on the crate, so maturin inherits it.

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -1,0 +1,14 @@
+"""goldenmatch-native — optional Rust/PyO3 acceleration kernels for goldenmatch.
+
+This package ships ONLY the compiled abi3 `_native` extension. You don't import
+it directly; `goldenmatch` discovers it through
+``goldenmatch.core._native_loader`` when present and falls back to its pure-
+Python paths when it isn't. Mirrors the polars / polars-runtime split: the
+frontend (`goldenmatch`) stays a pure-Python wheel, the compiled runtime ships
+separately and is pulled in via ``pip install goldenmatch[native]``.
+"""
+
+from . import _native as _native  # the compiled abi3 extension module
+
+__all__ = ["_native"]
+__version__ = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,13 @@ goldenpipe = { workspace = true }
 infermap = { workspace = true }
 goldensuite-mcp = { workspace = true }
 goldencheck-types = { workspace = true }
+# goldenmatch-native is the optional compiled runtime (goldenmatch[native]).
+# It's NOT a workspace member (it's a maturin/Rust crate under packages/rust/),
+# so point uv at the path for dev/CI resolution. uv reads its static PEP 621
+# metadata without building unless the `native` extra is actually installed; the
+# published goldenmatch wheel resolves goldenmatch-native from PyPI (uv.sources
+# is workspace-local, stripped from published Requires-Dist).
+goldenmatch-native = { path = "packages/rust/extensions/native" }
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## What

Stands up **`goldenmatch-native`** as a separate maturin-built abi3 package that ships only the compiled `_native` kernel, mirroring the **polars / polars-runtime** split:

- `goldenmatch` stays a pure-Python wheel.
- The compiled runtime distributes separately and is pulled in via `pip install goldenmatch[native]`.
- `goldenmatch.core._native_loader` discovers it automatically; absent it, the pure-Python paths run unchanged.

With the runtime present, the auto-config planner routes simple/fast-box plans through the native Arrow block-scorer (the 1.7-3.7x bucket+native win from #526). `GOLDENMATCH_PLANNER_BUCKET=0` still forces the Python path.

## How

- **`packages/rust/extensions/native/pyproject.toml`** - maturin, mixed layout, `module-name = "goldenmatch_native._native"` matches the existing `_native` pymodule (no Rust rename). The crate still builds in-tree via `scripts/build_native.py` for local dev / the parity lane.
- **`python/goldenmatch_native/__init__.py` + `README.md`** - thin wrapper exposing the ext.
- **`_native_loader.py`** - discover order: `goldenmatch._native` (in-tree build) -> `goldenmatch_native._native` (wheel) -> pure Python. No call-site changes.
- **goldenmatch `pyproject.toml`** - `[project.optional-dependencies] native` extra (kept out of `all`, like ray/duckdb).
- **`ci.yml`** - new `native_wheel` lane: builds the maturin wheel, installs it WITHOUT running `build_native.py`, and proves the loader falls back to the wheel path + the pinned fingerprint vector matches. Wired into `ci-required`.

## Test plan

- `native_wheel` CI lane is the end-to-end proof (build wheel -> install -> loader uses it -> fingerprint vector).
- ruff + TOML parse validated locally; uv workspace unaffected (members are `packages/python/*`, the crate pyproject is outside that glob).

## Follow-up (separate PR)

Multi-platform publish workflow (manylinux + macOS x86_64/arm64 + Windows abi3 wheels, `goldenmatch-native-v*` tag). This PR lands the package + CI proof that it builds and loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)