### PR TITLE
release(goldenmatch): 1.23.0 - auto-config recall fix + zero-label commit default

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -33,6 +33,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   being present (names alone collide too heavily to anchor an identity claim).
   Benchmarks: NCVR F1 0.871 → 0.969, Febrl3 0.897 → 0.912, DBLP-ACM and DQbench
   unchanged.
+- **Phonetic name+DOB identity matchkey** (#491). A sibling to the composite
+  above: the same name+DOB key but with a `soundex` transform on the name
+  fields, so equal-sounding spellings (Smith/Smyth, Catherine/Katherine) that
+  share a DOB still match when the exact composite misses them. Same date-anchor
+  gate, so DQbench (no DOB column) is untouched; matchkeys are OR'd, so it only
+  adds candidate pairs. Lifts Febrl3 F1 0.912 → 0.924 (CI smoke).
+
+### Internal
+
+- CI Febrl3 smoke-gate floor raised 0.85 → 0.90 (#438), reflecting the recall
+  improvements above (CI-measured Febrl3 F1 now 0.924, deterministic).
 
 ## [1.22.0] - 2026-05-27
 

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-05-27
+
 ### Changed
 
 - **Auto-config now commits by zero-label confidence by default** (issue #489).
@@ -17,6 +19,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   prior default on T1/T2/T3). Opt out with
   `GOLDENMATCH_AUTOCONFIG_ZERO_LABEL_COMMIT=0` to restore the legacy
   `-mass_separation` tiebreaker.
+
+### Fixed
+
+- **Composite name+DOB identity matchkey recovers person-data recall** (#538).
+  When individual name/year columns fall below the cardinality≥0.5 exact-matchkey
+  gate, auto-config previously degraded to a single weighted matchkey that
+  averages every field, so one corrupted field (e.g. an abbreviated address
+  scored by `token_sort`) could sink an otherwise-clean true pair. Auto-config
+  now also emits an exact matchkey on the name+DOB *combination* (highly unique
+  even when the individual fields aren't). Matchkeys are OR'd, so this only adds
+  candidate pairs — no fuzzy scorer is loosened. Gated on a date/year anchor
+  being present (names alone collide too heavily to anchor an identity claim).
+  Benchmarks: NCVR F1 0.871 → 0.969, Febrl3 0.897 → 0.912, DBLP-ACM and DQbench
+  unchanged.
 
 ## [1.22.0] - 2026-05-27
 

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.22.0"
+__version__ = "1.23.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.22.0"
+version = "1.23.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts **goldenmatch 1.23.0** (minor), bundling the two auto-config quality improvements merged since 1.22.0.

## What's in it
- **#537 (closes #489) - zero-label confidence is the default commit tiebreaker.** `pick_committed` now prefers higher `-overall_confidence` over `-mass_separation` among same-health-rank candidates carrying a `zero_label` profile. DQbench gate held (composite 92.03 >= 91.04). Opt out with `GOLDENMATCH_AUTOCONFIG_ZERO_LABEL_COMMIT=0`.
- **#538 - composite name+DOB identity matchkey (recall fix).** Person data whose individual name/year columns fall below the cardinality>=0.5 exact gate no longer degrades to a single field-averaging weighted matchkey. Adds an exact matchkey on the name+DOB combination (date-anchor-gated). NCVR F1 0.871 -> 0.969, Febrl3 0.897 -> 0.912; DBLP-ACM and DQbench unchanged.

## Why minor
Both change default auto-config *output* (not just internals), but there's no API break and the zero-label flip keeps an opt-out env var. Existing users on `pip install -U` will see improved clustering on person-shaped data.

## Version bump
`1.22.0 -> 1.23.0` in `pyproject.toml`, `goldenmatch/__init__.py`, and `CHANGELOG.md` (Unreleased rolled to `[1.23.0]`).

## Release steps after merge
Tag `v1.23.0` at the merge commit -> `publish-goldenmatch.yml` publishes to PyPI -> `publish-mcp.yml` syncs the registry. Version derived from the tag.

## Validation
Combined-code CI on both changes together was green before merge: `3045 passed, 197 skipped, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)