### PR TITLE
perf(bucket): widen fast path to accept match-mode (across_files_only / source_lookup / target_ids)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -216,13 +216,12 @@ def _resolve_fast_path(
     if getattr(mk, "llm", None):
         _decline("mk.llm is set")
         return None
-    if across_files_only or source_lookup or target_ids is not None:
-        _decline(
-            f"match-mode flag set "
-            f"(across_files_only={across_files_only}, source_lookup={source_lookup is not None}, "
-            f"target_ids={target_ids is not None})"
-        )
-        return None
+    # NOTE: match-mode (across_files_only / source_lookup / target_ids) USED
+    # to decline the fast path here. That was conservative -- the fast path
+    # can engage with these set because they only act as post-filters on
+    # emitted pairs, not as scoring math. The actual filtering happens after
+    # the worker emits candidate pairs (mirrors _score_one_bucket's behavior).
+    # Removed 2026-05-29 to widen the fast path for match-mode workloads.
     if not mk.fields:
         _decline("mk.fields is empty")
         return None
@@ -407,6 +406,27 @@ def score_buckets(
                 flush=True,
             )
 
+    def _apply_match_mode_filter(
+        pairs: list[tuple[int, int, float]],
+    ) -> list[tuple[int, int, float]]:
+        """Mirror the slow path's match-mode post-filter (_score_one_bucket
+        lines 544-553). Applies in two stages: across_files_only drops
+        same-source pairs; target_ids drops same-side-of-target pairs.
+
+        Both filters are O(pairs) and very cheap relative to scoring; safe
+        to apply unconditionally on the fast path now that the gate is gone."""
+        if across_files_only and source_lookup is not None:
+            pairs = [
+                (a, b, s) for a, b, s in pairs
+                if source_lookup.get(a) != source_lookup.get(b)
+            ]
+        if target_ids is not None:
+            pairs = [
+                (a, b, s) for a, b, s in pairs
+                if (a in target_ids) != (b in target_ids)
+            ]
+        return pairs
+
     def _score_one_bucket_fast(bucket_df: pl.DataFrame) -> tuple[list[tuple[int, int, float]], int]:
         # Fast path for tiny-block workloads. Pre-extracts each transformed
         # field as a Python list ONCE per bucket, then iterates pairs within
@@ -461,6 +481,10 @@ def score_buckets(
                     list(frozen_exclude),
                 )
             local_blocks = sum(1 for s in size_list if s >= 2)
+            # Match-mode post-filter (native path doesn't know about
+            # source_lookup or target_ids; apply in Python after emit).
+            if across_files_only or target_ids is not None:
+                pairs = _apply_match_mode_filter(pairs)
             return pairs, local_blocks
 
         # Python per-pair fallback: materialize the columns as lists.
@@ -507,6 +531,8 @@ def score_buckets(
                                 )
                 local_blocks += 1
             offset += size
+        if across_files_only or target_ids is not None:
+            local_pairs = _apply_match_mode_filter(local_pairs)
         return local_pairs, local_blocks
 
     def _score_one_bucket(bucket_df: pl.DataFrame) -> tuple[list[tuple[int, int, float]], int]:

--- a/packages/python/goldenmatch/tests/test_fast_path_match_mode.py
+++ b/packages/python/goldenmatch/tests/test_fast_path_match_mode.py
@@ -1,0 +1,146 @@
+"""Match-mode (across_files_only / source_lookup / target_ids) on the fast path.
+
+Previously `_resolve_fast_path` declined eligibility whenever any of these
+were set, forcing the matchkey onto the slow `find_fuzzy_matches` path.
+But these are post-filters on emitted pairs, not scoring math -- the fast
+path can engage and apply them inline. Unblocks dedupe-across-files and
+match-mode workloads (target_ids).
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.backends.score_buckets import _resolve_fast_path, score_buckets
+from goldenmatch.config.schemas import BlockingConfig, MatchkeyConfig, MatchkeyField
+from goldenmatch.core.matchkey import _xform_sig
+
+
+def _build_mk() -> MatchkeyConfig:
+    """Simple 1-field weighted matchkey -- the rest of the gates pass."""
+    return MatchkeyConfig(
+        name="test",
+        type="weighted",
+        threshold=0.5,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+    )
+
+
+def _build_prepared_df() -> pl.DataFrame:
+    mk = _build_mk()
+    xform = _xform_sig(mk.fields[0])
+    return pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "__source__": ["A", "A", "B", "B"],
+        "name": ["alice", "alice", "alice", "alice"],
+        xform: ["alice", "alice", "alice", "alice"],
+    })
+
+
+class TestResolveFastPathAcceptsMatchMode:
+    """Gate-level: _resolve_fast_path now accepts across_files_only,
+    source_lookup, and target_ids instead of declining."""
+
+    def test_accepts_across_files_only(self):
+        result = _resolve_fast_path(
+            _build_mk(), _build_prepared_df(),
+            across_files_only=True,
+            source_lookup={0: "A", 1: "A", 2: "B", 3: "B"},
+            target_ids=None,
+        )
+        assert result is not None, "fast path must accept across_files_only=True"
+
+    def test_accepts_source_lookup(self):
+        result = _resolve_fast_path(
+            _build_mk(), _build_prepared_df(),
+            across_files_only=False,
+            source_lookup={0: "A", 1: "B"},
+            target_ids=None,
+        )
+        assert result is not None, "fast path must accept source_lookup"
+
+    def test_accepts_target_ids(self):
+        result = _resolve_fast_path(
+            _build_mk(), _build_prepared_df(),
+            across_files_only=False,
+            source_lookup=None,
+            target_ids={0, 1},
+        )
+        assert result is not None, "fast path must accept target_ids"
+
+
+class TestMatchModeFiltersPairs:
+    """End-to-end via score_buckets: pairs are post-filtered correctly."""
+
+    def _run(self, **kwargs):
+        df = _build_prepared_df()
+        # Add block-key so blocking is deterministic.
+        df = df.with_columns(pl.lit("blockX").alias("__block_key__"))
+        mk = _build_mk()
+        # Use a constant blocking config -- bucket scorer expects keys list.
+        blocking = BlockingConfig(strategy="static", keys=["name"])
+        return score_buckets(
+            df, blocking, mk,
+            matched_pairs=set(),
+            **kwargs,
+        )
+
+    def test_across_files_only_drops_same_source_pairs(self):
+        # 4 rows, sources A/A/B/B. With across_files_only, only A<>B pairs
+        # should emit: (0,2), (0,3), (1,2), (1,3) = 4 pairs.
+        # Without filter we'd get all C(4,2)=6 pairs.
+        pairs = self._run(
+            across_files_only=True,
+            source_lookup={0: "A", 1: "A", 2: "B", 3: "B"},
+        )
+        assert pairs, "expected some cross-source pairs"
+        for a, b, _s in pairs:
+            sa = {0: "A", 1: "A", 2: "B", 3: "B"}[a]
+            sb = {0: "A", 1: "A", 2: "B", 3: "B"}[b]
+            assert sa != sb, f"pair ({a},{b}) has same source -- should have been filtered"
+
+    def test_target_ids_drops_same_side_pairs(self):
+        # target_ids = {0, 1}. Only pairs with exactly one side in target_ids
+        # should emit: (0,2), (0,3), (1,2), (1,3).
+        pairs = self._run(
+            target_ids={0, 1},
+        )
+        assert pairs, "expected target<>non-target pairs"
+        for a, b, _s in pairs:
+            in_a = a in {0, 1}
+            in_b = b in {0, 1}
+            assert in_a != in_b, f"pair ({a},{b}) has both or neither in target_ids"
+
+
+class TestParityWithSlowPath:
+    """Same input via fast vs slow should produce same pair set after filter."""
+
+    @pytest.mark.parametrize("kw", [
+        {"across_files_only": True, "source_lookup": {0: "A", 1: "A", 2: "B", 3: "B"}},
+        {"target_ids": {0, 1}},
+    ])
+    def test_fast_match_filter_subset_of_unfiltered(self, kw):
+        """Filtered pairs must be a subset of unfiltered pairs."""
+        unfiltered = self._unfiltered()
+        df = _build_prepared_df()
+        df = df.with_columns(pl.lit("blockX").alias("__block_key__"))
+        blocking = BlockingConfig(strategy="static", keys=["name"])
+        filtered = score_buckets(
+            df, blocking, _build_mk(),
+            matched_pairs=set(),
+            **kw,
+        )
+        unfiltered_keys = {(a, b) for a, b, _ in unfiltered}
+        filtered_keys = {(a, b) for a, b, _ in filtered}
+        assert filtered_keys <= unfiltered_keys, "filtered must be a subset of unfiltered"
+        assert len(filtered_keys) < len(unfiltered_keys), (
+            "filter should drop at least some pairs on this fixture"
+        )
+
+    def _unfiltered(self):
+        df = _build_prepared_df()
+        df = df.with_columns(pl.lit("blockX").alias("__block_key__"))
+        blocking = BlockingConfig(strategy="static", keys=["name"])
+        return score_buckets(
+            df, blocking, _build_mk(),
+            matched_pairs=set(),
+        )

--- a/packages/python/goldenmatch/tests/test_fast_path_match_mode.py
+++ b/packages/python/goldenmatch/tests/test_fast_path_match_mode.py
@@ -11,7 +11,12 @@ from __future__ import annotations
 import polars as pl
 import pytest
 from goldenmatch.backends.score_buckets import _resolve_fast_path, score_buckets
-from goldenmatch.config.schemas import BlockingConfig, MatchkeyConfig, MatchkeyField
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
 from goldenmatch.core.matchkey import _xform_sig
 
 
@@ -77,7 +82,9 @@ class TestMatchModeFiltersPairs:
         df = df.with_columns(pl.lit("blockX").alias("__block_key__"))
         mk = _build_mk()
         # Use a constant blocking config -- bucket scorer expects keys list.
-        blocking = BlockingConfig(strategy="static", keys=["name"])
+        blocking = BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["name"])]
+        )
         return score_buckets(
             df, blocking, mk,
             matched_pairs=set(),
@@ -123,7 +130,9 @@ class TestParityWithSlowPath:
         unfiltered = self._unfiltered()
         df = _build_prepared_df()
         df = df.with_columns(pl.lit("blockX").alias("__block_key__"))
-        blocking = BlockingConfig(strategy="static", keys=["name"])
+        blocking = BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["name"])]
+        )
         filtered = score_buckets(
             df, blocking, _build_mk(),
             matched_pairs=set(),
@@ -139,7 +148,9 @@ class TestParityWithSlowPath:
     def _unfiltered(self):
         df = _build_prepared_df()
         df = df.with_columns(pl.lit("blockX").alias("__block_key__"))
-        blocking = BlockingConfig(strategy="static", keys=["name"])
+        blocking = BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["name"])]
+        )
         return score_buckets(
             df, blocking, _build_mk(),
             matched_pairs=set(),


### PR DESCRIPTION
## Why

The fast path declined eligibility whenever any of `across_files_only`, `source_lookup`, or `target_ids` was set. But these flags only post-filter emitted pairs; they don't affect scoring math. The slow path applies the same filters after `find_fuzzy_matches` returns. The gate was conservative.

## What

- Drop the match-mode bail in `_resolve_fast_path` (lines 219-225 of pre-change).
- Add `_apply_match_mode_filter` helper that mirrors the slow path's filter logic (`_score_one_bucket` lines 544-553).
- Apply the filter at the end of `_score_one_bucket_fast` for both the native kernel path and the Python per-pair path.

The native kernel doesn't know about `source_lookup` / `target_ids` -- filter runs in Python on the kernel's output. O(pairs) and very cheap relative to scoring.

## Scope

Doesn't change QIS auto-config wall (no match-mode there). Unblocks fast path for:
- Across-files dedupe at scale
- Match-mode workloads (`target_ids` set)

## Tests

`tests/test_fast_path_match_mode.py`:
- Each match-mode flag set -> `_resolve_fast_path` returns non-None
- End-to-end via `score_buckets`: `across_files_only` only emits cross-source pairs
- End-to-end: `target_ids` only emits target<>non-target pairs
- Filtered pair set is a strict subset of unfiltered (parity sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)