### PR TITLE
feat(ray): ephemeral GCE Ray cluster bench harness (PR 1 of GCE lane)

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -1,0 +1,181 @@
+# Bench-ray-cluster: provision an ephemeral GCE Ray cluster, run the
+# QIS bench against it, tear the cluster down. Workflow_dispatch only.
+#
+# Costs: ~$1 per 30-minute bench at the default 4-node n2-standard-16
+# config (1 head + 3 preemptible workers). The tear-down step runs in
+# `if: always()` so a failed bench still releases the instances.
+#
+# Required GitHub secrets (provision once per repo, see
+# docs/distributed/ray-gce-cluster.md for the gcloud commands):
+#   GCP_PROJECT_ID   — GCP project to bill
+#   GCP_SA_KEY       — service account JSON with the roles below
+#
+# Required service account roles on GCP_PROJECT_ID:
+#   - roles/compute.admin       (create/delete instances + disks)
+#   - roles/iam.serviceAccountUser (let Ray attach the SA to instances)
+
+name: bench-ray-cluster
+
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "Rung size (5000000 = 5M, 100000000 = 100M)"
+        required: false
+        default: "5000000"
+      shape:
+        description: "realistic | phase5"
+        required: false
+        default: "realistic"
+      label:
+        description: "Tag for the output artifact"
+        required: false
+        default: "ad-hoc"
+      max_workers:
+        description: "Number of worker nodes (head is always +1)"
+        required: false
+        default: "3"
+
+permissions:
+  contents: read
+
+jobs:
+  ray-cluster-bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      # We render `.ray/cluster-gce.yaml` from the placeholder template
+      # at workflow runtime so each dispatch sees a fresh cluster name
+      # (avoids collisions if two dispatches overlap) and the right
+      # project_id + git SHA.
+      CLUSTER_NAME: "goldenmatch-bench-${{ github.run_id }}"
+      RAY_RELEASE: "2.30.0"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Ray + gcloud helpers
+        # Ray needs to be installed locally so the controller can drive
+        # `ray up` / `ray submit` / `ray down`. The version pin matches
+        # the cluster.yaml docker image.
+        run: |
+          pip install --upgrade pip
+          pip install "ray[default]==${{ env.RAY_RELEASE }}" "google-api-python-client"
+          pip install pyyaml
+
+      - name: Auth to GCP
+        # Hydrate the service account JSON onto disk and set
+        # GOOGLE_APPLICATION_CREDENTIALS so gcloud/google-api-client
+        # pick it up. The JSON itself is never written to logs.
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        run: |
+          if [ -z "$GCP_SA_KEY" ]; then
+            echo "::error::GCP_SA_KEY secret not set; see docs/distributed/ray-gce-cluster.md"
+            exit 1
+          fi
+          echo "$GCP_SA_KEY" > "$HOME/gcp-sa.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcp-sa.json" >> $GITHUB_ENV
+
+      - name: Render cluster.yaml with project + git SHA
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          if [ -z "$GCP_PROJECT_ID" ]; then
+            echo "::error::GCP_PROJECT_ID secret not set"
+            exit 1
+          fi
+          # Inject project_id, git SHA, cluster_name, and max_workers
+          # into the template. sed is fine; the placeholders are unique.
+          sed -i "s|GOLDENMATCH_GCP_PROJECT_PLACEHOLDER|$GCP_PROJECT_ID|g" .ray/cluster-gce.yaml
+          sed -i "s|GOLDENMATCH_GIT_SHA_PLACEHOLDER|${{ github.sha }}|g" .ray/cluster-gce.yaml
+          sed -i "s|cluster_name: goldenmatch-bench$|cluster_name: ${{ env.CLUSTER_NAME }}|" .ray/cluster-gce.yaml
+          sed -i "s|max_workers: 3$|max_workers: ${{ inputs.max_workers }}|" .ray/cluster-gce.yaml
+          echo "----- Rendered cluster.yaml -----"
+          head -40 .ray/cluster-gce.yaml
+
+      - name: Ray up
+        # Provisions head + workers, installs goldenmatch on each via
+        # the setup_commands block. Typical wall: ~3-5 min.
+        run: |
+          ray up -y --no-config-cache .ray/cluster-gce.yaml
+
+      - name: Submit bench
+        # `ray submit` ships the script to the head node and runs it.
+        # The script writes its JSON output to /tmp on the head; we
+        # rsync it back via `ray rsync_down` after the run.
+        run: |
+          set -euo pipefail
+          mkdir -p .profile_tmp/qis
+          OUT_REMOTE="/tmp/qis_${{ inputs.label }}.json"
+          ray submit .ray/cluster-gce.yaml \
+            scripts/quality_invariant_scale.py \
+            -- --rows ${{ inputs.rows }} \
+               --shape ${{ inputs.shape }} \
+               --backend ray \
+               --out "$OUT_REMOTE"
+          ray rsync_down .ray/cluster-gce.yaml \
+            "$OUT_REMOTE" ".profile_tmp/qis/qis_${{ inputs.label }}.json"
+
+      - name: Upload bench artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: "qis-${{ inputs.label }}"
+          path: ".profile_tmp/qis/qis_${{ inputs.label }}.json"
+          if-no-files-found: warn
+
+      - name: Ray down (always)
+        # The teardown runs even when previous steps fail so we don't
+        # leak GCE instances. --workers-only first to release the
+        # expensive workers fast, then the head.
+        if: always()
+        run: |
+          ray down -y --workers-only .ray/cluster-gce.yaml || true
+          ray down -y .ray/cluster-gce.yaml || true
+
+      - name: Defensive cleanup (instance-list sweep)
+        # Belt-and-braces: if `ray down` somehow missed instances,
+        # delete any GCE instance carrying our cluster name label.
+        # Suppress errors so the workflow doesn't itself fail here.
+        if: always()
+        run: |
+          gcloud auth activate-service-account \
+            --key-file="$GOOGLE_APPLICATION_CREDENTIALS" \
+            --project="${{ secrets.GCP_PROJECT_ID }}" || true
+          gcloud compute instances list \
+            --filter="labels.ray-cluster-name=${{ env.CLUSTER_NAME }}" \
+            --project="${{ secrets.GCP_PROJECT_ID }}" \
+            --format="value(name,zone)" 2>/dev/null | while read name zone; do
+              if [ -n "$name" ]; then
+                gcloud compute instances delete "$name" \
+                  --zone="$zone" --project="${{ secrets.GCP_PROJECT_ID }}" \
+                  --quiet || true
+              fi
+            done
+
+      - name: Post headline to step summary
+        if: always()
+        run: |
+          OUT=".profile_tmp/qis/qis_${{ inputs.label }}.json"
+          if [ ! -f "$OUT" ]; then
+            echo "no rung output -- earlier step failed" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          python - <<'PY' >> $GITHUB_STEP_SUMMARY
+          import json, os
+          d = json.load(open(os.environ["OUT"]))
+          rows = d.get("rows", "?")
+          wall = d.get("wall_s", {})
+          rss_gb = d.get("rss_mb_peak", 0) / 1024
+          f1 = d.get("pairwise", {}).get("f1", "?")
+          print(f"## bench-ray-cluster: {rows:,} rows")
+          print(f"- wall: {wall}")
+          print(f"- peak RSS: {rss_gb:.2f} GB (driver-side; per-node varies)")
+          print(f"- pairwise F1: {f1}")
+          PY
+        env:
+          OUT: ".profile_tmp/qis/qis_${{ inputs.label }}.json"

--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -1,0 +1,107 @@
+# Ray Cluster Launcher config for the goldenmatch Phase 5 bench harness.
+# Targets GCE; ephemeral by design (spun up per bench, torn down on exit).
+#
+# Provisioned by `.github/workflows/bench-ray-cluster.yml` via:
+#   ray up -y .ray/cluster-gce.yaml
+#   ray submit .ray/cluster-gce.yaml scripts/quality_invariant_scale.py ...
+#   ray down -y .ray/cluster-gce.yaml
+#
+# Costs: 1 head + 3 workers at n2-standard-16 = 4 × ~$0.50/hr.
+# A 30-min bench therefore runs ~$1; teardown is automatic.
+# Override the worker count via the `--max-workers` flag on `ray up`.
+
+cluster_name: goldenmatch-bench
+provider:
+  type: gcp
+  region: us-central1
+  availability_zone: us-central1-a
+  # project_id is injected by the workflow at dispatch time so the same
+  # cluster.yaml works across MJH GCP projects.
+  project_id: GOLDENMATCH_GCP_PROJECT_PLACEHOLDER
+
+# Single head node; 3 workers. Pick n2-standard-16 to mirror our existing
+# `large-new-64GB` GitHub runner baseline (16 vCPU / 64 GB) so per-node
+# behavior is directly comparable to the single-runner numbers in this
+# repo.
+auth:
+  ssh_user: ubuntu
+
+max_workers: 3
+upscaling_speed: 1.0
+idle_timeout_minutes: 5
+
+# The bench downloads input parquet from the bench-dataset-v1 GH Release
+# at runtime; no persistent disk needed beyond Ray's own scratch.
+file_mounts: {}
+file_mounts_sync_continuously: false
+rsync_exclude:
+  - "**/.git"
+  - "**/.git/**"
+
+# Docker image carries Ray + our Python env. We pin to a Ray release
+# series; the bench container layer installs goldenmatch on top via
+# pip.
+docker:
+  image: "rayproject/ray:2.30.0-py312"
+  container_name: "ray_container"
+  pull_before_run: true
+
+initialization_commands: []
+
+# Install goldenmatch from the repo's tag. The bench workflow stamps
+# this from the commit SHA so reruns hit identical code.
+setup_commands:
+  - >-
+    pip install --upgrade pip &&
+    pip install "polars>=1.0" "pandas>=2,<3" "pyarrow>=10" "psutil>=5.9" "rapidfuzz>=3.0" "jellyfish>=1.0" &&
+    pip install "git+https://github.com/benseverndev-oss/goldenmatch@GOLDENMATCH_GIT_SHA_PLACEHOLDER#subdirectory=packages/python/goldenmatch"
+head_setup_commands: []
+worker_setup_commands: []
+
+head_start_ray_commands:
+  - ray stop
+  - >-
+    ulimit -n 65536 && ray start --head --port=6379
+    --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
+
+worker_start_ray_commands:
+  - ray stop
+  - >-
+    ulimit -n 65536 && ray start --address=$RAY_HEAD_IP:6379
+    --object-manager-port=8076
+
+# Instance specs. n2-standard-16 = 16 vCPU / 64 GB RAM.
+available_node_types:
+  ray.head.default:
+    resources: {}
+    node_config:
+      machineType: n2-standard-16
+      disks:
+        - boot: true
+          autoDelete: true
+          type: PERSISTENT
+          initializeParams:
+            diskSizeGb: 100
+            sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
+      scheduling:
+        - preemptible: false
+  ray.worker.default:
+    min_workers: 3
+    max_workers: 3
+    resources: {}
+    node_config:
+      machineType: n2-standard-16
+      disks:
+        - boot: true
+          autoDelete: true
+          type: PERSISTENT
+          initializeParams:
+            diskSizeGb: 100
+            sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
+      # Preemptible (spot) workers are 60-80% cheaper. Phase 5 streaming
+      # is partition-resumable so preemption is tolerable at this scale.
+      # Flip to false if you see preemption-driven retries dominating wall.
+      scheduling:
+        - preemptible: true
+
+head_node_type: ray.head.default

--- a/docs/distributed/ray-gce-cluster.md
+++ b/docs/distributed/ray-gce-cluster.md
@@ -1,0 +1,121 @@
+# Ray on GCE — provisioning runbook
+
+The `bench-ray-cluster` workflow runs the goldenmatch QIS bench against an
+ephemeral GCE Ray cluster. This document covers the one-time GCP setup
+needed before the workflow can be dispatched.
+
+## What gets provisioned per bench
+
+| node | instance type | count | preemptible | $/hr (us-central1) |
+|---|---|---|---|---|
+| head | `n2-standard-16` | 1 | no | ~$0.78 |
+| worker | `n2-standard-16` | 3 (default) | yes | ~$0.20 each |
+
+Default cost: ~$1 per 30-minute bench. Override via the workflow's
+`max_workers` input.
+
+Teardown is automatic — `ray down` runs in `if: always()` and a defensive
+`gcloud compute instances delete` sweep catches any stragglers. Worst-case
+leak: ~$1/hr if both teardown steps fail.
+
+## One-time GCP setup
+
+### 1. Pick / create a GCP project
+
+```sh
+gcloud projects create goldenmatch-ray-bench --name="goldenmatch ray bench"
+gcloud config set project goldenmatch-ray-bench
+gcloud services enable compute.googleapis.com iam.googleapis.com
+```
+
+The project ID becomes the `GCP_PROJECT_ID` GitHub secret.
+
+### 2. Create the service account
+
+```sh
+gcloud iam service-accounts create gm-ray-bench \
+    --display-name="goldenmatch Ray bench"
+
+SA_EMAIL="gm-ray-bench@$(gcloud config get-value project).iam.gserviceaccount.com"
+
+# Compute Admin: create/delete instances + disks
+gcloud projects add-iam-policy-binding "$(gcloud config get-value project)" \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="roles/compute.admin"
+
+# Service Account User: let Ray attach this SA to the instances it creates
+gcloud projects add-iam-policy-binding "$(gcloud config get-value project)" \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="roles/iam.serviceAccountUser"
+
+# Issue a JSON key
+gcloud iam service-accounts keys create gm-ray-bench-key.json \
+    --iam-account="$SA_EMAIL"
+```
+
+### 3. Set the GitHub secrets
+
+```sh
+gh secret set GCP_PROJECT_ID \
+    --repo benseverndev-oss/goldenmatch \
+    --body "$(gcloud config get-value project)"
+
+gh secret set GCP_SA_KEY \
+    --repo benseverndev-oss/goldenmatch \
+    --body "$(cat gm-ray-bench-key.json)"
+
+rm gm-ray-bench-key.json   # don't keep the JSON on disk
+```
+
+### 4. Dispatch the workflow
+
+```sh
+gh workflow run bench-ray-cluster.yml \
+    --repo benseverndev-oss/goldenmatch \
+    -f rows=5000000 \
+    -f label=v44-5m-ray-gce \
+    -f max_workers=3
+```
+
+The workflow's step summary shows the wall / RSS / F1 numbers when it
+completes; the full JSON artifact is downloadable from the run page.
+
+## Verifying teardown
+
+If a run misbehaves, double-check no instances are leaked:
+
+```sh
+gcloud compute instances list \
+    --filter="labels.ray-cluster-name~goldenmatch-bench" \
+    --project="$(gcloud config get-value project)"
+```
+
+Anything that shows up there is a leak. Delete with:
+
+```sh
+gcloud compute instances delete <name> --zone=us-central1-a
+```
+
+## Cost guardrails
+
+- The workers are preemptible by default (60-80% cheaper, ~20% chance of
+  preemption per hour). Ray retries preempted partitions; for benches
+  under 30 min the retry cost is usually less than the savings.
+- Idle timeout is 5 minutes — if the bench finishes early, autoscaler
+  releases workers automatically.
+- The defensive `gcloud compute instances delete` step at the end of the
+  workflow catches anything `ray down` misses.
+- Set a GCP billing alert at, say, $20/month to catch surprises.
+
+## Switching off preemption
+
+If preemption-driven retries dominate the bench wall, edit
+`.ray/cluster-gce.yaml` and flip the worker `preemptible: true` to
+`false`. Cost roughly 4x but wall is more predictable.
+
+## Related
+
+- Spec: `docs/superpowers/specs/2026-05-30-ray-file-based-bench-spec.md`
+  (gitignored — local design notes for the broader lane)
+- Phase 5 distributed pipeline: `goldenmatch/distributed/pipeline.py`
+- QIS bench harness: `scripts/quality_invariant_scale.py`


### PR DESCRIPTION
## Headline

Provisions the infrastructure to bench Ray Phase 5 streaming on a **real multi-node cluster**. Single-runner bench numbers don't validate Ray because Ray can't out-scale bucket on one node by construction.

## What's in

- ``.ray/cluster-gce.yaml`` — Ray Cluster Launcher config: 1 head + 3 preemptible workers, all ``n2-standard-16`` (16 vCPU / 64 GB, matches our existing single-runner baseline so v40/v43 numbers are directly comparable). Pinned to Ray 2.30.0 / Python 3.12.
- ``.github/workflows/bench-ray-cluster.yml`` — workflow_dispatch that provisions, benches, tears down. ``ray down`` runs in ``if: always()`` plus a defensive ``gcloud compute instances delete`` sweep so failed runs don't leak instances.
- ``docs/distributed/ray-gce-cluster.md`` — one-time GCP setup runbook (project + service account + GitHub secrets).

## Cost

~$1 per 30-min bench at the default 4-node config. Preemptible workers (60-80% cheaper) make this tractable for repeated investigation. Idle timeout is 5 min. Defensive teardown catches anything ``ray down`` misses.

## What's NOT in (deferred to follow-ups)

- The Parquet bench dataset at 100M+ (PR 2 of the lane will add generator changes + upload to bench-dataset-v1 release).
- File-based ``dedupe(files=...)`` entry-point audit (PR 3 of the lane).
- Closing the documented cheat-lines in ``distributed/pipeline.py`` (PR 4+ of the lane, only after the kill-criterion bench passes at 100M).

## Required secrets (provisioned out-of-band)

- ``GCP_PROJECT_ID`` — GCP project to bill
- ``GCP_SA_KEY`` — service account JSON with ``roles/compute.admin`` and ``roles/iam.serviceAccountUser``

The workflow fails fast on auth if these aren't set. v44 (kill-criterion bench) waits on infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)