### PR TITLE
docs(readme): in-house embedding provider callout (#506)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Documentation
+
+- **In-house embedding provider callout** (#506). README surfaces `provider="inhouse"`
+  (the cloud-free `MatchkeyField(model="inhouse:<path>")` path that's been wired
+  since 1.21) with the Railway-validated 3-way result: in-house lands within
+  ~0.2pp of Vertex AI on structured ER (febrl3 0.949 vs 0.951, DBLP-ACM 0.971
+  vs 0.971, synthetic-20k 0.981 vs 0.983). Use it when you want embedding-grade
+  recall without a cloud dependency. Harness + Railway one-shot job in
+  `scripts/bench_embedding_providers.py` + `Dockerfile.embprov` (#543).
+
 ### Fixed
 
 - **Dual identity composite recovers more person-data recall** (#438). The

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -147,6 +147,7 @@ npm install goldenmatch
 ### Privacy
 - **PPRL multi-party linkage** — match across organizations without sharing raw data (92.4% F1 on FEBRL4)
 - **PPRL auto-configuration** — profiles your data and picks optimal fields, bloom filter parameters, and threshold
+- **In-house embedding (cloud-free)** — back the `embedding` / `record_embedding` scorer with a small numpy + ONNX model trained in-process on your labeled pairs (`goldenmatch.embeddings.inhouse.train_embedder`); set the matchkey field's `model="inhouse:<path>"`. No cloud calls, no torch. **Within ~0.2pp of Vertex AI on structured ER** (Railway-validated 3-way comparison, #506 / PR #543) — febrl3 in-house 0.9488 vs Vertex 0.9512, DBLP-ACM 0.9709 vs 0.9708, synthetic-20k 0.9814 vs 0.9834. Use it when you want embedding-grade recall without a cloud dependency.
 
 ### Integration
 - **REST API + MCP Server** — 31 tools for matching, explaining, reviewing, data quality, transforms, and AutoConfigController telemetry


### PR DESCRIPTION
Follow-up to #506 / #543. Surfaces the in-house embedding path in the README's Privacy section now that the Railway-validated 3-way comparison has confirmed it lands within ~0.2pp of Vertex AI on structured ER.

## What

- **README Privacy section** — adds an "In-house embedding (cloud-free)" bullet with the entry point (`MatchkeyField(model="inhouse:<path>")`, `goldenmatch.embeddings.inhouse.train_embedder`) and the Railway-validated numbers (febrl3 0.9488 vs 0.9512, DBLP-ACM 0.9709 vs 0.9708, synthetic-20k 0.9814 vs 0.9834).
- **CHANGELOG `[Unreleased] / Documentation`** — same callout for the changelog, references #506 + #543.

## Why this is a release candidate (and what kind)

Docs-only change to the **package** (`packages/python/goldenmatch/{README.md,CHANGELOG.md}`). No public API change, no behavior change. Natural fit for a **1.23.1** patch — ships the README/CHANGELOG that lets users actually discover the cloud-free embedding path. The runtime support was already in `1.21+`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)