### PR TITLE
perf(probabilistic): pre-resolved per-pair Fellegi-Sunter fast path

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1188,9 +1188,34 @@ def _run_dedupe_pipeline(
                 "F-S EM: converged=%s, iterations=%d, match_rate=%.4f",
                 em_result.converged, em_result.iterations, em_result.proportion_matched,
             )
+            # Fast path: pre-resolve per-field callables + level-mapping
+            # plan once per matchkey, then run an indexed Python loop per
+            # block. Resolved against the FIRST block_df so the xform
+            # column check sees a representative shape; subsequent blocks
+            # share the same columns. Falls back to score_probabilistic
+            # when any gate fails (model-backed scorer, levels > 3, missing
+            # xform column, etc).
+            from goldenmatch.core.probabilistic_fast import (
+                _resolve_probabilistic_fast_path,
+                score_probabilistic_fast,
+            )
+            _first_block_df = (
+                blocks[0].df.collect()
+                if blocks and isinstance(blocks[0].df, pl.LazyFrame)
+                else (blocks[0].df if blocks else None)
+            )
+            fast_spec = (
+                _resolve_probabilistic_fast_path(mk, _first_block_df, em_result)
+                if _first_block_df is not None else None
+            )
             for block in blocks:
                 block_df = block.df.collect() if isinstance(block.df, pl.LazyFrame) else block.df
-                pairs = score_probabilistic(block_df, mk, em_result, exclude_pairs=matched_pairs)
+                if fast_spec is not None:
+                    pairs = score_probabilistic_fast(
+                        block_df, fast_spec, exclude_pairs=matched_pairs,
+                    )
+                else:
+                    pairs = score_probabilistic(block_df, mk, em_result, exclude_pairs=matched_pairs)
                 if across_files_only:
                     pairs = [
                         (a, b, s) for a, b, s in pairs
@@ -1832,9 +1857,27 @@ def _run_match_pipeline(
                 blocks=blocks,
                 blocking_fields=blocking_fields,
             )
+            from goldenmatch.core.probabilistic_fast import (
+                _resolve_probabilistic_fast_path,
+                score_probabilistic_fast,
+            )
+            _first_block_df = (
+                blocks[0].df.collect()
+                if blocks and isinstance(blocks[0].df, pl.LazyFrame)
+                else (blocks[0].df if blocks else None)
+            )
+            fast_spec = (
+                _resolve_probabilistic_fast_path(mk, _first_block_df, em_result)
+                if _first_block_df is not None else None
+            )
             for block in blocks:
                 block_df = block.df.collect() if isinstance(block.df, pl.LazyFrame) else block.df
-                pairs = score_probabilistic(block_df, mk, em_result, exclude_pairs=matched_pairs)
+                if fast_spec is not None:
+                    pairs = score_probabilistic_fast(
+                        block_df, fast_spec, exclude_pairs=matched_pairs,
+                    )
+                else:
+                    pairs = score_probabilistic(block_df, mk, em_result, exclude_pairs=matched_pairs)
                 all_pairs.extend(pairs)
                 for a, b, _s in pairs:
                     matched_pairs.add((min(a, b), max(a, b)))

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
@@ -1,0 +1,221 @@
+"""Fast per-pair Fellegi-Sunter scoring for the bucket scorer's fast path.
+
+Sister module to `probabilistic.py::score_probabilistic` -- same scoring
+semantics (m/u-trained match weights, normalized to [0,1], thresholded
+by `mk.link_threshold` or the computed default), but pre-resolves all
+per-pair work at gate time so the scoring loop never:
+
+- Calls `score_field` (PluginRegistry dispatch per pair per field)
+- Calls `apply_transforms` per pair (the precomputed `__xform_<sig>__`
+  columns already encode the transformed values; this module reads them
+  directly)
+- Builds a per-row dict via `to_dicts()` (row_lookup in the slow path)
+- Looks up field values by name in the per-pair inner loop
+
+Gate eligibility (`_resolve_probabilistic_fast_path`):
+  - mk.type == "probabilistic"
+  - For every mk.field:
+      - scorer resolves via `_resolve_score_pair_callable`
+      - `__xform_<sig>__` column exists in `prepared_df`
+      - field.levels in {2, 3} (N>3 unsupported in fast path v1; falls back
+        to the slow `score_probabilistic` path)
+  - em_result has match_weights for every field
+
+When the gate fails, callers fall back to `score_probabilistic`. The fast
+path produces bit-equivalent output within rapidfuzz tolerance (parity
+asserted in `tests/test_fast_path_probabilistic.py`).
+
+Design parallels `_score_one_bucket_fast` in `backends/score_buckets.py`:
+pre-resolved spec at gate time + indexed Python loop over pre-materialized
+arrays at run time.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import polars as pl
+
+from goldenmatch.backends.score_buckets import _resolve_score_pair_callable
+
+if TYPE_CHECKING:
+    from goldenmatch.config.schemas import MatchkeyConfig
+    from goldenmatch.core.probabilistic import EMResult
+
+
+# Per-field spec for the probabilistic fast path:
+#   (xform_col, score_pair_fn, levels, partial_threshold, weights_per_level)
+# weights_per_level is em_result.match_weights[field], a list whose length
+# equals levels (so we can index by level without dict lookup).
+ProbFieldSpec = tuple[str, Any, int, float, list[float]]
+
+
+def _resolve_probabilistic_fast_path(
+    mk: MatchkeyConfig,
+    prepared_df: pl.DataFrame,
+    em_result: EMResult,
+) -> tuple[list[ProbFieldSpec], float, float, float, float] | None:
+    """Decide whether mk + em_result is eligible for the fast path and
+    pre-resolve every per-field plan needed by the inner loop.
+
+    Returns (field_specs, link_threshold, max_weight, min_weight, weight_range)
+    when eligible; None when any gate fails (caller falls back to slow path).
+
+    Eligibility gates (conservative -- the slow path remains correct for
+    everything not handled here):
+      - mk.type == "probabilistic"
+      - For every mk.field: scorer resolves via _resolve_score_pair_callable
+        (rules out embedding/record_embedding/unknown plugins) AND its
+        precomputed xform column is in prepared_df AND levels in {2, 3}.
+      - em_result has match_weights for every field.
+    """
+    from goldenmatch.core.matchkey import _xform_sig
+    from goldenmatch.core.probabilistic import compute_thresholds
+
+    if mk.type != "probabilistic":
+        return None
+    if not mk.fields:
+        return None
+
+    field_specs: list[ProbFieldSpec] = []
+    max_weight = 0.0
+    min_weight = 0.0
+    for f in mk.fields:
+        # Per-pair callable. None when scorer is model-backed or unknown.
+        fn = _resolve_score_pair_callable(f.scorer)
+        if fn is None:
+            return None
+        # Precomputed xform column must exist (precompute_matchkey_transforms
+        # iterates all matchkey fields, including probabilistic ones).
+        xform_col = _xform_sig(f)
+        if xform_col not in prepared_df.columns:
+            return None
+        # Fast path v1 supports 2 + 3 level fields. N > 3 falls back so the
+        # slow path's even-spaced threshold logic stays the source of truth.
+        if f.levels not in (2, 3):
+            return None
+        # em_result must have weights for this field.
+        weights = em_result.match_weights.get(f.field)
+        if not weights or len(weights) != f.levels:
+            return None
+        field_specs.append((
+            xform_col,
+            fn,
+            int(f.levels),
+            float(f.partial_threshold),
+            [float(w) for w in weights],
+        ))
+        max_weight += max(weights)
+        min_weight += min(weights)
+
+    # Resolve threshold the same way the slow path does.
+    if mk.link_threshold is not None:
+        link_threshold = float(mk.link_threshold)
+    else:
+        link_threshold, _ = compute_thresholds(em_result)
+        link_threshold = float(link_threshold)
+
+    weight_range = max_weight - min_weight
+    return field_specs, link_threshold, max_weight, min_weight, weight_range
+
+
+def score_probabilistic_fast(
+    block_df: pl.DataFrame,
+    spec: tuple[list[ProbFieldSpec], float, float, float, float],
+    exclude_pairs: set[tuple[int, int]] | None = None,
+) -> list[tuple[int, int, float]]:
+    """Score pairs in a block using a pre-resolved probabilistic spec.
+
+    Bit-equivalent (within rapidfuzz tolerance) to:
+
+        score_probabilistic(block_df, mk, em_result, exclude_pairs)
+
+    when the gate accepted the (mk, em_result, block_df) triple. The
+    per-pair work is:
+
+      for each (i, j):
+        for each field k:
+          sim_k = score_fn_k(xform_arr_k[i], xform_arr_k[j])
+          level_k = map_to_level(sim_k, levels_k, partial_threshold_k)
+          weight_sum += weights_k[level_k]
+        normalized = (weight_sum - min_weight) / weight_range
+        if normalized >= link_threshold: emit
+
+    No PluginRegistry dispatch, no per-pair dict construction, no
+    apply_transforms (precomputed xform columns already encode the
+    transformed values).
+    """
+    if exclude_pairs is None:
+        exclude_pairs = set()
+
+    field_specs, link_threshold, _max_weight, min_weight, weight_range = spec
+    n_fields = len(field_specs)
+    row_ids = block_df["__row_id__"].to_list()
+    n_rows = len(row_ids)
+    if n_rows < 2:
+        return []
+
+    # Pre-materialize all field columns + their plans as parallel arrays so
+    # the inner loop is pure index work.
+    xform_arrays: list[list[Any]] = []
+    score_fns: list[Any] = []
+    levels_list: list[int] = []
+    partial_thresholds: list[float] = []
+    weights_list: list[list[float]] = []
+    for xform_col, fn, levels, partial_threshold, weights in field_specs:
+        xform_arrays.append(block_df[xform_col].to_list())
+        score_fns.append(fn)
+        levels_list.append(levels)
+        partial_thresholds.append(partial_threshold)
+        weights_list.append(weights)
+
+    results: list[tuple[int, int, float]] = []
+    for i in range(n_rows):
+        ri = row_ids[i]
+        for j in range(i + 1, n_rows):
+            rj = row_ids[j]
+            if ri < rj:
+                pair_key = (ri, rj)
+            else:
+                pair_key = (rj, ri)
+            if pair_key in exclude_pairs:
+                continue
+
+            weight_sum = 0.0
+            for k in range(n_fields):
+                va = xform_arrays[k][i]
+                vb = xform_arrays[k][j]
+                if va is None or vb is None:
+                    # Slow path treats nulls as disagree (level 0).
+                    weight_sum += weights_list[k][0]
+                    continue
+                sim = score_fns[k](va, vb)
+                if sim is None:
+                    weight_sum += weights_list[k][0]
+                    continue
+                lvls = levels_list[k]
+                pt = partial_thresholds[k]
+                # Map similarity to level. Same logic as comparison_vector
+                # in core/probabilistic.py:67-77 -- 2-level binary threshold,
+                # 3-level uses 0.95 as the high cutoff. N > 3 was filtered
+                # out at gate time.
+                if lvls == 2:
+                    level = 1 if sim >= pt else 0
+                else:  # lvls == 3
+                    if sim >= 0.95:
+                        level = 2
+                    elif sim >= pt:
+                        level = 1
+                    else:
+                        level = 0
+                weight_sum += weights_list[k][level]
+
+            # Normalize and threshold. Identical to score_probabilistic's
+            # final block.
+            if weight_range > 0:
+                normalized = (weight_sum - min_weight) / weight_range
+            else:
+                normalized = 0.5
+            if normalized >= link_threshold:
+                results.append((pair_key[0], pair_key[1], round(normalized, 4)))
+
+    return results

--- a/packages/python/goldenmatch/tests/test_fast_path_probabilistic.py
+++ b/packages/python/goldenmatch/tests/test_fast_path_probabilistic.py
@@ -1,0 +1,180 @@
+"""Fast per-pair Fellegi-Sunter scoring (probabilistic_fast.py).
+
+Parity contract: same input through `score_probabilistic_fast` produces
+the same pair set + scores (within rapidfuzz tolerance) as the slow path
+through `score_probabilistic`, when the gate accepts.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.matchkey import _xform_sig, precompute_matchkey_transforms
+from goldenmatch.core.probabilistic import EMResult, score_probabilistic
+from goldenmatch.core.probabilistic_fast import (
+    _resolve_probabilistic_fast_path,
+    score_probabilistic_fast,
+)
+
+
+def _mk_probabilistic(levels: int = 2) -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="prob",
+        type="probabilistic",
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", levels=levels, partial_threshold=0.8),
+            MatchkeyField(field="last_name", scorer="jaro_winkler", levels=levels, partial_threshold=0.8),
+        ],
+        link_threshold=0.5,
+    )
+
+
+def _em_2level() -> EMResult:
+    return EMResult(
+        m_probs={"first_name": [0.1, 0.9], "last_name": [0.05, 0.95]},
+        u_probs={"first_name": [0.95, 0.05], "last_name": [0.97, 0.03]},
+        # log2(m/u) per level. agree weights > 0; disagree weights < 0.
+        match_weights={"first_name": [-3.25, 4.17], "last_name": [-4.27, 4.98]},
+        converged=True,
+        iterations=5,
+        proportion_matched=0.1,
+    )
+
+
+def _em_3level() -> EMResult:
+    return EMResult(
+        m_probs={"first_name": [0.05, 0.20, 0.75], "last_name": [0.03, 0.15, 0.82]},
+        u_probs={"first_name": [0.80, 0.15, 0.05], "last_name": [0.85, 0.12, 0.03]},
+        match_weights={"first_name": [-4.0, 0.41, 3.91], "last_name": [-4.82, 0.32, 4.77]},
+        converged=True,
+        iterations=5,
+        proportion_matched=0.1,
+    )
+
+
+def _prepared(first_names: list[str], last_names: list[str]) -> pl.DataFrame:
+    df = pl.DataFrame({
+        "__row_id__": list(range(len(first_names))),
+        "first_name": first_names,
+        "last_name": last_names,
+    })
+    return precompute_matchkey_transforms(df, [_mk_probabilistic()])
+
+
+class TestResolveProbabilisticFastPath:
+    def test_accepts_2level(self):
+        mk = _mk_probabilistic(levels=2)
+        df = _prepared(["alice", "alice"], ["smith", "smith"])
+        spec = _resolve_probabilistic_fast_path(mk, df, _em_2level())
+        assert spec is not None
+
+    def test_accepts_3level(self):
+        mk = _mk_probabilistic(levels=3)
+        df = _prepared(["alice", "alice"], ["smith", "smith"])
+        spec = _resolve_probabilistic_fast_path(mk, df, _em_3level())
+        assert spec is not None
+
+    def test_rejects_weighted_matchkey(self):
+        mk = MatchkeyConfig(
+            name="w", type="weighted", threshold=0.5,
+            fields=[MatchkeyField(field="first_name", scorer="jaro_winkler", weight=1.0)],
+        )
+        df = _prepared(["a", "a"], ["b", "b"])
+        assert _resolve_probabilistic_fast_path(mk, df, _em_2level()) is None
+
+    def test_rejects_missing_xform(self):
+        """xform_sig not in df.columns -> fall back."""
+        mk = _mk_probabilistic(levels=2)
+        # Don't run precompute_matchkey_transforms.
+        bare = pl.DataFrame({"__row_id__": [0, 1], "first_name": ["a", "a"], "last_name": ["b", "b"]})
+        assert _resolve_probabilistic_fast_path(mk, bare, _em_2level()) is None
+
+    def test_rejects_model_backed_scorer(self):
+        mk = MatchkeyConfig(
+            name="prob", type="probabilistic",
+            fields=[
+                MatchkeyField(field="x", scorer="embedding", levels=2, partial_threshold=0.8),
+            ],
+            link_threshold=0.5,
+        )
+        df = pl.DataFrame({"__row_id__": [0, 1], "x": ["a", "a"]})
+        # Add xform col so the missing-xform gate doesn't beat the scorer one.
+        df = df.with_columns(pl.col("x").alias(_xform_sig(mk.fields[0])))
+        assert _resolve_probabilistic_fast_path(mk, df, _em_2level()) is None
+
+    def test_rejects_levels_4(self):
+        mk = MatchkeyConfig(
+            name="prob", type="probabilistic",
+            fields=[
+                MatchkeyField(field="first_name", scorer="jaro_winkler", levels=4, partial_threshold=0.8),
+            ],
+            link_threshold=0.5,
+        )
+        df = _prepared(["a", "a"], ["b", "b"])
+        em = EMResult(
+            m_probs={"first_name": [0.05, 0.1, 0.2, 0.65]},
+            u_probs={"first_name": [0.8, 0.1, 0.05, 0.05]},
+            match_weights={"first_name": [-4.0, 0.0, 2.0, 3.7]},
+            converged=True, iterations=5, proportion_matched=0.1,
+        )
+        assert _resolve_probabilistic_fast_path(mk, df, em) is None
+
+
+class TestParityWithSlowPath:
+    """Pair set + scores from fast path must equal those from slow path
+    on representative blocks. Source of truth is `score_probabilistic`."""
+
+    @pytest.mark.parametrize("levels", [2, 3])
+    def test_parity_matching_pair(self, levels):
+        mk = _mk_probabilistic(levels=levels)
+        em = _em_2level() if levels == 2 else _em_3level()
+        # Two identical pairs + one disagree pair.
+        df = _prepared(
+            ["alice", "alice", "bob"],
+            ["smith", "smith", "jones"],
+        )
+        fast_spec = _resolve_probabilistic_fast_path(mk, df, em)
+        assert fast_spec is not None
+        fast_pairs = score_probabilistic_fast(df, fast_spec)
+        slow_pairs = score_probabilistic(df, mk, em)
+        fast_keys = sorted((a, b) for a, b, _ in fast_pairs)
+        slow_keys = sorted((a, b) for a, b, _ in slow_pairs)
+        assert fast_keys == slow_keys, (
+            f"pair-set mismatch:\n  fast={fast_pairs}\n  slow={slow_pairs}"
+        )
+        # Score parity within 0.01 (rounding + rapidfuzz noise).
+        for (fa, fb, fs), (sa, sb, ss) in zip(sorted(fast_pairs), sorted(slow_pairs)):
+            assert (fa, fb) == (sa, sb)
+            assert pytest.approx(fs, abs=0.01) == ss, (
+                f"score mismatch at ({fa},{fb}): fast={fs} slow={ss}"
+            )
+
+    def test_parity_disagree_below_threshold(self):
+        """Pair with disagreement should produce identical "not emitted"
+        decision on both paths."""
+        mk = _mk_probabilistic(levels=2)
+        em = _em_2level()
+        df = _prepared(["alice", "zzzzz"], ["smith", "ttttt"])
+        fast_spec = _resolve_probabilistic_fast_path(mk, df, em)
+        assert fast_spec is not None
+        fast_pairs = score_probabilistic_fast(df, fast_spec)
+        slow_pairs = score_probabilistic(df, mk, em)
+        assert sorted((a, b) for a, b, _ in fast_pairs) == sorted((a, b) for a, b, _ in slow_pairs)
+
+
+class TestExcludePairs:
+    def test_exclude_filters_pair(self):
+        mk = _mk_probabilistic(levels=2)
+        em = _em_2level()
+        df = _prepared(["alice", "alice"], ["smith", "smith"])
+        fast_spec = _resolve_probabilistic_fast_path(mk, df, em)
+        assert fast_spec is not None
+        # Without exclude: should emit (0, 1).
+        pairs_no_exclude = score_probabilistic_fast(df, fast_spec)
+        assert len(pairs_no_exclude) == 1
+        # With exclude: should emit nothing.
+        pairs_with_exclude = score_probabilistic_fast(df, fast_spec, exclude_pairs={(0, 1)})
+        assert pairs_with_exclude == []


### PR DESCRIPTION
## Why

Probabilistic matchkeys (Fellegi-Sunter with EM-trained m/u probabilities) take a separate code path from weighted matchkeys: `score_probabilistic` in `core/probabilistic.py`. Its inner loop does per-pair: `score_field` (PluginRegistry dispatch), `apply_transforms` per field per pair, dict lookups via `row_lookup.get`, and recomputes max/min weight on every call. The same pattern the bucket scorer's fast path eliminated for weighted matchkeys.

## What

New module `core/probabilistic_fast.py`:

- `_resolve_probabilistic_fast_path(mk, prepared_df, em_result)` -- gate at probabilistic dispatch time.
- `score_probabilistic_fast(block_df, spec, exclude_pairs)` -- pre-resolved per-pair scoring.

Gates (slow path remains correct for everything outside):
- mk.type == "probabilistic"
- Every field's scorer resolves via `_resolve_score_pair_callable`
- Every field's precomputed `__xform_<sig>__` column exists
- `field.levels in {2, 3}` (N > 3 falls back to slow path)
- em_result has match_weights for every field

`pipeline.py` wires the gate at both probabilistic dispatch sites. Falls back to `score_probabilistic` when the gate rejects.

## Tests

`tests/test_fast_path_probabilistic.py`:
- Gate accepts 2-level + 3-level matchkeys with jw scorer
- Gate rejects weighted matchkey / missing xform / embedding scorer / levels=4
- **Parity:** pair-set + scores match `score_probabilistic` on matching / disagree blocks
- `exclude_pairs` filters correctly

## Scope

Doesn't change QIS auto-config wall (auto-config picks weighted matchkeys, not probabilistic). Lift is for workloads that explicitly use `type: probabilistic` matchkeys -- DBLP-ACM-style structured records where Fellegi-Sunter is the right scoring framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)