### PR TITLE
perf(goldenflow): date_iso8601 fast path for 4-digit year STRING columns (-18% 10M wall on top of #560)

### DIFF
--- a/packages/python/goldenflow/goldenflow/transforms/dates.py
+++ b/packages/python/goldenflow/goldenflow/transforms/dates.py
@@ -17,20 +17,35 @@ def _parse_date(val: str | None) -> date | None:
         return None
 
 
+_YEAR_ONLY_RE = r"^\s*\d{4}\s*$"
+
+
 @register_transform(
     name="date_iso8601", input_types=["date"], auto_apply=True, priority=50, mode="series"
 )
 def date_iso8601(series: pl.Series) -> pl.Series:
-    # Fast path: numeric column (the inferred "date" type matched a column
+    # Fast path A: numeric column (the inferred "date" type matched a column
     # that's actually integer years -- e.g. birth_year=1995). Skip dateutil
     # entirely; format as "YYYY-01-01" via Polars vectorized string concat.
     # At 10M rows this drops the transform from ~150s (per-row dateutil) to
-    # <1s (Rust string concat under the hood). Diagnosed via goldenmatch QIS
-    # 10M bench: date_iso8601 was 49% of all pipeline_prep_transform wall.
-    # See packages/python/goldenflow/CLAUDE.md "date_iso8601 runs BEFORE
-    # auto_configure_df" gotcha for the upstream pipeline-order context.
+    # <1s (Rust string concat under the hood).
     if series.dtype.is_numeric():
         return series.cast(pl.Int64, strict=False).cast(pl.Utf8) + "-01-01"
+
+    # Fast path B: Utf8 column whose values are ALL 4-digit year strings
+    # (e.g. "1995"). This is the common shape when a year column was read
+    # from CSV as text. v15 measured 161s at 10M on this exact case -- the
+    # numeric fast path didn't trigger because the QIS fixture generates
+    # year_canon = rng.integers(1940, 2005).astype(str).tolist(), so Polars
+    # sees Utf8 values like "1995", not Int64. The dateutil slow path parses
+    # each "1995" -> date(1995, 1, 1) -> "1995-01-01" at ~16us per row.
+    # Vectorized: detect via regex (Rust-backed pl.str.contains), then strip
+    # + concat. ~150x speedup; falls through to dateutil for any column with
+    # non-year content.
+    if series.dtype == pl.Utf8:
+        non_null = series.drop_nulls()
+        if non_null.len() > 0 and bool(non_null.str.contains(_YEAR_ONLY_RE).all()):
+            return series.str.strip_chars() + "-01-01"
 
     def _fmt(val: str | None) -> str | None:
         if val is None:

--- a/packages/python/goldenflow/tests/transforms/test_dates.py
+++ b/packages/python/goldenflow/tests/transforms/test_dates.py
@@ -41,6 +41,41 @@ def test_date_iso8601_numeric_year_fast_path():
     assert result[3] is None
 
 
+def test_date_iso8601_string_year_fast_path():
+    """Utf8 column of 4-digit year strings takes the string fast path.
+
+    Common shape when a year column was read from CSV as text -- the QIS
+    realistic fixture's birth_year generator uses
+    .astype(str).tolist() which produces Polars Utf8 ('1995'). v15 measured
+    161s on this case at 10M because the numeric fast path didn't trigger;
+    the string fast path added in this commit drops it to <1s.
+    """
+    s = pl.Series("birth_year", ["1940", "1995", "2005", None], dtype=pl.Utf8)
+    result = date_iso8601(s)
+    assert result[0] == "1940-01-01"
+    assert result[1] == "1995-01-01"
+    assert result[2] == "2005-01-01"
+    assert result[3] is None
+
+
+def test_date_iso8601_string_year_with_whitespace_fast_path():
+    """Fast path strips whitespace before formatting (matches CSV quirks)."""
+    s = pl.Series("birth_year", [" 1995", "2005 ", " 1940 "], dtype=pl.Utf8)
+    result = date_iso8601(s)
+    assert result[0] == "1995-01-01"
+    assert result[1] == "2005-01-01"
+    assert result[2] == "1940-01-01"
+
+
+def test_date_iso8601_mixed_year_and_full_date_falls_through_to_slow_path():
+    """If ANY value isn't a 4-digit year, the slow dateutil path runs so
+    full dates ('2024-03-15') still parse correctly."""
+    s = pl.Series("d", ["2024-03-15", "Jan 5, 2023"], dtype=pl.Utf8)
+    result = date_iso8601(s)
+    assert result[0] == "2024-03-15"
+    assert result[1] == "2023-01-05"
+
+
 def test_date_iso8601_float_year_fast_path():
     """Float years (e.g. CSV with trailing .0) cast cleanly to Int64."""
     s = pl.Series("birth_year", [1995.0, 2005.0, None], dtype=pl.Float64)


### PR DESCRIPTION
﻿## Why

PR #560 added a fast path for **numeric** year columns. v15 measurement (10M-bucket-realistic, run 26610864753) showed it didn't engage on the QIS fixture because:

```python
# scripts/quality_invariant_scale.py: realistic shape's birth_year
year_canon = rng.integers(1940, 2005, n_clusters).astype(str).tolist()
```n
`.astype(str)` produces Utf8 in the resulting Polars column, not Int64. So `series.dtype.is_numeric()` was False; the slow dateutil path ran. Measured at v15: `gf:birth_year:date_iso8601 = 161s` at 10M (unchanged from pre-#560).

## What

Adds a second fast path that triggers on Utf8 columns whose values are all 4-digit year strings (the most common CSV shape for year columns). Detect via vectorized regex; if every non-null value matches `/^\s*\d{4}\s*$/`, format as `series.str.strip_chars() + `-01-01`` (all Rust-backed Polars string ops).

Mixed-content columns (years + full dates) still fall through to the dateutil slow path -- no regression on the existing test.

## Measured impact

Dispatched 10M-v16 (run 26611498742, feat/510-quality-invariant-scale, same fixture as v15):

| | v15 (numeric fast path only) | v16 (string fast path added) |
|---|---|---|
| Wall | 879 s | **716 s** (-18%) |
| `gf:birth_year:date_iso8601` | 161 s | **0.70 s** (~230x) |
| pipeline_prep_transform total | 320 s | 159 s |
| F1 | 0.9886 | 0.9886 |

## Tests

- `test_date_iso8601_string_year_fast_path`: int-stringified years (no whitespace), null preserved
- `test_date_iso8601_string_year_with_whitespace_fast_path`: leading/trailing whitespace stripped
- `test_date_iso8601_mixed_year_and_full_date_falls_through_to_slow_path`: mixed content still parses correctly via dateutil

Existing `test_date_iso8601` (string dates like `03/15/2024`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
