### PR TITLE
chore(bench): split pipeline_initial_collect from pipeline_prep_quality_scan (attribution fix)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -763,6 +763,21 @@ def _run_dedupe_pipeline(
             cached_disk = None
 
         if cached_disk is None:
+            # ── Step 1.3.5: FIRST INGEST MATERIALIZATION ──
+            # Pull the initial `combined_lf.collect()` out of whichever prep
+            # stage runs first so its cost isn't misattributed. v20 QIS
+            # instrumentation (2026-05-29) showed pipeline_prep_quality_scan
+            # = 117.4s of which only ~5s was actual goldencheck work; the
+            # other ~112s was THIS collect materializing the 10M-row ingest
+            # LazyFrame. The cost is fundamental Polars work the rest of
+            # the prep block needs anyway -- it just shouldn't read as
+            # "quality scan time" in bench reports. Subsequent .collect()s
+            # in the prep block (transform / auto_fix / cache_populate)
+            # see a lazy-wrapped eager df and unwrap cheaply.
+            with stage("pipeline_initial_collect"):
+                combined_df_tmp = combined_lf.collect()
+                combined_lf = combined_df_tmp.lazy()
+
             # ── Step 1.4: GOLDENCHECK QUALITY SCAN (if available) ──
             if config.quality is None or config.quality.mode != "disabled":
                 from goldenmatch.core.quality import run_quality_check


### PR DESCRIPTION
## Why

v20 quality-scan instrumentation (per-block `gc:*` markers inside `scan_dataframe_impl`) revealed:

| Block | Time |
|---|---|
| All of `scan_dataframe_impl` internals | **~4.8 s** |
| `pipeline_prep_quality_scan` total | **117.4 s** |

The 112 s gap is `combined_lf.collect()` materializing the 10M-row ingest LazyFrame -- a cost the prep block has to pay regardless. It just gets attributed to whichever prep stage runs first (today, quality_scan; if quality is disabled, it would shift to transform).

This misled both PR #562 (scan_dataframe, ~0 s wall savings) and PR #569 (cache n_unique, ~0 s wall savings) -- they optimized the right code for the wrong reason.

## What

Pull the initial `combined_lf.collect()` out into its own `pipeline_initial_collect` stage marker. Pure accounting; zero behavioral or wall-time change. Subsequent prep stages already saw a lazy-wrapped eager df and unwrapped cheaply.

## Expected effect on bench reports

- `pipeline_initial_collect`: ~110 s (new, was hiding inside quality_scan)
- `pipeline_prep_quality_scan`: ~5-10 s (down from 117 s; reflects actual scan work)
- Total wall: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)