### PR TITLE
perf(bucket): slim projection before bucket_assign (env-gated, GOLDENMATCH_BUCKET_SLIM_PROJECTION=1)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -364,9 +364,43 @@ def score_buckets(
     key_expr = _build_block_key_expr(blocking_config.keys[0])
     print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: key_expr built", flush=True)
 
+    # Slim projection: drop columns no score-worker reads. The audit
+    # (2026-05-29) showed every reader in this module touches only
+    # __row_id__ / __source__ / __block_key__ / __xform_*__ plus the
+    # raw source fields named by the blocking key. Everything else in
+    # prepared_df is dead weight from bucket_assign onward. Polars
+    # .select(cols) is zero-copy on Arrow chunks, so the projection
+    # itself is cheap; the bucket_assign with_columns COW then runs
+    # over the slim frame instead of the full one.
+    #
+    # Default OFF until v30 bench confirms the predicted RSS drop. Flip
+    # with GOLDENMATCH_BUCKET_SLIM_PROJECTION=1.
+    if os.environ.get("GOLDENMATCH_BUCKET_SLIM_PROJECTION") == "1":
+        with stage("bucket_slim_projection"):
+            keep: list[str] = ["__row_id__"]
+            if "__source__" in prepared_df.columns:
+                keep.append("__source__")
+            keep.extend(c for c in prepared_df.columns if c.startswith("__xform_"))
+            # Source fields the block-key expression reads. Multi-key blocking
+            # (rare today) accumulates fields across every key in the config.
+            block_key_sources: set[str] = set()
+            for key in blocking_config.keys:
+                block_key_sources.update(key.fields)
+            for col in block_key_sources:
+                if col in prepared_df.columns and col not in keep:
+                    keep.append(col)
+            slim_df = prepared_df.select(keep)
+            print(
+                f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: slim projection "
+                f"{len(prepared_df.columns)} -> {len(keep)} cols",
+                flush=True,
+            )
+    else:
+        slim_df = prepared_df
+
     with stage("bucket_assign"):
         _ta = time.perf_counter()
-        keyed = prepared_df.with_columns(key_expr)
+        keyed = slim_df.with_columns(key_expr)
         print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: keyed (with_columns key_expr) in {time.perf_counter()-_ta:.2f}s", flush=True)
 
     # #422 fix 1: small-block fast path. When prepared_df.height < n_buckets,


### PR DESCRIPTION
## Headline

Targets the +10 GB RSS jump at bucket_assign that v29 localized to the single `with_columns(key_expr)` call on the 13 GB `prepared_df` (`score_buckets.py:369`).

## What it does

Drops a Polars `.select(slim_cols)` between key_expr construction and bucket_assign. Slim cols = `__row_id__` + `__source__` + every `__xform_*__` + the raw source fields named by `blocking_config.keys[i].fields`. Polars `.select` is zero-copy on Arrow chunks; the savings come from `with_columns(key_expr)` now COW-ing the slim frame instead of the full one.

Default off. Flip with `GOLDENMATCH_BUCKET_SLIM_PROJECTION=1`. The v30 QIS bench (next dispatch) will set the flag and compare against the v29 markers-only baseline.

## Why this is safe

Audited every `prepared_df` / `bucket_df` read in `score_buckets.py`:

| reader | columns touched |
|---|---|
| `_build_block_key_expr` | raw `blocking_config.keys[i].fields` |
| `_score_one_bucket_fast` | `__row_id__`, `__block_key__`, `__xform_*__` (field + NE) |
| `_score_one_bucket` (slow path) | `__block_key__`, `__source__`; `find_fuzzy_matches` reads `__xform_*__` via precompute fast path |
| `_resolve_fast_path` / `_resolve_ne_specs` | `.columns` membership (superset same in slim and full) |

No worker reads raw source columns for scoring. The slim view preserves every column any reader touches.

## Expected RSS delta

Predicted 3-5 GB savings on `bucket_assign` propagating to peak (which currently lands during golden at 39.3 GB). F1 = 0.9886 invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)