### PR TITLE
perf(matchkey): batch precompute_matchkey_transforms into one fused Polars pass (-~75s 10M)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -229,8 +229,18 @@ def precompute_matchkey_transforms(
 
     Returns the augmented DataFrame. Original columns are untouched.
     """
+    # Batch all native-chain expressions into ONE with_columns call so
+    # Polars's planner fuses them into a single compute graph. The previous
+    # loop did `df.select(expr.alias(sig))[sig]` per signature, which
+    # eagerly materialized one 10M-row column at a time -- at 6 matchkey
+    # fields on the QIS bench that was 6 separate Polars passes over the
+    # full df, dominating the precompute_matchkey_transforms stage (90s
+    # at 10M). Slow-path Python apply_transforms still runs per signature
+    # (intrinsically per-row); those go into new_cols as today and get
+    # appended in the same final with_columns.
     seen: set[str] = set()
-    new_cols: list[pl.Series] = []
+    native_exprs: list[pl.Expr] = []
+    python_cols: list[pl.Series] = []
     for mk in matchkeys:
         for field in mk.fields:
             if field.scorer == "record_embedding":
@@ -242,16 +252,19 @@ def precompute_matchkey_transforms(
 
             native_expr = _try_native_chain(field.field, field.transforms)
             if native_expr is not None:
-                col = df.select(native_expr.alias(sig))[sig]
+                native_exprs.append(native_expr.alias(sig))
             else:
                 values = df[field.field].to_list()
-                col = pl.Series(
+                python_cols.append(pl.Series(
                     sig,
                     [apply_transforms(v, field.transforms) if v is not None else None
                      for v in values],
-                )
-            new_cols.append(col)
+                ))
 
-    if not new_cols:
+    if not native_exprs and not python_cols:
         return df
-    return df.with_columns(new_cols)
+    if native_exprs:
+        df = df.with_columns(native_exprs)
+    if python_cols:
+        df = df.with_columns(python_cols)
+    return df


### PR DESCRIPTION
## Why

After PRs #560/#561/#562/#563, the next-biggest stage in 10M QIS is `precompute_matchkey_transforms` at 90.7s. Reading the code: each (field, transforms) signature called `df.select(native_expr.alias(sig))[sig]` -- a full eager Polars materialization per signature. At 6 matchkey fields on the QIS bench that is 6 separate 10M-row Polars passes.

## What

Batch all native expressions into ONE `df.with_columns([expr1.alias(sig1), expr2.alias(sig2), ...])` call. Polars' query planner fuses these into a single compute graph, so the 10M-row scan happens once instead of K times.

Slow-path (non-native, per-row `apply_transforms`) signatures intrinsically iterate row-by-row; they accumulate into a separate Series list and get appended in a follow-up with_columns. Slow-path Series can't fuse with lazy native exprs but they CAN batch among themselves.

Same column names, same values, same caller contract. No behavioral change.

## Expected impact

QIS 10M with 6 native matchkey fields: 90.7s -> ~15s (one fused pass instead of six). Net ~75s of pipeline wall recovered. Combined with v17 (#562) + v18 (#563), 10M expected wall drops from v16's 716s to ~400s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)