### PR TITLE
docs(claude): capture goldenmatch-native + release learnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,11 @@ Local CWD = package dir (e.g. `packages/python/goldencheck`); CI CWD = repo root
 ## GitHub auth
 - `benzsevern/*` AND `benseverndev-oss/*` repos use personal account `benzsevern`, not work `benzsevern-mjh`. Always `gh auth switch --user benzsevern` before push, switch back after. (The `benseverndev-oss` org is owned by the personal `benzsevern` account; same auth dance applies.)
 
+## goldenmatch-native (optional compiled runtime)
+- `goldenmatch-native` is a SEPARATE maturin/abi3 package (polars / polars-runtime split): `goldenmatch` stays pure-Python; `pip install goldenmatch[native]` pulls the compiled `_native` kernel. Crate + maturin `pyproject.toml` at `packages/rust/extensions/native/`; same crate still builds in-tree via `scripts/build_native.py`.
+- Loader discover order (`goldenmatch/core/_native_loader.py`): `goldenmatch._native` (in-tree build) -> `goldenmatch_native._native` (the wheel) -> pure Python.
+- Release: tag `goldenmatch-native-v*` fires `publish-goldenmatch-native.yml` (distinct from Python `v*` / TS `goldenmatch-js-v*`). Build BOTH macOS arches on `macos-14` (cross-compile x86_64) -- `macos-13` Intel runners queue indefinitely in this org. `workflow_dispatch` has a `publish` toggle for a build-matrix dry run (no PyPI upload).
+
 ## Post-fold GitHub Actions
 Only `.github/workflows/` at the repo root runs. Workflow files left under `packages/python/<pkg>/.github/workflows/` from pre-fold repos are orphaned (silently ignored). v1.6.0 release shipped no PyPI publish until `publish-goldenmatch.yml` was added at the root.
 - `publish-goldenmatch.yml` — fires on `release: published` for `v*` tags (skips `goldenmatch-js-v*`); `workflow_dispatch` with `ref` input for retro-publish. Uses `PYPI_TOKEN` (trusted publishing not configured).

--- a/packages/python/CLAUDE.md
+++ b/packages/python/CLAUDE.md
@@ -7,6 +7,7 @@
 
 ## Common friction
 
+- An optional-dependency extra pointing at a package not yet on PyPI breaks `uv sync --all-packages` repo-wide (uv resolves the whole extra graph during lock). Fix: workspace-local `[tool.uv.sources] <pkg> = { path = "..." }` so dev/CI resolve locally; the published wheel still resolves from PyPI (uv.sources is workspace-local). Bit `goldenmatch[native]` -> `goldenmatch-native`.
 - After adding a workspace member, `uv sync` may not install it editable. If `import <pkg>` fails, run `uv pip install -e packages/python/<pkg>`.
 - `uv run pytest` sometimes misses workspace members on Windows. Prefer `.venv/Scripts/python.exe -m pytest <path>` for reliable runs.
 - pyarrow is required for polars `.from_pandas()`; if `ImportError: pyarrow is required`, run `uv pip install pyarrow`.

--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -292,7 +292,8 @@ Hosted on Railway, registered on Smithery:
 - GitHub Wiki repo uses `master` branch, main repo uses `main`
 - GitHub Wiki needs `_Sidebar.md` and `_Footer.md` for custom nav/footer
 - Rich terminal recording: `Console(record=True)` then `console.export_svg(title='...')`
-- PyPI version must be bumped in both `pyproject.toml` and `goldenmatch/__init__.py`
+- PyPI version must be bumped in THREE spots: `pyproject.toml`, `goldenmatch/__init__.py`, and `CHANGELOG.md` (new dated entry). Release flow: bump -> PR -> merge -> tag `v1.x.y` -> `publish-goldenmatch.yml` -> PyPI (~25s; JSON API lags ~20s).
+- `test_api.py::TestDedupeDf::test_dedupe_df_empty` observed flaky under `pytest -n auto` (`assert 3 == 0`, passed on rerun, with a `'Finding' has no attribute 'rule_id'` quality-scan warning) -- rerun rather than chase; a version-only PR can't cause it.
 - v1.0.0 is live on PyPI -- Production/Stable, semver enforced — `pip install goldenmatch` works
 - Adding a TUI tab: update `test_tabs_exist` in `tests/test_tui.py` — asserts exact tab count (currently 6)
 - OpenAI API key: set `OPENAI_API_KEY` env var. Used by LLM scorer and LLM boost. Key stored in `.testing/.env`


### PR DESCRIPTION
Doc-only CLAUDE.md updates capturing learnings from the goldenmatch-native / 1.21.0 / 1.22.0 release session.

- **root `CLAUDE.md`**: new `goldenmatch-native` section — the maturin/abi3 split package (polars-runtime model), loader discover order, the `goldenmatch-native-v*` release tag, and the macos-14 cross-compile (macos-13 Intel runners queue indefinitely in this org).
- **`packages/python/CLAUDE.md`**: an optional-dependency extra pointing at a not-yet-published package breaks `uv sync --all-packages` repo-wide; fix with a workspace-local `[tool.uv.sources]` path source.
- **`packages/python/goldenmatch/CLAUDE.md`**: version bump is THREE spots (pyproject + `__init__` + CHANGELOG) with the release flow; `test_dedupe_df_empty` observed flaky under `pytest -n auto`.

Doc-only — should run just the `changes` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)