### PR TITLE
feat(golden): provenance=True on build_golden_records_batch (per-field source_row_id)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -377,6 +377,7 @@ def _build_golden_records_polars_native(
     multi_df: pl.DataFrame,
     rules: GoldenRulesConfig,
     user_cols: list[str],
+    provenance: bool = False,
 ) -> list[dict]:
     """Polars-native fast path for the common simple-strategy case.
 
@@ -426,6 +427,20 @@ def _build_golden_records_polars_native(
             agg_exprs.append(
                 pl.col(col).drop_nulls().n_unique().alias(f"__nuniq_{col}__")
             )
+            if provenance:
+                # Pick __row_id__ with the IDENTICAL filter + sort key as the
+                # value above, so the same physical row wins both (Polars
+                # stable sort guarantees alignment). All three exprs filter on
+                # the same ``col.is_not_null()`` predicate, so they stay
+                # row-aligned. All-null column -> empty filter -> first() None.
+                agg_exprs.append(
+                    pl.col("__row_id__").filter(pl.col(col).is_not_null())
+                    .sort_by(
+                        pl.col(len_col_aliases[col]).filter(pl.col(col).is_not_null()),
+                        descending=True,
+                    )
+                    .first().alias(f"__rid_{col}__")
+                )
         agg = (
             prepped.group_by("__cluster_id__", maintain_order=True)
             .agg(agg_exprs)
@@ -439,6 +454,12 @@ def _build_golden_records_polars_native(
             agg_exprs.append(
                 pl.col(col).drop_nulls().n_unique().alias(f"__nuniq_{col}__")
             )
+            if provenance:
+                # row_id of the first non-null value (same filter + first()).
+                agg_exprs.append(
+                    pl.col("__row_id__").filter(pl.col(col).is_not_null())
+                    .first().alias(f"__rid_{col}__")
+                )
         agg = (
             multi_df.group_by("__cluster_id__", maintain_order=True)
             .agg(agg_exprs)
@@ -463,6 +484,10 @@ def _build_golden_records_polars_native(
         cluster_ids = batch["__cluster_id__"].to_list()
         val_arrays = {col: batch[f"__val_{col}__"].to_list() for col in user_cols}
         nuniq_arrays = {col: batch[f"__nuniq_{col}__"].to_list() for col in user_cols}
+        rid_arrays = (
+            {col: batch[f"__rid_{col}__"].to_list() for col in user_cols}
+            if provenance else None
+        )
         for i, cid in enumerate(cluster_ids):
             result: dict = {}
             confidences: list[float] = []
@@ -475,7 +500,11 @@ def _build_golden_records_polars_native(
                     conf = same_strategy_conf
                 else:
                     conf = diff_strategy_conf
-                result[col] = {"value": val, "confidence": conf}
+                field: dict = {"value": val, "confidence": conf}
+                if rid_arrays is not None:
+                    # None when val is None (filter on an all-null col is empty).
+                    field["source_row_id"] = rid_arrays[col][i]
+                result[col] = field
                 confidences.append(conf)
             result["__golden_confidence__"] = (
                 sum(confidences) / len(confidences) if confidences else 0.0
@@ -511,6 +540,7 @@ def build_golden_records_batch(
     multi_df: Any,  # pl.DataFrame | ray.data.Dataset (Phase 4)
     rules: GoldenRulesConfig,
     quality_scores: dict[tuple[int, str], float] | None = None,
+    provenance: bool = False,
 ) -> list[dict]:
     """Vectorized batch builder for many golden records sharing a parent df.
 
@@ -538,22 +568,33 @@ def build_golden_records_batch(
             May also be a ray.data.Dataset (Phase 4 distributed path).
         rules: golden rules configuration.
         quality_scores: optional per-(row_id, col) quality weights.
+        provenance: when True, each field dict additionally carries
+            ``source_row_id`` -- the ``__row_id__`` of the record whose value
+            won survivorship for that field (``None`` when the field is
+            all-null). Requires a ``__row_id__`` column. Preserves the
+            single-group_by-per-column vectorization (one extra agg expr per
+            column on the fast path; the slow path maps ``merge_field``'s
+            winning index).
 
     Returns:
         List of golden records (same dict shape as ``build_golden_record``),
         in ascending ``__cluster_id__`` order. Each result has its
-        ``__cluster_id__`` field set.
+        ``__cluster_id__`` field set. With ``provenance=True`` every field
+        dict gains ``source_row_id`` alongside ``value`` and ``confidence``.
     """
     # Phase 4: distributed path when multi_df is a Ray Dataset.
     from goldenmatch.distributed import is_ray_dataset
     if is_ray_dataset(multi_df):
-        if quality_scores:
+        # provenance (like quality_scores) needs per-row __row_id__ alignment
+        # that the distributed smart path doesn't carry; collect to driver and
+        # run the in-memory build.
+        if quality_scores or provenance:
             import logging
 
             import pyarrow as pa
             logging.getLogger(__name__).info(
-                "build_golden_records_batch: quality_scores set on Ray Dataset "
-                "input; collecting to driver for in-memory build.",
+                "build_golden_records_batch: quality_scores/provenance set on "
+                "Ray Dataset input; collecting to driver for in-memory build.",
             )
             tables = list(multi_df.iter_batches(batch_format="pyarrow"))
             multi_df = pl.from_arrow(pa.concat_tables(tables)) if tables else pl.DataFrame()
@@ -569,6 +610,8 @@ def build_golden_records_batch(
 
     if "__cluster_id__" not in multi_df.columns:
         raise ValueError("multi_df must contain __cluster_id__ column")
+    if provenance and "__row_id__" not in multi_df.columns:
+        raise ValueError("provenance=True requires a __row_id__ column")
     if multi_df.height == 0:
         return []
 
@@ -578,7 +621,9 @@ def build_golden_records_batch(
             if not _is_internal(c) and c != "__cluster_id__"
         ]
         if user_cols:
-            return _build_golden_records_polars_native(multi_df, rules, user_cols)
+            return _build_golden_records_polars_native(
+                multi_df, rules, user_cols, provenance=provenance,
+            )
 
     sorted_df = multi_df.sort("__cluster_id__")
     sizes = (
@@ -639,10 +684,16 @@ def build_golden_records_batch(
                     for rid in row_id_array[offset:offset + size]
                 ]
 
-            val, conf, _idx = merge_field(
+            val, conf, idx = merge_field(
                 values, field_rule, sources=sources, dates=dates, quality_weights=weights,
             )
-            result[col] = {"value": val, "confidence": conf}
+            field: dict = {"value": val, "confidence": conf}
+            if provenance:
+                # row_id_array is guaranteed non-None here (guarded above).
+                field["source_row_id"] = (
+                    row_id_array[offset + idx] if idx is not None else None
+                )
+            result[col] = field
             confidences.append(conf)
 
         result["__golden_confidence__"] = (

--- a/packages/python/goldenmatch/tests/test_golden_provenance_batch.py
+++ b/packages/python/goldenmatch/tests/test_golden_provenance_batch.py
@@ -1,0 +1,91 @@
+"""Field-level provenance for the vectorized batch golden builder.
+
+`build_golden_records_batch(..., provenance=True)` adds `source_row_id` to
+each field dict -- the `__row_id__` of the record whose value won survivorship
+for that field -- while preserving the single-group_by-per-column
+vectorization. These tests pin that the reported row is the actual winner
+across the fast path (most_complete / first_non_null) and the slow path
+(field_rules force the per-cluster merge_field loop).
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import GoldenFieldRule, GoldenRulesConfig
+from goldenmatch.core.golden import build_golden_records_batch
+
+
+def _one(results: list[dict], cid: int) -> dict:
+    return next(r for r in results if r["__cluster_id__"] == cid)
+
+
+def test_fast_path_most_complete_source_row_id():
+    # name: longest non-null is "Bobby" at row 11.
+    # email: both non-null identical ("a@x") -> winner is the first, row 10.
+    # note: all-null -> source_row_id None.
+    df = pl.DataFrame({
+        "__row_id__": [10, 11, 12],
+        "__cluster_id__": [1, 1, 1],
+        "name": ["Bob", "Bobby", None],
+        "email": ["a@x", None, "a@x"],
+        "note": [None, None, None],
+    })
+    rules = GoldenRulesConfig(default_strategy="most_complete")
+    res = build_golden_records_batch(df, rules, provenance=True)
+    rec = _one(res, 1)
+    assert rec["name"]["value"] == "Bobby"
+    assert rec["name"]["source_row_id"] == 11
+    assert rec["email"]["value"] == "a@x"
+    assert rec["email"]["source_row_id"] == 10
+    assert rec["note"]["value"] is None
+    assert rec["note"]["source_row_id"] is None
+
+
+def test_fast_path_first_non_null_source_row_id():
+    # first non-null phone is "555" at row 21.
+    df = pl.DataFrame({
+        "__row_id__": [20, 21, 22],
+        "__cluster_id__": [5, 5, 5],
+        "phone": [None, "555", "999"],
+    })
+    rules = GoldenRulesConfig(default_strategy="first_non_null")
+    rec = _one(build_golden_records_batch(df, rules, provenance=True), 5)
+    assert rec["phone"]["value"] == "555"
+    assert rec["phone"]["source_row_id"] == 21
+
+
+def test_slow_path_source_row_id():
+    # field_rules forces the per-cluster merge_field loop (not the fast path).
+    # most_complete winner is "Alice" at row 31.
+    df = pl.DataFrame({
+        "__row_id__": [30, 31],
+        "__cluster_id__": [7, 7],
+        "name": ["Al", "Alice"],
+    })
+    rules = GoldenRulesConfig(
+        default_strategy="most_complete",
+        field_rules={"name": GoldenFieldRule(strategy="most_complete")},
+    )
+    rec = _one(build_golden_records_batch(df, rules, provenance=True), 7)
+    assert rec["name"]["value"] == "Alice"
+    assert rec["name"]["source_row_id"] == 31
+
+
+def test_provenance_requires_row_id():
+    df = pl.DataFrame({"__cluster_id__": [1, 1], "name": ["a", "b"]})
+    rules = GoldenRulesConfig(default_strategy="most_complete")
+    with pytest.raises(ValueError, match="__row_id__"):
+        build_golden_records_batch(df, rules, provenance=True)
+
+
+def test_provenance_off_is_unchanged():
+    # Default (provenance=False): field dicts carry only value + confidence.
+    df = pl.DataFrame({
+        "__row_id__": [1, 2],
+        "__cluster_id__": [1, 1],
+        "name": ["Al", "Alice"],
+    })
+    rules = GoldenRulesConfig(default_strategy="most_complete")
+    rec = _one(build_golden_records_batch(df, rules), 1)
+    assert set(rec["name"]) == {"value", "confidence"}
+    assert "source_row_id" not in rec["name"]


### PR DESCRIPTION
## What

Adds a provenance-carrying mode to the scalable batch golden builder:

```python
build_golden_records_batch(multi_df, rules, provenance=True)
# -> [{ "name": {"value": "Bob", "confidence": 1.0, "source_row_id": 42}, ... }]
```

`source_row_id` is the `__row_id__` of the record whose value won survivorship for that field (`None` when the field is all-null). Today the pipeline uses only this vectorized builder (the rich per-cluster `build_golden_record_with_provenance` doesn't scale), so field-level provenance was unavailable at production scale. This is the enabling block.

## How (preserves the single-group_by-per-column vectorization)

- **Fast path** (`_build_golden_records_polars_native`): one extra agg expr per column selects `__row_id__` using the **identical** filter + `sort_by` as the value selection, so Polars' stable sort picks the same physical row. Still one `group_by`; the 500K-cluster streaming loop pulls a third per-column array.
- **Slow path**: maps `merge_field`'s returned winning index into the parallel `row_id` slice — the pattern `build_golden_record_with_provenance` already uses.
- **Edge cases**: `provenance=True` without `__row_id__` raises `ValueError`; Ray Dataset + provenance collects to driver then builds in-memory (reuses the existing `quality_scores` path); `provenance=False` (default) is byte-identical to today.

## Scope

Capability only — wiring into the pipeline / lineage `golden_provenance` hook is a deliberate follow-up.

## Test plan

`tests/test_golden_provenance_batch.py`: fast path (`most_complete` picks longest, `first_non_null` picks first), all-null → `None`, slow path via `field_rules`, missing-`__row_id__` raise, and `provenance=False` unchanged. (Local pytest blocked by this box's heavy-import saturation; relying on the `python (goldenmatch)` CI lane.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)