### PR TITLE
perf(bucket): close rechunk lane (v31 = wash) + del partition parents

### DIFF
--- a/.github/workflows/bench-quality-invariant-scale.yml
+++ b/.github/workflows/bench-quality-invariant-scale.yml
@@ -46,10 +46,6 @@ on:
         description: "GOLDENMATCH_BUCKET_SLIM_PROJECTION value (0 or 1). Default '1' = today's behavior; pass '0' to bench the pre-slim baseline."
         required: false
         default: "1"
-      precompute_rechunk:
-        description: "GOLDENMATCH_PRECOMPUTE_RECHUNK value (0 or 1). PR #591 RSS-reduction A/B."
-        required: false
-        default: "0"
 
 permissions:
   contents: read
@@ -86,9 +82,6 @@ jobs:
       # PR #588: slim Polars projection before bucket_assign. Default off
       # (matches v29 baseline); flip via workflow_dispatch input for A/B.
       GOLDENMATCH_BUCKET_SLIM_PROJECTION: ${{ inputs.slim_projection || '0' }}
-      # PR #591: rechunk after precompute_matchkey_transforms so the
-      # bucket_slim_projection .select() can be true zero-copy.
-      GOLDENMATCH_PRECOMPUTE_RECHUNK: ${{ inputs.precompute_rechunk || '0' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -444,6 +444,12 @@ def score_buckets(
             buckets_dict = bucketed.partition_by(
                 "__bucket__", as_dict=True,
             )
+            # Free the pre-partition `keyed` and `bucketed` parents. partition_by
+            # built N independent eager frames; the original contiguous parents
+            # are dead weight from this point forward and would otherwise stay
+            # resident through bucket_score + cluster + golden.
+            del keyed
+            del bucketed
             print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: partition_by(bucket) in {time.perf_counter()-_tp:.2f}s -> {len(buckets_dict)} buckets", flush=True)
 
     # Both held in RAM simultaneously: buckets_dict (N partitioned frames,

--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import os
 
 import polars as pl
 
@@ -378,15 +377,12 @@ def precompute_matchkey_transforms(
         df = df.with_columns(native_exprs)
     if python_cols:
         df = df.with_columns(python_cols)
-    # Optional rechunk experiment (PR #591). The v30 RSS leaderboard
-    # showed `bucket_slim_projection` allocating ~10 GB during its
-    # .select() call, hypothesized to be Polars consolidating __xform_*__
-    # chunks deposited here by separate with_columns calls. A proactive
-    # rechunk MOVES that consolidation cost from select-time (where it
-    # also has to pull from the still-resident prepared_df) to here,
-    # where the unconsolidated chunks can be freed immediately. Net peak
-    # could drop if the old chunks release before downstream peak. Gated
-    # off by default until v31 measures it.
-    if os.environ.get("GOLDENMATCH_PRECOMPUTE_RECHUNK") == "1":
-        df = df.rechunk()
+    # PR #591 explored a proactive rechunk here to consolidate the
+    # __xform_*__ chunks before bucket_slim_projection's .select(). The
+    # v31 QIS 10M bench (slim=1 rechunk=1) ran flat to v30 on peak RSS
+    # (35.5 -> 36.5 GB) and wall (518 -> 525s) -- the +10 GB allocation
+    # at bucket_slim_projection persisted regardless of pre-rechunk
+    # chunk layout. Polars' .select() copies on column projection for
+    # reasons other than chunk consolidation. Lane closed; remove the
+    # experiment plumbing to keep this hot path free of dead code.
     return df


### PR DESCRIPTION
## Close the rechunk lane

PR #591 added `GOLDENMATCH_PRECOMPUTE_RECHUNK` to test whether a proactive Polars rechunk at the end of `precompute_matchkey_transforms` would reduce `bucket_slim_projection`'s +10 GB allocation. v31 result: peak 35.5 -> 36.5 GB, wall 518 -> 525s. Slightly worse. The hypothesis (Polars copies during select because of fragmented chunks) was wrong -- the copy persists regardless.

Removes the experiment plumbing: env check + os import + workflow input + workflow env mapping.

## Add `del keyed; del bucketed` after partition_by

Small surgical edit. partition_by built N independent eager frames into buckets_dict; the original contiguous parents are dead weight from this point forward. Explicit del is defensive -- Python's refcount-immediate GC should already release them on rebind, but explicit makes the intent clear and would surface a win if Polars was somehow retaining them through closure capture.

No predicted RSS delta from the del. Genuine no-op risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)