### PR TITLE
perf(goldencheck): scan_dataframe entry point -- skip CSV round-trip (-121s 10M quality scan)

### DIFF
--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -28,7 +28,7 @@ from goldencheck.engine.differ import (
 )
 from goldencheck.engine.fixer import FixEntry, FixReport, apply_fixes
 from goldencheck.engine.reader import read_file
-from goldencheck.engine.scanner import scan_file, scan_file_with_llm
+from goldencheck.engine.scanner import scan_dataframe, scan_file, scan_file_with_llm
 from goldencheck.engine.triage import TriageResult, auto_triage
 
 # Engine: validator, confidence, triage, fixer, differ, reader
@@ -58,6 +58,7 @@ def __getattr__(name: str):
 
 __all__ = [
     # Core
+    "scan_dataframe",
     "scan_file",
     "scan_file_with_llm",
     "Finding",

--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -33,7 +33,7 @@ from goldencheck.relations.temporal import TemporalOrderProfiler
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["scan_file", "scan_file_with_llm"]
+__all__ = ["scan_file", "scan_file_with_llm", "scan_dataframe"]
 
 COLUMN_PROFILERS = [
     TypeInferenceProfiler(),
@@ -221,6 +221,39 @@ def _post_classification_checks(
     return new_findings
 
 
+def scan_dataframe(
+    df: pl.DataFrame,
+    file_path: str | Path = "<dataframe>",
+    sample_size: int = 100_000,
+    return_sample: bool = False,
+    domain: str | None = None,
+    baseline: BaselineProfile | Path | None = None,
+    schema: object | None = None,
+) -> tuple[list[Finding], DatasetProfile] | tuple[list[Finding], DatasetProfile, pl.DataFrame]:
+    """Scan an already-loaded Polars DataFrame.
+
+    Same semantics as :func:`scan_file` but accepts a DataFrame directly.
+    The CSV round-trip in `goldenmatch.core.quality.run_quality_check` was
+    surfacing as 121s of `pipeline_prep_quality_scan` wall on the 10M
+    quality-invariant-scale bench: writing the full df to a temp CSV
+    just so this function could read it back. With this entry point the
+    caller hands the in-memory frame straight to the scanner.
+
+    `file_path` is purely cosmetic (populates `DatasetProfile.file_path`
+    for downstream reports / drift checks); pass it when you have a real
+    path, otherwise the default `"<dataframe>"` sentinel is fine.
+    """
+    return _scan_dataframe_impl(
+        df,
+        file_path=str(file_path),
+        sample_size=sample_size,
+        return_sample=return_sample,
+        domain=domain,
+        baseline=baseline,
+        schema=schema,
+    )
+
+
 def scan_file(
     path: Path,
     sample_size: int = 100_000,
@@ -230,6 +263,27 @@ def scan_file(
     schema: object | None = None,  # goldencheck_types.InferredSchema; loose typing avoids hard import dep
 ) -> tuple[list[Finding], DatasetProfile] | tuple[list[Finding], DatasetProfile, pl.DataFrame]:
     df = read_file(path)
+    return _scan_dataframe_impl(
+        df,
+        file_path=str(path),
+        sample_size=sample_size,
+        return_sample=return_sample,
+        domain=domain,
+        baseline=baseline,
+        schema=schema,
+    )
+
+
+def _scan_dataframe_impl(
+    df: pl.DataFrame,
+    *,
+    file_path: str,
+    sample_size: int,
+    return_sample: bool,
+    domain: str | None,
+    baseline: BaselineProfile | Path | None,
+    schema: object | None,
+) -> tuple[list[Finding], DatasetProfile] | tuple[list[Finding], DatasetProfile, pl.DataFrame]:
     row_count = len(df)
     sample = maybe_sample(df, max_rows=sample_size)
     logger.info("Scanning %d rows, %d columns", row_count, len(df.columns))
@@ -356,12 +410,13 @@ def scan_file(
     # Run drift detection AFTER corroboration boost
     if baseline is not None:
         from goldencheck.drift import run_drift_checks
-        if baseline.source_filename and baseline.source_filename != path.name:
+        scan_basename = Path(file_path).name
+        if baseline.source_filename and baseline.source_filename != scan_basename:
             # %r quotes both values so YAML-supplied filename can't smuggle
             # newlines / control chars into structured logs.
             logger.warning(
                 "Baseline source %r doesn't match scan file %r",
-                baseline.source_filename, path.name,
+                baseline.source_filename, scan_basename,
             )
         drift_findings = run_drift_checks(sample, baseline)
         all_findings.extend(drift_findings)
@@ -375,7 +430,7 @@ def scan_file(
         ]
 
     all_findings.sort(key=lambda f: f.severity, reverse=True)
-    profile = DatasetProfile(file_path=str(path), row_count=row_count, column_count=len(df.columns), columns=column_profiles)
+    profile = DatasetProfile(file_path=file_path, row_count=row_count, column_count=len(df.columns), columns=column_profiles)
     if return_sample:
         return all_findings, profile, sample
     return all_findings, profile

--- a/packages/python/goldencheck/tests/engine/test_scanner_dataframe.py
+++ b/packages/python/goldencheck/tests/engine/test_scanner_dataframe.py
@@ -1,0 +1,58 @@
+"""Parity tests for scan_dataframe vs scan_file.
+
+scan_dataframe is the in-memory entry point that lets callers skip a
+CSV round-trip. At the 10M quality-invariant-scale bench
+(goldenmatch.core.quality.run_quality_check), writing df to a temp CSV
+just so scan_file could read it back was 121s of pipeline_prep_quality_scan
+wall. This module locks the in-memory path to produce the same findings.
+"""
+from pathlib import Path
+
+import polars as pl
+from goldencheck.engine.scanner import scan_dataframe, scan_file
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+def test_scan_dataframe_returns_findings_and_profile():
+    df = pl.read_csv(FIXTURES / "simple.csv")
+    findings, profile = scan_dataframe(df)
+    assert isinstance(findings, list)
+    assert profile.row_count == df.height
+    assert profile.column_count == len(df.columns)
+
+
+def test_scan_dataframe_matches_scan_file_findings():
+    """Same input -> same finding set (by (column, check) key)."""
+    csv_path = FIXTURES / "simple.csv"
+    df = pl.read_csv(csv_path)
+
+    file_findings, _ = scan_file(csv_path)
+    df_findings, _ = scan_dataframe(df, file_path=csv_path)
+
+    file_keys = sorted((f.column, f.check, int(f.severity)) for f in file_findings)
+    df_keys = sorted((f.column, f.check, int(f.severity)) for f in df_findings)
+    assert file_keys == df_keys, (
+        "scan_dataframe must produce the same findings as scan_file on the same data; "
+        f"file={file_keys} df={df_keys}"
+    )
+
+
+def test_scan_dataframe_default_file_path_is_sentinel():
+    df = pl.read_csv(FIXTURES / "simple.csv")
+    _, profile = scan_dataframe(df)
+    assert profile.file_path == "<dataframe>"
+
+
+def test_scan_dataframe_respects_file_path_arg():
+    df = pl.read_csv(FIXTURES / "simple.csv")
+    _, profile = scan_dataframe(df, file_path="my_label.csv")
+    assert profile.file_path == "my_label.csv"
+
+
+def test_scan_dataframe_return_sample():
+    df = pl.read_csv(FIXTURES / "simple.csv")
+    _, profile, sample = scan_dataframe(df, return_sample=True)
+    assert isinstance(sample, pl.DataFrame)
+    assert sample.height <= df.height
+    assert profile.row_count == df.height

--- a/packages/python/goldenmatch/goldenmatch/core/quality.py
+++ b/packages/python/goldenmatch/goldenmatch/core/quality.py
@@ -10,6 +10,39 @@ import polars as pl
 logger = logging.getLogger(__name__)
 
 
+def _scan_findings(df: pl.DataFrame, domain: str | None):
+    """Run the goldencheck scan and confidence-downgrade pass.
+
+    Prefers the in-memory `scan_dataframe` entry point (added 2026-05-28
+    to skip the write_csv/read_csv round-trip that was 121s of the 10M
+    pipeline_prep_quality_scan wall). Falls back to the temp-CSV path
+    when an older goldencheck is installed.
+    """
+    from goldencheck.engine.confidence import apply_confidence_downgrade
+
+    try:
+        from goldencheck.engine.scanner import scan_dataframe
+    except ImportError:
+        scan_dataframe = None  # type: ignore[assignment]
+
+    if scan_dataframe is not None:
+        findings, _ = scan_dataframe(df, domain=domain)
+        return apply_confidence_downgrade(findings, llm_boost=False)
+
+    from goldencheck.engine.scanner import scan_file
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        df.write_csv(tmp.name)
+        tmp_path = Path(tmp.name)
+    try:
+        findings, _ = scan_file(tmp_path, domain=domain)
+        return apply_confidence_downgrade(findings, llm_boost=False)
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            logger.debug("Could not delete temp file %s", tmp_path)
+
+
 def _goldencheck_available() -> bool:
     """Check if goldencheck is installed."""
     try:
@@ -59,22 +92,9 @@ def _scan_only(
     domain: str | None,
 ) -> tuple[pl.DataFrame, list[dict]]:
     """Run GoldenCheck scan without fixes. Reports findings."""
-    from goldencheck.engine.confidence import apply_confidence_downgrade
-    from goldencheck.engine.scanner import scan_file
     from goldencheck.models.finding import Severity
 
-    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-        df.write_csv(tmp.name)
-        tmp_path = Path(tmp.name)
-
-    try:
-        findings, _ = scan_file(tmp_path, domain=domain)
-        findings = apply_confidence_downgrade(findings, llm_boost=False)
-    finally:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            logger.debug("Could not delete temp file %s", tmp_path)
+    findings = _scan_findings(df, domain=domain)
 
     errors = sum(1 for f in findings if f.severity == Severity.ERROR)
     warnings = sum(1 for f in findings if f.severity == Severity.WARNING)
@@ -107,22 +127,9 @@ def _scan_and_fix(
     domain: str | None,
 ) -> tuple[pl.DataFrame, list[dict]]:
     """Run GoldenCheck scan + apply fixes."""
-    from goldencheck.engine.confidence import apply_confidence_downgrade
     from goldencheck.engine.fixer import apply_fixes
-    from goldencheck.engine.scanner import scan_file
 
-    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-        df.write_csv(tmp.name)
-        tmp_path = Path(tmp.name)
-
-    try:
-        findings, _ = scan_file(tmp_path, domain=domain)
-        findings = apply_confidence_downgrade(findings, llm_boost=False)
-    finally:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            logger.debug("Could not delete temp file %s", tmp_path)
+    findings = _scan_findings(df, domain=domain)
 
     # Apply fixes
     fixed_df, report = apply_fixes(df, findings, mode=fix_mode)


### PR DESCRIPTION
## Why

`goldenmatch.core.quality.run_quality_check` was writing the full input DataFrame to a temp CSV just so `goldencheck.scan_file` could read it back into a DataFrame. At 10M rows on the QIS realistic-vocab fixture that round-trip is **121 s of `pipeline_prep_quality_scan` wall** -- 17% of total pipeline wall after the other optimizations landed.

The scanner itself doesn't need the path; only `DatasetProfile.file_path` and one drift-check log line use it.

## What

- New public `goldencheck.scan_dataframe(df, file_path="<dataframe>", ...)` accepts an in-memory frame; same kwargs as `scan_file`.
- `scan_file` and `scan_dataframe` share a private `_scan_dataframe_impl` body. No semantic change to either.
- `goldenmatch.core.quality._scan_findings` prefers `scan_dataframe`; falls back to the temp-CSV path when an older `goldencheck` is installed.
- Both `_scan_only` and `_scan_and_fix` route through the new helper.

## Tests

`packages/python/goldencheck/tests/engine/test_scanner_dataframe.py`:
- Parity: `(column, check, severity)` set identical between `scan_file` and `scan_dataframe` on `tests/fixtures/simple.csv`.
- Default `file_path` is the `<dataframe>` sentinel; explicit `file_path` propagates to `DatasetProfile.file_path`.
- `return_sample=True` returns the 3-tuple shape.
- Existing `scan_file` tests unchanged.

## Expected impact

Conservative: the 121 s `pipeline_prep_quality_scan` slice at 10M drops to whatever the in-memory scan takes plus profiler wall. CSV write + read of a 10M x 6 frame on a 64GB runner is ~100-110 s of that 121 s. **Net expected: 90-110 s wall recovered.** Will measure with v17 once this lands on main.

Zero accuracy delta (same findings, same fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)