### PR TITLE
perf(bench): record per-stage peak RSS in BenchmarkRecorder

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/bench.py
+++ b/packages/python/goldenmatch/goldenmatch/core/bench.py
@@ -47,6 +47,7 @@ not per scorer-per-block).
 """
 from __future__ import annotations
 
+import sys
 import threading
 import time
 from collections.abc import Generator
@@ -54,6 +55,28 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any
+
+# RSS sampling: `resource.getrusage().ru_maxrss` is the process-lifetime peak
+# resident set size (Linux: KB, macOS: bytes). It's monotonically non-decreasing
+# — sampling at every stage exit gives the cumulative curve, and diffing
+# consecutive stages gives each stage's contribution to the peak. Windows has
+# no equivalent in the stdlib, so the field stays empty there (rare on bench
+# paths — every bench-* workflow runs on Linux).
+try:
+    import resource  # type: ignore[import-not-found]
+    _HAS_RESOURCE = True
+except ImportError:  # pragma: no cover - Windows path, exercised manually
+    resource = None  # type: ignore[assignment]
+    _HAS_RESOURCE = False
+
+
+def _peak_rss_kb() -> int | None:
+    """Process-lifetime peak RSS in KB, or None on Windows."""
+    if not _HAS_RESOURCE:
+        return None
+    ru = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss  # type: ignore[union-attr]
+    # Linux reports KB; macOS reports bytes. Normalize to KB.
+    return int(ru) if sys.platform != "darwin" else int(ru) // 1024
 
 
 @dataclass
@@ -72,6 +95,12 @@ class BenchmarkRecorder:
     """
     timings: dict[str, float] = field(default_factory=dict)
     metrics: dict[str, Any] = field(default_factory=dict)
+    # Peak RSS (KB) observed at each stage's exit. ru_maxrss is monotonic, so
+    # the LATEST exit-time value per stage name wins (last-write-wins matches
+    # the existing metrics shape; reusing a stage name overwrites). To get
+    # per-stage contribution to the peak, diff consecutive entries in
+    # insertion order. Empty on Windows (resource module unavailable).
+    stage_peak_rss_kb: dict[str, int] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
 
     def add_timing(self, name: str, elapsed: float) -> None:
@@ -82,9 +111,20 @@ class BenchmarkRecorder:
         with self._lock:
             self.metrics[key] = value
 
+    def set_stage_peak_rss(self, name: str, peak_kb: int) -> None:
+        """Record the process-lifetime peak RSS observed at stage exit.
+
+        Called from ``stage(...)`` after the timed block completes. No-op on
+        Windows (caller passes the result of ``_peak_rss_kb`` which is None
+        there, but we accept int only — the caller branches).
+        """
+        with self._lock:
+            self.stage_peak_rss_kb[name] = peak_kb
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "stage_timings_seconds": {k: round(v, 4) for k, v in self.timings.items()},
+            "stage_peak_rss_kb": dict(self.stage_peak_rss_kb),
             "metrics": dict(self.metrics),
         }
 
@@ -138,6 +178,13 @@ def stage(name: str) -> Generator[None, None, None]:
         yield
     finally:
         rec.add_timing(name, time.perf_counter() - t0)
+        # Record the process-lifetime peak RSS at stage exit. ru_maxrss is a
+        # cheap syscall (microseconds) and only runs once per stage, so this
+        # doesn't violate the hot-path-tax rule documented above. Skip on
+        # Windows where the resource module is unavailable.
+        peak = _peak_rss_kb()
+        if peak is not None:
+            rec.set_stage_peak_rss(name, peak)
 
 
 def record_metric(key: str, value: Any) -> None:

--- a/packages/python/goldenmatch/tests/test_bench.py
+++ b/packages/python/goldenmatch/tests/test_bench.py
@@ -41,6 +41,19 @@ class TestBenchmarkRecorder:
         assert out["stage_timings_seconds"]["foo"] == 1.2346
         assert out["metrics"]["count"] == 100
 
+    def test_to_dict_exposes_stage_peak_rss(self):
+        """The new RSS-instrumentation surface ships an empty dict by default."""
+        rec = BenchmarkRecorder()
+        assert "stage_peak_rss_kb" in rec.to_dict()
+        assert rec.to_dict()["stage_peak_rss_kb"] == {}
+
+    def test_set_stage_peak_rss_last_writer_wins(self):
+        """ru_maxrss is monotonic; reusing a stage name takes the later peak."""
+        rec = BenchmarkRecorder()
+        rec.set_stage_peak_rss("scoring", 12_000)
+        rec.set_stage_peak_rss("scoring", 18_000)
+        assert rec.to_dict()["stage_peak_rss_kb"] == {"scoring": 18_000}
+
 
 class TestStageHelper:
     def test_stage_with_no_recorder_is_noop(self):
@@ -74,6 +87,22 @@ class TestStageHelper:
                 pass
         assert "error_phase" in rec.timings
         assert rec.timings["error_phase"] >= 0.005
+
+    def test_stage_records_peak_rss_on_linux(self):
+        """stage(...) populates stage_peak_rss_kb on platforms with the resource module."""
+        import sys
+        if sys.platform == "win32":
+            import pytest
+            pytest.skip("resource module unavailable on Windows; ru_maxrss has no equivalent")
+        with bench_capture() as rec:
+            with stage("rss_phase"):
+                # Allocate ~50 MB so ru_maxrss likely advances measurably.
+                blob = bytearray(50 * 1024 * 1024)  # noqa: F841
+                time.sleep(0.001)
+        assert "rss_phase" in rec.stage_peak_rss_kb
+        # ru_maxrss is in KB on Linux; any sane process running this test is
+        # already >5 MB. Just assert the field is populated with a real value.
+        assert rec.stage_peak_rss_kb["rss_phase"] > 5_000
 
     def test_nested_stages_record_independently(self):
         with bench_capture() as rec:


### PR DESCRIPTION
﻿## Why

Goldenmatch's perf work has been wall-time optimization for months. Peak RSS has been a side-effect, never an objective. CLAUDE.md notes the 25M-bucket peak as 57.7 GB but that's a process-lifetime total -- no per-stage breakdown exists, so we can't say where the RSS goes.

This bit us on PR #547's 10M-bucket-realistic dispatch: the runner OOM-killed (cancelled at 32 min, no MemoryError traceback) and we have no data to say whether it was scoring (bucket_score block orchestration), clustering (2M-cluster dict overhead), or golden (PR #334's streaming agg in 500K-cluster batches).

## What

Extends core/bench.py's stage(...) context manager to record resource.getrusage(RUSAGE_SELF).ru_maxrss at every stage exit. ru_maxrss is the process-lifetime peak RSS, monotonically non-decreasing -- recording it at every stage exit gives the cumulative curve, and diffing consecutive stages gives each stage's contribution to the peak.

## Cost

- One extra getrusage syscall per stage exit (microseconds).
- Still gated behind the existing 'recorder is None' guard -- zero cost when no bench is capturing.
- Linux/macOS only (resource module not available on Windows; field stays empty there).
- No hot-path tax: the existing 'don't wrap stage() inside per-block hot loops' rule is unchanged.

## Not in this PR

- Wiring through scripts/quality_invariant_scale.py -- follow-up.
- Any actual RSS optimization -- this is just the measurement infrastructure.

## Constraint going forward

Per feedback_rss_optimization_constraint: same wall, same accuracy, lower peak RSS. Optimizations that trade RSS for wall are disallowed by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
