### PR TITLE
feat(snowflake): handler module for Snowpark + SPCS UDFs (Phase 1)

### DIFF
--- a/packages/python/goldenmatch/dbt-goldensuite/docs/snowflake-handlers.md
+++ b/packages/python/goldenmatch/dbt-goldensuite/docs/snowflake-handlers.md
@@ -1,0 +1,128 @@
+# Snowflake handler module
+
+The Snowflake-side surface in this package ships in two halves:
+
+| Half | Where it lives | What it does |
+|---|---|---|
+| **Outside** | `dbt-goldensuite/macros/`, `cli/snowflake.py` | How Snowflake calls into goldenmatch (CREATE FUNCTION DDL, dbt macros). |
+| **Inside** | `goldenmatch.snowflake.udfs` | The Python functions Snowflake's UDF / Stored Procedure HANDLER clauses point at. |
+
+PR #553 shipped the outside. This module ships the inside.
+
+## Phase 1 -- scalar UDFs (working)
+
+Per-string transforms and read-only identity lookups. All run as pure
+Snowpark Python UDFs -- no Snowpark `Session` required, no writes.
+
+### GoldenFlow transforms (8)
+
+| Handler | Wraps |
+|---|---|
+| `normalize_email` | `goldenflow.transforms.email.email_normalize` |
+| `normalize_phone` | `goldenflow.transforms.phone.phone_e164` |
+| `normalize_date` | `goldenflow.transforms.dates.date_iso8601` |
+| `normalize_name_proper` | `goldenflow.transforms.names.name_proper` |
+| `canonicalize_url` | `goldenflow.transforms.url.url_normalize` |
+| `canonicalize_address` | `goldenflow.transforms.address.address_standardize` |
+| `strip` | `str.strip` |
+| `whitespace_normalize` | `" ".join(s.split())` |
+
+All eight accept `str | None` and return `str | None`. NULLs propagate
+cleanly because Snowflake hands the Python UDF `None` for NULL inputs.
+
+### Identity reads (5)
+
+| Handler | Wraps |
+|---|---|
+| `identity_resolve(record_id, db_path)` | `goldenmatch.identity.query.find_by_record` |
+| `identity_view(entity_id, db_path)` | `goldenmatch.identity.query.get_entity` |
+| `identity_history(entity_id, db_path)` | `goldenmatch.identity.query.history` |
+| `identity_conflicts(dataset, db_path)` | `goldenmatch.identity.query.find_conflicts` |
+| `identity_list(dataset, status, db_path)` | `goldenmatch.identity.query.list_entities` |
+
+The `db_path` argument points at a SQLite `IdentityStore` file. Pass
+the empty string to use the default `identity.db` at the Snowflake
+IMPORTS stage root (the location the
+`goldenmatch snowflake init --identity-db` flag uploads to). Inside a
+UDF the IMPORTS dir is resolved via
+``sys._xoptions['snowflake_import_directory']``; outside Snowflake
+(local tests) the handler falls back to `GOLDENMATCH_UDF_IMPORTS`,
+then to the package directory.
+
+The IdentityStore is opened *read-only* per call -- Snowpark UDFs run
+sandboxed and the IMPORTS filesystem is read-only anyway, so any
+write attempt errors fast. Writes happen via Phase 2 stored
+procedures.
+
+## Phase 2 -- stored procedures (scaffolds + NotImplementedError)
+
+Operations that read or write Snowflake tables can't run as pure
+UDFs -- they need a Snowpark `Session`, which only stored procedures
+get. Phase 2 ships the SP variants in a follow-up.
+
+| Scaffold | Reason it's deferred |
+|---|---|
+| `correction_add` | Writes to MemoryStore -- needs a Snowflake-native MemoryStore backend (writes via Session, not SQLite-on-stage). |
+| `scan_table` | Reads a Snowflake relation into a Polars frame for `goldencheck.engine.scanner.scan_file` (which currently expects a file path). |
+| `health_score` | Same Session requirement as `scan_table`. |
+| `DedupeFull` / `DedupeClusters` / `DedupePairs` | Read the input relation, call `goldenmatch.dedupe_df(df, cfg)`, write the output back -- all Session-bound. |
+
+Each scaffold raises `NotImplementedError("... ships in Phase 2 ...")`
+with a workable remediation hint pointing at out-of-band paths today.
+
+## Single source of truth across paths
+
+Both the Snowpark Python UDF path (from
+[snowflake-setup.md](snowflake-setup.md)) and the SPCS service path
+(from [snowflake-spcs.md](snowflake-spcs.md)) call into the same
+`goldenmatch.snowflake.udfs` module. The two paths can't diverge:
+
+| Path | Where handlers run | Module imported |
+|---|---|---|
+| Snowpark Python UDF | Snowflake's UDF sandbox | `goldenmatch.snowflake.udfs.<func>` via the `HANDLER` clause |
+| SPCS service | Container running goldenmatch[native] | Same `goldenmatch.snowflake.udfs.<func>` re-exported through Flask routes in `spcs/server.py` |
+
+The SPCS server's `# TODO(spcs):` markers from PR #553 are gone --
+the routes now delegate directly to the handler module.
+
+## Testing
+
+Phase 1 handlers are unit-tested in
+`tests/snowflake/test_udfs.py` (28 tests):
+
+  - 8 transform handlers: input/output check against real goldenflow
+    primitives.
+  - 5 identity reads: against an on-disk SQLite IdentityStore the
+    test seeds via the public `IdentityStore` API.
+  - 6 Phase 2 scaffolds: assert `NotImplementedError` with the
+    documented "ships in Phase 2" message.
+  - IMPORTS-directory resolution (env override, relative path,
+    absolute path, empty fallback).
+
+All run with no live Snowflake connection.
+
+## Phase 2 design notes
+
+When the SP migration lands, the natural shape:
+
+1. **MemoryStore Snowflake backend.** Add a `snowflake` backend
+   alongside `sqlite` / `postgres` in
+   `goldenmatch.core.memory.store.MemoryStore`. Writes go through
+   `session.write_pandas(...)` against a
+   `<db>.goldenmatch.corrections` table.
+
+2. **GoldenCheck Snowflake scan.** Add `scan_relation(session,
+   relation_name)` to `goldencheck.engine.scanner` -- reads the
+   relation into Polars via Snowpark, profiles + scans, returns the
+   same `list[Finding]` shape the file-based path emits.
+
+3. **Dedupe Stored Procedures.** Each of the three output shapes
+   becomes a Snowpark SP receiving Session as first arg, reading the
+   relation, calling `goldenmatch.dedupe_df`, writing back via
+   `result.write.save_as_table(...)`. The dbt
+   `goldenmatch_dedupe` materialization switches from
+   `CREATE TABLE ... AS SELECT * FROM TABLE(<udtf>(...))` to
+   `CALL goldenmatch.goldenmatch_dedupe_full('<in>', '<config>', '<out>')`
+   plus a `SELECT * FROM <out>`.
+
+Tracking issue to be filed alongside this PR.

--- a/packages/python/goldenmatch/dbt-goldensuite/spcs/server.py
+++ b/packages/python/goldenmatch/dbt-goldensuite/spcs/server.py
@@ -39,7 +39,6 @@ walkthrough.
 """
 from __future__ import annotations
 
-import json
 import logging
 import os
 from collections.abc import Callable
@@ -114,80 +113,73 @@ def _table_handler(fn: Callable[..., list[list[Any]]]):
 
 
 # ---------------------------------------------------------------------------
-# Identity graph reads -- thin wrappers around goldenmatch.identity
+# Shared handler module -- the same goldenmatch.snowflake.udfs functions
+# that the Snowpark Python UDFs call into. SPCS just exposes them via
+# HTTP instead of being invoked by Snowflake directly. Single source of
+# truth for the goldenmatch-side glue keeps the two paths bit-identical.
 # ---------------------------------------------------------------------------
+
+
+from goldenmatch.snowflake import udfs as _gm  # noqa: E402
 
 
 def _identity_resolve(record_id: str, db_path: str) -> Any:
-    # TODO(spcs): wire to the goldenmatch.identity entry point that
-    # `goldenmatch_identity_resolve` in the DuckDB / pgrx extensions
-    # already calls. The Postgres + DuckDB SQL UDFs return JSON in
-    # the same shape, so the same Python helper should serve here.
-    raise NotImplementedError(
-        f"identity_resolve({record_id!r}, db={db_path or DEFAULT_IDENTITY_DB!r})"
-    )
+    return _gm.identity_resolve(record_id, db_path or DEFAULT_IDENTITY_DB)
 
 
 def _identity_view(entity_id: str, db_path: str) -> Any:
-    # TODO(spcs): wire to goldenmatch.identity equivalent of
-    # `goldenmatch_identity_view`.
-    raise NotImplementedError(
-        f"identity_view({entity_id!r}, db={db_path or DEFAULT_IDENTITY_DB!r})"
-    )
+    return _gm.identity_view(entity_id, db_path or DEFAULT_IDENTITY_DB)
 
 
 def _identity_history(entity_id: str, db_path: str) -> Any:
-    raise NotImplementedError(
-        f"identity_history({entity_id!r}, db={db_path or DEFAULT_IDENTITY_DB!r})"
-    )
+    return _gm.identity_history(entity_id, db_path or DEFAULT_IDENTITY_DB)
 
 
 def _identity_conflicts(dataset: str, db_path: str) -> Any:
-    raise NotImplementedError(
-        f"identity_conflicts({dataset!r}, db={db_path or DEFAULT_IDENTITY_DB!r})"
-    )
+    return _gm.identity_conflicts(dataset, db_path or DEFAULT_IDENTITY_DB)
 
 
 def _identity_list(dataset: str, status: str, db_path: str) -> Any:
-    raise NotImplementedError(
-        f"identity_list(dataset={dataset!r}, status={status!r}, "
-        f"db={db_path or DEFAULT_IDENTITY_DB!r})"
-    )
+    return _gm.identity_list(dataset, status, db_path or DEFAULT_IDENTITY_DB)
 
 
 # ---------------------------------------------------------------------------
-# GoldenCheck / quality
+# GoldenCheck / quality -- Phase 2 (table-reading; needs Snowpark Session).
 # ---------------------------------------------------------------------------
 
 
 def _goldencheck_scan_table(relation: str, domain: str) -> str:
-    # TODO(spcs): wire to goldencheck's scan entry point. The DuckDB
-    # UDF `goldencheck_scan_table` returns a JSON array of findings
-    # in this exact shape; reuse the same serializer.
-    raise NotImplementedError(
-        f"goldencheck_scan_table({relation!r}, domain={domain!r})"
-    )
+    # Mirrors the goldenmatch.snowflake.udfs.scan_table scaffold --
+    # Phase 2, gated on the Snowflake-native goldencheck profiler.
+    return _gm.scan_table(relation, domain)
 
 
 def _goldencheck_health_score(relation: str) -> float:
-    # TODO(spcs): wire to goldencheck's health-score entry point.
-    raise NotImplementedError(f"goldencheck_health_score({relation!r})")
+    return _gm.health_score(relation)
 
 
 # ---------------------------------------------------------------------------
-# GoldenFlow transforms
+# GoldenFlow transforms -- map server endpoint name -> handler function.
 # ---------------------------------------------------------------------------
+
+
+_FLOW_HANDLERS = {
+    "normalize_email":       _gm.normalize_email,
+    "normalize_phone":       _gm.normalize_phone,
+    "normalize_date":        _gm.normalize_date,
+    "normalize_name_proper": _gm.normalize_name_proper,
+    "canonicalize_url":      _gm.canonicalize_url,
+    "canonicalize_address":  _gm.canonicalize_address,
+    "strip":                 _gm.strip,
+    "whitespace_normalize":  _gm.whitespace_normalize,
+}
 
 
 def _make_flow(name: str):
-    # TODO(spcs): import the resolved transform once -- module-level,
-    # not per-request -- and call it here. The DuckDB UDFs already do
-    # this for each transform; mirror the same import path.
+    fn = _FLOW_HANDLERS[name]
 
     def call(value: str | None) -> str | None:
-        if value is None:
-            return None
-        raise NotImplementedError(f"goldenflow_{name}({value!r})")
+        return fn(value)
 
     call.__name__ = f"flow_{name}"
     return call
@@ -201,49 +193,30 @@ def _make_flow(name: str):
 def _correction_add(
     decision: str, dataset: str, memory_path: str, args_json: str,
 ) -> str:
-    # TODO(spcs): wire to goldenmatch.core.memory.store.add_correction.
-    # The DuckDB UDF `goldenmatch_correction_add` already takes the
-    # same (decision, dataset, memory_path, args_json) tuple --
-    # reuse its handler verbatim.
-    args = json.loads(args_json or "{}")
-    raise NotImplementedError(
-        f"correction_add(decision={decision!r}, dataset={dataset!r}, "
-        f"memory_path={memory_path or DEFAULT_MEMORY_DB!r}, args={args!r})"
+    return _gm.correction_add(
+        decision, dataset, memory_path or DEFAULT_MEMORY_DB, args_json,
     )
 
 
 # ---------------------------------------------------------------------------
-# Dedupe -- the three output shapes
+# Dedupe -- the three output shapes. Phase 2 in goldenmatch.snowflake.udfs;
+# SPCS exposes them once the SP migration lands.
 # ---------------------------------------------------------------------------
 
 
 def _dedupe_full(input_table: str, config_json: str) -> list[list[Any]]:
-    # TODO(spcs): use Snowpark Session to read the input table into
-    # a Polars frame, then call goldenmatch.dedupe_df(df, config=cfg)
-    # and emit one [cluster_id, golden_variant] row per cluster.
-    # Reference the DuckDB UDF `goldenmatch_dedupe_full` for the
-    # exact serialization shape.
-    raise NotImplementedError(
-        f"dedupe_full(input_table={input_table!r}, "
-        f"config_bytes={len(config_json)})"
-    )
+    rows = _gm.DedupeFull().process(input_table, config_json)
+    return [list(r) for r in rows] if rows else []
 
 
 def _dedupe_clusters(input_table: str, config_json: str) -> list[list[Any]]:
-    # TODO(spcs): emit one [cluster_id, member_id, score] row per
-    # cluster member. Same input + config handling as _dedupe_full.
-    raise NotImplementedError(
-        f"dedupe_clusters(input_table={input_table!r})"
-    )
+    rows = _gm.DedupeClusters().process(input_table, config_json)
+    return [list(r) for r in rows] if rows else []
 
 
 def _dedupe_pairs(input_table: str, config_json: str) -> list[list[Any]]:
-    # TODO(spcs): emit one [id_a, id_b, score] row per scored pair
-    # above the configured threshold. The Postgres pgrx UDF
-    # `goldenmatch_dedupe_pairs` is the reference shape.
-    raise NotImplementedError(
-        f"dedupe_pairs(input_table={input_table!r})"
-    )
+    rows = _gm.DedupePairs().process(input_table, config_json)
+    return [list(r) for r in rows] if rows else []
 
 
 # ---------------------------------------------------------------------------

--- a/packages/python/goldenmatch/goldenmatch/snowflake/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/snowflake/__init__.py
@@ -1,0 +1,24 @@
+"""Snowflake handler module -- the inside of the goldenmatch UDF surface.
+
+``packages/python/goldenmatch/dbt-goldensuite/macros/`` and
+``packages/python/goldenmatch/goldenmatch/cli/snowflake.py`` are the
+*outside* of the Snowflake surface: how Snowflake calls into
+goldenmatch. This subpackage is the *inside*: the Python functions
+Snowflake's UDF / Stored Procedure HANDLER clauses point at.
+
+Re-exports ``goldenmatch.snowflake.udfs`` symbols at the top level so
+the HANDLER paths in the CLI catalog (``goldenmatch_udfs.foo``) can
+also be expressed as ``goldenmatch.snowflake.foo`` once a goldenmatch
+release ships them.
+
+Phase 1 in this module ships scalar UDF handlers (transforms +
+identity reads). Phase 2 will ship Stored Procedure handlers for
+the table-reading operations (dedupe, quality scans, correction
+writes) -- those need a Snowpark ``Session`` which is only
+available inside Stored Procedures, not pure UDFs.
+"""
+from __future__ import annotations
+
+from goldenmatch.snowflake import udfs  # noqa: F401  (re-export)
+
+__all__ = ["udfs"]

--- a/packages/python/goldenmatch/goldenmatch/snowflake/udfs.py
+++ b/packages/python/goldenmatch/goldenmatch/snowflake/udfs.py
@@ -1,0 +1,426 @@
+"""Snowflake handler functions for goldenmatch UDFs and Stored Procedures.
+
+The ``goldenmatch snowflake init`` CLI registers UDFs with
+``HANDLER = 'goldenmatch_udfs.<func>'`` (or, equivalently,
+``goldenmatch.snowflake.udfs.<func>``). This module IS that handler
+catalog.
+
+## Phase 1: scalar UDFs (this module, working)
+
+Per-string transforms and read-only identity lookups. All run as
+pure Snowpark Python UDFs -- no Session required, no writes.
+
+  - ``normalize_email`` / ``normalize_phone`` / ``normalize_date``
+  - ``normalize_name_proper`` / ``canonicalize_url`` /
+    ``canonicalize_address`` / ``strip`` / ``whitespace_normalize``
+  - ``identity_resolve`` / ``identity_view`` / ``identity_history``
+  - ``identity_conflicts`` / ``identity_list``
+
+The identity reads open a read-only SQLite ``IdentityStore`` from
+the path bundled into the UDF via the ``IMPORTS`` clause. Pass
+the empty string as ``db_path`` to pick up the default file
+(``identity.db`` at the IMPORTS root).
+
+## Phase 2: Stored Procedures (scaffolded, NotImplementedError)
+
+Operations that need a Snowpark ``Session`` -- because they read
+or write Snowflake tables -- are scaffolded with clear
+NotImplementedError messages and inline TODO markers. These ship
+in a follow-up PR once the Snowflake-native ``MemoryStore`` and
+``IdentityStore`` backends land.
+
+  - ``correction_add`` (writes a Correction to MemoryStore)
+  - ``scan_table`` / ``health_score`` (run GoldenCheck against a
+    Snowflake relation)
+  - ``DedupeFull`` / ``DedupeClusters`` / ``DedupePairs`` (run a
+    full goldenmatch dedupe against a Snowflake relation)
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Polars is shipped in Snowflake's Anaconda channel and bundled into
+# the UDF imports anyway -- but we import lazily so the cost is paid
+# once per worker process.
+_pl: Any = None
+
+
+def _polars():
+    global _pl
+    if _pl is None:
+        import polars as pl
+        _pl = pl
+    return _pl
+
+
+# ---------------------------------------------------------------------------
+# Helpers: locate the IMPORTS directory inside a running UDF.
+# ---------------------------------------------------------------------------
+
+
+def _import_dir() -> Path:
+    """Resolve the Snowflake IMPORTS stage directory.
+
+    Inside a Snowpark Python UDF, ``sys._xoptions['snowflake_import_directory']``
+    points at the unpacked IMPORTS root -- the path that the wheel /
+    ``identity.db`` are accessible from. Outside Snowflake (local tests)
+    we fall back to a ``GOLDENMATCH_UDF_IMPORTS`` env var, then to the
+    package directory.
+    """
+    snowflake_dir = getattr(sys, "_xoptions", {}).get(
+        "snowflake_import_directory"
+    )
+    if snowflake_dir:
+        return Path(snowflake_dir)
+    env_dir = os.environ.get("GOLDENMATCH_UDF_IMPORTS")
+    if env_dir:
+        return Path(env_dir)
+    return Path(__file__).resolve().parent
+
+
+def _resolve_db_path(db_path: str | None) -> str:
+    """Pick the SQLite path for an identity-read UDF.
+
+    Empty string + None both fall back to ``identity.db`` at the
+    IMPORTS root, which is the convention the CLI install script
+    documents in ``snowflake-setup.md``.
+    """
+    if db_path:
+        # Absolute paths are honored as-is; relative paths resolve
+        # against the IMPORTS root.
+        p = Path(db_path)
+        if p.is_absolute():
+            return str(p)
+        return str(_import_dir() / p)
+    return str(_import_dir() / "identity.db")
+
+
+# ---------------------------------------------------------------------------
+# Identity reads -- pure UDFs, read-only against a staged SQLite IdentityStore.
+# ---------------------------------------------------------------------------
+
+
+def _identity_store(db_path: str | None):
+    """Open a read-only IdentityStore at the resolved path.
+
+    Snowpark UDFs run sandboxed; the only filesystem access is the
+    IMPORTS directory (read-only). The IdentityStore class opens
+    SQLite in read-only mode when given an existing file, so this is
+    safe.
+    """
+    from goldenmatch.identity.store import IdentityStore
+    return IdentityStore(backend="sqlite", path=_resolve_db_path(db_path))
+
+
+def identity_resolve(record_id: str, db_path: str) -> dict[str, Any] | None:
+    """``goldenmatch.goldenmatch_identity_resolve(record_id, db_path)``.
+
+    Look up a record's current identity. Returns a serializable
+    summary or None if the record_id is unknown.
+    """
+    from goldenmatch.identity.query import find_by_record
+    store = _identity_store(db_path)
+    try:
+        view = find_by_record(store, record_id)
+        return view.to_dict() if view is not None else None
+    finally:
+        store.close()
+
+
+def identity_view(entity_id: str, db_path: str) -> dict[str, Any] | None:
+    """``goldenmatch.goldenmatch_identity_view(entity_id, db_path)``.
+
+    Full IdentityView JSON for an entity_id.
+    """
+    from goldenmatch.identity.query import get_entity
+    store = _identity_store(db_path)
+    try:
+        view = get_entity(store, entity_id)
+        return view.to_dict() if view is not None else None
+    finally:
+        store.close()
+
+
+def identity_history(entity_id: str, db_path: str) -> list[dict[str, Any]]:
+    """``goldenmatch.goldenmatch_identity_history(entity_id, db_path)``.
+
+    Append-only event log for an entity_id. ``history`` returns
+    dicts directly -- no further .to_dict() needed.
+    """
+    from goldenmatch.identity.query import history as _history
+    store = _identity_store(db_path)
+    try:
+        return _history(store, entity_id)
+    finally:
+        store.close()
+
+
+def identity_conflicts(dataset: str, db_path: str) -> list[dict[str, Any]]:
+    """``goldenmatch.goldenmatch_identity_conflicts(dataset, db_path)``.
+
+    Conflict edges in a dataset. ``find_conflicts`` returns dicts
+    directly.
+    """
+    from goldenmatch.identity.query import find_conflicts
+    store = _identity_store(db_path)
+    try:
+        return find_conflicts(store, dataset=(dataset or None))
+    finally:
+        store.close()
+
+
+def identity_list(dataset: str, status: str, db_path: str) -> list[dict[str, Any]]:
+    """``goldenmatch.goldenmatch_identity_list(dataset, status, db_path)``.
+
+    List identities, optionally filtered. ``list_entities`` returns
+    dicts directly.
+    """
+    from goldenmatch.identity.query import list_entities
+    store = _identity_store(db_path)
+    try:
+        return list_entities(
+            store,
+            dataset=(dataset or None),
+            status=(status or None),
+        )
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# GoldenFlow transforms -- pure scalar UDFs, string -> string.
+# ---------------------------------------------------------------------------
+
+
+def _series_apply(transform_callable, value: str | None) -> str | None:
+    """Apply a Polars ``Series -> Series`` goldenflow transform to a single
+    value. The Polars round-trip is the price we pay for keeping the
+    handler bit-identical with the dbt + DuckDB transform path."""
+    if value is None:
+        return None
+    pl = _polars()
+    series = pl.Series([value])
+    out = transform_callable(series)
+    result = out[0]
+    return None if result is None else str(result)
+
+
+def _expr_apply(expr_callable, value: str | None,
+                col_name: str = "_v") -> str | None:
+    """Apply a Polars ``column-name -> Expr`` goldenflow transform to a
+    single value. Builds a 1-row DataFrame, projects through the Expr,
+    pulls back the only cell."""
+    if value is None:
+        return None
+    pl = _polars()
+    df = pl.DataFrame({col_name: [value]})
+    out = df.select(expr_callable(col_name).alias("_o"))
+    result = out["_o"][0]
+    return None if result is None else str(result)
+
+
+def normalize_email(s: str | None) -> str | None:
+    """``goldenmatch.goldenflow_normalize_email(s)``.
+
+    Lowercases, strips, drops +tags, normalizes Gmail aliases.
+    """
+    from goldenflow.transforms.email import email_normalize
+    return _series_apply(email_normalize, s)
+
+
+def normalize_phone(s: str | None) -> str | None:
+    """``goldenmatch.goldenflow_normalize_phone(s)``.
+
+    E.164-normalize a phone number. Returns the input unchanged
+    when ``phonenumbers`` can't parse it.
+    """
+    from goldenflow.transforms.phone import phone_e164
+    return _series_apply(phone_e164, s)
+
+
+def normalize_date(s: str | None) -> str | None:
+    """``goldenmatch.goldenflow_normalize_date(s)``.
+
+    Parse + emit ISO-8601 ``YYYY-MM-DD``. Returns the input unchanged
+    when the parser can't agree on a date.
+    """
+    from goldenflow.transforms.dates import date_iso8601
+    return _series_apply(date_iso8601, s)
+
+
+def normalize_name_proper(s: str | None) -> str | None:
+    """``goldenmatch.goldenflow_normalize_name_proper(s)``.
+
+    Proper-case a person name via ``goldenflow.transforms.names.name_proper``.
+    For the full strip-titles -> strip-suffixes -> proper-case
+    composition, run ``goldenflow.transform_df`` out-of-band with a
+    GoldenFlowConfig -- the UDF stays focused on the case-fix step
+    that's the actual matchkey-side normalization.
+    """
+    from goldenflow.transforms.names import name_proper
+    return _series_apply(name_proper, s)
+
+
+def canonicalize_url(s: str | None) -> str | None:
+    """``goldenmatch.goldenflow_canonicalize_url(s)``.
+
+    Lowercases scheme + host, strips default port, drops trailing
+    slashes. Wraps ``goldenflow.transforms.url.url_normalize``.
+    """
+    from goldenflow.transforms.url import url_normalize
+    return _series_apply(url_normalize, s)
+
+
+def canonicalize_address(s: str | None) -> str | None:
+    """``goldenmatch.goldenflow_canonicalize_address(s)``.
+
+    USPS-style address normalization: expand abbreviations,
+    standardize unit indicators. Wraps
+    ``goldenflow.transforms.address.address_standardize``.
+    """
+    from goldenflow.transforms.address import address_standardize
+    return _expr_apply(address_standardize, s)
+
+
+def strip(s: str | None) -> str | None:
+    """``goldenmatch.goldenflow_strip(s)``.
+
+    Strip leading + trailing whitespace.
+    """
+    if s is None:
+        return None
+    return s.strip()
+
+
+def whitespace_normalize(s: str | None) -> str | None:
+    """``goldenmatch.goldenflow_whitespace_normalize(s)``.
+
+    Collapse all internal whitespace runs to single spaces, strip
+    edges. Idempotent.
+    """
+    if s is None:
+        return None
+    return " ".join(s.split())
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Stored Procedures -- scaffolds with clear TODOs.
+# ---------------------------------------------------------------------------
+
+
+def correction_add(decision: str, dataset: str, memory_path: str,
+                   args_json: str) -> str:
+    """Stored Procedure: ``goldenmatch.goldenmatch_correction_add(...)``.
+
+    Write a Correction to MemoryStore. Phase 2 -- requires a
+    Snowflake-native MemoryStore backend (writes via Snowpark
+    Session, not SQLite-on-stage).
+
+    The fully-loaded path in Phase 2 will:
+
+      1. Receive a ``snowflake.snowpark.Session`` as the first
+         implicit argument (Stored Procedures get one for free).
+      2. Insert a row into ``<db>.goldenmatch.corrections`` mirroring
+         ``goldenmatch.core.memory.store.Correction``.
+      3. Return the Correction's UUID7 as the procedure result.
+
+    Tracking issue: see ``docs/snowflake-handlers.md``.
+    """
+    raise NotImplementedError(
+        "correction_add ships in Phase 2 of the Snowflake handler module. "
+        "Today, file corrections via the dbt macro on Postgres/DuckDB, "
+        "or via REST: POST /api/v1/memory/corrections."
+    )
+
+
+def scan_table(relation_name: str, domain: str) -> str:
+    """Stored Procedure: ``goldenmatch.goldencheck_scan_table(...)``.
+
+    Run GoldenCheck against a Snowflake relation. Phase 2 -- needs
+    a Snowpark Session to read the table into a Polars frame for
+    ``goldencheck.engine.scanner.scan_file`` (which currently
+    expects a file path).
+
+    Tracking issue: ``docs/snowflake-handlers.md``.
+    """
+    raise NotImplementedError(
+        "scan_table ships in Phase 2. Run `goldencheck scan <export>` "
+        "out-of-band against a UNLOADed parquet for now."
+    )
+
+
+def health_score(relation_name: str) -> float:
+    """Stored Procedure: ``goldenmatch.goldencheck_health_score(...)``.
+
+    Phase 2 -- wraps ``DatasetProfile.health_score`` after profiling
+    the relation. Same Session requirement as ``scan_table``.
+    """
+    raise NotImplementedError(
+        "health_score ships in Phase 2."
+    )
+
+
+class DedupeFull:
+    """Stored Procedure handler: ``goldenmatch_dedupe_full``.
+
+    Phase 2 -- reads the input relation into a Polars frame via
+    Snowpark, calls ``goldenmatch.dedupe_df(df, config)``, writes
+    the golden output back as the procedure result table.
+
+    Tracking issue: ``docs/snowflake-handlers.md``.
+    """
+
+    def process(self, input_table: str, config_json: str):  # noqa: D401
+        raise NotImplementedError(
+            "DedupeFull ships in Phase 2 of the Snowflake handler module. "
+            "Today, run dedupe out-of-band: `pip install goldenmatch[snowflake]` "
+            "then `from goldenmatch import dedupe_df`."
+        )
+
+
+class DedupeClusters:
+    """Stored Procedure handler: ``goldenmatch_dedupe_clusters``.
+
+    Phase 2 -- emits ``(cluster_id, member_id, score)`` rows per
+    cluster member instead of one golden row per cluster.
+    """
+
+    def process(self, input_table: str, config_json: str):  # noqa: D401
+        raise NotImplementedError(
+            "DedupeClusters ships in Phase 2."
+        )
+
+
+class DedupePairs:
+    """Stored Procedure handler: ``goldenmatch_dedupe_pairs``.
+
+    Phase 2 -- emits the raw scored pairs above the configured
+    threshold, for downstream review queue or audit-trail use.
+    """
+
+    def process(self, input_table: str, config_json: str):  # noqa: D401
+        raise NotImplementedError(
+            "DedupePairs ships in Phase 2."
+        )
+
+
+__all__ = [
+    # Phase 1 (working).
+    "identity_resolve", "identity_view", "identity_history",
+    "identity_conflicts", "identity_list",
+    "normalize_email", "normalize_phone", "normalize_date",
+    "normalize_name_proper", "canonicalize_url", "canonicalize_address",
+    "strip", "whitespace_normalize",
+    # Phase 2 (scaffolded).
+    "correction_add", "scan_table", "health_score",
+    "DedupeFull", "DedupeClusters", "DedupePairs",
+]
+
+
+# A top-level shim so the CLI catalog's ``HANDLER = 'goldenmatch_udfs.<func>'``
+# resolves whether the wheel is installed as ``goldenmatch`` or unpacked
+# under that legacy module name from the IMPORTS stage. The setup script
+# adds a ``goldenmatch_udfs.py`` symlink/copy that re-exports these.

--- a/packages/python/goldenmatch/tests/snowflake/test_udfs.py
+++ b/packages/python/goldenmatch/tests/snowflake/test_udfs.py
@@ -1,0 +1,261 @@
+"""Unit tests for the Snowflake handler module.
+
+Phase 1 handlers (the 8 GoldenFlow transforms + 5 identity reads) are
+exercised against real upstream implementations -- no live Snowflake
+required because the handlers are pure Python and the IdentityStore
+runs against an on-disk SQLite file the test seeds.
+
+Phase 2 scaffolds (correction_add, scan_table, health_score,
+DedupeFull / Clusters / Pairs) are asserted to raise NotImplementedError
+with the documented "ships in Phase 2" message.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from goldenmatch.snowflake import udfs
+
+# ---------------------------------------------------------------------------
+# GoldenFlow transforms (8) -- pure-string handlers.
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_email_lowercases() -> None:
+    assert udfs.normalize_email("  Foo@BAR.com  ") == "foo@bar.com"
+
+
+def test_normalize_email_strips_plus_tag() -> None:
+    # email_normalize drops +tags on Gmail and elsewhere.
+    out = udfs.normalize_email("alice+spam@gmail.com")
+    assert out == "alice@gmail.com"
+
+
+def test_normalize_email_none_passthrough() -> None:
+    assert udfs.normalize_email(None) is None
+
+
+def test_normalize_phone_e164() -> None:
+    out = udfs.normalize_phone("+1 (415) 555-2671")
+    # phone_e164 returns E.164 when parseable.
+    assert out == "+14155552671"
+
+
+def test_normalize_phone_unparseable_passes_through() -> None:
+    # phone_e164 preserves the input when phonenumbers can't parse it --
+    # the handler just propagates that policy.
+    assert udfs.normalize_phone("not-a-phone") == "not-a-phone"
+
+
+def test_normalize_date_iso8601() -> None:
+    out = udfs.normalize_date("2023-04-15")
+    assert out == "2023-04-15"
+    out2 = udfs.normalize_date("04/15/2023")
+    assert out2 == "2023-04-15"
+
+
+def test_normalize_name_proper_titlecases() -> None:
+    out = udfs.normalize_name_proper("JOHN SMITH")
+    # name_proper returns title-cased form.
+    assert out is not None
+    assert out.lower() == "john smith"
+    assert out[0].isupper()
+
+
+def test_canonicalize_url_normalizes() -> None:
+    out = udfs.canonicalize_url("HTTPS://Example.COM/Foo/")
+    # url_normalize lowercases the scheme + host; path case preserved.
+    assert out is not None
+    assert out.startswith("https://example.com")
+
+
+def test_canonicalize_address_standardizes() -> None:
+    out = udfs.canonicalize_address("123 Main Street, Apt #4")
+    # address_standardize abbreviates Street -> St and normalizes #.
+    assert out is not None
+    # Some transformation happened.
+    assert out != "123 Main Street, Apt #4"
+
+
+def test_strip() -> None:
+    # Ruff B005 false-positives because the call shape matches
+    # ``str.strip(chars)`` even though udfs.strip is a UDF handler.
+    fn = udfs.strip
+    assert fn("  hello  ") == "hello"
+    assert fn("hello") == "hello"
+    assert fn("") == ""
+    assert fn(None) is None
+
+
+def test_whitespace_normalize() -> None:
+    assert udfs.whitespace_normalize("  a   b\tc\n d ") == "a b c d"
+    assert udfs.whitespace_normalize("hello") == "hello"
+    assert udfs.whitespace_normalize(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Identity reads (5) -- against a seeded SQLite IdentityStore.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def seeded_identity_db(tmp_path: Path) -> Path:
+    """Build an IdentityStore with one identity + record + history event
+    so the read UDFs have something to find."""
+    from goldenmatch.identity.model import (
+        EvidenceEdge,
+        IdentityEvent,
+        IdentityNode,
+        SourceRecord,
+    )
+    from goldenmatch.identity.store import IdentityStore, new_entity_id
+
+    db = tmp_path / "identity.db"
+    store = IdentityStore(backend="sqlite", path=str(db))
+    eid = new_entity_id()
+    store.upsert_identity(IdentityNode(
+        entity_id=eid, dataset="customers", status="active",
+        confidence=0.99, merged_into=None,
+    ))
+    store.upsert_record(SourceRecord(
+        record_id="salesforce:001",
+        source="salesforce",
+        source_pk="001",
+        record_hash="hash-1",
+        entity_id=eid,
+        payload={"name": "Alice Smith", "email": "alice@example.com"},
+        dataset="customers",
+    ))
+    store.add_edge(EvidenceEdge(
+        entity_id=eid,
+        record_a_id="salesforce:001",
+        record_b_id="hubspot:42",
+        kind="same_as",
+        score=0.91,
+        matchkey_name="email_exact",
+        run_name="test",
+    ))
+    store.emit_event(IdentityEvent(
+        entity_id=eid, kind="created", payload={"source": "test"},
+        run_name="test",
+    ))
+    store.close()
+    return db
+
+
+def test_identity_resolve_returns_view(seeded_identity_db: Path) -> None:
+    out = udfs.identity_resolve("salesforce:001", str(seeded_identity_db))
+    assert out is not None
+    assert out["dataset"] == "customers"
+    assert out["status"] == "active"
+    # The records list includes the seeded record.
+    record_ids = [r["record_id"] for r in out["records"]]
+    assert "salesforce:001" in record_ids
+
+
+def test_identity_resolve_unknown_returns_none(seeded_identity_db: Path) -> None:
+    out = udfs.identity_resolve("nope:nada", str(seeded_identity_db))
+    assert out is None
+
+
+def test_identity_view_round_trip(seeded_identity_db: Path) -> None:
+    # First resolve to get the entity_id.
+    resolved = udfs.identity_resolve("salesforce:001", str(seeded_identity_db))
+    assert resolved is not None
+    eid = resolved["entity_id"]
+    out = udfs.identity_view(eid, str(seeded_identity_db))
+    assert out is not None
+    assert out["entity_id"] == eid
+
+
+def test_identity_history_returns_events(seeded_identity_db: Path) -> None:
+    resolved = udfs.identity_resolve("salesforce:001", str(seeded_identity_db))
+    assert resolved is not None
+    eid = resolved["entity_id"]
+    events = udfs.identity_history(eid, str(seeded_identity_db))
+    kinds = [e["kind"] for e in events]
+    assert "created" in kinds
+
+
+def test_identity_conflicts_lists_edges(seeded_identity_db: Path) -> None:
+    # The seeded edge has kind="match" -- find_conflicts filters to
+    # `conflicts_with` edges, so it should return empty for this dataset.
+    out = udfs.identity_conflicts("customers", str(seeded_identity_db))
+    assert isinstance(out, list)
+
+
+def test_identity_list_returns_dataset(seeded_identity_db: Path) -> None:
+    out = udfs.identity_list("customers", "active", str(seeded_identity_db))
+    assert len(out) == 1
+    assert out[0]["dataset"] == "customers"
+    assert out[0]["status"] == "active"
+
+
+def test_identity_list_empty_filter_returns_all(seeded_identity_db: Path) -> None:
+    out = udfs.identity_list("", "", str(seeded_identity_db))
+    # Empty strings collapse to None filters; still returns the seeded row.
+    assert len(out) == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 scaffolds -- assert clean NotImplementedError, not silent failure.
+# ---------------------------------------------------------------------------
+
+
+def test_correction_add_phase_2_stub() -> None:
+    with pytest.raises(NotImplementedError, match="Phase 2"):
+        udfs.correction_add("approve", "customers", "", "{}")
+
+
+def test_scan_table_phase_2_stub() -> None:
+    with pytest.raises(NotImplementedError, match="Phase 2"):
+        udfs.scan_table("my_table", "")
+
+
+def test_health_score_phase_2_stub() -> None:
+    with pytest.raises(NotImplementedError, match="Phase 2"):
+        udfs.health_score("my_table")
+
+
+@pytest.mark.parametrize("klass", [
+    udfs.DedupeFull, udfs.DedupeClusters, udfs.DedupePairs,
+])
+def test_dedupe_classes_phase_2_stub(klass) -> None:
+    with pytest.raises(NotImplementedError, match="Phase 2"):
+        klass().process("my_table", "{}")
+
+
+# ---------------------------------------------------------------------------
+# IMPORTS-directory resolution.
+# ---------------------------------------------------------------------------
+
+
+def test_import_dir_picks_up_env_override(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GOLDENMATCH_UDF_IMPORTS", str(tmp_path))
+    assert udfs._import_dir() == tmp_path
+
+
+def test_resolve_db_path_relative_to_imports(tmp_path: Path,
+                                              monkeypatch) -> None:
+    monkeypatch.setenv("GOLDENMATCH_UDF_IMPORTS", str(tmp_path))
+    out = udfs._resolve_db_path("custom.db")
+    assert out == str(tmp_path / "custom.db")
+
+
+def test_resolve_db_path_absolute_passthrough(tmp_path: Path) -> None:
+    # Use a real absolute path so the test runs on both Windows and
+    # POSIX. ``Path("/var/...").is_absolute()`` is False on Windows.
+    abs_path = str(tmp_path / "identity.db")
+    assert udfs._resolve_db_path(abs_path) == abs_path
+
+
+def test_resolve_db_path_empty_falls_back_to_default(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    monkeypatch.setenv("GOLDENMATCH_UDF_IMPORTS", str(tmp_path))
+    out = udfs._resolve_db_path("")
+    assert out == str(tmp_path / "identity.db")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/packages/python/goldenmatch/tests/snowflake/test_udfs.py
+++ b/packages/python/goldenmatch/tests/snowflake/test_udfs.py
@@ -65,8 +65,13 @@ def test_normalize_name_proper_titlecases() -> None:
 def test_canonicalize_url_normalizes() -> None:
     out = udfs.canonicalize_url("HTTPS://Example.COM/Foo/")
     # url_normalize lowercases the scheme + host; path case preserved.
+    # CodeQL flags startswith("https://...") as an incomplete URL
+    # sanitization check (it's looking for URL allowlists, not test
+    # assertions) -- use ``split('/')`` to make the intent unambiguous.
     assert out is not None
-    assert out.startswith("https://example.com")
+    parts = out.split("/")
+    assert parts[0] == "https:"
+    assert parts[2] == "example.com"
 
 
 def test_canonicalize_address_standardizes() -> None:


### PR DESCRIPTION
## Summary

PR #553 shipped the *outside* of the Snowflake UDF surface (CREATE FUNCTION DDL, dbt macros, SPCS service spec). The `HANDLER` clauses pointed at `goldenmatch_udfs.<func>` which didn't exist anywhere. **This PR ships that module.**

13 handlers run as pure Snowpark Python UDFs today (Phase 1). The 6 table-reading operations that need a Snowpark Session ship as Phase 2 scaffolds with clear `NotImplementedError("... ships in Phase 2 ...")` messages.

Both the Snowpark Python UDF path and the SPCS service path call into the same handler module — single source of truth, no drift.

## Phase 1 (working)

### GoldenFlow transforms (8)

| Handler | Wraps |
|---|---|
| `normalize_email` | `goldenflow.transforms.email.email_normalize` |
| `normalize_phone` | `goldenflow.transforms.phone.phone_e164` |
| `normalize_date` | `goldenflow.transforms.dates.date_iso8601` |
| `normalize_name_proper` | `goldenflow.transforms.names.name_proper` |
| `canonicalize_url` | `goldenflow.transforms.url.url_normalize` |
| `canonicalize_address` | `goldenflow.transforms.address.address_standardize` |
| `strip` | `str.strip` |
| `whitespace_normalize` | `" ".join(s.split())` |

All accept `str | None`, return `str | None`. NULL propagates.

### Identity reads (5)

| Handler | Wraps |
|---|---|
| `identity_resolve` | `goldenmatch.identity.query.find_by_record` |
| `identity_view` | `goldenmatch.identity.query.get_entity` |
| `identity_history` | `goldenmatch.identity.query.history` |
| `identity_conflicts` | `goldenmatch.identity.query.find_conflicts` |
| `identity_list` | `goldenmatch.identity.query.list_entities` |

`db_path=""` falls back to `identity.db` at the Snowflake IMPORTS root (resolved via `sys._xoptions['snowflake_import_directory']` inside a UDF, or `GOLDENMATCH_UDF_IMPORTS` env var outside one).

## Phase 2 (scaffolded with NotImplementedError)

Operations that read or write Snowflake tables need a Snowpark `Session` — Stored Procedures only. Six scaffolds ship in this PR; the SP migration is a follow-up.

| Scaffold | Reason it's deferred |
|---|---|
| `correction_add` | MemoryStore needs Snowflake-native backend |
| `scan_table` / `health_score` | Need Session to read the relation into Polars |
| `DedupeFull` / `DedupeClusters` / `DedupePairs` | Need Session for both read + write |

Each raises `NotImplementedError("... Phase 2 ...")` with a workable remediation hint.

## SPCS server.py — TODO markers retired

PR #553's `# TODO(spcs):` stubs in `dbt-goldensuite/spcs/server.py` now delegate directly to `goldenmatch.snowflake.udfs.*`:

```python
from goldenmatch.snowflake import udfs as _gm

def _identity_resolve(record_id: str, db_path: str) -> Any:
    return _gm.identity_resolve(record_id, db_path or DEFAULT_IDENTITY_DB)

_FLOW_HANDLERS = {
    "normalize_email":       _gm.normalize_email,
    "normalize_phone":       _gm.normalize_phone,
    ...
}
```

Both the Snowpark Python UDF path (Snowflake calls into a Python module directly) and the SPCS path (Flask routes HTTP → handler module) use the same `goldenmatch.snowflake.udfs.*` source of truth.

## Tests

28 passing in `tests/snowflake/test_udfs.py`:

```
============================= 28 passed in 0.94s ==============================
```

- 8 transform handlers exercised against real goldenflow primitives.
- 5 identity reads against a seeded SQLite IdentityStore (in-process fixture, no Snowflake required).
- 6 Phase 2 scaffolds asserted to raise `NotImplementedError` with the "ships in Phase 2" message.
- 4 IMPORTS-directory resolution cases (env override, relative paths, absolute paths, empty fallback).

Ruff clean on all touched files.

## Docs

New `dbt-goldensuite/docs/snowflake-handlers.md`:
- Two-halves architecture (outside / inside)
- Per-handler upstream mapping
- `db_path` resolution rules + IMPORTS conventions
- Phase 2 design sketch (MemoryStore Snowflake backend, GoldenCheck `scan_relation`, dedupe SPs)

## Test plan

- [x] All 28 handler tests pass locally
- [x] Ruff clean
- [ ] SPCS server.py wiring exercised by an integration test (follow-up: requires the SPCS image build from PR #553's workflow + a live deployment)
- [ ] Snowpark Python UDF path exercised by `goldenmatch snowflake init --dry-run` showing the HANDLER clauses now point at a real module + `goldenmatch snowflake smoke-test` against a live account post-install

## Phase 2 follow-up

When the SP migration lands:

1. **MemoryStore Snowflake backend** alongside `sqlite`/`postgres`.
2. **`goldencheck.engine.scanner.scan_relation(session, name)`** — reads relation into Polars via Snowpark, profiles + scans.
3. **Dedupe SPs** — each output shape becomes `CALL goldenmatch.goldenmatch_dedupe_full('<in>', '<config>', '<out>')`. The dbt materialization switches from CTAS-from-UDTF to CALL+SELECT.

Tracking issue to file once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
