### PR TITLE
feat(mongo): Phase 1 MongoDB connector + IdentityStore backend

### DIFF
--- a/packages/python/goldenmatch/docs/mongo-setup.md
+++ b/packages/python/goldenmatch/docs/mongo-setup.md
@@ -1,0 +1,139 @@
+# MongoDB integration
+
+GoldenMatch ships two MongoDB-aware pieces in Phase 1:
+
+| Component | What it does |
+|---|---|
+| `goldenmatch.connectors.mongo.MongoConnector` | Read documents from a Mongo collection into a Polars DataFrame; write golden records back. |
+| `goldenmatch.identity.mongo_backend.MongoIdentityStore` | Persistent Identity Graph backed by Mongo collections instead of SQLite or Postgres. |
+
+Both depend on `pymongo`:
+
+```bash
+pip install goldenmatch[mongo]
+```
+
+For local development / CI tests, `mongomock` lets you exercise the surface without a real Mongo:
+
+```bash
+pip install goldenmatch[mongo,dev]
+```
+
+## Connector
+
+```python
+from goldenmatch.connectors import load_connector
+
+reader = load_connector("mongo", {"credentials_env": None})
+
+df = reader.read({
+    "connection": "mongodb://localhost:27017",
+    "database":   "crm",
+    "collection": "contacts",
+    "filter":     {"status": "active"},
+    "projection": {"name": 1, "email": 1, "address.city": 1},
+    "limit":      10_000,
+    "flatten":    True,   # nested fields become dot-paths
+}).collect()
+```
+
+`flatten=True` (default) turns `{"address": {"city": "Raleigh"}}` into a column named `address.city`. Set `flatten=False` if a downstream stage needs the nested structure.
+
+Write-back supports three modes:
+
+| Mode | Behavior |
+|---|---|
+| `append`  (default) | `insert_many` -- raw inserts. |
+| `upsert`            | One `update_one(upsert=True)` per row, keyed by `config["key"]`. |
+| `replace`           | `delete_many({})` + `insert_many`. |
+
+Internal pipeline columns (`__row_id__`, `__source__`) are stripped before write by default; set `drop_internal=False` to keep them.
+
+Connection sourcing falls back through:
+
+1. `config["connection"]` -- passed at call time
+2. `_credentials["key"]` -- if `credentials_env` is wired
+3. `MONGO_URI` env var
+
+## Identity Store
+
+For the Identity Graph, `MongoIdentityStore` ships a standalone class with the same surface that the SQL backends expose for reads + writes. It's a sibling of `IdentityStore(backend="sqlite")` / `IdentityStore(backend="postgres")`, not a `backend=` branch on the existing class -- that unification is Phase 2 follow-up.
+
+```python
+from goldenmatch.identity.mongo_backend import MongoIdentityStore
+from goldenmatch.identity.model import IdentityNode, SourceRecord
+from goldenmatch.identity.store import new_entity_id
+
+store = MongoIdentityStore(
+    connection="mongodb://localhost:27017",
+    database="goldenmatch",
+)
+
+eid = new_entity_id()
+store.upsert_identity(IdentityNode(
+    entity_id=eid, dataset="customers", status="active", confidence=0.99,
+))
+store.upsert_record(SourceRecord(
+    record_id="salesforce:001",
+    source="salesforce", source_pk="001", record_hash="h1",
+    entity_id=eid, payload={"name": "Alice"}, dataset="customers",
+))
+store.close()
+```
+
+Use it as a context manager to auto-close the client:
+
+```python
+with MongoIdentityStore(connection="mongodb://...", database="gm") as store:
+    ...
+```
+
+### Schema
+
+One collection per logical table from the SQL backends, with the same indexes:
+
+| Collection | Purpose | Key indexes |
+|---|---|---|
+| `identity_nodes` | One doc per entity | `entity_id` (unique), `dataset`, `status` |
+| `source_records` | One doc per source record observed | `record_id` (unique), `entity_id`, `source`, `record_hash` |
+| `evidence_edges` | Match-evidence between records | Compound unique on `(entity_id, record_a_id, record_b_id, kind, run_name)` |
+| `identity_events` | Append-only event log | `entity_id`, `kind`, `run_name` |
+| `identity_aliases` | External-id ↔ entity_id mapping | Compound unique on `(alias, kind, dataset)` |
+
+Indexes are created idempotently on every store open -- no separate migration runner needed for Phase 1.
+
+### Methods (Phase 1)
+
+| Group | Methods |
+|---|---|
+| Lifecycle | `close`, `__enter__`/`__exit__` |
+| Identity nodes | `upsert_identity`, `get_identity` (alias `get_node`), `list_identities`, `count_identities`, `retire_identity` |
+| Source records | `upsert_record`, `get_record`, `get_records_for_entity`, `find_entity_by_record`, `lookup_entity_ids` |
+| Evidence edges | `add_edge`, `edges_for_entity`, `find_conflicts` |
+| Events | `emit_event`, `history`, `has_run_event` |
+| Aliases | `add_alias`, `resolve_alias` |
+
+Methods NOT in Phase 1 (and so not available through `MongoIdentityStore` yet):
+
+- `bulk_*` writers (Postgres-only fast-path; the SQL backend uses COPY).
+- `IdentityStore(backend="mongo")` dispatch -- you instantiate `MongoIdentityStore` directly.
+- The Alembic migration trail (`goldenmatch identity migrate`) targets the Postgres schema; Mongo's index-create-on-open is the equivalent.
+
+These land in Phase 2 alongside a Protocol-based dispatch refactor that lets the existing `IdentityStore` route `backend="mongo"` through `MongoIdentityStore` transparently.
+
+## Why MongoDB?
+
+The Snowflake adapter (PR #553) made sense because Snowflake gave goldenmatch a uniquely deep integration surface: Cortex embeddings + SPCS + dbt + Snowpark UDFs. Mongo doesn't have an analog to any of those.
+
+What Mongo *does* fit naturally:
+
+- **Identity Graph as a document store.** UUIDv7 entity_ids, nested payloads, fast point lookups, append-only event collections -- Mongo's strengths line up cleanly with the Identity Graph schema.
+- **Source-data connector.** Many CRM / e-commerce / IoT workloads land in Mongo. Reading them into the Polars-based ER pipeline is a real workflow today.
+
+What ships in Phase 1 (this PR) is precisely those two pieces. Phase 2 candidates (not in this PR):
+
+- Atlas Vector Search as an ANN blocker via `goldenmatch.db.ann_index`.
+- `IdentityStore(backend="mongo")` dispatch (Protocol refactor in `goldenmatch.identity.store`).
+- Mongo-as-MemoryStore-backend for Learning Memory writes.
+
+None of those have a built-in Mongo audience the way Snowpark / Cortex did for Snowflake, so they're flagged for follow-up rather than rolled into Phase 1.

--- a/packages/python/goldenmatch/goldenmatch/connectors/base.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/base.py
@@ -87,6 +87,8 @@ def load_connector(connector_name: str, config: dict) -> BaseConnector:
         "bigquery": "goldenmatch.connectors.bigquery:BigQueryConnector",
         "hubspot": "goldenmatch.connectors.hubspot:HubSpotConnector",
         "salesforce": "goldenmatch.connectors.salesforce:SalesforceConnector",
+        "mongo": "goldenmatch.connectors.mongo:MongoConnector",
+        "mongodb": "goldenmatch.connectors.mongo:MongoConnector",
     }
 
     if connector_name not in _BUILTIN:

--- a/packages/python/goldenmatch/goldenmatch/connectors/mongo.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/mongo.py
@@ -1,0 +1,225 @@
+"""MongoDB connector for GoldenMatch.
+
+Reads documents from a Mongo collection into a Polars DataFrame and
+writes golden records back. Nested fields are flattened on read via
+projection + dot-path expansion, mirroring the shape goldenmatch's
+matchkeys expect (one column per leaf field).
+
+Requires: ``pip install goldenmatch[mongo]`` (pulls ``pymongo``).
+
+## Connection sourcing
+
+The connector reads connection settings from three layers, in order
+of precedence:
+
+1. ``config['connection']`` -- explicit mongo URI passed at call time
+2. ``self._credentials['key']`` -- env-var value if the consumer set
+   ``credentials_env`` on the connector config
+3. ``MONGO_URI`` env var -- the package-wide default
+
+Database + collection are read from ``config`` on every call:
+
+  - ``database``   -- target database name (required)
+  - ``collection`` -- target collection name (required)
+
+## Reading
+
+``config['filter']``      -- Mongo query filter (default ``{}``)
+``config['projection']``  -- field projection (default all)
+``config['limit']``       -- optional row cap
+``config['flatten']``     -- dot-flatten nested fields (default True);
+                             ``{'a': {'b': 1}}`` -> column ``a.b``.
+
+## Writing
+
+``config['mode']`` is one of:
+
+  - ``"append"`` (default)   -- ``insert_many``
+  - ``"upsert"``             -- ``update_one(... upsert=True)`` per row,
+                                keyed by ``config['key']`` (a column
+                                name in the DataFrame)
+  - ``"replace"``             -- drop the collection, then insert
+
+Polars columns become document fields. ``__cluster_id__`` and other
+internal columns are passed through; downstream code can drop them
+before write via the ``drop`` kwarg.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import polars as pl
+
+from goldenmatch.connectors.base import BaseConnector, ConnectorError
+
+logger = logging.getLogger(__name__)
+
+
+_INTERNAL_COLUMNS = {"__row_id__", "__source__"}
+
+
+def _flatten_doc(doc: dict, prefix: str = "") -> dict:
+    """Flatten a nested Mongo document into a one-level dict.
+
+    ``{"name": "Alice", "address": {"city": "Raleigh"}}`` becomes
+    ``{"name": "Alice", "address.city": "Raleigh"}``.
+
+    Lists are NOT flattened element-wise (they stay as lists in the
+    DataFrame). Mongo's ``_id`` is preserved as-is.
+    """
+    out: dict[str, Any] = {}
+    for k, v in doc.items():
+        key = f"{prefix}{k}" if prefix == "" else f"{prefix}.{k}"
+        if isinstance(v, dict) and not _looks_like_objectid(v):
+            out.update(_flatten_doc(v, key))
+        else:
+            out[key] = v
+    return out
+
+
+def _looks_like_objectid(obj: Any) -> bool:
+    """Heuristic: BSON ObjectId surfaces as a class with ``binary`` +
+    ``generation_time`` attrs. Treat it as a leaf value, not a nested
+    document."""
+    return type(obj).__name__ in {"ObjectId", "Binary"}
+
+
+def _drop_internal(df: pl.DataFrame) -> pl.DataFrame:
+    cols = [c for c in df.columns if c not in _INTERNAL_COLUMNS]
+    return df.select(cols)
+
+
+class MongoConnector(BaseConnector):
+    """Read/write documents from MongoDB.
+
+    The Mongo storage model is document-oriented; goldenmatch's
+    matchkey pipeline is column-oriented. This connector bridges
+    the two by projecting + flattening nested fields on read.
+    """
+
+    name = "mongo"
+
+    def _connect(self, config: dict):
+        try:
+            import pymongo  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ConnectorError(
+                "Mongo connector requires pymongo. "
+                "Install with: pip install goldenmatch[mongo]"
+            ) from exc
+
+        uri = (
+            config.get("connection")
+            or self._credentials.get("key")
+            or os.environ.get("MONGO_URI")
+        )
+        if not uri:
+            raise ConnectorError(
+                "Mongo connector needs a connection URI. Pass it as "
+                "config['connection'], set MONGO_URI, or wire "
+                "credentials_env."
+            )
+        return pymongo.MongoClient(uri)
+
+    def _collection(self, client, config: dict):
+        db_name = config.get("database")
+        col_name = config.get("collection")
+        if not db_name:
+            raise ConnectorError("Mongo connector requires 'database'.")
+        if not col_name:
+            raise ConnectorError("Mongo connector requires 'collection'.")
+        return client[db_name][col_name]
+
+    def read(self, config: dict) -> pl.LazyFrame:
+        client = self._connect(config)
+        try:
+            collection = self._collection(client, config)
+            filter_ = config.get("filter") or {}
+            projection = config.get("projection")
+            limit = config.get("limit")
+            flatten = config.get("flatten", True)
+
+            cursor = collection.find(filter_, projection=projection)
+            if limit is not None:
+                cursor = cursor.limit(int(limit))
+
+            rows: list[dict[str, Any]] = []
+            for doc in cursor:
+                # ObjectId -> str so Polars can hold it as Utf8.
+                if "_id" in doc:
+                    doc["_id"] = str(doc["_id"])
+                if flatten:
+                    rows.append(_flatten_doc(doc))
+                else:
+                    rows.append(doc)
+
+            if not rows:
+                logger.info("Mongo: read 0 rows from %s.%s",
+                            config["database"], config["collection"])
+                return pl.DataFrame().lazy()
+
+            # Build the DataFrame from row dicts. Polars handles
+            # heterogeneous rows by null-filling missing keys.
+            df = pl.DataFrame(rows, infer_schema_length=min(1000, len(rows)))
+            logger.info(
+                "Mongo: read %d rows (%d columns) from %s.%s",
+                df.height, df.width, config["database"], config["collection"],
+            )
+            return df.lazy()
+        finally:
+            client.close()
+
+    def write(self, df: pl.DataFrame, config: dict) -> None:
+        if df.height == 0:
+            logger.info("Mongo: write skipped on empty DataFrame.")
+            return
+
+        mode = config.get("mode", "append")
+        if mode not in ("append", "upsert", "replace"):
+            raise ConnectorError(
+                f"Mongo connector: unknown mode {mode!r}. "
+                "Choose one of: append, upsert, replace."
+            )
+
+        client = self._connect(config)
+        try:
+            collection = self._collection(client, config)
+            df_out = _drop_internal(df) if config.get("drop_internal", True) else df
+            docs = df_out.to_dicts()
+
+            if mode == "replace":
+                collection.delete_many({})
+                if docs:
+                    collection.insert_many(docs)
+            elif mode == "upsert":
+                key = config.get("key")
+                if not key:
+                    raise ConnectorError(
+                        "Mongo upsert requires config['key'] -- the column "
+                        "name to use as the document filter."
+                    )
+                for doc in docs:
+                    if key not in doc:
+                        raise ConnectorError(
+                            f"Upsert key {key!r} missing from a row; "
+                            "every row must carry the key."
+                        )
+                    filter_ = {key: doc[key]}
+                    # Don't try to mutate the key field; Mongo rejects
+                    # updates that touch the query field on upsert.
+                    update = {"$set": {k: v for k, v in doc.items() if k != key}}
+                    collection.update_one(filter_, update, upsert=True)
+            else:  # append
+                collection.insert_many(docs)
+
+            logger.info(
+                "Mongo: wrote %d rows to %s.%s (mode=%s)",
+                df.height, config["database"], config["collection"], mode,
+            )
+        finally:
+            client.close()
+
+
+__all__ = ["MongoConnector"]

--- a/packages/python/goldenmatch/goldenmatch/identity/mongo_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/mongo_backend.py
@@ -1,0 +1,463 @@
+"""MongoDB-backed Identity Store.
+
+Phase 1: a standalone ``MongoIdentityStore`` class with the same public
+surface as the read/write side of ``IdentityStore`` for the methods the
+core pipeline + REST + MCP surfaces actually use.
+
+Why standalone instead of an ``IdentityStore(backend="mongo")``
+branch: the existing SQLite + Postgres backends are deeply inlined in
+``store.py`` (~600 lines of SQL strings and per-method branches).
+Squeezing Mongo into that pattern would either duplicate every method
+or require a big refactor. Standalone here keeps the change scoped;
+unifying through ``IdentityStore`` is a Phase 2 follow-up that can
+land via a Protocol-based dispatch without disturbing existing
+callers.
+
+Surface implemented in Phase 1:
+
+  - Identity nodes: ``upsert_identity``, ``get_identity``,
+    ``list_identities``, ``count_identities``, ``retire_identity``
+  - Source records: ``upsert_record``, ``get_record``,
+    ``get_records_for_entity``, ``find_entity_by_record``,
+    ``lookup_entity_ids``
+  - Evidence edges: ``add_edge``, ``edges_for_entity``,
+    ``find_conflicts``
+  - Events: ``emit_event``, ``history``, ``has_run_event``
+  - Aliases: ``add_alias``, ``resolve_alias``
+  - Lifecycle: ``close``, ``__enter__`` / ``__exit__``
+
+Schema -- one collection per logical table from the SQL backends:
+
+  - ``identity_nodes``  (entity_id PRIMARY)
+  - ``source_records``  (record_id PRIMARY)
+  - ``evidence_edges``  (entity_id + record_a_id + record_b_id +
+                          kind + run_name UNIQUE compound)
+  - ``identity_events`` (event_id auto, entity_id indexed)
+  - ``identity_aliases`` (alias + kind + dataset PRIMARY compound)
+
+Indexes mirror the Postgres definitions byte-for-byte. The unique
+indexes are CREATEd with ``unique=True`` so duplicate ``upsert_*``
+calls collapse to the single-document update path.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any
+
+from goldenmatch.identity.model import (
+    EvidenceEdge,
+    IdentityAlias,
+    IdentityEvent,
+    IdentityNode,
+    SourceRecord,
+)
+
+log = logging.getLogger(__name__)
+
+
+# Collection names mirror the SQL table names.
+_NODES = "identity_nodes"
+_RECORDS = "source_records"
+_EDGES = "evidence_edges"
+_EVENTS = "identity_events"
+_ALIASES = "identity_aliases"
+
+
+class MongoIdentityStore:
+    """Identity Store backed by MongoDB.
+
+    Typically constructed with a MongoDB URI:
+
+        store = MongoIdentityStore(
+            connection="mongodb://localhost:27017",
+            database="goldenmatch",
+        )
+
+    Or with an existing ``pymongo.MongoClient``:
+
+        client = pymongo.MongoClient(...)
+        store = MongoIdentityStore(client=client, database="gm")
+    """
+
+    def __init__(
+        self,
+        connection: str | None = None,
+        database: str = "goldenmatch",
+        *,
+        client: Any = None,
+    ) -> None:
+        if client is None:
+            uri = connection or os.environ.get("MONGO_URI")
+            if not uri:
+                raise ValueError(
+                    "MongoIdentityStore needs a connection URI; pass "
+                    "connection=, set MONGO_URI, or pass client="
+                )
+            try:
+                import pymongo  # type: ignore[import-not-found]
+            except ImportError as exc:
+                raise ImportError(
+                    "MongoIdentityStore requires pymongo: "
+                    "pip install goldenmatch[mongo]"
+                ) from exc
+            client = pymongo.MongoClient(uri)
+            self._owns_client = True
+        else:
+            self._owns_client = False
+        self._client = client
+        self._db = client[database]
+        self._init_indexes()
+
+    # ----- lifecycle ---------------------------------------------------
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> MongoIdentityStore:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    # ----- one-time index setup ---------------------------------------
+
+    def _init_indexes(self) -> None:
+        """Create the indexes that mirror the SQL DDL on first connect.
+
+        ``create_index`` is idempotent; running this on every store
+        open keeps the surface in lockstep with the schema without a
+        separate migration runner.
+        """
+        # identity_nodes
+        self._db[_NODES].create_index("entity_id", unique=True)
+        self._db[_NODES].create_index("dataset")
+        self._db[_NODES].create_index("status")
+        # source_records
+        self._db[_RECORDS].create_index("record_id", unique=True)
+        self._db[_RECORDS].create_index("entity_id")
+        self._db[_RECORDS].create_index("source")
+        self._db[_RECORDS].create_index("record_hash")
+        # evidence_edges
+        self._db[_EDGES].create_index(
+            [
+                ("entity_id", 1),
+                ("record_a_id", 1),
+                ("record_b_id", 1),
+                ("kind", 1),
+                ("run_name", 1),
+            ],
+            unique=True,
+            name="edges_unique",
+        )
+        self._db[_EDGES].create_index("entity_id")
+        self._db[_EDGES].create_index([("record_a_id", 1), ("record_b_id", 1)])
+        self._db[_EDGES].create_index("run_name")
+        # identity_events
+        self._db[_EVENTS].create_index("entity_id")
+        self._db[_EVENTS].create_index("kind")
+        self._db[_EVENTS].create_index("run_name")
+        # identity_aliases
+        self._db[_ALIASES].create_index(
+            [("alias", 1), ("kind", 1), ("dataset", 1)],
+            unique=True,
+            name="aliases_unique",
+        )
+        self._db[_ALIASES].create_index("entity_id")
+
+    # ----- identity nodes ---------------------------------------------
+
+    def upsert_identity(self, node: IdentityNode) -> None:
+        doc = {
+            "entity_id": node.entity_id,
+            "status": node.status,
+            "merged_into": node.merged_into,
+            "golden_record": node.golden_record,
+            "confidence": node.confidence,
+            "dataset": node.dataset,
+            "updated_at": datetime.now(),
+        }
+        self._db[_NODES].update_one(
+            {"entity_id": node.entity_id},
+            {
+                "$set": doc,
+                "$setOnInsert": {"created_at": node.created_at},
+            },
+            upsert=True,
+        )
+
+    def get_identity(self, entity_id: str) -> IdentityNode | None:
+        d = self._db[_NODES].find_one({"entity_id": entity_id})
+        return _to_node(d) if d else None
+
+    # Alias used by the query layer.
+    def get_node(self, entity_id: str) -> IdentityNode | None:
+        return self.get_identity(entity_id)
+
+    def list_identities(
+        self,
+        dataset: str | None = None,
+        status: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[IdentityNode]:
+        q: dict[str, Any] = {}
+        if dataset is not None:
+            q["dataset"] = dataset
+        if status is not None:
+            q["status"] = status
+        cur = self._db[_NODES].find(q).sort("updated_at", -1).skip(offset).limit(limit)
+        return [_to_node(d) for d in cur]
+
+    def count_identities(self, dataset: str | None = None) -> int:
+        q: dict[str, Any] = {}
+        if dataset is not None:
+            q["dataset"] = dataset
+        return self._db[_NODES].count_documents(q)
+
+    def retire_identity(
+        self,
+        entity_id: str,
+        merged_into: str | None = None,
+        status: str = "retired",
+    ) -> None:
+        self._db[_NODES].update_one(
+            {"entity_id": entity_id},
+            {
+                "$set": {
+                    "status": status,
+                    "merged_into": merged_into,
+                    "updated_at": datetime.now(),
+                },
+            },
+        )
+
+    # ----- source records ---------------------------------------------
+
+    def upsert_record(self, rec: SourceRecord) -> None:
+        self._db[_RECORDS].update_one(
+            {"record_id": rec.record_id},
+            {
+                "$set": {
+                    "source": rec.source,
+                    "source_pk": rec.source_pk,
+                    "record_hash": rec.record_hash,
+                    "entity_id": rec.entity_id,
+                    "payload": rec.payload,
+                    "dataset": rec.dataset,
+                    "last_seen_at": datetime.now(),
+                },
+                "$setOnInsert": {"first_seen_at": rec.first_seen_at},
+            },
+            upsert=True,
+        )
+
+    def get_record(self, record_id: str) -> SourceRecord | None:
+        d = self._db[_RECORDS].find_one({"record_id": record_id})
+        return _to_record(d) if d else None
+
+    def get_records_for_entity(self, entity_id: str) -> list[SourceRecord]:
+        cur = self._db[_RECORDS].find({"entity_id": entity_id})
+        return [_to_record(d) for d in cur]
+
+    def find_entity_by_record(self, record_id: str) -> str | None:
+        d = self._db[_RECORDS].find_one(
+            {"record_id": record_id}, {"entity_id": 1},
+        )
+        return d.get("entity_id") if d else None
+
+    def lookup_entity_ids(self, record_ids: Iterable[str]) -> dict[str, str]:
+        ids = list(record_ids)
+        if not ids:
+            return {}
+        cur = self._db[_RECORDS].find(
+            {"record_id": {"$in": ids}},
+            {"record_id": 1, "entity_id": 1},
+        )
+        return {d["record_id"]: d["entity_id"] for d in cur if d.get("entity_id")}
+
+    # ----- evidence edges ---------------------------------------------
+
+    def add_edge(self, edge: EvidenceEdge) -> int | None:
+        """Insert an evidence edge. Mongo's upsert returns the
+        post-update doc's ``_id`` -- we surface it as the edge_id so
+        the SQL signature stays compatible. Replay-safe via the
+        compound unique index."""
+        doc = {
+            "entity_id": edge.entity_id,
+            "record_a_id": edge.record_a_id,
+            "record_b_id": edge.record_b_id,
+            "kind": edge.kind,
+            "score": edge.score,
+            "matchkey_name": edge.matchkey_name,
+            "field_scores": edge.field_scores,
+            "negative_evidence": edge.negative_evidence,
+            "controller_snapshot": edge.controller_snapshot,
+            "run_name": edge.run_name,
+            "dataset": edge.dataset,
+            "recorded_at": edge.recorded_at,
+        }
+        result = self._db[_EDGES].update_one(
+            {
+                "entity_id": edge.entity_id,
+                "record_a_id": edge.record_a_id,
+                "record_b_id": edge.record_b_id,
+                "kind": edge.kind,
+                "run_name": edge.run_name,
+            },
+            {"$setOnInsert": doc},
+            upsert=True,
+        )
+        # upserted_id is the BSON ObjectId on insert, None on hit.
+        return _objectid_to_int(result.upserted_id) if result.upserted_id else None
+
+    def edges_for_entity(self, entity_id: str) -> list[EvidenceEdge]:
+        cur = self._db[_EDGES].find({"entity_id": entity_id}).sort("recorded_at", -1)
+        return [_to_edge(d) for d in cur]
+
+    def find_conflicts(self, dataset: str | None = None) -> list[EvidenceEdge]:
+        q: dict[str, Any] = {"kind": "conflicts_with"}
+        if dataset is not None:
+            q["dataset"] = dataset
+        cur = self._db[_EDGES].find(q).sort("recorded_at", -1)
+        return [_to_edge(d) for d in cur]
+
+    # ----- events ------------------------------------------------------
+
+    def emit_event(self, event: IdentityEvent) -> int | None:
+        doc = {
+            "entity_id": event.entity_id,
+            "kind": event.kind,
+            "payload": event.payload,
+            "run_name": event.run_name,
+            "dataset": event.dataset,
+            "recorded_at": event.recorded_at,
+        }
+        result = self._db[_EVENTS].insert_one(doc)
+        return _objectid_to_int(result.inserted_id)
+
+    def history(
+        self, entity_id: str, limit: int | None = None,
+    ) -> list[IdentityEvent]:
+        cur = self._db[_EVENTS].find({"entity_id": entity_id}).sort(
+            "recorded_at", 1,
+        )
+        if limit is not None:
+            cur = cur.limit(int(limit))
+        return [_to_event(d) for d in cur]
+
+    def has_run_event(self, entity_id: str, run_name: str, kind: str) -> bool:
+        return self._db[_EVENTS].count_documents(
+            {"entity_id": entity_id, "run_name": run_name, "kind": kind},
+            limit=1,
+        ) > 0
+
+    # ----- aliases -----------------------------------------------------
+
+    def add_alias(self, alias: IdentityAlias) -> None:
+        self._db[_ALIASES].update_one(
+            {
+                "alias": alias.alias,
+                "kind": alias.kind,
+                "dataset": alias.dataset,
+            },
+            {
+                "$set": {
+                    "entity_id": alias.entity_id,
+                    "recorded_at": alias.recorded_at,
+                },
+            },
+            upsert=True,
+        )
+
+    def resolve_alias(
+        self, alias: str, kind: str = "external_id",
+    ) -> str | None:
+        d = self._db[_ALIASES].find_one(
+            {"alias": alias, "kind": kind}, {"entity_id": 1},
+        )
+        return d.get("entity_id") if d else None
+
+
+# ---------------------------------------------------------------------------
+# Doc <-> model conversion helpers.
+# ---------------------------------------------------------------------------
+
+
+def _to_node(d: dict[str, Any]) -> IdentityNode:
+    return IdentityNode(
+        entity_id=d["entity_id"],
+        status=d.get("status", "active"),
+        merged_into=d.get("merged_into"),
+        golden_record=d.get("golden_record"),
+        confidence=d.get("confidence"),
+        dataset=d.get("dataset"),
+        created_at=d.get("created_at") or datetime.now(),
+        updated_at=d.get("updated_at") or datetime.now(),
+    )
+
+
+def _to_record(d: dict[str, Any]) -> SourceRecord:
+    return SourceRecord(
+        record_id=d["record_id"],
+        source=d["source"],
+        source_pk=d["source_pk"],
+        record_hash=d["record_hash"],
+        entity_id=d.get("entity_id"),
+        payload=d.get("payload"),
+        dataset=d.get("dataset"),
+        first_seen_at=d.get("first_seen_at") or datetime.now(),
+        last_seen_at=d.get("last_seen_at") or datetime.now(),
+    )
+
+
+def _to_edge(d: dict[str, Any]) -> EvidenceEdge:
+    return EvidenceEdge(
+        entity_id=d["entity_id"],
+        record_a_id=d["record_a_id"],
+        record_b_id=d["record_b_id"],
+        kind=d.get("kind", "same_as"),
+        score=d.get("score"),
+        matchkey_name=d.get("matchkey_name"),
+        field_scores=d.get("field_scores"),
+        negative_evidence=d.get("negative_evidence"),
+        controller_snapshot=d.get("controller_snapshot"),
+        run_name=d.get("run_name"),
+        dataset=d.get("dataset"),
+        recorded_at=d.get("recorded_at") or datetime.now(),
+        edge_id=_objectid_to_int(d.get("_id")) if d.get("_id") else None,
+    )
+
+
+def _to_event(d: dict[str, Any]) -> IdentityEvent:
+    return IdentityEvent(
+        entity_id=d["entity_id"],
+        kind=d["kind"],
+        payload=d.get("payload"),
+        run_name=d.get("run_name"),
+        dataset=d.get("dataset"),
+        recorded_at=d.get("recorded_at") or datetime.now(),
+        event_id=_objectid_to_int(d.get("_id")) if d.get("_id") else None,
+    )
+
+
+def _objectid_to_int(oid: Any) -> int:
+    """The SQL backends return ``int`` ids; Mongo's ObjectId is
+    12 bytes. Pack into an ``int`` so existing callers see the same
+    shape. Comparisons stay stable as long as the ObjectId is the
+    source of truth."""
+    if oid is None:
+        return 0
+    if isinstance(oid, int):
+        return oid
+    s = str(oid)
+    try:
+        return int(s, 16)
+    except ValueError:
+        return hash(s) & 0x7FFFFFFFFFFFFFFF
+
+
+__all__ = ["MongoIdentityStore"]

--- a/packages/python/goldenmatch/tests/mongo/test_connector.py
+++ b/packages/python/goldenmatch/tests/mongo/test_connector.py
@@ -1,0 +1,232 @@
+"""Tests for the MongoDB connector.
+
+Uses ``mongomock`` so no live MongoDB instance is required. The
+connector takes a ``pymongo``-shaped client at runtime, and
+mongomock is API-compatible enough to exercise every method.
+"""
+from __future__ import annotations
+
+import pytest
+
+# Skip the whole module if mongomock isn't installed. CI installs it
+# via the `mongo` test extra; local dev pulls it with
+# `pip install goldenmatch[mongo,dev]`.
+mongomock = pytest.importorskip("mongomock")
+
+
+def _stub_pymongo_module(monkeypatch, client_factory):
+    """Make ``import pymongo`` return a module whose
+    ``MongoClient(uri)`` returns the supplied client."""
+    import sys
+    import types
+
+    fake = types.ModuleType("pymongo")
+    fake.MongoClient = client_factory  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pymongo", fake)
+
+
+@pytest.fixture
+def mongo_connector(monkeypatch):
+    """A MongoConnector wired up to a single mongomock client.
+
+    Yields (connector, client) so tests can seed + inspect docs.
+    """
+    client = mongomock.MongoClient()
+    _stub_pymongo_module(monkeypatch, lambda uri: client)
+
+    from goldenmatch.connectors.mongo import MongoConnector
+    connector = MongoConnector(
+        {"credentials_env": None},
+    )
+    yield connector, client
+
+
+def test_read_flattens_nested(mongo_connector):
+    connector, client = mongo_connector
+    client["gm"]["customers"].insert_many([
+        {"_id": "1", "name": "Alice", "address": {"city": "Raleigh"}},
+        {"_id": "2", "name": "Bob",   "address": {"city": "Durham"}},
+    ])
+
+    lf = connector.read({
+        "connection": "mongodb://fake",
+        "database": "gm",
+        "collection": "customers",
+    })
+    df = lf.collect()
+    assert df.height == 2
+    cols = set(df.columns)
+    # _id, name, address.city -- nested field flattened.
+    assert {"_id", "name", "address.city"} <= cols
+
+
+def test_read_unflattened_preserves_nested(mongo_connector):
+    connector, client = mongo_connector
+    client["gm"]["customers"].insert_one(
+        {"_id": "1", "address": {"city": "Raleigh"}},
+    )
+    lf = connector.read({
+        "connection": "mongodb://fake",
+        "database": "gm",
+        "collection": "customers",
+        "flatten": False,
+    })
+    df = lf.collect()
+    assert "address" in df.columns
+    assert "address.city" not in df.columns
+
+
+def test_read_filter_and_limit(mongo_connector):
+    connector, client = mongo_connector
+    client["gm"]["customers"].insert_many([
+        {"_id": str(i), "name": f"P{i}", "score": i} for i in range(10)
+    ])
+    lf = connector.read({
+        "connection": "mongodb://fake",
+        "database": "gm",
+        "collection": "customers",
+        "filter": {"score": {"$gte": 5}},
+        "limit": 2,
+    })
+    df = lf.collect()
+    assert df.height == 2
+
+
+def test_read_empty_returns_empty_frame(mongo_connector):
+    connector, client = mongo_connector
+    lf = connector.read({
+        "connection": "mongodb://fake",
+        "database": "gm",
+        "collection": "missing",
+    })
+    df = lf.collect()
+    assert df.height == 0
+
+
+def test_read_missing_database_errors(mongo_connector):
+    from goldenmatch.connectors.base import ConnectorError
+
+    connector, _ = mongo_connector
+    with pytest.raises(ConnectorError, match="'database'"):
+        connector.read({"connection": "mongodb://fake", "collection": "x"})
+
+
+def test_write_append_inserts(mongo_connector):
+    import polars as pl
+
+    connector, client = mongo_connector
+    df = pl.DataFrame({"name": ["Alice", "Bob"], "city": ["R", "D"]})
+    connector.write(df, {
+        "connection": "mongodb://fake",
+        "database": "gm",
+        "collection": "customers",
+    })
+
+    docs = list(client["gm"]["customers"].find())
+    assert len(docs) == 2
+    names = {d["name"] for d in docs}
+    assert names == {"Alice", "Bob"}
+
+
+def test_write_replace_clears_first(mongo_connector):
+    import polars as pl
+
+    connector, client = mongo_connector
+    client["gm"]["customers"].insert_many([{"old": True}])
+
+    df = pl.DataFrame({"name": ["Carol"]})
+    connector.write(df, {
+        "connection": "mongodb://fake",
+        "database": "gm",
+        "collection": "customers",
+        "mode": "replace",
+    })
+
+    docs = list(client["gm"]["customers"].find())
+    assert len(docs) == 1
+    assert docs[0]["name"] == "Carol"
+
+
+def test_write_upsert_keys_on_field(mongo_connector):
+    import polars as pl
+
+    connector, client = mongo_connector
+    client["gm"]["customers"].insert_one(
+        {"id": "u1", "name": "Old", "city": "R"},
+    )
+
+    df = pl.DataFrame({"id": ["u1", "u2"], "name": ["New", "Bob"]})
+    connector.write(df, {
+        "connection": "mongodb://fake",
+        "database": "gm",
+        "collection": "customers",
+        "mode": "upsert",
+        "key": "id",
+    })
+
+    docs = {d["id"]: d for d in client["gm"]["customers"].find()}
+    # u1 updated in place; u2 inserted.
+    assert docs["u1"]["name"] == "New"
+    assert docs["u2"]["name"] == "Bob"
+
+
+def test_write_strips_internal_columns_by_default(mongo_connector):
+    import polars as pl
+
+    connector, client = mongo_connector
+    df = pl.DataFrame({
+        "name": ["Alice"], "__row_id__": [0], "__source__": ["test"],
+    })
+    connector.write(df, {
+        "connection": "mongodb://fake",
+        "database": "gm",
+        "collection": "customers",
+    })
+    doc = client["gm"]["customers"].find_one()
+    assert "__row_id__" not in doc
+    assert "__source__" not in doc
+    assert doc["name"] == "Alice"
+
+
+def test_write_upsert_requires_key(mongo_connector):
+    import polars as pl
+    from goldenmatch.connectors.base import ConnectorError
+
+    connector, _ = mongo_connector
+    df = pl.DataFrame({"name": ["x"]})
+    with pytest.raises(ConnectorError, match="upsert requires"):
+        connector.write(df, {
+            "connection": "mongodb://fake",
+            "database": "gm",
+            "collection": "customers",
+            "mode": "upsert",
+        })
+
+
+def test_write_empty_frame_is_noop(mongo_connector):
+    import polars as pl
+
+    connector, client = mongo_connector
+    df = pl.DataFrame({"name": []})
+    connector.write(df, {
+        "connection": "mongodb://fake",
+        "database": "gm",
+        "collection": "customers",
+    })
+    assert client["gm"]["customers"].count_documents({}) == 0
+
+
+def test_load_connector_registers_mongo(monkeypatch):
+    """``load_connector("mongo", ...)`` resolves via the _BUILTIN
+    table without requiring pymongo at import time."""
+    # Stub pymongo so the import inside MongoConnector._connect doesn't
+    # explode -- we never actually call read/write here.
+    _stub_pymongo_module(monkeypatch, lambda uri: mongomock.MongoClient())
+
+    from goldenmatch.connectors.base import load_connector
+    from goldenmatch.connectors.mongo import MongoConnector
+
+    conn = load_connector("mongo", {"credentials_env": None})
+    assert isinstance(conn, MongoConnector)
+    conn_alias = load_connector("mongodb", {"credentials_env": None})
+    assert isinstance(conn_alias, MongoConnector)

--- a/packages/python/goldenmatch/tests/mongo/test_identity_store.py
+++ b/packages/python/goldenmatch/tests/mongo/test_identity_store.py
@@ -1,0 +1,267 @@
+"""Tests for the MongoDB Identity Store backend.
+
+Uses ``mongomock`` so no live MongoDB instance is required.
+"""
+from __future__ import annotations
+
+import pytest
+
+mongomock = pytest.importorskip("mongomock")
+
+
+@pytest.fixture
+def store(monkeypatch):
+    """Fresh MongoIdentityStore on a clean mongomock client."""
+    client = mongomock.MongoClient()
+    from goldenmatch.identity.mongo_backend import MongoIdentityStore
+    s = MongoIdentityStore(client=client, database="gm")
+    yield s
+    s.close()
+
+
+# ----- identity nodes -----------------------------------------------------
+
+
+def test_upsert_identity_and_get(store) -> None:
+    from goldenmatch.identity.model import IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    store.upsert_identity(IdentityNode(
+        entity_id=eid, dataset="customers", status="active",
+        confidence=0.99, merged_into=None,
+    ))
+    n = store.get_identity(eid)
+    assert n is not None
+    assert n.entity_id == eid
+    assert n.dataset == "customers"
+    assert n.confidence == 0.99
+
+
+def test_upsert_identity_is_idempotent(store) -> None:
+    from goldenmatch.identity.model import IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    node = IdentityNode(entity_id=eid, dataset="customers", status="active")
+    store.upsert_identity(node)
+    store.upsert_identity(node)
+    assert store.count_identities() == 1
+
+
+def test_list_identities_filters(store) -> None:
+    from goldenmatch.identity.model import IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    for ds in ("customers", "customers", "vendors"):
+        store.upsert_identity(IdentityNode(
+            entity_id=new_entity_id(), dataset=ds, status="active",
+        ))
+    customers = store.list_identities(dataset="customers")
+    vendors = store.list_identities(dataset="vendors")
+    assert len(customers) == 2
+    assert len(vendors) == 1
+
+
+def test_retire_identity_sets_status(store) -> None:
+    from goldenmatch.identity.model import IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    store.upsert_identity(IdentityNode(entity_id=eid, dataset="customers"))
+    store.retire_identity(eid, merged_into="some-other-eid")
+    n = store.get_identity(eid)
+    assert n is not None
+    assert n.status == "retired"
+    assert n.merged_into == "some-other-eid"
+
+
+# ----- source records ----------------------------------------------------
+
+
+def test_upsert_record_and_lookup(store) -> None:
+    from goldenmatch.identity.model import IdentityNode, SourceRecord
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    store.upsert_identity(IdentityNode(entity_id=eid, dataset="customers"))
+    store.upsert_record(SourceRecord(
+        record_id="salesforce:001",
+        source="salesforce", source_pk="001", record_hash="h1",
+        entity_id=eid, payload={"name": "Alice"}, dataset="customers",
+    ))
+
+    assert store.find_entity_by_record("salesforce:001") == eid
+    rec = store.get_record("salesforce:001")
+    assert rec is not None
+    assert rec.payload is not None
+    assert rec.payload["name"] == "Alice"
+
+    records = store.get_records_for_entity(eid)
+    assert len(records) == 1
+    assert records[0].record_id == "salesforce:001"
+
+
+def test_lookup_entity_ids_batch(store) -> None:
+    from goldenmatch.identity.model import IdentityNode, SourceRecord
+    from goldenmatch.identity.store import new_entity_id
+
+    eid1, eid2 = new_entity_id(), new_entity_id()
+    for eid in (eid1, eid2):
+        store.upsert_identity(IdentityNode(entity_id=eid))
+    store.upsert_record(SourceRecord(
+        record_id="a", source="s", source_pk="a", record_hash="h",
+        entity_id=eid1,
+    ))
+    store.upsert_record(SourceRecord(
+        record_id="b", source="s", source_pk="b", record_hash="h",
+        entity_id=eid2,
+    ))
+
+    out = store.lookup_entity_ids(["a", "b", "missing"])
+    assert out == {"a": eid1, "b": eid2}
+
+
+# ----- evidence edges ----------------------------------------------------
+
+
+def test_add_edge_and_list(store) -> None:
+    from goldenmatch.identity.model import EvidenceEdge, IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    store.upsert_identity(IdentityNode(entity_id=eid))
+    store.add_edge(EvidenceEdge(
+        entity_id=eid, record_a_id="a", record_b_id="b",
+        kind="same_as", score=0.91, run_name="test",
+    ))
+    edges = store.edges_for_entity(eid)
+    assert len(edges) == 1
+    assert edges[0].score == 0.91
+
+
+def test_add_edge_replay_is_idempotent(store) -> None:
+    from goldenmatch.identity.model import EvidenceEdge, IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    store.upsert_identity(IdentityNode(entity_id=eid))
+    edge = EvidenceEdge(
+        entity_id=eid, record_a_id="a", record_b_id="b",
+        kind="same_as", score=0.91, run_name="test",
+    )
+    store.add_edge(edge)
+    store.add_edge(edge)
+    assert len(store.edges_for_entity(eid)) == 1
+
+
+def test_find_conflicts_filters_by_kind(store) -> None:
+    from goldenmatch.identity.model import EvidenceEdge, IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    store.upsert_identity(IdentityNode(entity_id=eid, dataset="customers"))
+    store.add_edge(EvidenceEdge(
+        entity_id=eid, record_a_id="a", record_b_id="b",
+        kind="same_as", run_name="test", dataset="customers",
+    ))
+    store.add_edge(EvidenceEdge(
+        entity_id=eid, record_a_id="c", record_b_id="d",
+        kind="conflicts_with", run_name="test", dataset="customers",
+    ))
+    conflicts = store.find_conflicts("customers")
+    assert len(conflicts) == 1
+    assert conflicts[0].kind == "conflicts_with"
+
+
+# ----- events ------------------------------------------------------------
+
+
+def test_emit_event_and_history_order(store) -> None:
+    from goldenmatch.identity.model import IdentityEvent, IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    store.upsert_identity(IdentityNode(entity_id=eid))
+    store.emit_event(IdentityEvent(
+        entity_id=eid, kind="created", payload={"by": "test"}, run_name="r1",
+    ))
+    store.emit_event(IdentityEvent(
+        entity_id=eid, kind="absorbed", payload={"src": "x"}, run_name="r2",
+    ))
+    events = store.history(eid)
+    kinds = [e.kind for e in events]
+    assert kinds == ["created", "absorbed"]
+
+
+def test_history_limit(store) -> None:
+    from goldenmatch.identity.model import IdentityEvent, IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    store.upsert_identity(IdentityNode(entity_id=eid))
+    for k in ("a", "b", "c"):
+        store.emit_event(IdentityEvent(entity_id=eid, kind=k))
+    events = store.history(eid, limit=2)
+    assert len(events) == 2
+
+
+def test_has_run_event(store) -> None:
+    from goldenmatch.identity.model import IdentityEvent, IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    store.upsert_identity(IdentityNode(entity_id=eid))
+    store.emit_event(IdentityEvent(
+        entity_id=eid, kind="merged", run_name="run-42",
+    ))
+    assert store.has_run_event(eid, "run-42", "merged") is True
+    assert store.has_run_event(eid, "run-42", "split") is False
+    assert store.has_run_event(eid, "run-other", "merged") is False
+
+
+# ----- aliases -----------------------------------------------------------
+
+
+def test_add_alias_and_resolve(store) -> None:
+    from goldenmatch.identity.model import IdentityAlias, IdentityNode
+    from goldenmatch.identity.store import new_entity_id
+
+    eid = new_entity_id()
+    store.upsert_identity(IdentityNode(entity_id=eid))
+    store.add_alias(IdentityAlias(
+        alias="external:abc", entity_id=eid, kind="external_id",
+        dataset="customers",
+    ))
+    assert store.resolve_alias("external:abc") == eid
+
+
+def test_resolve_alias_unknown_returns_none(store) -> None:
+    assert store.resolve_alias("never-seen") is None
+
+
+# ----- lifecycle ---------------------------------------------------------
+
+
+def test_context_manager_closes(monkeypatch) -> None:
+    """``with MongoIdentityStore(...)`` closes the client on exit."""
+    client = mongomock.MongoClient()
+    from goldenmatch.identity.mongo_backend import MongoIdentityStore
+
+    with MongoIdentityStore(client=client, database="gm") as s:
+        from goldenmatch.identity.model import IdentityNode
+        from goldenmatch.identity.store import new_entity_id
+        s.upsert_identity(IdentityNode(entity_id=new_entity_id()))
+    # Client passed in is not owned, so the test's outer client stays
+    # usable -- no AttributeError on the next call.
+    assert client.list_database_names() is not None
+
+
+def test_index_setup_runs_on_open(store) -> None:
+    """First-open creates the indexes that mirror the SQL DDL."""
+    # mongomock surfaces indexes via list_indexes(); each collection
+    # gets at least the _id index plus our named ones.
+    names = {ix["name"] for ix in store._db["identity_nodes"].list_indexes()}
+    assert "entity_id_1" in names
+    names = {ix["name"] for ix in store._db["evidence_edges"].list_indexes()}
+    assert "edges_unique" in names


### PR DESCRIPTION
## Summary

Ships the two MongoDB-aware pieces with a natural goldenmatch fit:

1. **`MongoConnector`** — read documents into a Polars DataFrame, write golden records back. Three write modes (append/upsert/replace), nested-field flattening, internal column stripping. Joins the existing connector family (Snowflake, Databricks, BigQuery, HubSpot, Salesforce).
2. **`MongoIdentityStore`** — standalone Identity Graph backend mirroring the SQLite + Postgres schema, just in collections. Same 17-method surface the SQL backends expose.

28 tests passing, all driven by `mongomock` — no live MongoDB required.

## Why MongoDB at all (honest scope)

The Snowflake adapter (PR #553) made sense because Snowflake gave goldenmatch a uniquely deep integration surface — Cortex + SPCS + dbt + Snowpark. **Mongo doesn't have an analog to any of those.**

What Mongo *does* fit naturally:

- **Identity Graph as a document store** — UUIDv7 entity_ids, nested payloads, append-only event collections, fast point lookups. Mongo's strengths line up cleanly with the Identity Graph schema.
- **Source-data connector** — many CRM / e-commerce / IoT workloads land in Mongo and want to feed the Polars-based ER pipeline.

Phase 1 ships exactly those two pieces. Phase 2 candidates (out of scope here):

- Atlas Vector Search as an ANN blocker via `goldenmatch.db.ann_index`.
- `IdentityStore(backend="mongo")` dispatch — needs a Protocol refactor of the existing SQL-inlined `IdentityStore`.
- Mongo-as-MemoryStore-backend for Learning Memory writes.

None have a built-in Mongo audience the way Snowpark/Cortex did for Snowflake, so they're flagged for follow-up.

## Phase 1 surface

### Connector (`goldenmatch/connectors/mongo.py`)

```python
from goldenmatch.connectors import load_connector

reader = load_connector("mongo", {"credentials_env": None})
df = reader.read({
    "connection": "mongodb://localhost:27017",
    "database":   "crm",
    "collection": "contacts",
    "filter":     {"status": "active"},
    "limit":      10_000,
    "flatten":    True,   # nested -> dot-paths
}).collect()
```

Write modes:

| Mode | Behavior |
|---|---|
| `append`  (default) | `insert_many` |
| `upsert`            | `update_one(upsert=True)` per row, keyed by `config["key"]` |
| `replace`           | `delete_many({})` + `insert_many` |

Registered in `_BUILTIN` under both `mongo` and `mongodb` aliases.

### IdentityStore (`goldenmatch/identity/mongo_backend.py`)

```python
from goldenmatch.identity.mongo_backend import MongoIdentityStore

with MongoIdentityStore(
    connection="mongodb://localhost:27017",
    database="goldenmatch",
) as store:
    store.upsert_identity(...)
    store.add_edge(...)
```

Standalone class — not a `backend="mongo"` branch on `IdentityStore`. The existing SQLite + Postgres logic is ~600 lines of inlined SQL; adding a Mongo branch would either duplicate every method or trigger a Protocol refactor. **That refactor is the Phase 2 unify-under-IdentityStore work.** Phase 1 ships a callable class today.

Methods implemented (1:1 with the SQL backends):

| Group | Methods |
|---|---|
| Lifecycle | `close`, `__enter__`/`__exit__` |
| Identity nodes | `upsert_identity`, `get_identity` (alias `get_node`), `list_identities`, `count_identities`, `retire_identity` |
| Source records | `upsert_record`, `get_record`, `get_records_for_entity`, `find_entity_by_record`, `lookup_entity_ids` |
| Evidence edges | `add_edge`, `edges_for_entity`, `find_conflicts` |
| Events | `emit_event`, `history`, `has_run_event` |
| Aliases | `add_alias`, `resolve_alias` |

Schema: one collection per logical SQL table (`identity_nodes`, `source_records`, `evidence_edges`, `identity_events`, `identity_aliases`). Indexes mirror the Postgres DDL — compound unique on `evidence_edges` and `identity_aliases`. `_init_indexes` runs on every store open; idempotent, no migration runner.

## Tests (28 passing)

```
============================= 28 passed in 2.50s ==============================
```

- 12 connector tests: read (flatten on/off, filter, limit, empty, missing config), write (append, replace, upsert keyed + missing-key error, empty-frame noop, internal columns stripped), `load_connector` dispatching `mongo` + `mongodb` aliases.
- 16 IdentityStore tests: upsert + idempotency on every collection, dataset/status filters, lookup_entity_ids batch shape, edge replay idempotency, find_conflicts kind filter, history order + limit, has_run_event, alias add + resolve + unknown-returns-none, context-manager lifecycle, first-open index creation.

All driven by `mongomock` — no live MongoDB required in CI.

## Docs

New `docs/mongo-setup.md`:
- Connector usage + all three write modes
- IdentityStore API + schema
- Honest scope of what's NOT in Phase 1 (bulk_* writers, IdentityStore dispatch, Atlas Vector Search, MemoryStore)
- Why Mongo at all (rationale above)

## Test plan

- [x] 28 mongo tests pass locally with mongomock
- [x] Ruff clean
- [ ] CI on this PR — covers the same lane the Snowflake adapter ships through
- [ ] Live MongoDB integration test (covered by a follow-up that runs against a real Mongo instance; mongomock is API-compatible enough for unit-level coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
