### PR TITLE
perf(standardize): port name_proper to native Polars chain (-19s prep wall)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/standardize.py
+++ b/packages/python/goldenmatch/goldenmatch/core/standardize.py
@@ -234,6 +234,17 @@ def _native_name_lower(expr: pl.Expr) -> pl.Expr:
     return _null_if_empty(e)
 
 
+def _native_name_proper(expr: pl.Expr) -> pl.Expr:
+    """Native equivalent of std_name_proper: strip + title-case, empty -> null.
+
+    Python's str.title() and Polars' str.to_titlecase() both treat
+    non-alphabetic chars (including hyphens) as word separators, so
+    'mary-jane'.title() == 'Mary-Jane' matches both implementations.
+    """
+    e = expr.str.strip_chars().str.to_titlecase()
+    return _null_if_empty(e)
+
+
 def _native_state(expr: pl.Expr) -> pl.Expr:
     """Native equivalent of std_state: strip + uppercase, empty -> null."""
     e = expr.str.strip_chars().str.to_uppercase()
@@ -296,6 +307,7 @@ _NATIVE_STANDARDIZERS: dict[str, object] = {
     "strip": _native_strip,
     "name_upper": _native_name_upper,
     "name_lower": _native_name_lower,
+    "name_proper": _native_name_proper,
     "state": _native_state,
     "trim_whitespace": _native_trim_whitespace,
     "phone": _native_phone,


### PR DESCRIPTION
## Headline

v37 attributed 19s of the 54s standardize wall to `std_col_pymap_first_name` + `std_col_pymap_last_name` -- both running `std_name_proper` (strip + Python title()) as a per-row `map_elements` callback at 10M scale.

`str.title()` and Polars' `str.to_titlecase()` both treat non-alpha chars (including hyphens) as word boundaries, so `'mary-jane'.title() == 'Mary-Jane'` matches both. Port is a clean two-line chain.

## What changed

- Added `_native_name_proper(expr)` mirroring the existing `_native_name_upper` / `_native_name_lower` pattern.
- Registered it in `_NATIVE_STANDARDIZERS`.
- The QIS auto-config chain `['strip', 'name_proper']` now routes fully native via `_try_build_native_chain` -- existing integration test at `test_standardize.py:202` covers parity.

## Expected impact

-19s on standardize wall (60% of the dual name-column hit), -19s on total dedupe wall. F1 invariant.

## What's left

`std_col_pymap_address` at 31s is the remaining elephant. Bigger port (two-word phrase lookups + abbreviation dict + title-case-on-miss) -- separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)