### PR TITLE
diag(prep): force intermediate collects (env-gated) to attribute combined_lf_collect's 80s

### DIFF
--- a/.github/workflows/bench-quality-invariant-scale.yml
+++ b/.github/workflows/bench-quality-invariant-scale.yml
@@ -50,6 +50,10 @@ on:
         description: "GOLDENMATCH_GOLDEN_SLIM_MULTIDF value (0 or 1). Default '1' = today's behavior; pass '0' to bench the pre-slim baseline."
         required: false
         default: "1"
+      prep_staged_collect:
+        description: "GOLDENMATCH_PREP_STAGED_COLLECT value (0 or 1). PR #599 forces intermediate collects to localize combined_lf_collect's 80s wall. WILL slow the run (defeats fusion) -- diagnostic only."
+        required: false
+        default: "0"
 
 permissions:
   contents: read
@@ -89,6 +93,9 @@ jobs:
       # PR #595: slim multi_df before golden_attach_cluster_id's with_columns
       # COW. v32 attribution showed that step held the entire +9 GB peak jump.
       GOLDENMATCH_GOLDEN_SLIM_MULTIDF: ${{ inputs.golden_slim_multidf || '0' }}
+      # PR #599: forces intermediate collects in the prep graph to attribute
+      # combined_lf_collect's 80s wall. Diagnostic-only; defeats Polars fusion.
+      GOLDENMATCH_PREP_STAGED_COLLECT: ${{ inputs.prep_staged_collect || '0' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -882,13 +882,28 @@ def _run_dedupe_pipeline(
         pass
 
     # ── Step 1.5b: STANDARDIZE ──
+    # When GOLDENMATCH_PREP_STAGED_COLLECT=1, FORCE an intermediate collect
+    # after each prep step so the bench can attribute combined_lf_collect's
+    # 80s wall to standardize vs domain_extraction vs compute_matchkeys.
+    # Default off (the forced materializations defeat Polars fusion and
+    # only exist to localize the wall hotspot for the next perf PR).
+    _staged_collect = os.environ.get("GOLDENMATCH_PREP_STAGED_COLLECT") == "1"
+
+    def _force_collect_if_staged(lf: pl.LazyFrame, label: str) -> pl.LazyFrame:
+        if not _staged_collect:
+            return lf
+        with stage(f"prep_force_collect_{label}"):
+            return lf.collect().lazy()
+
     if config.standardization and config.standardization.rules:
         with stage("standardize"):
             combined_lf = apply_standardization(combined_lf, config.standardization.rules)
+        combined_lf = _force_collect_if_staged(combined_lf, "standardize")
 
     # ── Step 1.5c: DOMAIN FEATURE EXTRACTION ──
     with stage("domain_extraction"):
         combined_lf = _apply_domain_extraction(combined_lf, config)
+    combined_lf = _force_collect_if_staged(combined_lf, "domain_extraction")
 
     # ── Learning Memory: pre-scoring learner overlay ──
     with stage("memory_pre_overlay"):
@@ -897,6 +912,7 @@ def _run_dedupe_pipeline(
     # ── Step 2: TRANSFORM ──
     with stage("compute_matchkeys"):
         combined_lf = compute_matchkeys(combined_lf, matchkeys)
+    combined_lf = _force_collect_if_staged(combined_lf, "compute_matchkeys")
 
     # ── Step 2.5: AUTO-SUGGEST blocking keys ──
     # Hoist matchkey transforms onto the materialized df once — eliminates


### PR DESCRIPTION
## Why

combined_lf_collect at 80s is the biggest single untouched wall hotspot. Three lazy ops stack into the collect: `apply_standardization`, `_apply_domain_extraction`, `compute_matchkeys`. Each is `stage()`-wrapped but those measure the LAZY graph add, not execution.

## Approach

`GOLDENMATCH_PREP_STAGED_COLLECT=1` forces `.collect().lazy()` after each prep op so the wall attributes per-step. **Will slow the run** (defeats Polars fusion across the three ops). Diagnostic only -- the next perf PR uses the attribution to target the actual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)