### PR TITLE
feat(lineage): wire field-level golden provenance into the pipeline (opt-in)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -587,6 +587,12 @@ class OutputConfig(BaseModel):
     format: str | None = None
     directory: str | None = None
     run_name: str | None = None
+    # When True, the lineage sidecar gains a `golden_records` section with
+    # per-field provenance (value + source_row_id of the winning record).
+    # Default off: at large scale this materializes one provenance object per
+    # cluster + a large JSON sidecar. The vectorized batch builder makes it
+    # feasible (per-field source_row_id, no per-row candidate list).
+    lineage_provenance: bool = False
 
 
 # ── LLM Budget / Scorer Config ────────────────────────────────────────────

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -706,6 +706,62 @@ def build_golden_records_batch(
     return results
 
 
+def golden_records_to_provenance(
+    golden_records: list[dict],
+    clusters: dict[int, dict],
+    rules: GoldenRulesConfig,
+) -> list[ClusterProvenance]:
+    """Adapt ``build_golden_records_batch(..., provenance=True)`` output to the
+    ``ClusterProvenance`` shape that lineage's ``golden_provenance`` consumes.
+
+    Each enriched record dict ({col: {value, confidence, source_row_id}, plus
+    ``__cluster_id__`` / ``__golden_confidence__``) becomes a
+    ``ClusterProvenance``. ``cluster_quality`` / ``cluster_confidence`` come
+    from ``clusters``; per-field ``strategy`` is re-derived from the rules
+    (cluster override -> field rule -> default). ``candidates`` is always ``[]``
+    -- the batch builder deliberately doesn't compute the per-row candidate
+    list (that's the per-cluster work the vectorized path avoids), so this
+    provenance is value + source_row_id, not the full slow-path candidate set.
+
+    Requires the records to carry ``source_row_id`` (i.e. built with
+    ``provenance=True``); missing keys degrade to ``None`` rather than raising.
+    """
+    cluster_overrides = getattr(rules, "cluster_overrides", None)
+
+    def _strategy_for(cid: int, col: str) -> str:
+        if cluster_overrides:
+            per_cluster = cluster_overrides.get(int(cid))
+            if per_cluster and col in per_cluster:
+                return per_cluster[col].strategy
+        rule = rules.field_rules.get(col)
+        return rule.strategy if rule is not None else rules.default_strategy
+
+    out: list[ClusterProvenance] = []
+    for rec in golden_records:
+        cid = rec["__cluster_id__"]
+        cinfo = clusters.get(cid, {})
+        fields: dict[str, FieldProvenance] = {}
+        for col, info in rec.items():
+            if col in ("__cluster_id__", "__golden_confidence__"):
+                continue
+            if not (isinstance(info, dict) and "value" in info):
+                continue
+            fields[col] = FieldProvenance(
+                value=info["value"],
+                source_row_id=info.get("source_row_id"),
+                strategy=_strategy_for(cid, col),
+                confidence=info.get("confidence", 0.0),
+                candidates=[],
+            )
+        out.append(ClusterProvenance(
+            cluster_id=cid,
+            cluster_quality=cinfo.get("cluster_quality", "strong"),
+            cluster_confidence=cinfo.get("confidence", 0.0),
+            fields=fields,
+        ))
+    return out
+
+
 def build_golden_record(
     cluster_df: pl.DataFrame,
     rules: GoldenRulesConfig,

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1311,7 +1311,13 @@ def _run_dedupe_pipeline(
             # eager DataFrames AND called cluster_df[col].to_list() ~6.7M
             # times. New path: 4 to_list() calls + Python list slicing.
             # Measured: golden stage 307s -> ~30s at 5M.
-            golden_records = build_golden_records_batch(multi_df, golden_rules)
+            # provenance=True (opt-in) enriches each field with source_row_id
+            # for the lineage sidecar; the golden_df builder below ignores the
+            # extra key, so the same records feed both paths (no double build).
+            golden_records = build_golden_records_batch(
+                multi_df, golden_rules,
+                provenance=config.output.lineage_provenance,
+            )
 
     # Build golden DataFrame
     golden_df = None
@@ -1397,7 +1403,15 @@ def _run_dedupe_pipeline(
         try:
             from goldenmatch.core.lineage import build_lineage, save_lineage
             lineage = build_lineage(all_pairs, collected_df, matchkeys, clusters)
-            save_lineage(lineage, directory, run_name)
+            golden_provenance = None
+            if config.output.lineage_provenance and golden_records:
+                from goldenmatch.core.golden import golden_records_to_provenance
+                golden_provenance = golden_records_to_provenance(
+                    golden_records, clusters, golden_rules,
+                )
+            save_lineage(
+                lineage, directory, run_name, golden_provenance=golden_provenance,
+            )
         except Exception as e:
             logger.warning("Lineage generation failed: %s", e)
 

--- a/packages/python/goldenmatch/tests/test_golden_provenance_batch.py
+++ b/packages/python/goldenmatch/tests/test_golden_provenance_batch.py
@@ -89,3 +89,72 @@ def test_provenance_off_is_unchanged():
     rec = _one(build_golden_records_batch(df, rules), 1)
     assert set(rec["name"]) == {"value", "confidence"}
     assert "source_row_id" not in rec["name"]
+
+
+def test_records_to_provenance_adapter():
+    from goldenmatch.core.golden import golden_records_to_provenance
+    df = pl.DataFrame({
+        "__row_id__": [10, 11],
+        "__cluster_id__": [1, 1],
+        "name": ["Bob", "Bobby"],
+    })
+    rules = GoldenRulesConfig(default_strategy="most_complete")
+    records = build_golden_records_batch(df, rules, provenance=True)
+    clusters = {1: {"members": [10, 11], "size": 2,
+                    "cluster_quality": "strong", "confidence": 0.9}}
+    prov = golden_records_to_provenance(records, clusters, rules)
+    assert len(prov) == 1
+    cp = prov[0]
+    assert cp.cluster_id == 1
+    assert cp.cluster_quality == "strong"
+    assert cp.cluster_confidence == 0.9
+    fp = cp.fields["name"]
+    assert fp.value == "Bobby"
+    assert fp.source_row_id == 11
+    assert fp.strategy == "most_complete"
+    assert fp.candidates == []  # scale tradeoff: no per-row candidate list
+
+
+def test_pipeline_writes_golden_provenance_when_flag_on(tmp_path):
+    """End-to-end: lineage_provenance=True -> the lineage sidecar carries a
+    golden_records section with per-field source_row_id; off -> no such key."""
+    import json
+
+    from goldenmatch.config.schemas import (
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+        OutputConfig,
+    )
+    from goldenmatch.core.pipeline import run_dedupe_df
+
+    # Bob/Bobby share an email -> one multi-member cluster; Carol is unique.
+    df = pl.DataFrame({
+        "name": ["Bob", "Bobby", "Carol"],
+        "email": ["b@x", "b@x", "c@x"],
+    })
+    mks = [MatchkeyConfig(name="email", type="exact",
+                          fields=[MatchkeyField(field="email")])]
+
+    def _run(flag: bool, run_name: str):
+        cfg = GoldenMatchConfig(
+            matchkeys=mks,
+            output=OutputConfig(directory=str(tmp_path), run_name=run_name,
+                                lineage_provenance=flag),
+        )
+        run_dedupe_df(df, cfg, output_clusters=True)
+        return json.loads((tmp_path / f"{run_name}_lineage.json").read_text())
+
+    on = _run(True, "prov_on")
+    assert "golden_records" in on
+    name_provs = [
+        f["source_row_id"]
+        for rec in on["golden_records"]
+        for col, f in rec["fields"].items()
+        if col == "name"
+    ]
+    # most_complete picks "Bobby" (row index 1) over "Bob" (row 0).
+    assert 1 in name_provs
+
+    off = _run(False, "prov_off")
+    assert "golden_records" not in off


### PR DESCRIPTION
## What

Follow-up to #533. The pipeline now feeds the batch builder's per-field `source_row_id` into the lineage sidecar's `golden_records` section — field-level provenance **at scale**.

```python
GoldenMatchConfig(output=OutputConfig(directory=..., lineage_provenance=True))
# -> {run_name}_lineage.json gains:
#    "golden_records": [{ "cluster_id": 3, "fields": {
#        "name": {"value": "Bobby", "source_row_id": 11, "strategy": "most_complete", ...}}}]
```

## How

- **`config.output.lineage_provenance: bool = False`** — opt-in. At 5M/1.67M clusters this materializes one provenance object per cluster + a large JSON sidecar, so default off; the vectorized builder (#533) is what makes it *feasible*.
- **`golden.py` adapter** `golden_records_to_provenance(records, clusters, rules)` maps the enriched `list[dict]` → `list[ClusterProvenance]` (the shape `save_lineage` already consumes). `cluster_quality`/`confidence` from `clusters`; per-field `strategy` re-derived (cluster override → field rule → default); `candidates=[]` — the scale tradeoff (no per-row candidate list).
- **`pipeline.py`**: `build_golden_records_batch(..., provenance=flag)` — the same records still feed `golden_df` (extra key ignored, **no double build**); the lineage step adapts + passes `golden_provenance` to `save_lineage` when on. Flag off is byte-identical to today.

## Test plan

`tests/test_golden_provenance_batch.py`: adapter unit test + end-to-end (`run_dedupe_df` with `lineage_provenance=True` → sidecar has `golden_records` with `source_row_id`; off → no key). Local pytest blocked by this box's heavy-import saturation; relying on the `python (goldenmatch)` CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)