### PR TITLE
feat(autoconfig): phonetic name+DOB identity matchkey (#491 heuristic path)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -742,6 +742,26 @@ def build_matchkeys(
             type="exact",
             fields=composite_fields,
         ))
+        # Phonetic sibling (#491 heuristic path): same name+DOB composite but
+        # with a `soundex` transform on the name fields, so phonetically-equal
+        # spellings (Smith/Smyth, Catherine/Katherine) that the EXACT composite
+        # misses still match — provided the DOB anchor agrees. Reuses the same
+        # DOB gate: name-only soundex keys collide far too much to be an
+        # identity claim, but soundex(name)+DOB stays specific, and adversarial
+        # data without a DOB column (DQbench tier3) gets neither composite.
+        # OR'd in, so it only adds candidate pairs.
+        phonetic_fields = [
+            MatchkeyField(field=p.name, transforms=["lowercase", "strip", "soundex"])
+            for p in _name_fields
+        ] + [
+            MatchkeyField(field=p.name, transforms=["lowercase", "strip"])
+            for p in _date_fields
+        ]
+        matchkeys.append(MatchkeyConfig(
+            name="phonetic_identity",
+            type="exact",
+            fields=phonetic_fields,
+        ))
 
     # Weighted matchkey from fuzzy fields
     all_weighted = list(fuzzy_fields)

--- a/packages/python/goldenmatch/tests/test_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig.py
@@ -241,6 +241,27 @@ class TestBuildMatchkeys:
         ]
         mks = build_matchkeys(profiles)
         assert not [mk for mk in mks if mk.name == "exact_identity"]
+        assert not [mk for mk in mks if mk.name == "phonetic_identity"]
+
+    def test_phonetic_identity_matchkey_soundex_on_names(self):
+        # #491 heuristic path: alongside the exact name+DOB composite, emit a
+        # phonetic sibling that soundex-encodes the name fields so equal-sounding
+        # spellings (Smith/Smyth) sharing a DOB still match. Same DOB gate as the
+        # exact composite (name-only soundex keys collide too much to be identity).
+        profiles = [
+            ColumnProfile("first_name", "Utf8", "name", 0.9, cardinality_ratio=0.3),
+            ColumnProfile("last_name", "Utf8", "name", 0.9, cardinality_ratio=0.3),
+            ColumnProfile("birth_year", "Int64", "year", 0.9, cardinality_ratio=0.02),
+        ]
+        mks = build_matchkeys(profiles)
+        phonetic = [mk for mk in mks if mk.name == "phonetic_identity"]
+        assert len(phonetic) == 1
+        assert phonetic[0].type == "exact"
+        # name fields carry the soundex transform; the DOB anchor does not
+        name_fields = [f for f in phonetic[0].fields if f.field in ("first_name", "last_name")]
+        assert name_fields and all("soundex" in f.transforms for f in name_fields)
+        dob = [f for f in phonetic[0].fields if f.field == "birth_year"]
+        assert dob and "soundex" not in dob[0].transforms
 
     def test_description_uses_record_embedding(self):
         profiles = [


### PR DESCRIPTION
Addresses the **heuristic-path** half of #491's `soundex_match` lever (the optimizer/empirical path was already covered — see the issue thread; the remaining open item after this is ANN blocking).

## What

Adds a `phonetic_identity` exact matchkey next to #538's `exact_identity`: the same name+DOB composite, but the name fields carry a `soundex` transform. Equal-sounding spellings (Smith/Smyth, Catherine/Katherine) that share a DOB now match even when the exact composite misses them.

## Why it's gate-safe

Reuses #538's **DOB-anchor gate**. Name-only soundex keys collide far too much to be an identity claim (measured: DQbench tier3 name keys pile up to max-group-13 / 85% of rows in multi-record groups). Requiring a DOB anchor keeps the key specific. **DQbench has no DOB column, so it provably gets neither the exact nor the phonetic composite — its tier3 precision is untouched.** DBLP-ACM has no name column → also unaffected. Matchkeys are OR'd, so this only adds candidate pairs.

## Validation

- `TestBuildMatchkeys` green locally (8 passed), incl. the new `test_phonetic_identity_matchkey_soundex_on_names` and the without-DOB negative case.
- Full pytest suite + the **Febrl3 smoke lane** run in CI here. Febrl3 is the phonetic-heavy benchmark, so its smoke F1 is the relevant signal for whether soundex helps; NCVR/DBLP/DQbench aren't in CI but are unaffected-or-additive by construction (DOB gate + OR semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)