### PR TITLE
perf(golden): slim multi_df before attach_cluster_id COW (env-gated)

### DIFF
--- a/.github/workflows/bench-quality-invariant-scale.yml
+++ b/.github/workflows/bench-quality-invariant-scale.yml
@@ -46,6 +46,10 @@ on:
         description: "GOLDENMATCH_BUCKET_SLIM_PROJECTION value (0 or 1). Default '1' = today's behavior; pass '0' to bench the pre-slim baseline."
         required: false
         default: "1"
+      golden_slim_multidf:
+        description: "GOLDENMATCH_GOLDEN_SLIM_MULTIDF value (0 or 1). PR #595 RSS-reduction A/B for golden's +9 GB attach_cluster_id COW."
+        required: false
+        default: "0"
 
 permissions:
   contents: read
@@ -82,6 +86,9 @@ jobs:
       # PR #588: slim Polars projection before bucket_assign. Default off
       # (matches v29 baseline); flip via workflow_dispatch input for A/B.
       GOLDENMATCH_BUCKET_SLIM_PROJECTION: ${{ inputs.slim_projection || '0' }}
+      # PR #595: slim multi_df before golden_attach_cluster_id's with_columns
+      # COW. v32 attribution showed that step held the entire +9 GB peak jump.
+      GOLDENMATCH_GOLDEN_SLIM_MULTIDF: ${{ inputs.golden_slim_multidf || '0' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1404,6 +1404,24 @@ def _run_dedupe_pipeline(
                     pl.col("__row_id__").is_in(member_ids_all)
                 )
 
+            # Slim projection (PR #595). v32 attribution localized the
+            # +9 GB peak jump entirely to golden_attach_cluster_id's
+            # with_columns COW -- multi_df carries every column from
+            # collected_df including __xform_*__ / __mk_*__ / __block_key__
+            # / __bucket__ internals that survivorship never reads. Drop
+            # them BEFORE the with_columns so the COW runs over a smaller
+            # frame. Default OFF until v33 measures it; flip via
+            # GOLDENMATCH_GOLDEN_SLIM_MULTIDF=1.
+            if os.environ.get("GOLDENMATCH_GOLDEN_SLIM_MULTIDF") == "1":
+                with stage("golden_slim_multidf"):
+                    _internal_prefixes = (
+                        "__xform_", "__mk_", "__block_key__", "__bucket__",
+                    )
+                    multi_df = multi_df.select([
+                        c for c in multi_df.columns
+                        if not any(c.startswith(p) for p in _internal_prefixes)
+                    ])
+
             with stage("golden_attach_cluster_id"):
                 # Attach __cluster_id__ via replace_strict. The old keys/new
                 # vals lists are tiny (1 entry per member); the join itself


### PR DESCRIPTION
## Headline

Targets the +9 GB RSS jump v32 localized to golden_attach_cluster_id's `with_columns(replace_strict)` call (`pipeline.py:1411`).

## Diagnosis

`multi_df = collected_df.filter(...)` at line 1402 carries every column from `collected_df` -- source columns AND all internal `__xform_*__` / `__mk_*__` / `__block_key__` / `__bucket__` that survivorship never reads. `with_columns(__cluster_id__)` COWs the full ~13 GB frame to add one int64 column.

## Fix

Drop the internal columns via `.select()` between `golden_multi_df_filter` and `golden_attach_cluster_id` so the COW runs over a smaller frame. Same pattern as the bucket slim projection (#588/#590) -- Polars .select() is zero-copy on Arrow chunks.

Default off. Flip with `GOLDENMATCH_GOLDEN_SLIM_MULTIDF=1` (workflow input added). v33 will A/B.

Predicted peak savings: -4 to -5 GB. F1 invariant (source columns + __row_id__ + __source__ all preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)