### PR TITLE
perf(bucket): default slim projection ON (-3.8 GB peak, F1 invariant)

### DIFF
--- a/.github/workflows/bench-quality-invariant-scale.yml
+++ b/.github/workflows/bench-quality-invariant-scale.yml
@@ -43,9 +43,9 @@ on:
         required: false
         default: "large-new-64GB"
       slim_projection:
-        description: "GOLDENMATCH_BUCKET_SLIM_PROJECTION value (0 or 1). PR #588 RSS-reduction A/B."
+        description: "GOLDENMATCH_BUCKET_SLIM_PROJECTION value (0 or 1). Default '1' = today's behavior; pass '0' to bench the pre-slim baseline."
         required: false
-        default: "0"
+        default: "1"
 
 permissions:
   contents: read

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -368,14 +368,17 @@ def score_buckets(
     # (2026-05-29) showed every reader in this module touches only
     # __row_id__ / __source__ / __block_key__ / __xform_*__ plus the
     # raw source fields named by the blocking key. Everything else in
-    # prepared_df is dead weight from bucket_assign onward. Polars
-    # .select(cols) is zero-copy on Arrow chunks, so the projection
-    # itself is cheap; the bucket_assign with_columns COW then runs
-    # over the slim frame instead of the full one.
+    # prepared_df is dead weight from bucket_assign onward.
     #
-    # Default OFF until v30 bench confirms the predicted RSS drop. Flip
-    # with GOLDENMATCH_BUCKET_SLIM_PROJECTION=1.
-    if os.environ.get("GOLDENMATCH_BUCKET_SLIM_PROJECTION") == "1":
+    # v30 QIS 10M bench (2026-05-29): peak RSS dropped 39.3 GB -> 35.5 GB
+    # (-3.8 GB, -9.7%) at F1=0.9886 invariant and wall flat. The savings
+    # come from downstream stages (partition_by, bucket_score, cluster,
+    # golden) holding a smaller per-bucket frame -- NOT from the .select()
+    # being zero-copy as initially hypothesized (Polars allocates ~10 GB
+    # to consolidate __xform_*__ chunks during select). Default ON;
+    # opt out via GOLDENMATCH_BUCKET_SLIM_PROJECTION=0 if a workload
+    # downstream of score_buckets ever needs a column we drop.
+    if os.environ.get("GOLDENMATCH_BUCKET_SLIM_PROJECTION", "1") != "0":
         with stage("bucket_slim_projection"):
             keep: list[str] = ["__row_id__"]
             if "__source__" in prepared_df.columns:


### PR DESCRIPTION
## Headline

v30 confirms the slim projection: **35.5 GB peak vs v29's 39.3 GB** (-3.8 GB, -9.7%), F1=0.9886 invariant, wall flat. Flip the default to ON.

## v30 vs v29 deltas

| stage | v29 | v30 |
|---|---|---|
| bucket_partition | 24.9 GB | 23.5 GB |
| bucket_post_partition_setup | 25.9 GB | 24.5 GB |
| bucket_score | 28.2 GB | 26.3 GB |
| cluster | 30.3 GB | 28.4 GB |
| **golden (peak)** | **38.6 GB** | **34.9 GB** |

## Mechanism (revised vs PR #588)

PR #588 hypothesized the win came from zero-copy `.select()`. v30 telemetry showed otherwise: `bucket_slim_projection` lands at 22.96 GB -- Polars allocates ~10 GB consolidating `__xform_*__` chunks during select. The real savings happen DOWNSTREAM, where partition_by + per-bucket scoring + cluster + golden all operate on the slimmer per-bucket frame.

## Opt-out

`GOLDENMATCH_BUCKET_SLIM_PROJECTION=0` restores the pre-slim behavior. Audit in #588's body shows no current caller reads a dropped column -- this is here for future-proofing if a downstream path ever needs full prepared_df shape.

## Also

QIS workflow input default flips '0' -> '1' so explicit dispatches stay on the recommended path; pass '0' to bench the pre-slim baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)