### PR TITLE
release(goldenmatch): 1.22.0 — field-level golden provenance at scale

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.22.0] - 2026-05-27
+
+### Added — field-level golden-record provenance at scale
+
+- **`build_golden_records_batch(..., provenance=True)`** adds `source_row_id`
+  to each field dict — the `__row_id__` of the record whose value won
+  survivorship for that field — while preserving the single-group_by-per-column
+  vectorization (one extra agg expr per column on the fast path). `None` for
+  all-null fields; raises if there's no `__row_id__` column.
+- **`config.output.lineage_provenance`** (default `False`): when enabled, the
+  lineage sidecar (`{run_name}_lineage.json`) gains a `golden_records` section
+  with per-field provenance (value, `source_row_id`, strategy, confidence)
+  for every cluster. Default off because at large scale this materializes one
+  provenance object per cluster plus a large JSON sidecar; the vectorized
+  builder is what makes it feasible. `candidates` is empty in this path (the
+  per-row candidate list is the slow-path-only detail that breaks
+  vectorization).
+- **`golden_records_to_provenance(records, clusters, rules)`** adapts the
+  batch builder's output to the `ClusterProvenance` shape lineage consumes.
+
 ## [1.21.0] - 2026-05-27
 
 ### Added — optional native acceleration runtime

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.21.0"
+__version__ = "1.22.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.21.0"
+version = "1.22.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps `goldenmatch` 1.21.0 -> 1.22.0. Only the goldenmatch Python package changed since 1.21.0 (PRs #533, #534).

## New
- `build_golden_records_batch(..., provenance=True)` — per-field `source_row_id`, vectorization preserved.
- `config.output.lineage_provenance` (opt-in) — lineage sidecar `golden_records` gains field-level provenance at scale; `golden_records_to_provenance` adapter.

## Changes
- `pyproject.toml` + `__init__.py`: version 1.22.0
- `CHANGELOG.md`: 1.22.0 entry

## Release
Merge then tag `v1.22.0` -> `publish-goldenmatch.yml` -> PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)