### PR TITLE
fix(scoring-health): YELLOW only when borderline outweighs above-threshold tail

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -351,7 +351,15 @@ class ScoringProfile:
             return HealthVerdict.RED
         if self.dip_statistic < 0.005 and self.n_pairs_scored > 0:
             return HealthVerdict.RED
-        if self.mass_in_borderline > 0.3:
+        # YELLOW only when the borderline band outweighs the above-threshold
+        # tail. The legacy `mass_in_borderline > 0.3` rule fired YELLOW on any
+        # noisy-but-correct shape (heavy-typo person data lands 30%+ of
+        # scored pairs in a 0.2-wide band around the threshold by
+        # construction; F1 stays >0.98). Tie the verdict to separation
+        # instead: when above-tail mass dominates the borderline band, the
+        # config is fine; only flip YELLOW when borderline genuinely
+        # swamps confident matches.
+        if self.mass_in_borderline > 0.3 and self.mass_in_borderline > self.mass_above_threshold:
             return HealthVerdict.YELLOW
         return HealthVerdict.GREEN
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_llm_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_llm_policy.py
@@ -56,8 +56,8 @@ def _yellow_profile() -> ComplexityProfile:
         ),
         scoring=ScoringProfile(
             n_pairs_scored=200, candidates_compared=500,
-            mass_above_threshold=0.4, dip_statistic=0.05,
-            mass_in_borderline=0.4,  # YELLOW: > 0.3
+            mass_above_threshold=0.2, dip_statistic=0.05,
+            mass_in_borderline=0.4,  # YELLOW: > 0.3 AND > mass_above_threshold
         ),
         cluster=ClusterProfile(transitivity_rate=0.95),
         matchkey=MatchkeyProfile(per_field={"a": FieldStats(0.5, 0.0, 10)}),

--- a/packages/python/goldenmatch/tests/test_autoconfig_llm_smoke.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_llm_smoke.py
@@ -45,8 +45,8 @@ def test_llm_policy_real_api_round_trip():
         ),
         scoring=ScoringProfile(
             n_pairs_scored=200, candidates_compared=500,
-            mass_above_threshold=0.4, dip_statistic=0.05,
-            mass_in_borderline=0.4,  # YELLOW
+            mass_above_threshold=0.2, dip_statistic=0.05,
+            mass_in_borderline=0.4,  # YELLOW: > 0.3 AND > mass_above_threshold
         ),
         cluster=ClusterProfile(transitivity_rate=0.95),
         matchkey=MatchkeyProfile(per_field={"name": FieldStats(0.5, 0.0, 10)}),

--- a/packages/python/goldenmatch/tests/test_complexity_profile.py
+++ b/packages/python/goldenmatch/tests/test_complexity_profile.py
@@ -167,7 +167,19 @@ def test_scoring_yellow_when_borderline_heavy():
         n_pairs_scored=500, score_histogram=[0] * 14 + [100, 100, 100] + [0] * 3,
         dip_statistic=0.05, mass_above_threshold=0.4, mass_in_borderline=0.5,
     )
+    # borderline (0.5) > above_threshold (0.4) -> separation negative -> YELLOW
     assert sp.health() == HealthVerdict.YELLOW
+
+
+def test_scoring_green_when_above_threshold_dominates_borderline():
+    # Heavy-typo person data: ~40% of scored pairs land near the threshold
+    # band, but the above-threshold tail is larger. Separation is positive;
+    # config is fine; verdict should not regress to YELLOW.
+    sp = ScoringProfile(
+        n_pairs_scored=500, score_histogram=[0] * 10 + [50] * 10,
+        dip_statistic=0.05, mass_above_threshold=0.55, mass_in_borderline=0.4,
+    )
+    assert sp.health() == HealthVerdict.GREEN
 
 
 def test_cluster_red_when_one_giant_cluster():


### PR DESCRIPTION
## Headline

Drops a false-alarm YELLOW from `ScoringProfile.health()`.

## Diagnosis

v27 QIS telemetry confirmed that after the data + matchkey sub-profile fixes (#579, #581, #583), the only remaining persistent YELLOW signal came from `scoring`. Verdict trigger was `mass_in_borderline > 0.3` -- fraction of pairs scoring in the 0.2-wide band around the configured threshold.

On heavy-typo person data (the QIS realistic-vocab shape), that band captures 30%+ of scored pairs by construction. F1 = 0.9886 confirms the signal is not predicting failure.

## Fix

YELLOW only when borderline mass *outweighs* the above-threshold tail:

```python
if self.mass_in_borderline > 0.3 and self.mass_in_borderline > self.mass_above_threshold:
    return HealthVerdict.YELLOW
```

This is the `mass_separation < 0` signal already used in `autoconfig_history.py` as the controller's primary tiebreaker -- now applied to the verdict itself for consistency.

## Test coverage

- Existing `test_scoring_yellow_when_borderline_heavy` (borderline=0.5, above=0.4) still YELLOWs -- separation negative.
- New `test_scoring_green_when_above_threshold_dominates_borderline` (borderline=0.4, above=0.55) GREENs -- separation positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)