### PR TITLE
perf(prep): rechunk after precompute_matchkey_transforms (env-gated, GOLDENMATCH_PRECOMPUTE_RECHUNK=1)

### DIFF
--- a/.github/workflows/bench-quality-invariant-scale.yml
+++ b/.github/workflows/bench-quality-invariant-scale.yml
@@ -46,6 +46,10 @@ on:
         description: "GOLDENMATCH_BUCKET_SLIM_PROJECTION value (0 or 1). PR #588 RSS-reduction A/B."
         required: false
         default: "0"
+      precompute_rechunk:
+        description: "GOLDENMATCH_PRECOMPUTE_RECHUNK value (0 or 1). PR #591 RSS-reduction A/B."
+        required: false
+        default: "0"
 
 permissions:
   contents: read
@@ -82,6 +86,9 @@ jobs:
       # PR #588: slim Polars projection before bucket_assign. Default off
       # (matches v29 baseline); flip via workflow_dispatch input for A/B.
       GOLDENMATCH_BUCKET_SLIM_PROJECTION: ${{ inputs.slim_projection || '0' }}
+      # PR #591: rechunk after precompute_matchkey_transforms so the
+      # bucket_slim_projection .select() can be true zero-copy.
+      GOLDENMATCH_PRECOMPUTE_RECHUNK: ${{ inputs.precompute_rechunk || '0' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 

--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 
 import polars as pl
 
@@ -377,4 +378,15 @@ def precompute_matchkey_transforms(
         df = df.with_columns(native_exprs)
     if python_cols:
         df = df.with_columns(python_cols)
+    # Optional rechunk experiment (PR #591). The v30 RSS leaderboard
+    # showed `bucket_slim_projection` allocating ~10 GB during its
+    # .select() call, hypothesized to be Polars consolidating __xform_*__
+    # chunks deposited here by separate with_columns calls. A proactive
+    # rechunk MOVES that consolidation cost from select-time (where it
+    # also has to pull from the still-resident prepared_df) to here,
+    # where the unconsolidated chunks can be freed immediately. Net peak
+    # could drop if the old chunks release before downstream peak. Gated
+    # off by default until v31 measures it.
+    if os.environ.get("GOLDENMATCH_PRECOMPUTE_RECHUNK") == "1":
+        df = df.rechunk()
     return df


### PR DESCRIPTION
## Headline

Adds a proactive `rechunk()` at the end of `precompute_matchkey_transforms` to consolidate the `__xform_*__` chunks deposited by separate `with_columns` calls. Hypothesis from the v30 leaderboard: the +10 GB allocation at `bucket_slim_projection` IS Polars consolidating those chunks during select. Moving the consolidation upstream MIGHT let the fragmented chunks free immediately instead of staying resident through select-time.

Default off. Flip with `GOLDENMATCH_PRECOMPUTE_RECHUNK=1` (workflow input added). v31 will A/B.

## Honest expectation

May be a wash. Rechunk itself allocates the same contiguous buffer that select would have to allocate later. The win depends on the old chunks being freed faster than the double-allocation window. If v31 shows it's a wash we close + try the next idea on the list. If it works, default-on flip after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)