### PR TITLE
chore(autoconfig): drop all-uniform-column-types YELLOW from DataProfile.health()

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -117,9 +117,24 @@ class DataProfile:
     column_priors: dict[str, ColumnPrior] | None = None
 
     def health(self) -> HealthVerdict:
+        """RED for empty data, YELLOW for single-column inputs, GREEN otherwise.
+
+        Historical (pre-2026-05-29): also returned YELLOW when every column
+        shared the same `column_types` value -- the intent was to flag "all
+        your columns are strings, you might want richer typing." In practice
+        that's the shape of MOST CSV inputs (every cell parses as text until
+        a typed downstream step says otherwise), so it tripped almost every
+        real dataset INCLUDING the QIS realistic fixture which produces a
+        clean F1=0.9886. v23 telemetry (#577) showed this signal stayed
+        YELLOW for all 5 controller iterations with no rule addressing it
+        because the verdict isn't actionable -- there's no config change
+        that fixes "your data is all strings." Removing the uniform-types
+        clause turns this from a noisy false-positive into a precise signal
+        for the genuinely-degenerate single-column case.
+        """
         if self.n_rows == 0:
             return HealthVerdict.RED
-        if self.n_cols == 1 or len(set(self.column_types.values())) == 1:
+        if self.n_cols == 1:
             return HealthVerdict.YELLOW
         return HealthVerdict.GREEN
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_controller.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_controller.py
@@ -891,13 +891,20 @@ def _red_blocking_subprofile_dict():
 def _yellow_subprofiles():
     """Return sub-profile dict that yields ComplexityProfile.health() == YELLOW.
 
-    Uses a DataProfile with only one column type (all 'text') so DataProfile.health()
-    returns YELLOW. Other sub-profiles are GREEN-safe so YELLOW rolls up.
+    Uses a MatchkeyProfile field with cardinality > 0.95 so
+    MatchkeyProfile.health() returns YELLOW. Other sub-profiles are
+    GREEN-safe so YELLOW rolls up via _max_severity.
+
+    Pre-#579 this used the all-text-columns DataProfile signal, but that
+    signal was removed (it was definitional, not actionable -- most CSVs
+    are all-text). Switched to the matchkey signal which is still active
+    and actionable (see rule_matchkey_demote_high_cardinality_field in
+    #578).
     """
     return dict(
         data=DataProfile(
             n_rows=100, n_cols=2,
-            column_types={"a": "text", "b": "text"},
+            column_types={"a": "text", "b": "id-like"},
         ),
         blocking=BlockingProfile(
             keys_used=[["a"]], n_blocks=10, total_comparisons=500,
@@ -912,7 +919,8 @@ def _yellow_subprofiles():
             n_clusters=20, cluster_size_p50=2, cluster_size_p99=5,
             cluster_size_max=8, transitivity_rate=0.95,
         ),
-        matchkey=MatchkeyProfile(per_field={"a": FieldStats(0.5, 0.0, 10)}),
+        # cardinality 0.99 > 0.95 -> MatchkeyProfile.health() == YELLOW.
+        matchkey=MatchkeyProfile(per_field={"a": FieldStats(0.99, 0.0, 10)}),
     )
 
 

--- a/packages/python/goldenmatch/tests/test_complexity_profile.py
+++ b/packages/python/goldenmatch/tests/test_complexity_profile.py
@@ -72,6 +72,20 @@ def test_data_yellow_when_one_col():
     assert DataProfile(n_rows=10, n_cols=1, column_types={"a": "text"}).health() == HealthVerdict.YELLOW
 
 
+def test_data_green_when_all_columns_share_type():
+    """v23 (2026-05-29): all-uniform-types no longer YELLOW. CSV inputs are
+    overwhelmingly "every column parsed as text" -- treating that as a
+    quality signal flagged every dataset and produced no actionable rule
+    response in the controller. The QIS realistic fixture (F1=0.9886) was
+    being committed YELLOW solely because of this. Now: GREEN as long as
+    there's more than one column."""
+    p = DataProfile(
+        n_rows=100, n_cols=8,
+        column_types={f"c{i}": "text" for i in range(8)},
+    )
+    assert p.health() == HealthVerdict.GREEN
+
+
 def test_domain_yellow_when_low_conf_with_derived_cols():
     dp = DomainProfile(detected_domain="bibliographic", confidence=0.2,
                        derived_columns=["__title_key__"], low_confidence_row_count=10)


### PR DESCRIPTION
## Why

v23 QIS telemetry (#577) showed `data` sub-profile YELLOW from iter 0 to iter 4 across all controller iterations with no rule addressing it. Root cause: `DataProfile.health()` returned YELLOW when every column shared the same `column_types` value:

```python
if self.n_cols == 1 or len(set(self.column_types.values())) == 1:
    return YELLOW
```

That second clause is the shape of MOST CSV inputs -- every cell parses as text until a typed downstream step says otherwise. It trips on almost every real dataset INCLUDING the QIS realistic fixture, which produces a clean F1=0.9886.

The signal isn't actionable: there's no config change that fixes 'your data is all strings.' Keeping it YELLOW just pinned the controller's final commit at YELLOW (via `_max_severity` aggregation) for a definitional property, not a quality problem.

## What

Removed the uniform-types clause from `DataProfile.health()`. `n_cols == 1` still returns YELLOW (genuinely degenerate single-column case).

## Tests

- `test_data_yellow_when_one_col` -- preserved.
- `test_data_green_when_all_columns_share_type` -- new, locks in the change.

## Companion to #578

`#578` adds `rule_matchkey_demote_high_cardinality_field` which addresses the OTHER persistent YELLOW v23 identified (matchkey sub-profile). Both together should produce GREEN commits on QIS-shape inputs that currently end YELLOW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)