### PR TITLE
perf(goldenflow): normalize_unicode ASCII fast path (expected ~150s on 10M QIS)

### DIFF
--- a/packages/python/goldenflow/goldenflow/transforms/text.py
+++ b/packages/python/goldenflow/goldenflow/transforms/text.py
@@ -34,10 +34,30 @@ def title_case(column: str) -> pl.Expr:
     return pl.col(column).str.to_titlecase()
 
 
+_NON_ASCII_RE = r"[^\x00-\x7F]"
+
+
 @register_transform(
     name="normalize_unicode", input_types=["string"], auto_apply=True, priority=85, mode="series"
 )
 def normalize_unicode(series: pl.Series) -> pl.Series:
+    # Fast path: pure-ASCII columns are a no-op for NFKD + combining-char
+    # strip. Detect via vectorized regex on the non-null subset and bail
+    # before paying for per-row unicodedata.normalize calls. At 10M rows
+    # across 6 string columns this transform was the second-largest slice
+    # of pipeline_prep_transform wall after date_iso8601 (per the QIS
+    # bench gf:<col>:normalize_unicode markers, ~25-30s each). Any
+    # column that round-trips through CSV with only ASCII bytes (the
+    # common shape for hash-derived synthetic data + ASCII-only real
+    # datasets) hits this branch.
+    if series.dtype != pl.Utf8:
+        return series
+    non_null = series.drop_nulls()
+    if non_null.len() == 0:
+        return series
+    if not bool(non_null.str.contains(_NON_ASCII_RE).any()):
+        return series
+
     def _normalize(val: str | None) -> str | None:
         if val is None:
             return None

--- a/packages/python/goldenflow/tests/transforms/test_text.py
+++ b/packages/python/goldenflow/tests/transforms/test_text.py
@@ -58,6 +58,34 @@ def test_normalize_unicode():
     assert result.to_list() == ["e", "cafe", "naive"]
 
 
+def test_normalize_unicode_ascii_fast_path_is_noop():
+    """Pure-ASCII columns hit the fast path and skip per-row NFKD.
+
+    QIS 10M bench surfaced ~25-30s per ASCII string column on the
+    `gf:<col>:normalize_unicode` markers (6 columns x 30s = 180s of
+    pipeline_prep_transform wall). Hash-derived synthetic names and
+    most real-world ASCII columns (codes, IDs, latin text) are no-ops
+    under NFKD + combining-char strip. Detect via vectorized regex
+    [^\\x00-\\x7F] and short-circuit -- zero per-row Python.
+    """
+    s = pl.Series("a", ["Alice", "Bob", "Charlie", None])
+    result = normalize_unicode(s)
+    assert result.to_list() == ["Alice", "Bob", "Charlie", None]
+
+
+def test_normalize_unicode_mixed_column_takes_slow_path():
+    """Any non-ASCII byte forces the slow path; non-ASCII rows get NFKD."""
+    s = pl.Series("a", ["Alice", "caf\u00e9", "Bob"])
+    result = normalize_unicode(s)
+    assert result.to_list() == ["Alice", "cafe", "Bob"]
+
+
+def test_normalize_unicode_empty_or_all_null():
+    """Empty + all-null series short-circuit before regex scan."""
+    assert normalize_unicode(pl.Series("a", [], dtype=pl.Utf8)).to_list() == []
+    assert normalize_unicode(pl.Series("a", [None, None], dtype=pl.Utf8)).to_list() == [None, None]
+
+
 def test_remove_punctuation():
     result = _apply_expr(remove_punctuation, "a", ["hello!", "test@123", "a-b_c"])
     assert all(c.isalnum() or c.isspace() for val in result for c in val)


### PR DESCRIPTION
## Why

Continuing the GoldenFlow per-transform audit started by PR #560/#561. After date_iso8601 dropped from 161s to 0.7s, the next-biggest slice of pipeline_prep_transform wall at 10M is normalize_unicode -- ~25-30s per string column on the QIS bench's gf:<col>:normalize_unicode markers, ~150s combined across 6 columns.

The transform is auto_apply=True on every string column, and uses series.map_elements(_normalize, ...) -- per-row Python calling unicodedata.normalize(NFKD, val) + combining-char strip. At 10M rows that is 60M Python function calls.

Hash-derived synthetic names + most real-world ASCII columns (codes, IDs, latin text) round-trip cleanly under NFKD; the transform is a no-op for them. Skipping them entirely is correct.

## What

Vectorized ASCII detection via Polars regex `[^\x00-\x7F]` on the non-null subset; if no row contains a non-ASCII byte, return the input series unchanged. Mixed columns still pay the slow path -- correctness preserved.

Same pattern as date_iso8601 string year fast path (#561). All-Rust detection, zero per-row Python on the common case.

## Expected impact

10M-v16: pipeline_prep_transform = 158.7s (after date_iso8601). v17 with this should drop another ~120-150s, putting pipeline_prep_transform under 40s. Total expected 10M wall: ~600s (down from v16's 716s).

Zero accuracy delta (no-op on ASCII; same NFKD output on mixed).

## Tests

3 new cases in tests/transforms/test_text.py:
- ASCII fast path: pure-ASCII series returns identity
- Mixed slow path: any non-ASCII byte forces NFKD on the whole series
- Empty/all-null: short-circuit before regex scan

Existing test_normalize_unicode (true non-ASCII) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)