### PR TITLE
feat(ray): route backend=ray through Phase 5 streaming (env-gated, PR 1 of N)

### DIFF
--- a/.github/workflows/bench-quality-invariant-scale.yml
+++ b/.github/workflows/bench-quality-invariant-scale.yml
@@ -58,6 +58,10 @@ on:
         description: "GOLDENMATCH_STANDARDIZE_STAGED value (0 or 1). Forces per-column collects in apply_standardization to localize the 54s wall. WILL slow further -- diagnostic only."
         required: false
         default: "0"
+      ray_phase5_routing:
+        description: "GOLDENMATCH_RAY_PHASE5_ROUTING value (0 or 1). PR #603 routes backend=ray through run_dedupe_pipeline_distributed (Phase 5 streaming) instead of the legacy ray_backend swap. Default OFF until measured."
+        required: false
+        default: "0"
 
 permissions:
   contents: read
@@ -103,6 +107,9 @@ jobs:
       # PR #600: per-column staged collect inside apply_standardization to
       # attribute the 54s wall per rule. Diagnostic only.
       GOLDENMATCH_STANDARDIZE_STAGED: ${{ inputs.standardize_staged || '0' }}
+      # PR #603 (Ray Phase 5 routing lane, PR 1): route backend=ray through
+      # the streaming pipeline instead of the legacy ray_backend swap.
+      GOLDENMATCH_RAY_PHASE5_ROUTING: ${{ inputs.ray_phase5_routing || '0' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -427,6 +427,24 @@ def dedupe_df(
         if cfg_excl and _kwarg_token is None:
             _kwarg_token = _RUNTIME_EXCLUDE_COLUMNS.set(list(cfg_excl))
 
+        # PR 1 of the Ray Phase 5 routing lane (spec: docs/superpowers/
+        # specs/2026-05-30-ray-phase5-routing-spec.md, gitignored).
+        # When the resolved config says backend=ray AND the env gate is
+        # on, hand the DataFrame to run_dedupe_pipeline_distributed under
+        # Phase 5 streaming mode instead of the legacy ray_backend swap.
+        # The legacy swap OOMs at 5M (v41 bench, 2026-05-30) -- it reuses
+        # the bucket prep frame on the driver while workers each hold a
+        # ~1.7 GB deserialized exclude set.
+        #
+        # Default OFF. Returns DedupeResult-compatible shape via
+        # _route_ray_via_phase5. v42 bench measures it.
+        import os as _os
+        if (
+            getattr(config, "backend", None) == "ray"
+            and _os.environ.get("GOLDENMATCH_RAY_PHASE5_ROUTING") == "1"
+        ):
+            from goldenmatch.core.pipeline import _route_ray_via_phase5
+            return _route_ray_via_phase5(df, config, source_name)
         result = run_dedupe_df(
             df, config, source_name=source_name,
             auto_config=False,

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1615,6 +1615,45 @@ def _run_dedupe_pipeline(
     return results
 
 
+def _route_ray_via_phase5(
+    df: pl.DataFrame,
+    config: GoldenMatchConfig,
+    source_name: str,
+) -> Any:
+    """Convert the input DataFrame to a Ray Dataset and route through
+    run_dedupe_pipeline_distributed under Phase 5 streaming mode.
+
+    PR 1 of the Ray Phase 5 routing lane. The conversion uses
+    ray.data.from_arrow on df.to_arrow() (zero-copy at the Arrow buffer
+    level; Ray Dataset partitions the chunks lazily). The subsequent
+    streaming pipeline avoids the driver-side take_all that the Phase 2
+    cheat-line still performs.
+
+    Stamps GOLDENMATCH_DISTRIBUTED_PIPELINE=2 for the duration so the
+    dispatcher in distributed/pipeline.py routes to _run_phase5_pipeline.
+    The previous value (if any) is restored on exit so callers that set
+    it explicitly are honored.
+    """
+    import ray.data as _rd  # noqa: PLC0415
+
+    from goldenmatch.distributed.pipeline import (  # noqa: PLC0415
+        run_dedupe_pipeline_distributed,
+    )
+
+    ds = _rd.from_arrow(df.to_arrow())
+    prev = os.environ.get("GOLDENMATCH_DISTRIBUTED_PIPELINE")
+    os.environ["GOLDENMATCH_DISTRIBUTED_PIPELINE"] = "2"
+    try:
+        return run_dedupe_pipeline_distributed(
+            ds, config=config, source_name=source_name,
+        )
+    finally:
+        if prev is None:
+            os.environ.pop("GOLDENMATCH_DISTRIBUTED_PIPELINE", None)
+        else:
+            os.environ["GOLDENMATCH_DISTRIBUTED_PIPELINE"] = prev
+
+
 def run_dedupe_df(
     df: pl.DataFrame,
     config: GoldenMatchConfig,


### PR DESCRIPTION
## Headline

PR 1 of a multi-PR initiative to wire backend=ray through Phase 5 streaming instead of the legacy ray_backend swap. Smallest possible diff: 30 lines of routing.

## v41 baseline (2026-05-30)

`backend='ray'` at 5M-realistic OOMs at ~14 min:
- Driver retains ~32 GB (full prep frame + Ray IPC + accumulated pairs)
- Workers each hold ~1.7 GB (deserialized exclude set)
- 50+ GB combined hits Ray's 95% memory threshold -> OOM kill loop -> SIGTERM

Reproduces the May 2026 soft-revert pathology. Bucket at 5M finishes in 240s / 18 GB.

## What changed

In `_api.dedupe_df`, when `config.backend == 'ray'` AND `GOLDENMATCH_RAY_PHASE5_ROUTING=1`, route the DataFrame to `run_dedupe_pipeline_distributed` under Phase 5 streaming mode (`GOLDENMATCH_DISTRIBUTED_PIPELINE=2` stamped for the call).

`_route_ray_via_phase5`: converts the input via `ray.data.from_arrow(df.to_arrow())`, stamps the env, calls `run_dedupe_pipeline_distributed`, restores the prior env on exit.

Default OFF. Workflow input `ray_phase5_routing` plumbed.

## Out of scope (subsequent PRs)

- Phase 5 path's own driver cheat-lines (`materialize_cluster_dict`, `auto_configure_df` controller sample)
- Replacing the entry-side conversion (`from_arrow`) with a lazy partitioned loader
- Multi-node cluster orchestration

## Kill criterion for PR 1

v42 at 5M-ray with the flag on must **complete without OOM**. If it OOMs, the streaming pipeline has its own issues the lane needs to address before going further.

Spec: docs/superpowers/specs/2026-05-30-ray-phase5-routing-spec.md (local, gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)