### PR TITLE
fix(autoconfig): dual identity composite (name+DOB AND high-card+DOB) (#438)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dual identity composite recovers more person-data recall** (#438). The
+  composite identity matchkey (1.23.0) picks its fields by cardinality among
+  `col_type=="name"` columns; on datasets where the classifier mislabels an
+  address as a "name" (e.g. Febrl3), that keys the composite on addresses. Since
+  different datasets corrupt different fields (Febrl3 mangles names, NCVR mangles
+  addresses), auto-config now ALSO emits a second composite keyed on the
+  person-name-pattern columns (given_name/surname) + DOB, so a true pair clean on
+  EITHER field-set matches. Same date-anchor gate; OR'd, so it only adds candidate
+  pairs. Febrl3 F1 0.924 → 0.933 (recall 0.905 → 0.921, precision unchanged);
+  NCVR flat (0.969); DBLP-ACM and DQbench unchanged (no DOB column → no composite).
+
 ## [1.23.0] - 2026-05-27
 
 ### Changed

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -763,6 +763,29 @@ def build_matchkeys(
             fields=phonetic_fields,
         ))
 
+    # Dual-composite: also emit a name+DOB composite keyed on person-name-PATTERN
+    # columns (given_name/surname/first/last) when they exist and differ from the
+    # cardinality pick above. The data classifier sometimes mislabels address
+    # columns as col_type="name" (Febrl3: address_1/address_2 outrank the real
+    # names by cardinality), so the cardinality composite can key on addresses.
+    # Different datasets corrupt different fields (Febrl3 mangles names, NCVR
+    # mangles addresses), so anchoring on BOTH field-sets means a true pair clean
+    # on EITHER matches. Same DOB gate; OR'd, so it only adds candidate pairs.
+    _pattern_name_fields = sorted(
+        [p for p in profiles if p.null_rate < 0.3 and _classify_by_name(p.name) == "name"],
+        key=lambda p: p.cardinality_ratio, reverse=True,
+    )[:2]
+    if (_date_fields and _pattern_name_fields
+            and {p.name for p in _pattern_name_fields} != {p.name for p in _name_fields}):
+        matchkeys.append(MatchkeyConfig(
+            name="exact_identity_name",
+            type="exact",
+            fields=[
+                MatchkeyField(field=p.name, transforms=["lowercase", "strip"])
+                for p in (_pattern_name_fields + _date_fields)
+            ],
+        ))
+
     # Weighted matchkey from fuzzy fields
     all_weighted = list(fuzzy_fields)
 

--- a/packages/python/goldenmatch/tests/test_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig.py
@@ -243,6 +243,29 @@ class TestBuildMatchkeys:
         assert not [mk for mk in mks if mk.name == "exact_identity"]
         assert not [mk for mk in mks if mk.name == "phonetic_identity"]
 
+    def test_dual_composite_when_cardinality_pick_differs_from_names(self):
+        # When the data classifier mislabels a high-cardinality column as
+        # col_type="name" (e.g. an address on Febrl3), the cardinality pick keys
+        # the composite on it. A second composite keyed on the person-name-pattern
+        # columns (given_name/surname) must also be emitted, so a pair clean on
+        # EITHER field-set matches (different datasets corrupt different fields).
+        profiles = [
+            # mislabeled, very high cardinality -> wins the cardinality pick
+            ColumnProfile("address_1", "Utf8", "name", 0.9, cardinality_ratio=0.99),
+            ColumnProfile("given_name", "Utf8", "name", 0.9, cardinality_ratio=0.30),
+            ColumnProfile("surname", "Utf8", "name", 0.9, cardinality_ratio=0.30),
+            ColumnProfile("date_of_birth", "Utf8", "date", 0.9, cardinality_ratio=0.05),
+        ]
+        mks = build_matchkeys(profiles)
+        cardinality_pick = [mk for mk in mks if mk.name == "exact_identity"]
+        name_pick = [mk for mk in mks if mk.name == "exact_identity_name"]
+        assert len(cardinality_pick) == 1 and len(name_pick) == 1
+        # cardinality composite keyed on the high-card (mislabeled) column
+        assert "address_1" in {f.field for f in cardinality_pick[0].fields}
+        # name-pattern composite keyed on the real person names + DOB
+        name_fields = {f.field for f in name_pick[0].fields}
+        assert {"given_name", "surname", "date_of_birth"} <= name_fields
+
     def test_phonetic_identity_matchkey_soundex_on_names(self):
         # #491 heuristic path: alongside the exact name+DOB composite, emit a
         # phonetic sibling that soundex-encodes the name fields so equal-sounding


### PR DESCRIPTION
Advances #438. Follows up the [#438 localization](https://github.com/benseverndev-oss/goldenmatch/issues/438#issuecomment-4558770705), which found the composite keys on `address_1+address_2+DOB` on Febrl3 (the classifier mislabels addresses as `col_type="name"`, and they outrank the real names by cardinality).

## What

A first attempt — preferring person-name-pattern columns over the cardinality pick — *regressed* Febrl3 (0.924 → 0.909), because **Febrl3 corrupts names harder than addresses**, so exact name+DOB misses the name-corrupted pairs that address+DOB caught. The address anchor is empirically better *there*.

The real fix: different datasets corrupt different fields, so anchor on **both**. Auto-config now emits the existing cardinality composite **and** a second `exact_identity_name` composite keyed on the person-name-pattern columns (`given_name`/`surname` via `_classify_by_name`) + DOB. Matchkeys are OR'd, so a true pair clean on *either* field-set matches — additive recall, no scorer loosening.

## Validation (local diagnostics; full `run_benchmarks` is unreliable on the dev box)

| Benchmark | before | after | |
|---|---|---|---|
| **Febrl3** | 0.9244 | **0.9332** | recall 0.905 → 0.921, **precision unchanged** (+106 TP, 0 new FP) |
| NCVR | 0.9692 | 0.9690 | flat (recall up, precision down a touch) |
| DBLP-ACM | 0.9641 | unchanged | no DOB → no composite |
| DQbench | 92.03 | unchanged | no DOB → no composite (tier3 precision untouched) |

`TestBuildMatchkeys` green (9 passed) incl. a new test for the mislabeled-address case. CI's febrl3 smoke will confirm ~0.933 against the 0.90 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)