### PR TITLE
revert(ray): remove dedupe_df Phase 5 routing (#603, #605) — wrong workload for Ray

### DIFF
--- a/.github/workflows/bench-quality-invariant-scale.yml
+++ b/.github/workflows/bench-quality-invariant-scale.yml
@@ -58,10 +58,6 @@ on:
         description: "GOLDENMATCH_STANDARDIZE_STAGED value (0 or 1). Forces per-column collects in apply_standardization to localize the 54s wall. WILL slow further -- diagnostic only."
         required: false
         default: "0"
-      ray_phase5_routing:
-        description: "GOLDENMATCH_RAY_PHASE5_ROUTING value (0 or 1). PR #603 routes backend=ray through run_dedupe_pipeline_distributed (Phase 5 streaming) instead of the legacy ray_backend swap. Default OFF until measured."
-        required: false
-        default: "0"
 
 permissions:
   contents: read
@@ -107,9 +103,6 @@ jobs:
       # PR #600: per-column staged collect inside apply_standardization to
       # attribute the 54s wall per rule. Diagnostic only.
       GOLDENMATCH_STANDARDIZE_STAGED: ${{ inputs.standardize_staged || '0' }}
-      # PR #603 (Ray Phase 5 routing lane, PR 1): route backend=ray through
-      # the streaming pipeline instead of the legacy ray_backend swap.
-      GOLDENMATCH_RAY_PHASE5_ROUTING: ${{ inputs.ray_phase5_routing || '0' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
@@ -130,9 +123,9 @@ jobs:
       - name: Install ray + pandas (for backend=ray rungs only)
         if: ${{ inputs.backend == 'ray' }}
         # pandas is a hard import dep of ray.data (loaded at module init).
-        # Without it, _route_ray_via_phase5 -> `import ray.data` raises
-        # ModuleNotFoundError before any streaming work begins. v42 hit
-        # this. pinned <3 to match ray's own pandas range.
+        # Without it any `import ray.data` -- on legacy ray_backend OR
+        # the distributed pipeline -- raises ModuleNotFoundError. Pinned
+        # <3 to match ray's own pandas range.
         run: uv pip install "ray>=2.30,<3" "pandas>=2,<3"
 
       - name: Set up Rust toolchain (for native build)

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -427,24 +427,6 @@ def dedupe_df(
         if cfg_excl and _kwarg_token is None:
             _kwarg_token = _RUNTIME_EXCLUDE_COLUMNS.set(list(cfg_excl))
 
-        # PR 1 of the Ray Phase 5 routing lane (spec: docs/superpowers/
-        # specs/2026-05-30-ray-phase5-routing-spec.md, gitignored).
-        # When the resolved config says backend=ray AND the env gate is
-        # on, hand the DataFrame to run_dedupe_pipeline_distributed under
-        # Phase 5 streaming mode instead of the legacy ray_backend swap.
-        # The legacy swap OOMs at 5M (v41 bench, 2026-05-30) -- it reuses
-        # the bucket prep frame on the driver while workers each hold a
-        # ~1.7 GB deserialized exclude set.
-        #
-        # Default OFF. Returns DedupeResult-compatible shape via
-        # _route_ray_via_phase5. v42 bench measures it.
-        import os as _os
-        if (
-            getattr(config, "backend", None) == "ray"
-            and _os.environ.get("GOLDENMATCH_RAY_PHASE5_ROUTING") == "1"
-        ):
-            from goldenmatch.core.pipeline import _route_ray_via_phase5
-            return _route_ray_via_phase5(df, config, source_name)
         result = run_dedupe_df(
             df, config, source_name=source_name,
             auto_config=False,

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1615,56 +1615,6 @@ def _run_dedupe_pipeline(
     return results
 
 
-def _route_ray_via_phase5(
-    df: pl.DataFrame,
-    config: GoldenMatchConfig,
-    source_name: str,
-) -> Any:
-    """Convert the input DataFrame to a Ray Dataset and route through
-    run_dedupe_pipeline_distributed under Phase 5 streaming mode.
-
-    PR 1 of the Ray Phase 5 routing lane. The conversion uses
-    ray.data.from_arrow on df.to_arrow() (zero-copy at the Arrow buffer
-    level; Ray Dataset partitions the chunks lazily). The subsequent
-    streaming pipeline avoids the driver-side take_all that the Phase 2
-    cheat-line still performs.
-
-    Stamps GOLDENMATCH_DISTRIBUTED_PIPELINE=2 for the duration so the
-    dispatcher in distributed/pipeline.py routes to _run_phase5_pipeline.
-    The previous value (if any) is restored on exit so callers that set
-    it explicitly are honored.
-    """
-    import ray.data as _rd  # noqa: PLC0415
-
-    from goldenmatch.distributed.pipeline import (  # noqa: PLC0415
-        run_dedupe_pipeline_distributed,
-    )
-
-    ds = _rd.from_arrow(df.to_arrow())
-    prev = os.environ.get("GOLDENMATCH_DISTRIBUTED_PIPELINE")
-    os.environ["GOLDENMATCH_DISTRIBUTED_PIPELINE"] = "2"
-    try:
-        # v42b surfaced that _run_phase5_pipeline re-runs auto_configure_df
-        # internally and raises ControllerNotConfidentError when the
-        # controller commits RED -- which it does on QIS realistic shape
-        # (failing_subprofile=blocking). The bucket path tolerates the
-        # same RED commit (v40 produced F1=0.9923 on a RED config); match
-        # that posture here by passing confidence_required=False. Phase 5
-        # ignoring the pre-built `config` and re-auto-configuring is a
-        # separate design flaw -- it deserves its own PR (PR 3+ in this
-        # lane). For PR 1's "smallest possible diff" scope, this is the
-        # workaround that unblocks the kill-criterion bench.
-        return run_dedupe_pipeline_distributed(
-            ds, config=config, source_name=source_name,
-            confidence_required=False,
-        )
-    finally:
-        if prev is None:
-            os.environ.pop("GOLDENMATCH_DISTRIBUTED_PIPELINE", None)
-        else:
-            os.environ["GOLDENMATCH_DISTRIBUTED_PIPELINE"] = prev
-
-
 def run_dedupe_df(
     df: pl.DataFrame,
     config: GoldenMatchConfig,


### PR DESCRIPTION
## Why

v43 (this session, 2026-05-30) shipped the routing wrapper around `dedupe_df(df)` and completed 5M-ray at 370s / 16 GB / F1 0.9925 vs bucket's 240s / 18 GB / F1 0.9923. **Ray lost wall by 1.54×; won RSS by 2 GB.**

Honest reframe: `dedupe_df(df)` assumes the input is already materialized in driver memory -- bucket's home turf by construction. Ray's value is in AVOIDING the driver materialization. Wrapping `dedupe_df` for Ray puts it on a workload it can never win.

The QIS bench is also single-runner (16 cores / 64 GB on one box). Ray cannot out-scale bucket on one node. The bench validates correctness, not scale-out.

## What stays

- **#604** (pandas dep on bench workflow) -- kept. `ray.data` imports pandas at module init regardless of which path is engaged.
- **#606** (driver-collect for `dedup_pairs_distributed`) -- kept. Documented cheat-line workaround for a real Ray Dataset bug (single-partition HashAggregate) in the underlying Phase 5 path. Other callers (Ray-on-cluster) may hit the same issue.

## What's reverted

- **#603** -- the `_route_ray_via_phase5` function + workflow input/env.
- **#605** -- the `confidence_required=False` workaround that piggybacked on #603's routing. Goes with the function.

## What's next

The honest path forward is a file-based bench harness against a real Ray cluster. Spec: `docs/superpowers/specs/2026-05-30-ray-file-based-bench-spec.md` (local, gitignored). Two open questions there gate next steps:

1. Will someone provision a real multi-node Ray cluster (`RAY_ADDRESS` secret)?
2. Is the deployment shape we care about `dedupe_df(df)` (bucket) or `dedupe(files=...)` (Ray)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)