### PR TITLE
diag(standardize): per-column collect attribution for the 54s wall

### DIFF
--- a/.github/workflows/bench-quality-invariant-scale.yml
+++ b/.github/workflows/bench-quality-invariant-scale.yml
@@ -54,6 +54,10 @@ on:
         description: "GOLDENMATCH_PREP_STAGED_COLLECT value (0 or 1). PR #599 forces intermediate collects to localize combined_lf_collect's 80s wall. WILL slow the run (defeats fusion) -- diagnostic only."
         required: false
         default: "0"
+      standardize_staged:
+        description: "GOLDENMATCH_STANDARDIZE_STAGED value (0 or 1). Forces per-column collects in apply_standardization to localize the 54s wall. WILL slow further -- diagnostic only."
+        required: false
+        default: "0"
 
 permissions:
   contents: read
@@ -96,6 +100,9 @@ jobs:
       # PR #599: forces intermediate collects in the prep graph to attribute
       # combined_lf_collect's 80s wall. Diagnostic-only; defeats Polars fusion.
       GOLDENMATCH_PREP_STAGED_COLLECT: ${{ inputs.prep_staged_collect || '0' }}
+      # PR #600: per-column staged collect inside apply_standardization to
+      # attribute the 54s wall per rule. Diagnostic only.
+      GOLDENMATCH_STANDARDIZE_STAGED: ${{ inputs.standardize_staged || '0' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 

--- a/packages/python/goldenmatch/goldenmatch/core/standardize.py
+++ b/packages/python/goldenmatch/goldenmatch/core/standardize.py
@@ -325,6 +325,15 @@ def _try_build_native_chain(column: str, std_names: list[str]) -> pl.Expr | None
 # ── Apply to DataFrame ──────────────────────────────────────────────────────
 
 
+def _staged_per_col_enabled() -> bool:
+    """When GOLDENMATCH_STANDARDIZE_STAGED=1, apply each column's rule chain
+    via a forced collect+lazy round-trip so the bench attributes per-column
+    wall. Defeats Polars fusion across columns -- diagnostic only.
+    """
+    import os
+    return os.environ.get("GOLDENMATCH_STANDARDIZE_STAGED") == "1"
+
+
 def apply_standardization(
     lf: pl.LazyFrame,
     rules: dict[str, list[str]],
@@ -342,6 +351,11 @@ def apply_standardization(
     """
     available_cols = set(lf.collect_schema().names())
     exprs = []
+    # Diagnostic mode: log per-column rule list + chain path so the bench
+    # can see WHICH columns + rules are running. Cheap, always-on logging
+    # (info-level; one line per column at most).
+    from goldenmatch.core.bench import stage as _bench_stage
+    _staged = _staged_per_col_enabled()
 
     for column, std_names in rules.items():
         if column not in available_cols:
@@ -349,11 +363,19 @@ def apply_standardization(
                 f"Standardization: column {column!r} not found in data, skipping."
             )
             continue
+        logger.info(
+            "standardize rule: column=%r rules=%s",
+            column, std_names,
+        )
 
         # Try fully native chain first (fastest)
         native_expr = _try_build_native_chain(column, std_names)
         if native_expr is not None:
-            exprs.append(native_expr)
+            if _staged:
+                with _bench_stage(f"std_col_native_{column}"):
+                    lf = lf.with_columns([native_expr]).collect().lazy()
+            else:
+                exprs.append(native_expr)
             continue
 
         # If only one standardizer has no native, use native for the ones that do
@@ -379,7 +401,11 @@ def apply_standardization(
                 return val
 
             expr = expr.map_elements(chained_fn, return_dtype=pl.Utf8).alias(column)
-            exprs.append(expr)
+            if _staged:
+                with _bench_stage(f"std_col_mixed_{column}"):
+                    lf = lf.with_columns([expr]).collect().lazy()
+            else:
+                exprs.append(expr)
         else:
             # All non-native, pure map_elements
             funcs = [get_standardizer(name) for name in std_names]
@@ -395,7 +421,11 @@ def apply_standardization(
                 .map_elements(chained_fn, return_dtype=pl.Utf8)
                 .alias(column)
             )
-            exprs.append(expr)
+            if _staged:
+                with _bench_stage(f"std_col_pymap_{column}"):
+                    lf = lf.with_columns([expr]).collect().lazy()
+            else:
+                exprs.append(expr)
 
     if exprs:
         lf = lf.with_columns(exprs)


### PR DESCRIPTION
v36 localized 54s of the prep wall to apply_standardization. This PR attributes that 54s per column + code path (native / mixed / pymap) when GOLDENMATCH_STANDARDIZE_STAGED=1. The pymap path is the likely culprit -- if any rule falls back to map_elements at 10M, that alone explains the wall.

Diagnostic only. Default off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)