### PR TITLE
fix(docker): un-aggressive .dockerignore so goldensuite-mcp build sees packages/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,15 +1,41 @@
-# Scopes the repo-root Docker build context to scripts/ only. The embedding-
-# provider Railway job (Dockerfile.embprov) installs goldenmatch from PyPI and
-# only needs scripts/, so excluding everything else keeps `railway up`'s upload
-# tiny (the monorepo's .venv/node_modules/.git/target are tens of GB).
+# Exclude generated artifacts + the bulky directories that don't belong in any
+# Docker build context. Per-Dockerfile carve-outs aren't needed: every Dockerfile
+# in the repo wants source code; we just don't want the bytes-on-disk noise.
 #
-# Safe for the other Dockerfiles: Dockerfile.mcp / Dockerfile.bench build with
-# rootDirectory=packages/python/goldenmatch, so they read THAT directory's
-# ignore rules, not this repo-root one.
-*
-!scripts/
-!Dockerfile.embprov
+# History note: a prior version of this file aggressive-excluded everything
+# except scripts/, Dockerfile.embprov, Dockerfile.qis. That broke
+# packages/python/goldensuite-mcp/Dockerfile.mcp's `COPY . /app` step because
+# goldensuite-mcp is the one image in publish-containers.yml that builds with
+# repo root as context (the other 6 use their own package dir as context and
+# ignore this file entirely). Don't reintroduce the `*` pattern without first
+# fixing the goldensuite-mcp build to either (a) use a per-Dockerfile
+# `Dockerfile.mcp.dockerignore` or (b) install its deps from PyPI instead of
+# from local paths.
 
-# even within scripts/, drop caches
+# Build / cache artifacts
+.venv/
+node_modules/
+target/
+dist/
+build/
+*.egg-info/
 **/__pycache__/
 **/*.pyc
+**/*.pyo
+
+# Local CI / dev artifacts
+.profile_tmp/
+.dqbench/
+.testing/
+.railway/
+*.log
+
+# Pre-fold archive: the standalone goldenmatch repo's frozen git history.
+# Useful for spec archaeology, not for any container image.
+_archive/
+
+# Repo metadata not needed inside images.
+.git/
+.github/
+.claude/
+docs/superpowers/


### PR DESCRIPTION
﻿## Why

publish-containers.yml has been failing on every run for ~12 hours with:

`error: Distribution not found at: file:///app/packages/python/goldenmatch`

Root cause: the .dockerignore landed in #547 used '*' with carve-outs only for scripts/, Dockerfile.embprov, Dockerfile.qis. That stripped packages/ out of the build context for packages/python/goldensuite-mcp/Dockerfile.mcp -- the ONE image in publish-containers.yml that builds with repo root as context. The other 6 per-package Dockerfiles use their own package dir as context and ignore root .dockerignore entirely, so nobody noticed locally.

Last green: 26543590875 (Tue 22:55 UTC). First failure: 26550488008 (Wed 02:15 UTC).

## What

Replaces the wildcard with explicit excludes for the actual bulk (.venv, node_modules, target, _archive at tens of GB). Railway one-shot uploads still skip the bloat; goldensuite-mcp gets packages/ back.

Leaves a comment block in the file explaining the failure mode so the next 'optimize the upload size' person doesn't re-break it.

## CI

This PR doesn't run publish-containers itself (it's release-triggered, not PR-triggered). Validation will be the next manual dispatch / release after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
