### PR TITLE
perf(bucket): allow fast path when NE entries are all known-broken scorers

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -100,6 +100,40 @@ def _resolve_score_pair_callable(scorer_name: str) -> Any:
     return fn  # may itself be None for matrix-only plugins
 
 
+# Scorers that score_field() handles directly (without raising). NE entries
+# whose scorer is NOT in this set get silently skipped at runtime via the
+# _NE_BROKEN cache in core/scorer.py::_apply_negative_evidence -- so they
+# contribute zero penalty to the final score. The fast path can safely run
+# when every NE scorer is one of these "will-fail" names, because the
+# computed score matches what the slow path would produce (penalty=0 either
+# way). Without this check, auto-config's promote_negative_evidence on
+# 'ensemble' / 'embedding' / 'record_embedding' (none of which score_field
+# implements) forces the entire workload onto the slow path even though the
+# NE entries don't actually do anything at runtime.
+_SCORE_FIELD_DIRECT_SCORERS: frozenset[str] = frozenset({
+    "exact", "jaro_winkler", "levenshtein", "token_sort",
+    "soundex_match", "dice", "jaccard",
+})
+
+
+def _ne_effectively_empty(mk: MatchkeyConfig) -> bool:
+    """True when matchkey.negative_evidence is empty OR every NE entry uses
+    a scorer name that score_field doesn't handle (raises ValueError). Those
+    entries are silently skipped at runtime (PR #546's _NE_BROKEN cache), so
+    they contribute zero penalty and the fast path's NE-free computation
+    matches the slow path's NE-applied computation bit-for-bit."""
+    ne = getattr(mk, "negative_evidence", None)
+    if not ne:
+        return True
+    for ne_entry in ne:
+        scorer = getattr(ne_entry, "scorer", None)
+        if scorer is None or scorer in _SCORE_FIELD_DIRECT_SCORERS:
+            # This NE entry IS callable at runtime -> it contributes real
+            # penalty -> fast path would produce a different score -> bail.
+            return False
+    return True
+
+
 def _resolve_fast_path(
     mk: MatchkeyConfig,
     prepared_df: pl.DataFrame,
@@ -131,7 +165,7 @@ def _resolve_fast_path(
         return None
     if mk.threshold is None:
         return None
-    if getattr(mk, "negative_evidence", None):
+    if not _ne_effectively_empty(mk):
         return None
     if getattr(mk, "rerank", False):
         return None

--- a/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
+++ b/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
@@ -103,8 +103,8 @@ class TestResolveFastPath:
         # fixture stays in sync with the implementation. The original
         # comment claimed the column name was "__mk_X__" -- wrong; that
         # is the EXACT-matchkey concat alias, not the xform sig.
-        from goldenmatch.core.matchkey import _xform_sig
         from goldenmatch.config.schemas import MatchkeyField
+        from goldenmatch.core.matchkey import _xform_sig
         col_first = _xform_sig(MatchkeyField(field="first_name", scorer="jaro_winkler", weight=1.0))
         col_last = _xform_sig(MatchkeyField(field="last_name", scorer="jaro_winkler", weight=1.0))
         return pl.DataFrame({

--- a/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
+++ b/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
@@ -1,0 +1,137 @@
+"""Unit tests for ``_ne_effectively_empty`` and the broader fast-path gate
+in ``score_buckets._resolve_fast_path``.
+
+Background: at auto-config time on the QIS realistic shape (10M rows),
+``promote_negative_evidence`` was adding an NE entry on the ``id`` column
+with scorer name ``ensemble``. ``score_field`` doesn't implement
+``ensemble`` and raises ``ValueError`` -- ``core/scorer.py::_NE_BROKEN``
+catches this once per (scorer, field) and silently skips it on subsequent
+calls. The NE contributes zero penalty at runtime.
+
+But the old fast-path gate declined eligibility whenever
+``mk.negative_evidence`` was truthy, regardless of whether the entries were
+actually callable. That forced the entire workload onto the slow Python
+``find_fuzzy_matches`` path and blocked the native + ExcludeSet handle
+optimizations (PR #552). The smarter gate looks at the NE scorer names and
+only declines when at least one would actually fire at runtime.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from goldenmatch.backends.score_buckets import (
+    _ne_effectively_empty,
+    _resolve_fast_path,
+)
+from goldenmatch.config.schemas import (
+    MatchkeyConfig,
+    MatchkeyField,
+    NegativeEvidenceField,
+)
+
+
+def _mk_with_ne(ne_entries: list[NegativeEvidenceField]) -> MatchkeyConfig:
+    """A minimal weighted matchkey with the given NE entries -- the rest of
+    the gate's prerequisites (threshold, weighted type, no rerank/llm) are
+    satisfied so eligibility hinges on NE alone."""
+    return MatchkeyConfig(
+        name="weighted_test",
+        type="weighted",
+        threshold=0.7,
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", weight=1.0),
+            MatchkeyField(field="last_name", scorer="jaro_winkler", weight=1.0),
+        ],
+        negative_evidence=ne_entries,
+    )
+
+
+class TestNeEffectivelyEmpty:
+    def test_empty_ne_is_effectively_empty(self):
+        mk = _mk_with_ne([])
+        assert _ne_effectively_empty(mk) is True
+
+    def test_none_ne_is_effectively_empty(self):
+        mk = MatchkeyConfig(
+            name="no_ne", type="weighted", threshold=0.7,
+            fields=[MatchkeyField(field="a", scorer="jaro_winkler", weight=1.0)],
+        )
+        assert _ne_effectively_empty(mk) is True
+
+    @pytest.mark.parametrize("broken_scorer", ["ensemble", "embedding", "record_embedding"])
+    def test_broken_scorer_ne_is_effectively_empty(self, broken_scorer: str):
+        """NE entries whose scorer score_field doesn't implement -- the
+        _NE_BROKEN cache in core/scorer.py skips them at runtime, so they
+        contribute zero penalty. The gate should treat NE as empty."""
+        mk = _mk_with_ne([
+            NegativeEvidenceField(field="id", scorer=broken_scorer, threshold=0.8, penalty=0.5),
+        ])
+        assert _ne_effectively_empty(mk) is True, (
+            f"NE with broken scorer {broken_scorer!r} should be treated as empty"
+        )
+
+    @pytest.mark.parametrize("real_scorer", ["jaro_winkler", "levenshtein", "token_sort", "exact"])
+    def test_callable_scorer_ne_is_not_empty(self, real_scorer: str):
+        """NE entries with scorers score_field actually implements would
+        contribute a real penalty at runtime. The gate must NOT treat
+        these as empty -- the fast path would silently change the score."""
+        mk = _mk_with_ne([
+            NegativeEvidenceField(field="phone", scorer=real_scorer, threshold=0.8, penalty=0.5),
+        ])
+        assert _ne_effectively_empty(mk) is False, (
+            f"NE with callable scorer {real_scorer!r} must NOT be treated as empty"
+        )
+
+    def test_mixed_broken_and_callable_is_not_empty(self):
+        """Conservative: if ANY NE entry is callable, the whole set must be
+        honored. The fast path is all-or-nothing on NE awareness."""
+        mk = _mk_with_ne([
+            NegativeEvidenceField(field="id", scorer="ensemble", threshold=0.8, penalty=0.5),
+            NegativeEvidenceField(field="phone", scorer="jaro_winkler", threshold=0.8, penalty=0.5),
+        ])
+        assert _ne_effectively_empty(mk) is False
+
+
+class TestResolveFastPath:
+    """End-to-end: with broken-scorer NE, _resolve_fast_path should return a
+    spec (non-None). With callable NE, it should still return None."""
+
+    def _prepared_df(self) -> pl.DataFrame:
+        # Minimal prepared df with the xform columns the matchkey needs.
+        # _xform_sig builds the column name from the field + transforms;
+        # for plain field=X with no transforms it's just "__mk_X__".
+        return pl.DataFrame({
+            "__row_id__": [0, 1],
+            "__mk_first_name__": ["alice", "alice"],
+            "__mk_last_name__": ["smith", "smith"],
+        })
+
+    def test_fast_path_engaged_with_broken_ne(self):
+        mk = _mk_with_ne([
+            NegativeEvidenceField(field="id", scorer="ensemble", threshold=0.8, penalty=0.5),
+        ])
+        result = _resolve_fast_path(
+            mk, self._prepared_df(),
+            across_files_only=False, source_lookup=None, target_ids=None,
+        )
+        # _resolve_fast_path returns None when not eligible. With broken-NE
+        # only, we should get the spec back. It's None ONLY if some other
+        # prerequisite failed -- this fixture satisfies all of them, so a
+        # None here would mean the broken-NE gate logic didn't fire.
+        assert result is not None, (
+            "broken-NE matchkey should be fast-path eligible after the gate fix"
+        )
+
+    def test_fast_path_declined_with_callable_ne(self):
+        mk = _mk_with_ne([
+            NegativeEvidenceField(field="phone", scorer="jaro_winkler", threshold=0.8, penalty=0.5),
+        ])
+        result = _resolve_fast_path(
+            mk, self._prepared_df(),
+            across_files_only=False, source_lookup=None, target_ids=None,
+        )
+        assert result is None, (
+            "callable-NE matchkey must still decline the fast path -- the "
+            "fast path doesn't apply NE penalty math"
+        )

--- a/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
+++ b/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import polars as pl
 import pytest
-
 from goldenmatch.backends.score_buckets import (
     _ne_effectively_empty,
     _resolve_fast_path,

--- a/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
+++ b/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
@@ -98,12 +98,19 @@ class TestResolveFastPath:
 
     def _prepared_df(self) -> pl.DataFrame:
         # Minimal prepared df with the xform columns the matchkey needs.
-        # _xform_sig builds the column name from the field + transforms;
-        # for plain field=X with no transforms it's just "__mk_X__".
+        # _xform_sig builds `__xform_<field>_<blake2b-8hex>__` from the
+        # field name + repr(field.transforms); compute it here so the
+        # fixture stays in sync with the implementation. The original
+        # comment claimed the column name was "__mk_X__" -- wrong; that
+        # is the EXACT-matchkey concat alias, not the xform sig.
+        from goldenmatch.core.matchkey import _xform_sig
+        from goldenmatch.config.schemas import MatchkeyField
+        col_first = _xform_sig(MatchkeyField(field="first_name", scorer="jaro_winkler", weight=1.0))
+        col_last = _xform_sig(MatchkeyField(field="last_name", scorer="jaro_winkler", weight=1.0))
         return pl.DataFrame({
             "__row_id__": [0, 1],
-            "__mk_first_name__": ["alice", "alice"],
-            "__mk_last_name__": ["smith", "smith"],
+            col_first: ["alice", "alice"],
+            col_last: ["smith", "smith"],
         })
 
     def test_fast_path_engaged_with_broken_ne(self):


### PR DESCRIPTION
﻿## Why

10M-v10 (post #552 ExcludeSet handle) measured wall=2364s peak=35.8 GB -- essentially identical to v9. Runtime log revealed the cause:
```n[score_buckets] starting bucket_score with max_workers=16 path=find_fuzzy_matches
```n
The bucket fast path declined eligibility because the auto-configured matchkey had `mk.negative_evidence` populated with an 'ensemble' scorer entry (added by `promote_negative_evidence` on the realistic-shape 'id' column). `score_field` doesn't implement 'ensemble' -- PR #546's `_NE_BROKEN` cache silently skips broken NE at runtime, so the entry contributes ZERO penalty. But the old gate bailed whenever NE was truthy, forcing the entire workload onto the slow Python `find_fuzzy_matches` path (the 1370s of bucket_score wall, which never reached the native + ExcludeSet path from #552).

## What

New helper `_ne_effectively_empty` walks NE entries; treats them as empty when every scorer is one `score_field` doesn't implement (`ensemble`, `embedding`, `record_embedding`). The fast path's no-NE compute matches the slow path's apply-then-skip compute bit-for-bit (penalty is 0 either way) -- pure perf unlock, no accuracy change.

## Expected impact

At 10M-realistic with bucket backend + native:
- `bucket_score` wall: 1370 s -> ~200 s (Track 1 Fix B finally engages).
- Total wall: 2370 s -> ~1200 s (~50% reduction).
- F1: identical.

## Tests

7 cases in `test_score_buckets_fast_path_gate.py`:
- empty NE -> effectively empty (True)
- None NE -> effectively empty (True)
- broken-scorer NE (ensemble/embedding/record_embedding) -> effectively empty (True)
- callable-scorer NE (jaro_winkler/levenshtein/token_sort/exact) -> NOT empty (False)
- mixed broken + callable -> NOT empty (False, conservative)
- `_resolve_fast_path` end-to-end: returns spec for broken-NE matchkey, returns None for callable-NE matchkey

🤖 Generated with [Claude Code](https://claude.com/claude-code)
