### PR TITLE
ci(native): multi-platform publish workflow for goldenmatch-native

### DIFF
--- a/.github/workflows/publish-goldenmatch-native.yml
+++ b/.github/workflows/publish-goldenmatch-native.yml
@@ -1,0 +1,139 @@
+name: Publish goldenmatch-native to PyPI
+
+# Builds the SEPARATE compiled runtime (maturin/abi3 wheels) across platforms
+# and publishes to PyPI. The pure-Python `goldenmatch` frontend is published by
+# publish-goldenmatch.yml; this is its polars-runtime counterpart.
+#
+# Fires on a release tagged `goldenmatch-native-v*` (kept distinct from the
+# Python `v*` and TS `goldenmatch-js-v*` tags so the publish workflows never
+# cross-trigger). workflow_dispatch with a `ref` allows a manual/retro build.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      publish:
+        description: "Upload to PyPI (uncheck for a build-matrix dry run)"
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
+  MANIFEST: packages/rust/extensions/native/Cargo.toml
+
+jobs:
+  linux:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenmatch-native-v')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+      - name: Build wheels (maturin, abi3, manylinux)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          manylinux: "2_28"
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: dist
+
+  windows:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenmatch-native-v')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: x64
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-windows-x64
+          path: dist
+
+  macos:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenmatch-native-v')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: macos-13, target: x86_64 }   # Intel
+          - { runner: macos-14, target: aarch64 }   # Apple Silicon
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist
+
+  sdist:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenmatch-native-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Build sdist
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          command: sdist
+          args: --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  publish:
+    needs: [linux, windows, macos, sdist]
+    # Release events always publish; a workflow_dispatch publishes only when the
+    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
+    if: github.event_name != 'workflow_dispatch' || inputs.publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          # Merge every wheels-* artifact into a single dist/ for upload.
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        with:
+          packages-dir: dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
## What

The publish counterpart to #529. Builds **maturin/abi3 wheels** for the `goldenmatch-native` runtime across platforms and publishes to PyPI — the polars-runtime analogue of `publish-goldenmatch.yml`.

| Job | Targets |
|---|---|
| linux | x86_64 + aarch64 (manylinux 2_28) |
| windows | x64 |
| macos | x86_64 (Intel) + aarch64 (Apple Silicon) |
| sdist | source dist |
| publish | merges all artifacts -> PyPI |

abi3 means one wheel per platform (CPython 3.11+).

## Triggers

- `release: published` tagged **`goldenmatch-native-v*`** (distinct from Python `v*` / TS `goldenmatch-js-v*` so publish workflows never cross-trigger).
- `workflow_dispatch` with `ref` (retro/manual build) and a **`publish` toggle** — uncheck for a build-matrix dry run with **no PyPI upload**. Lets us validate the cross-platform matrix safely before any real release.

## Validation

- Same manifest + `maturin build` arg shape that the `native_wheel` CI lane (#529) already proves green on linux.
- The cross-platform matrix (manylinux container, macOS, Windows) is exercised on the first dispatch — recommend a `publish=false` dry run before cutting a real tag.

## First-release prerequisites (nothing uploads until a tag/dispatch)

1. **`secrets.PYPI_TOKEN` must be account-scoped** (or the `goldenmatch-native` project pre-created on PyPI). A project-scoped `goldenmatch` token cannot create a brand-new project.
2. The first `goldenmatch-native-v*` tag must point at a commit that already contains this workflow (workflow-trigger-ordering gotcha) — or use `workflow_dispatch` with `--ref`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)