### PR TITLE
perf(golden): default slim multi_df ON (-2.6 GB at attach_cluster_id, F1 invariant)

### DIFF
--- a/.github/workflows/bench-quality-invariant-scale.yml
+++ b/.github/workflows/bench-quality-invariant-scale.yml
@@ -47,9 +47,9 @@ on:
         required: false
         default: "1"
       golden_slim_multidf:
-        description: "GOLDENMATCH_GOLDEN_SLIM_MULTIDF value (0 or 1). PR #595 RSS-reduction A/B for golden's +9 GB attach_cluster_id COW."
+        description: "GOLDENMATCH_GOLDEN_SLIM_MULTIDF value (0 or 1). Default '1' = today's behavior; pass '0' to bench the pre-slim baseline."
         required: false
-        default: "0"
+        default: "1"
 
 permissions:
   contents: read

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1410,9 +1410,13 @@ def _run_dedupe_pipeline(
             # collected_df including __xform_*__ / __mk_*__ / __block_key__
             # / __bucket__ internals that survivorship never reads. Drop
             # them BEFORE the with_columns so the COW runs over a smaller
-            # frame. Default OFF until v33 measures it; flip via
-            # GOLDENMATCH_GOLDEN_SLIM_MULTIDF=1.
-            if os.environ.get("GOLDENMATCH_GOLDEN_SLIM_MULTIDF") == "1":
+            # frame.
+            #
+            # v33 measured: -2.6 GB peak vs v32 baseline, F1 invariant,
+            # wall flat. Default ON; opt out via
+            # GOLDENMATCH_GOLDEN_SLIM_MULTIDF=0 if any downstream golden
+            # path ever needs an internal column.
+            if os.environ.get("GOLDENMATCH_GOLDEN_SLIM_MULTIDF", "1") != "0":
                 with stage("golden_slim_multidf"):
                     _internal_prefixes = (
                         "__xform_", "__mk_", "__block_key__", "__bucket__",


### PR DESCRIPTION
## Headline

v33 confirms #595's slim multi_df. `golden_attach_cluster_id` COW jump dropped +8.99 -> +6.46 GB (-2.53 GB), F1=0.9886 invariant, wall flat. Flip the default to ON.

## v33 vs v32 deltas

```
                              v32       v33      delta
golden_multi_df_filter        29.44 →   29.35    -0.09
golden_slim_multidf            new  →   29.35    +0.00   ← free as predicted
golden_attach_cluster_id      38.44 →   35.81    -2.63   ← real win
golden_build_records_df_fast  38.49 →   35.89    -2.60
```

## Mechanism

`.select()` is zero-copy on Arrow chunks (slim_multidf marker shows no allocation). The win lands at the downstream `with_columns(replace_strict)` COW which now runs over the slimmer frame.

Smaller than predicted (-2.6 GB vs predicted -4 to -5 GB) -- the internal columns were less of the frame than estimated. But real and measurable.

## Opt out

`GOLDENMATCH_GOLDEN_SLIM_MULTIDF=0` restores the pre-slim behavior. Audit in #595's body confirmed only `__xform_*__ / __mk_*__ / __block_key__ / __bucket__` get dropped -- survivorship never reads these.

Workflow input default flips '0' -> '1' to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)