### PR TITLE
release(goldenmatch): 1.21.0 — native extra + record_fingerprint

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-05-27
+
+### Added — optional native acceleration runtime
+
+- **`goldenmatch[native]` extra** pulls in `goldenmatch-native`, a separately
+  distributed compiled (Rust/PyO3, abi3) runtime — the polars / polars-runtime
+  split. `goldenmatch` itself stays a pure-Python wheel; install
+  `pip install "goldenmatch[native]"` (or `pip install goldenmatch-native`
+  directly) and it's discovered automatically. Absent it, the pure-Python paths
+  run unchanged.
+- With the runtime present, the auto-config planner routes simple/fast-box plans
+  through the **native Arrow block-scorer** (1.7–3.7x faster at 1k–60k rows,
+  byte-identical clusters). Opt out with `GOLDENMATCH_PLANNER_BUCKET=0`.
+- Wheels: linux x86_64 + aarch64, windows x64, macOS x86_64 + arm64 (CPython
+  3.11+).
+
+### Added — stable record fingerprint
+
+- **`record_fingerprint(record)`** in the public API (and the TypeScript port):
+  a canonical, cross-language SHA-256 over a type-tagged, key-sorted byte
+  canonicalization. Stable across Python/TypeScript/SQL surfaces and used to
+  derive identity record ids.
+
 ## [1.20.0] - 2026-05-26
 
 ### Added — cluster-decision tuner (RFC from MJH Print Modernization)

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.20.0"
+__version__ = "1.21.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.20.0"
+version = "1.21.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps `goldenmatch` 1.20.0 -> 1.21.0 so the published wheel carries the `native` optional-dependency extra.

The `[native]` extra was wired in #529 but PyPI's 1.20.0 predates it, so `pip install "goldenmatch[native]"` is currently a no-op. This release makes it pull `goldenmatch-native` (live on PyPI as 0.1.0), which `_native_loader` discovers automatically.

## Changes
- `pyproject.toml` + `__init__.py`: version 1.21.0
- `CHANGELOG.md`: native acceleration runtime + `record_fingerprint` public API entries

## Release
Merging then tagging `v1.21.0` fires `publish-goldenmatch.yml` -> PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)