### PR TITLE
perf(bucket): NE penalty math on the fast path (widen vs find_fuzzy_matches)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -151,20 +151,68 @@ _SCORE_FIELD_DIRECT_SCORERS: frozenset[str] = frozenset({
 
 def _ne_effectively_empty(mk: MatchkeyConfig) -> bool:
     """True when matchkey.negative_evidence is empty OR every NE entry uses
-    a scorer name that score_field doesn't handle (raises ValueError). Those
-    entries are silently skipped at runtime (PR #546's _NE_BROKEN cache), so
-    they contribute zero penalty and the fast path's NE-free computation
-    matches the slow path's NE-applied computation bit-for-bit."""
+    a scorer name that score_field doesn't handle.
+
+    Historical role (pre-2026-05-29): this gated fast-path eligibility --
+    NE with callable scorers forced the slow path. Now the fast path engages
+    with NE math inline (`_resolve_ne_specs` + per-pair penalty in
+    `_score_one_bucket_fast`). The helper survives because:
+      1. The slow path's `_NE_BROKEN` cache still uses the same classification
+         to silently skip broken NE entries.
+      2. Tests in test_score_buckets_fast_path_gate.py assert this classification
+         independently of whether the fast path declines or engages.
+      3. Controller / planner policy decisions can still consult it to detect
+         "NE no-op" workloads.
+    """
     ne = getattr(mk, "negative_evidence", None)
     if not ne:
         return True
     for ne_entry in ne:
         scorer = getattr(ne_entry, "scorer", None)
         if scorer is None or scorer in _SCORE_FIELD_DIRECT_SCORERS:
-            # This NE entry IS callable at runtime -> it contributes real
-            # penalty -> fast path would produce a different score -> bail.
             return False
     return True
+
+
+# NE spec layout: (xform_col, score_pair_fn, threshold, penalty). One per
+# resolvable NE entry. Empty list means "no NE math needed" -- either NE
+# was empty or every NE entry's scorer is in _NE_BROKEN territory (matches
+# the slow path's silent-skip behavior).
+NeSpec = tuple[str, Any, float, float]
+
+
+def _resolve_ne_specs(
+    mk: MatchkeyConfig,
+    prepared_df: pl.DataFrame,
+) -> list[NeSpec]:
+    """Resolve mk.negative_evidence into per-pair callable specs.
+
+    Mirrors the slow path's `_apply_negative_evidence`:
+      - NE entries whose scorer isn't in `_SCORE_FIELD_DIRECT_SCORERS`
+        are silently skipped (the slow path's _NE_BROKEN cache does this
+        at runtime; we replicate the policy at gate-time).
+      - Entries whose xform column isn't precomputed are skipped (same
+        rationale -- caller can't access transformed values without it).
+      - Penalty math is `final = max(0, score_positive - sum(penalties))`
+        applied where the slow path uses the same formula.
+    """
+    from goldenmatch.core.matchkey import _xform_sig
+
+    out: list[NeSpec] = []
+    ne_list = getattr(mk, "negative_evidence", None) or []
+    for ne in ne_list:
+        scorer = getattr(ne, "scorer", None)
+        if scorer is None or scorer not in _SCORE_FIELD_DIRECT_SCORERS:
+            # Mirror slow-path _NE_BROKEN behavior: contribute zero penalty.
+            continue
+        fn = _resolve_score_pair_callable(scorer)
+        if fn is None:
+            continue
+        xform_col = _xform_sig(ne)
+        if xform_col not in prepared_df.columns:
+            continue
+        out.append((xform_col, fn, float(ne.threshold), float(ne.penalty)))
+    return out
 
 
 def _resolve_fast_path(
@@ -174,23 +222,30 @@ def _resolve_fast_path(
     across_files_only: bool,
     source_lookup: dict[int, str] | None,
     target_ids: set[int] | None,
-) -> tuple[float, float, list[tuple[str, float, Any, str]]] | None:
+) -> tuple[float, float, list[tuple[str, float, Any, str]], list[NeSpec]] | None:
     """Decide whether mk is fast-path eligible and pre-resolve field specs.
 
-    Returns (threshold, total_weight, [(xform_col, weight, score_fn), ...])
-    when eligible, else None. Resolution is done ONCE at score_buckets entry
-    so per-pair work never touches the PluginRegistry, _get_transformed_values,
-    or scorer-name dispatch.
+    Returns (threshold, total_weight, field_specs, ne_specs) when eligible,
+    else None. Resolution is done ONCE at score_buckets entry so per-pair
+    work never touches the PluginRegistry, _get_transformed_values, or
+    scorer-name dispatch.
+
+    field_specs: list of (xform_col, weight, score_pair_fn, scorer_name).
+    ne_specs:    list of (xform_col, score_pair_fn, threshold, penalty);
+                 empty when NE is missing or all-broken (matches today's
+                 _ne_effectively_empty behavior). Non-empty when NE has
+                 resolvable scorer entries that contribute real penalty
+                 (new in 2026-05-29 -- previously declined).
 
     Eligibility gates (conservative — fall back to find_fuzzy_matches for
     anything more complex):
       - mk.type == "weighted"
       - mk.threshold set
-      - no negative_evidence
       - no rerank / LLM
-      - across_files_only=False, target_ids=None (dedupe single-source case)
       - every field resolves to a score_pair callable via
         _resolve_score_pair_callable AND has its xform column precomputed
+      - NE entries with resolvable scorers WERE a decline gate; now they
+        engage the fast path with per-pair penalty math.
     """
     from goldenmatch.core.matchkey import _xform_sig
 
@@ -206,10 +261,6 @@ def _resolve_fast_path(
     if mk.threshold is None:
         _decline("mk.threshold is None")
         return None
-    if not _ne_effectively_empty(mk):
-        ne_scorers = [getattr(e, "scorer", "?") for e in (mk.negative_evidence or [])]
-        _decline(f"NE has callable scorer(s): {ne_scorers}")
-        return None
     if getattr(mk, "rerank", False):
         _decline("mk.rerank=True (auto-config enables for 3+ field weighted matchkeys)")
         return None
@@ -221,7 +272,9 @@ def _resolve_fast_path(
     # can engage with these set because they only act as post-filters on
     # emitted pairs, not as scoring math. The actual filtering happens after
     # the worker emits candidate pairs (mirrors _score_one_bucket's behavior).
-    # Removed 2026-05-29 to widen the fast path for match-mode workloads.
+    # Removed in PR #572 (match-mode widening); NE penalty math composes
+    # cleanly on top because NE is per-pair scoring and match-mode is
+    # per-pair post-filter -- they don't interact.
     if not mk.fields:
         _decline("mk.fields is empty")
         return None
@@ -246,6 +299,7 @@ def _resolve_fast_path(
     if total_weight <= 0:
         _decline(f"total_weight={total_weight}")
         return None
+    ne_specs = _resolve_ne_specs(mk, prepared_df)
     # Diagnostic on the success path: log matchkey shape so we can compare
     # what the controller commits at different row counts (rerank thresholds
     # and NE promotion are scale-dependent).
@@ -255,10 +309,10 @@ def _resolve_fast_path(
         f"[score_buckets._resolve_fast_path] ENGAGED: "
         f"n_fields={len(mk.fields)} scorers={scorer_names} "
         f"threshold={mk.threshold} rerank={getattr(mk, 'rerank', False)} "
-        f"ne_scorers={ne_scorers}",
+        f"ne_scorers={ne_scorers} ne_resolved={len(ne_specs)}",
         flush=True,
     )
-    return (float(mk.threshold), total_weight, field_specs)
+    return (float(mk.threshold), total_weight, field_specs, ne_specs)
 
 
 def score_buckets(
@@ -374,11 +428,20 @@ def score_buckets(
 
     # Native fast-path eligibility resolved ONCE: gated on, and every field's
     # scorer implemented by the native kernel. None -> Python per-pair loop.
+    # When NE has resolvable entries, force the Python path -- the native
+    # kernel emits pairs filtered against `threshold` BEFORE NE penalty is
+    # applied, so we'd have to re-emit + re-threshold downstream. The Python
+    # path handles NE math inline at the same per-pair cost. Returning to
+    # native-with-NE would mean teaching the kernel to emit pre-penalty
+    # candidate pairs (~2x emit volume) -- not worth it until measurement
+    # demands it.
     native_scorer_ids: list[int] | None = None
     if fast_path_specs is not None and native_enabled("block_scoring"):
-        ids = [_NATIVE_SCORER_IDS.get(spec[3]) for spec in fast_path_specs[2]]
-        if all(i is not None for i in ids):
-            native_scorer_ids = ids  # type: ignore[assignment]
+        _, _, _field_specs, _ne_specs = fast_path_specs
+        if not _ne_specs:
+            ids = [_NATIVE_SCORER_IDS.get(spec[3]) for spec in _field_specs]
+            if all(i is not None for i in ids):
+                native_scorer_ids = ids  # type: ignore[assignment]
 
     # Track 1 Fix B: build the native ExcludeSet ONCE here, BEFORE the bucket
     # worker loop. Previously _score_one_bucket_fast called
@@ -435,7 +498,7 @@ def score_buckets(
         # is a 3x3 array and the alloc/free + np.zeros call cost dwarfs the
         # actual rapidfuzz work.
         assert fast_path_specs is not None  # gated by dispatcher
-        threshold, total_weight, field_specs = fast_path_specs
+        threshold, total_weight, field_specs, ne_specs = fast_path_specs
         sorted_df = bucket_df.sort("__block_key__")
         sizes = (
             sorted_df.lazy()
@@ -495,6 +558,13 @@ def score_buckets(
         ]
         score_fns = [fn for _col, _w, fn, _name in field_specs]
         n_fields = len(field_specs)
+        # NE per-pair specs (post-2026-05-29 widening). Pre-materialize the
+        # NE xform columns; empty when NE missing / all-broken (no overhead).
+        ne_arrays = [sorted_df[col].to_list() for col, _fn, _t, _p in ne_specs]
+        ne_fns = [fn for _col, fn, _t, _p in ne_specs]
+        ne_thresholds = [t for _col, _fn, t, _p in ne_specs]
+        ne_penalties = [p for _col, _fn, _t, p in ne_specs]
+        n_ne = len(ne_specs)
         local_pairs: list[tuple[int, int, float]] = []
         local_blocks = 0
         offset = 0
@@ -523,12 +593,31 @@ def score_buckets(
                                 continue
                             score_sum += s * weights[f_idx]
                             weight_sum += weights[f_idx]
-                        if weight_sum > 0:
-                            combined = score_sum / total_weight
-                            if combined >= threshold:
-                                local_pairs.append(
-                                    (pair_key[0], pair_key[1], float(combined))
-                                )
+                        if weight_sum <= 0:
+                            continue
+                        combined = score_sum / total_weight
+                        # NE penalty math (mirrors core/scorer.py
+                        # _apply_negative_evidence): subtract penalty when an
+                        # NE field's similarity is below its threshold. Clamp
+                        # at 0. Same formula as the slow path.
+                        if n_ne > 0:
+                            penalty = 0.0
+                            for k in range(n_ne):
+                                na = ne_arrays[k][i]
+                                nb = ne_arrays[k][j]
+                                if na is None or nb is None:
+                                    continue
+                                sim = ne_fns[k](na, nb)
+                                if sim is None:
+                                    continue
+                                if sim < ne_thresholds[k]:
+                                    penalty += ne_penalties[k]
+                            if penalty > 0:
+                                combined = max(0.0, combined - penalty)
+                        if combined >= threshold:
+                            local_pairs.append(
+                                (pair_key[0], pair_key[1], float(combined))
+                            )
                 local_blocks += 1
             offset += size
         if across_files_only or target_ids is not None:

--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -241,25 +241,43 @@ def precompute_matchkey_transforms(
     seen: set[str] = set()
     native_exprs: list[pl.Expr] = []
     python_cols: list[pl.Series] = []
+
+    def _materialize_xform(field_obj):
+        """Resolve one (field, transforms) sig; appends to native_exprs or
+        python_cols. Idempotent via `seen` -- the same (field, transforms)
+        across multiple matchkeys / NE entries reuses one column.
+
+        Accepts any object with `.field` and `.transforms` attrs --
+        MatchkeyField and NegativeEvidenceField both qualify (the latter
+        is the new caller in the NE fast-path widening, 2026-05-29)."""
+        if getattr(field_obj, "scorer", None) == "record_embedding":
+            return
+        sig = _xform_sig(field_obj)
+        if sig in seen or sig in df.columns:
+            return
+        seen.add(sig)
+        native_expr = _try_native_chain(field_obj.field, field_obj.transforms)
+        if native_expr is not None:
+            native_exprs.append(native_expr.alias(sig))
+        else:
+            values = df[field_obj.field].to_list()
+            python_cols.append(pl.Series(
+                sig,
+                [apply_transforms(v, field_obj.transforms) if v is not None else None
+                 for v in values],
+            ))
+
     for mk in matchkeys:
         for field in mk.fields:
-            if field.scorer == "record_embedding":
-                continue
-            sig = _xform_sig(field)
-            if sig in seen or sig in df.columns:
-                continue
-            seen.add(sig)
-
-            native_expr = _try_native_chain(field.field, field.transforms)
-            if native_expr is not None:
-                native_exprs.append(native_expr.alias(sig))
-            else:
-                values = df[field.field].to_list()
-                python_cols.append(pl.Series(
-                    sig,
-                    [apply_transforms(v, field.transforms) if v is not None else None
-                     for v in values],
-                ))
+            _materialize_xform(field)
+        # v1.11 NE fast-path widening: precompute NE field xforms too so
+        # _resolve_fast_path's NE resolution can find the columns at gate
+        # time. NegativeEvidenceField has the same (field, transforms)
+        # duck-type as MatchkeyField, so _xform_sig reuses unchanged. Same
+        # signature => same column => NE on a field that ALSO appears in
+        # mk.fields with identical transforms is a free reuse.
+        for ne in (getattr(mk, "negative_evidence", None) or []):
+            _materialize_xform(ne)
 
     if not native_exprs and not python_cols:
         return df

--- a/packages/python/goldenmatch/tests/test_fast_path_ne_penalty.py
+++ b/packages/python/goldenmatch/tests/test_fast_path_ne_penalty.py
@@ -1,0 +1,179 @@
+"""Negative-evidence penalty math on the fast path (2026-05-29).
+
+Pre-this-PR: any NE entry with a callable scorer declined fast-path
+eligibility, forcing find_fuzzy_matches. Now `_resolve_ne_specs` resolves
+the NE entries to per-pair penalty callables and the Python fast path
+applies `combined = max(0, combined - sum(penalties))` inline.
+
+Formula source: core/scorer.py `_apply_negative_evidence`. Same semantics.
+
+Native kernel: skipped when ne_specs is non-empty -- it threshold-filters
+inside the kernel pre-penalty, so we'd need to teach it to emit pre-penalty
+candidates (~2x emit volume) to keep using it. Not yet justified.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.backends.score_buckets import (
+    _resolve_fast_path,
+    _resolve_ne_specs,
+    score_buckets,
+)
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    NegativeEvidenceField,
+)
+from goldenmatch.core.matchkey import _xform_sig
+
+
+def _mk(ne_entries: list[NegativeEvidenceField] | None = None) -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="t",
+        type="weighted",
+        threshold=0.5,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+        negative_evidence=ne_entries or [],
+    )
+
+
+def _prepared(name_vals, phone_vals):
+    mk = _mk()
+    name_col = _xform_sig(mk.fields[0])
+    phone_col = _xform_sig(
+        MatchkeyField(field="phone", scorer="jaro_winkler", weight=1.0)
+    )
+    return pl.DataFrame({
+        "__row_id__": list(range(len(name_vals))),
+        "name": name_vals,
+        "phone": phone_vals,
+        name_col: name_vals,
+        phone_col: phone_vals,
+    })
+
+
+class TestResolveNeSpecs:
+    def test_empty_ne_returns_empty(self):
+        df = _prepared(["a", "a"], ["1", "1"])
+        assert _resolve_ne_specs(_mk(), df) == []
+
+    def test_broken_scorer_silently_skipped(self):
+        """ensemble / embedding scorers aren't in _SCORE_FIELD_DIRECT_SCORERS;
+        mirror the slow path's _NE_BROKEN behavior and silently drop them."""
+        df = _prepared(["a", "a"], ["1", "1"])
+        mk = _mk([NegativeEvidenceField(field="phone", scorer="ensemble", threshold=0.8, penalty=0.5)])
+        assert _resolve_ne_specs(mk, df) == []
+
+    def test_missing_xform_silently_skipped(self):
+        """NE on a field whose xform column isn't precomputed should drop
+        silently -- can't compute, treat as broken."""
+        df = pl.DataFrame({"__row_id__": [0, 1], "name": ["a", "a"]})
+        mk = _mk([NegativeEvidenceField(field="phone", scorer="jaro_winkler", threshold=0.8, penalty=0.5)])
+        assert _resolve_ne_specs(mk, df) == []
+
+    def test_resolvable_ne_produces_spec(self):
+        df = _prepared(["a", "a"], ["555-1234", "555-9999"])
+        mk = _mk([NegativeEvidenceField(field="phone", scorer="jaro_winkler", threshold=0.8, penalty=0.4)])
+        specs = _resolve_ne_specs(mk, df)
+        assert len(specs) == 1
+        xform_col, fn, threshold, penalty = specs[0]
+        assert xform_col == _xform_sig(MatchkeyField(field="phone", scorer="jaro_winkler", weight=1.0))
+        assert callable(fn)
+        assert threshold == 0.8
+        assert penalty == 0.4
+
+
+class TestFastPathEngagedWithNe:
+    def test_gate_accepts_resolvable_ne(self):
+        df = _prepared(["alice", "alice"], ["555-1234", "555-9999"])
+        mk = _mk([NegativeEvidenceField(field="phone", scorer="jaro_winkler", threshold=0.8, penalty=0.5)])
+        result = _resolve_fast_path(
+            mk, df,
+            across_files_only=False, source_lookup=None, target_ids=None,
+        )
+        assert result is not None, "fast path must engage with resolvable NE"
+        _, _, field_specs, ne_specs = result
+        assert len(field_specs) == 1
+        assert len(ne_specs) == 1
+
+
+class TestPerPairNePenalty:
+    """End-to-end: an NE field that disagrees on a candidate pair drops the
+    final score below threshold and the pair is filtered out."""
+
+    def _run(self, name_vals, phone_vals, ne_penalty=0.5):
+        df = _prepared(name_vals, phone_vals).with_columns(
+            pl.lit("blockX").alias("__block_key__")
+        )
+        mk = _mk([NegativeEvidenceField(
+            field="phone", scorer="jaro_winkler",
+            threshold=0.9, penalty=ne_penalty,
+        )])
+        blocking = BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["name"])]
+        )
+        return score_buckets(df, blocking, mk, matched_pairs=set())
+
+    def test_ne_agreement_keeps_pair(self):
+        """When phone matches (NE sim >= threshold), no penalty -- pair survives."""
+        pairs = self._run(["alice", "alice"], ["555-1234", "555-1234"])
+        assert pairs, "matching phone -> no penalty -> pair must survive"
+
+    def test_ne_disagreement_drops_pair(self):
+        """When phone differs strongly (NE sim < threshold), penalty subtracts
+        from score. With penalty=1.0 and base score 1.0, final = 0 < threshold."""
+        pairs = self._run(
+            ["alice", "alice"],
+            ["555-1234", "999-9999"],
+            ne_penalty=1.0,  # large enough to push final below threshold
+        )
+        assert pairs == [], (
+            f"NE disagreement with penalty=1.0 must drop the pair below "
+            f"threshold; got {pairs}"
+        )
+
+    def test_ne_partial_penalty_reduces_but_keeps(self):
+        """Small penalty drops the score but stays above threshold."""
+        pairs = self._run(
+            ["alice", "alice"],
+            ["555-1234", "999-9999"],
+            ne_penalty=0.1,  # small enough that 1.0 - 0.1 = 0.9 >= threshold 0.5
+        )
+        assert pairs, "small NE penalty should not push pair below threshold"
+        # Score should be reduced from base 1.0 by exactly 0.1.
+        assert pytest.approx(pairs[0][2], abs=0.001) == 0.9
+
+
+class TestParityWithSlowPath:
+    """Sanity: fast-path-with-NE-math output equals slow-path output on
+    representative shapes. The slow path is the source of truth."""
+
+    def test_parity_phone_disagree(self):
+        from goldenmatch.config.schemas import BlockingConfig as _BC
+        from goldenmatch.core.scorer import find_fuzzy_matches
+
+        df = _prepared(["alice", "alice"], ["555-1234", "999-9999"]).with_columns(
+            pl.lit("blockX").alias("__block_key__")
+        )
+        mk = _mk([NegativeEvidenceField(
+            field="phone", scorer="jaro_winkler",
+            threshold=0.9, penalty=0.3,
+        )])
+        blocking = _BC(strategy="static", keys=[BlockingKeyConfig(fields=["name"])])
+        fast_pairs = score_buckets(df, blocking, mk, matched_pairs=set())
+        slow_pairs = find_fuzzy_matches(df, mk, exclude_pairs=frozenset(), pre_scored_pairs=None)
+        fast_keys = sorted((min(a, b), max(a, b)) for a, b, _ in fast_pairs)
+        slow_keys = sorted((min(a, b), max(a, b)) for a, b, _ in slow_pairs)
+        assert fast_keys == slow_keys, (
+            f"fast vs slow pair-set mismatch:\n  fast={fast_pairs}\n  slow={slow_pairs}"
+        )
+        for (fa, fb, fs), (sa, sb, ss) in zip(
+            sorted(fast_pairs), sorted(slow_pairs)
+        ):
+            assert (fa, fb) == (sa, sb)
+            assert pytest.approx(fs, abs=0.01) == ss, (
+                f"score mismatch at ({fa},{fb}): fast={fs} slow={ss}"
+            )

--- a/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
+++ b/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
@@ -129,7 +129,14 @@ class TestResolveFastPath:
             "broken-NE matchkey should be fast-path eligible after the gate fix"
         )
 
-    def test_fast_path_declined_with_callable_ne(self):
+    def test_fast_path_engaged_with_callable_ne_missing_xform(self):
+        """Callable-NE on a field whose xform column isn't in prepared_df
+        falls through silently (mirrors the slow path's `_NE_BROKEN` cache
+        semantics: NE without computable inputs contributes zero penalty).
+
+        Pre-2026-05-29 this declined the fast path outright. Now the gate
+        engages and `_resolve_ne_specs` silently drops the unresolvable
+        entry."""
         mk = _mk_with_ne([
             NegativeEvidenceField(field="phone", scorer="jaro_winkler", threshold=0.8, penalty=0.5),
         ])
@@ -137,7 +144,39 @@ class TestResolveFastPath:
             mk, self._prepared_df(),
             across_files_only=False, source_lookup=None, target_ids=None,
         )
-        assert result is None, (
-            "callable-NE matchkey must still decline the fast path -- the "
-            "fast path doesn't apply NE penalty math"
+        assert result is not None, (
+            "callable-NE on a missing-xform field should silently skip and "
+            "engage the fast path (matches slow path's _NE_BROKEN semantics)"
         )
+        # And: ne_specs should be empty since the NE entry was skipped.
+        _, _, _, ne_specs = result
+        assert ne_specs == [], (
+            f"NE entry on missing-xform field should be silently dropped, "
+            f"got ne_specs={ne_specs}"
+        )
+
+    def test_fast_path_engaged_with_callable_ne_present_xform(self):
+        """Callable-NE on a field whose xform IS in prepared_df engages the
+        fast path AND populates ne_specs with the per-pair penalty math
+        plan. The bucket worker applies the penalty inline."""
+        from goldenmatch.config.schemas import MatchkeyField
+        from goldenmatch.core.matchkey import _xform_sig
+        # Build a fixture that has the phone xform column too.
+        phone_field = MatchkeyField(field="phone", scorer="jaro_winkler", weight=1.0)
+        phone_col = _xform_sig(phone_field)
+        prepared = self._prepared_df().with_columns(
+            pl.Series(phone_col, ["555-1234", "555-9999"])
+        )
+        mk = _mk_with_ne([
+            NegativeEvidenceField(field="phone", scorer="jaro_winkler", threshold=0.8, penalty=0.5),
+        ])
+        result = _resolve_fast_path(
+            mk, prepared,
+            across_files_only=False, source_lookup=None, target_ids=None,
+        )
+        assert result is not None, "callable-NE with present xform should engage"
+        _, _, _, ne_specs = result
+        assert len(ne_specs) == 1, f"expected 1 resolved NE spec, got {ne_specs}"
+        assert ne_specs[0][0] == phone_col
+        assert ne_specs[0][2] == 0.8  # threshold
+        assert ne_specs[0][3] == 0.5  # penalty


### PR DESCRIPTION
## Why

`_resolve_fast_path` declined whenever any NE entry used a callable scorer, forcing the matchkey onto `find_fuzzy_matches`. NE math is well-defined per-pair: subtract penalty when NE similarity < threshold, clamp at 0. Same formula slow path uses. Move it inline.

## What

3 coordinated changes:

1. **`precompute_matchkey_transforms`** also walks `mk.negative_evidence`. Same `_xform_sig` -> same column when matchkey field + NE field share `(field, transforms)` -> zero extra work.

2. **`_resolve_ne_specs`** (new helper) resolves NE entries to per-pair specs. Mirrors slow path's `_NE_BROKEN` policy: drops non-callable NE scorers silently; drops entries with missing xform columns.

3. **`_resolve_fast_path`** returns a 4-tuple now (threshold, total_weight, field_specs, ne_specs). **`_score_one_bucket_fast`** applies `max(0, combined - sum(penalties))` per pair.

## Native kernel

Skipped when `ne_specs` is non-empty -- kernel threshold-filters inside the call, so post-emit NE math would need pre-penalty emit shape (~2x volume). Python path runs at the same per-pair cost.

## Tests

- `tests/test_fast_path_ne_penalty.py` (new): classification, gate acceptance, per-pair penalty math, **parity vs `find_fuzzy_matches`**.
- `tests/test_score_buckets_fast_path_gate.py` updated: callable-NE-on-missing-xform silently drops; callable-NE-with-xform engages with NE math.

## Scope

Doesn't change QIS auto-config wall (QIS NE is `ensemble`, silently skipped both before and after). Unblocks fast path for explicit-config / domain-pack workloads that set NE with a callable scorer (e.g. phone disagreement penalty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)