### PR TITLE
perf(cluster): drop sorted(members) in result_dict_init (~10-15s wall at 10M)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -381,8 +381,17 @@ def build_clusters(
         result: dict[int, dict] = {}
         for cluster_id, members in enumerate(sorted_clusters, start=1):
             size = len(members)
+            # v34 attribution showed this loop at 21.7s / 29% of cluster
+            # wall, dominated by the 2M `sorted(members)` calls (one per
+            # cluster). The sort isn't load-bearing -- every reader
+            # iterates or treats members as a set; even add_to_cluster
+            # (the only incremental writer) re-sorts after appending,
+            # proving the contract doesn't assume sorted input. Keep
+            # whatever order the native UF kernel returned -- it's
+            # deterministic across runs (id-anchored) which is the only
+            # invariant any caller actually consumes.
             result[cluster_id] = {
-                "members": sorted(members),
+                "members": list(members),
                 "size": size,
                 "oversized": size > max_cluster_size,
                 "pair_scores": {},


### PR DESCRIPTION
## Headline

v34 attribution showed `cluster_result_dict_init` at 21.7s / 29% of cluster's 75s wall. The hot line is the `sorted(members)` inside the per-cluster loop -- 2M cluster_id means 2M small-list sorts.

## Audit

Every reader of `info["members"]` either iterates or treats it as a set:

- `api/server.py`, `lineage.py`, `graph_er.py`, `llm_cluster.py`, `pipeline.py` (golden + identity) -- plain iteration
- `compare_clusters.py` -- `set(info["members"])`
- `cluster.py::split_oversized_cluster` -- treats as collection

The smoking gun: `add_to_cluster` (line 599) does `sorted(cinfo["members"] + [record_id])` -- the only incremental writer re-sorts after appending, proving the contract doesn't assume sorted input.

Native UF return order is deterministic across runs (id-anchored), which is the only invariant any caller actually consumes.

## Fix

`sorted(members)` -> `list(members)`. Expected: ~10-15s saved on cluster at 10M (about half of result_dict_init). F1 invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)