### PR TITLE
fix(autoconfig): thread full_n_rows into DataProfile so Chao1 extrapolates correctly

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -509,6 +509,11 @@ class AutoConfigController:
             _df_for_gates = df  # type: ignore[assignment]
             n_rows = df.height  # type: ignore[union-attr]
             init_sample = df  # type: ignore[assignment]  # alias; never collected twice
+        # Stash the full dataset row count for _assemble_profile() so per-
+        # iteration profiles carry data.n_full_rows. Chao1 extrapolation in
+        # MatchkeyProfile.health() and rule_matchkey_demote_high_cardinality_field
+        # depend on this being the FULL data count, not the sample size.
+        self._current_run_full_n_rows = n_rows
 
         # Pathological gates ------------------------------------------------
         if _df_for_gates.height == 0:
@@ -1470,6 +1475,7 @@ class AutoConfigController:
         is_sample: bool = True,
         reference: pl.DataFrame | None = None,
         config: GoldenMatchConfig | None = None,
+        full_n_rows: int | None = None,
     ) -> ComplexityProfile:
         """Build ComplexityProfile from emitter writes. Missing sub-profiles
         fall back to defaults computed from ``df`` (plus ``reference`` in match
@@ -1493,6 +1499,19 @@ class AutoConfigController:
         )
 
         data = emitter.data or self._compute_data_profile(df, reference=reference)
+        # Stamp the full dataset row count when the caller knows it. Prefer
+        # the explicit param; fall back to the controller's per-run stash
+        # set at the entry of run() so iteration call sites don't all need
+        # to thread it through. Chao1 in MatchkeyProfile.health() and
+        # rule_matchkey_demote_high_cardinality_field need the full row
+        # count to extrapolate sample cardinality correctly.
+        effective_full_n_rows = (
+            full_n_rows
+            if full_n_rows is not None
+            else getattr(self, "_current_run_full_n_rows", None)
+        )
+        if effective_full_n_rows is not None and data.n_full_rows != effective_full_n_rows:
+            data = dataclasses.replace(data, n_full_rows=effective_full_n_rows)
         scoring = emitter.scoring or ScoringProfile()
 
         # Tier 1a: compute random-pair recall probe (only on real iterations, not the

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -1161,7 +1161,10 @@ def rule_matchkey_demote_high_cardinality_field(
     # every sampled value is unique). Without this correction the rule
     # misfired on `first_name`. With Chao1, only fields that ARE uniquely
     # identifying at the bench's actual row count cross the threshold.
-    n_full_rows = profile.data.n_rows
+    # data.effective_n_rows = n_full_rows when controller threaded it
+    # through; falls back to n_rows when not (e.g., non-controller emission
+    # paths where n_rows IS the full data).
+    n_full_rows = profile.data.effective_n_rows
     for mk in current.matchkeys or []:
         if mk.type != "weighted":
             continue

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -106,6 +106,20 @@ def _max_severity(*verdicts: HealthVerdict) -> HealthVerdict:
 
 @dataclass(frozen=True)
 class DataProfile:
+    """Per-dataset profile. `n_rows` is the size of whatever DataFrame was
+    profiled -- on the controller's per-iteration emission that's the
+    SAMPLE, not the full dataset.
+
+    `n_full_rows` (added 2026-05-29) is the full dataset's row count when
+    the controller has it (i.e., when this profile was emitted from a
+    sample but the controller knows the total). Chao1 extrapolation in
+    `MatchkeyProfile.health()` and `rule_matchkey_demote_high_cardinality_
+    field` needs the full row count, not the sample row count, to
+    correctly extrapolate sample-scale singleton/doubleton evidence to
+    full-data cardinality.
+
+    Falls back to `n_rows` when not set, preserving pre-2026-05-29 behavior.
+    """
     _version: int = 1
     n_rows: int = 0
     n_cols: int = 0
@@ -115,6 +129,14 @@ class DataProfile:
     value_length_p50: dict[str, int] = field(default_factory=dict)
     value_length_p99: dict[str, int] = field(default_factory=dict)
     column_priors: dict[str, ColumnPrior] | None = None
+    n_full_rows: int | None = None
+
+    @property
+    def effective_n_rows(self) -> int:
+        """Full-dataset row count when the controller threaded it through;
+        otherwise the local `n_rows` (which on a non-controller emission IS
+        the full data)."""
+        return self.n_full_rows if self.n_full_rows is not None else self.n_rows
 
     def health(self) -> HealthVerdict:
         """RED for empty data, YELLOW for single-column inputs, GREEN otherwise.
@@ -420,10 +442,14 @@ class ComplexityProfile:
     zero_label: ZeroLabelConfidenceProfile | None = None
 
     def health(self) -> HealthVerdict:
+        # Use data.effective_n_rows (= n_full_rows when threaded by the
+        # controller, n_rows otherwise) for Chao1 extrapolation. blocking
+        # and cluster health() existed before Chao1 and keep using n_rows
+        # to preserve their meaning ("rows in the profiled DataFrame").
         return _max_severity(
             self.data.health(),
             self.domain.health(),
-            self.matchkey.health(n_full_rows=self.data.n_rows),
+            self.matchkey.health(n_full_rows=self.data.effective_n_rows),
             self.blocking.health(n_rows=self.data.n_rows),
             self.scoring.health(),
             self.cluster.health(n_rows=self.data.n_rows),


### PR DESCRIPTION
## Why

PR #581 added Chao1 scale-aware cardinality but v25 showed it didn't actually fire on QIS. Root cause: `DataProfile.n_rows` on the controller-emitted profile is the SAMPLE size (~3K), not the full dataset (10M). Chao1 extrapolates relative to that size, so with sample == 'full', the estimate just equals the raw sample cardinality.

## What

- `DataProfile.n_full_rows: int | None = None` (new field).
- `DataProfile.effective_n_rows` property: returns `n_full_rows` when set, else `n_rows`.
- `AutoConfigController.run()` stashes `self._current_run_full_n_rows` at entry.
- `_assemble_profile()` reads either an explicit `full_n_rows` param OR the stash, and stamps it onto the emitted `DataProfile`.
- `ComplexityProfile.health()` and the rule both consult `data.effective_n_rows`.

Backward compat: when `n_full_rows` is None (non-controller paths where `n_rows` IS the full data), behavior is unchanged.

## Expected impact

v26 should show controller commit GREEN on QIS. First_name's Chao1 estimate at 10M extrapolation: 2998 + 2996²/(2·2) ≈ 2.25M → cardinality ≈ 0.225 → below the 0.99 rule threshold and below the 0.95 verdict threshold. Misfire fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)