### PR TITLE
fix(workflow): remove duplicate default key on precompute_rechunk input

### DIFF
--- a/.github/workflows/bench-quality-invariant-scale.yml
+++ b/.github/workflows/bench-quality-invariant-scale.yml
@@ -45,12 +45,11 @@ on:
       slim_projection:
         description: "GOLDENMATCH_BUCKET_SLIM_PROJECTION value (0 or 1). Default '1' = today's behavior; pass '0' to bench the pre-slim baseline."
         required: false
-        default: "0"
+        default: "1"
       precompute_rechunk:
         description: "GOLDENMATCH_PRECOMPUTE_RECHUNK value (0 or 1). PR #591 RSS-reduction A/B."
         required: false
         default: "0"
-        default: "1"
 
 permissions:
   contents: read


### PR DESCRIPTION
PR #591's rebase resolution left the slim_projection 0->1 flip from #590 orphaned below precompute_rechunk's default. YAML rejects both inputs with 'default already defined', blocking all workflow_dispatch calls. One-line removal of the orphan.