### PR TITLE
ci(febrl3): raise smoke-gate floor 0.85 -> 0.90 (#438)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,9 +524,10 @@ jobs:
           uv run python -c "
           import json
           r = json.load(open('/tmp/febrl3_smoke.json'))['results'][0]
-          # #438 raised this from 0.80 -> 0.85 after blocking improvements
-          # (DOB pass + surname-substring pass) lifted F1 from 0.83 -> 0.90.
-          assert r['f1'] >= 0.85, f'Febrl3 smoke regressed: {r}'
+          # #438: 0.80 -> 0.85 (DOB + surname-substring blocking passes),
+          # then 0.85 -> 0.90 after #538's composite name+DOB exact matchkey
+          # lifted the CI-measured F1 to 0.9124 (deterministic, memory off).
+          assert r['f1'] >= 0.90, f'Febrl3 smoke regressed: {r}'
           print('febrl3 smoke F1=', r['f1'])
           "
       - name: Smoke summary


### PR DESCRIPTION
Partial progress on #438 (second acceptance criterion).

#538's composite name+DOB exact matchkey lifted the CI-measured Febrl3 smoke F1 from 0.897 to **0.9124** (deterministic — two consecutive `main` runs identical, `GOLDENMATCH_AUTOCONFIG_MEMORY=0`). Per #438's acceptance ("smoke threshold can be bumped from 0.80 -> 0.90 once stable"), this raises the CI floor 0.85 -> 0.90.

The remaining ~6pp to the historical 0.97 (#438's primary goal) is a separate scoring-side optimization pass — see the forthcoming localization comment on #438.

Changing `ci.yml` re-runs every job, so the new gate is exercised by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)