### PR TITLE
feat(native): build_clusters_native prototype kernel (measure-then-wire)

### DIFF
--- a/packages/python/goldenmatch/tests/test_native_cluster_orchestration_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_cluster_orchestration_parity.py
@@ -1,0 +1,169 @@
+"""Parity: native build_clusters_native vs the Python orchestration in
+core/cluster.py::build_clusters.
+
+The native kernel is a prototype that subsumes the Python loop from
+connected_components through compute_cluster_confidence (the v34
+attribution's 70-75% of cluster wall). This file locks down the
+behavior contract before any wiring lands.
+
+Skipped when the native module isn't built (pure-Python install).
+"""
+from __future__ import annotations
+
+import pytest
+
+native = pytest.importorskip("goldenmatch._native")
+if not hasattr(native, "build_clusters_native"):
+    pytest.skip(
+        "native module loaded but build_clusters_native not exposed",
+        allow_module_level=True,
+    )
+
+from goldenmatch.core.cluster import build_clusters as py_build_clusters
+
+
+def _canon_pair_scores(d):
+    """Canonicalize a pair_scores dict for comparison: sort by key tuple
+    (Python tolerates either (a,b) or (b,a) insertion order; we don't
+    assert on iteration order, only the set of entries + values)."""
+    return sorted(d.items())
+
+
+def _assert_clusters_equal(py_result, rs_result, *, with_quality_fields=False):
+    """Deep-equal on the cluster dict structure, modulo:
+      - cluster_id assignments (compare by frozenset(members) -> cluster_id mapping)
+      - pair_scores dict iteration order (compare canonicalized)
+    """
+    assert set(py_result.keys()) == set(rs_result.keys()), (
+        f"cluster_id sets differ: py={set(py_result.keys())} "
+        f"rs={set(rs_result.keys())}"
+    )
+
+    # Map by frozenset of members so we don't depend on cluster_id labelling
+    # if both paths converge on the same partitioning. (They should --
+    # both sort by min(member) and enumerate from 1 -- but compare by
+    # content to be safe.)
+    py_by_set = {frozenset(info["members"]): info for info in py_result.values()}
+    rs_by_set = {frozenset(info["members"]): info for info in rs_result.values()}
+    assert set(py_by_set.keys()) == set(rs_by_set.keys()), (
+        "cluster member sets differ"
+    )
+
+    for members_set in py_by_set:
+        py_info = py_by_set[members_set]
+        rs_info = rs_by_set[members_set]
+
+        assert py_info["size"] == rs_info["size"]
+        assert py_info["oversized"] == rs_info["oversized"]
+        assert sorted(py_info["members"]) == sorted(rs_info["members"])
+        assert _canon_pair_scores(py_info["pair_scores"]) == _canon_pair_scores(
+            rs_info["pair_scores"]
+        )
+        assert py_info["confidence"] == pytest.approx(rs_info["confidence"], abs=1e-9)
+        # bottleneck_pair: either ordering valid (Python's min() is "first min wins";
+        # the kernel mirrors the same iteration order, but the BOTTLENECK ITSELF
+        # has only one canonical answer per cluster).
+        assert py_info["bottleneck_pair"] == rs_info["bottleneck_pair"], (
+            f"bottleneck mismatch for members {sorted(members_set)}: "
+            f"py={py_info['bottleneck_pair']} rs={rs_info['bottleneck_pair']}"
+        )
+
+        if with_quality_fields:
+            assert py_info.get("cluster_quality") == rs_info.get("cluster_quality")
+
+
+def _native_then_python_wrap(pairs, all_ids, max_cluster_size=1000):
+    """Drive the native kernel directly so we can compare it to Python's
+    build_clusters output BEFORE doing the auto_split + quality layering
+    Python does on top."""
+    return native.build_clusters_native(pairs, all_ids, max_cluster_size)
+
+
+class TestSimpleShapes:
+    def test_two_disjoint_pairs(self):
+        pairs = [(0, 1, 0.9), (2, 3, 0.8)]
+        all_ids = [0, 1, 2, 3]
+        py = py_build_clusters(pairs, all_ids, max_cluster_size=1000, auto_split=False)
+        rs = _native_then_python_wrap(pairs, all_ids)
+        # py adds cluster_quality after the loop; the kernel doesn't. Compare
+        # the pre-quality structural fields only.
+        _assert_clusters_equal(py, rs, with_quality_fields=False)
+
+    def test_chain_three_members(self):
+        # 0-1-2 chain becomes one cluster.
+        pairs = [(0, 1, 0.95), (1, 2, 0.85)]
+        all_ids = [0, 1, 2]
+        py = py_build_clusters(pairs, all_ids, max_cluster_size=1000, auto_split=False)
+        rs = _native_then_python_wrap(pairs, all_ids)
+        _assert_clusters_equal(py, rs)
+
+    def test_singleton_ids(self):
+        # Nodes 5 and 6 have no edges; both stay as singletons.
+        pairs = [(0, 1, 0.9)]
+        all_ids = [0, 1, 5, 6]
+        py = py_build_clusters(pairs, all_ids, max_cluster_size=1000, auto_split=False)
+        rs = _native_then_python_wrap(pairs, all_ids)
+        _assert_clusters_equal(py, rs)
+
+    def test_empty_pairs(self):
+        pairs = []
+        all_ids = [0, 1, 2]
+        py = py_build_clusters(pairs, all_ids, max_cluster_size=1000, auto_split=False)
+        rs = _native_then_python_wrap(pairs, all_ids)
+        _assert_clusters_equal(py, rs)
+
+
+class TestOversized:
+    def test_oversized_flag(self):
+        # Fully connected 5-node cluster, max=3 -> oversized.
+        pairs = []
+        for a in range(5):
+            for b in range(a + 1, 5):
+                pairs.append((a, b, 0.9))
+        all_ids = list(range(5))
+        # Use auto_split=False so we compare the pre-split structure.
+        py = py_build_clusters(pairs, all_ids, max_cluster_size=3, auto_split=False)
+        rs = _native_then_python_wrap(pairs, all_ids, max_cluster_size=3)
+        _assert_clusters_equal(py, rs)
+
+
+class TestConfidenceParity:
+    def test_weak_link_chain_confidence(self):
+        # Long chain with one very weak link -> bottleneck should match.
+        pairs = [(0, 1, 0.99), (1, 2, 0.30), (2, 3, 0.95)]
+        all_ids = [0, 1, 2, 3]
+        py = py_build_clusters(pairs, all_ids, max_cluster_size=1000, auto_split=False)
+        rs = _native_then_python_wrap(pairs, all_ids)
+        _assert_clusters_equal(py, rs)
+
+    def test_dense_cluster_high_confidence(self):
+        pairs = [(0, 1, 0.95), (0, 2, 0.92), (1, 2, 0.94)]
+        all_ids = [0, 1, 2]
+        py = py_build_clusters(pairs, all_ids, max_cluster_size=1000, auto_split=False)
+        rs = _native_then_python_wrap(pairs, all_ids)
+        _assert_clusters_equal(py, rs)
+
+
+class TestSyntheticScale:
+    """Profile target: 10K records, 50K pairs. Verifies the kernel returns
+    the right shape on a non-trivial input; perf measured separately via
+    scripts/bench_native_cluster_kernel.py."""
+
+    def test_10k_records_50k_pairs(self):
+        import random
+        random.seed(42)
+        n_records = 10_000
+        n_pairs = 50_000
+        all_ids = list(range(n_records))
+        # Generate pairs that produce ~2000 multi-record clusters.
+        pairs = []
+        for _ in range(n_pairs):
+            a = random.randint(0, n_records - 1)
+            b = random.randint(0, n_records - 1)
+            if a == b:
+                continue
+            pairs.append((min(a, b), max(a, b), random.random() * 0.4 + 0.6))
+
+        py = py_build_clusters(pairs, all_ids, max_cluster_size=1000, auto_split=False)
+        rs = _native_then_python_wrap(pairs, all_ids)
+        _assert_clusters_equal(py, rs)

--- a/packages/rust/extensions/native/src/cluster.rs
+++ b/packages/rust/extensions/native/src/cluster.rs
@@ -141,3 +141,138 @@ pub fn cluster_confidence(edges: Vec<(i64, i64, f64)>, size: usize) -> Confidenc
     let confidence = 0.4 * min_edge + 0.3 * avg_edge + 0.3 * connectivity;
     (Some(min_edge), Some(avg_edge), connectivity, bottleneck, confidence)
 }
+
+// =============================================================================
+// build_clusters_native -- post-UF orchestration kernel (prototype).
+// =============================================================================
+// Subsumes the Python loop in core/cluster.py:cluster.build_clusters from
+// "connected_components" through "compute_cluster_confidence" (steps 1-5 of
+// the v34 attribution -- 70-75% of cluster wall). The auto_split + quality
+// assignment stay in Python on the returned dict.
+//
+// Spec: docs/superpowers/specs/2026-05-30-cluster-orchestration-kernel-spec.md
+// (gitignored; local design notes).
+
+use pyo3::types::{PyDict, PyList, PyTuple};
+
+/// Build cluster dict[int, dict] from raw pair edges + all node IDs.
+///
+/// Returns a Python dict matching the existing build_clusters output shape:
+///   {cluster_id: {
+///      "members": list[int],
+///      "size": int,
+///      "oversized": bool,
+///      "pair_scores": dict[tuple[int,int], float],
+///      "confidence": float,
+///      "bottleneck_pair": tuple[int,int] | None,
+///   }}
+///
+/// Order invariants the Python path depends on:
+/// - cluster_id assignment is enumerate(sorted_clusters, start=1) where
+///   sorted is by min(member). This kernel preserves that.
+/// - pair_scores dict insertion order is the order edges are encountered
+///   during the input pair iteration. CPython 3.7+ dicts preserve insertion
+///   order; pyo3 PyDict::set_item likewise. The kernel iterates input pairs
+///   once and inserts into the destination dict directly, so order matches.
+/// - cluster_confidence's bottleneck-pair tie-break is "first minimum wins"
+///   which depends on the same insertion order; identical sequence here.
+#[pyfunction]
+pub fn build_clusters_native<'py>(
+    py: Python<'py>,
+    pairs: Vec<(i64, i64, f64)>,
+    all_ids: Vec<i64>,
+    max_cluster_size: usize,
+) -> PyResult<Bound<'py, PyDict>> {
+    // ---- 1. Union-Find (reuse the find() logic from connected_components). --
+    let mut parent: HashMap<i64, i64> = HashMap::with_capacity(
+        all_ids.len() + pairs.len() * 2,
+    );
+    for id in &all_ids {
+        parent.entry(*id).or_insert(*id);
+    }
+    for (a, b, _s) in &pairs {
+        parent.entry(*a).or_insert(*a);
+        parent.entry(*b).or_insert(*b);
+    }
+    for (a, b, _s) in &pairs {
+        let ra = find(&mut parent, *a);
+        let rb = find(&mut parent, *b);
+        if ra != rb {
+            parent.insert(ra, rb);
+        }
+    }
+
+    // ---- 2. Group nodes by root; build member_to_cid via the canonical
+    //         "sorted by min(member), enumerate from 1" assignment. ----------
+    let keys: Vec<i64> = parent.keys().copied().collect();
+    let mut root_to_members: HashMap<i64, Vec<i64>> = HashMap::new();
+    for k in keys {
+        let r = find(&mut parent, k);
+        root_to_members.entry(r).or_default().push(k);
+    }
+    let mut clusters: Vec<Vec<i64>> = root_to_members.into_values().collect();
+    // Same key as the Python `sorted(clusters, key=lambda s: min(s))`.
+    clusters.sort_by_key(|c| *c.iter().min().expect("non-empty by construction"));
+
+    // member_to_cid: node -> 1-based cluster_id.
+    let mut member_to_cid: HashMap<i64, i64> =
+        HashMap::with_capacity(parent.len());
+    for (idx, members) in clusters.iter().enumerate() {
+        let cid = (idx + 1) as i64;
+        for &m in members {
+            member_to_cid.insert(m, cid);
+        }
+    }
+
+    // ---- 3. Bucket input edges by cluster_id -- order-preserving Vec. ------
+    // We use Vec (not HashMap) so the per-cluster edge ordering matches the
+    // order edges appear in `pairs`. This is the invariant cluster_confidence
+    // relies on for the bottleneck-pair tie-break.
+    let n_clusters = clusters.len();
+    let mut per_cluster_edges: Vec<Vec<(i64, i64, f64)>> =
+        vec![Vec::new(); n_clusters];
+    for (a, b, s) in pairs {
+        if let Some(&cid) = member_to_cid.get(&a) {
+            // cid is 1-based; per_cluster_edges is 0-indexed.
+            per_cluster_edges[(cid - 1) as usize].push((a, b, s));
+        }
+    }
+
+    // ---- 4. Build the output Python dict. -----------------------------------
+    let out = PyDict::new(py);
+    for (idx, members) in clusters.iter().enumerate() {
+        let cid = (idx + 1) as i64;
+        let size = members.len();
+        let edges = &per_cluster_edges[idx];
+
+        // Per-cluster sub-dict.
+        let sub = PyDict::new(py);
+
+        // members: list[int]. Python no longer sorts (PR #598).
+        let members_list = PyList::new(py, members)?;
+        sub.set_item("members", members_list)?;
+        sub.set_item("size", size)?;
+        sub.set_item("oversized", size > max_cluster_size)?;
+
+        // pair_scores: dict[tuple[int,int], float]. Insertion order = edges
+        // iteration order = Python's old loop order.
+        let pair_scores = PyDict::new(py);
+        for &(a, b, s) in edges {
+            let key = PyTuple::new(py, [a, b])?;
+            pair_scores.set_item(key, s)?;
+        }
+        sub.set_item("pair_scores", pair_scores)?;
+
+        // confidence + bottleneck_pair via the existing helper.
+        let (_min_e, _avg_e, _conn, bn, conf) = cluster_confidence(edges.clone(), size);
+        sub.set_item("confidence", conf)?;
+        match bn {
+            Some((a, b)) => sub.set_item("bottleneck_pair", PyTuple::new(py, [a, b])?)?,
+            None => sub.set_item("bottleneck_pair", py.None())?,
+        }
+
+        out.set_item(cid, sub)?;
+    }
+
+    Ok(out)
+}

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -19,6 +19,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cluster::connected_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::severe_bridge_count, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::cluster_confidence, m)?)?;
+    m.add_function(wrap_pyfunction!(cluster::build_clusters_native, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::canonicalize_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::dedup_pairs_max_score, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::candidate_pair_count, m)?)?;

--- a/scripts/bench_native_cluster_kernel.py
+++ b/scripts/bench_native_cluster_kernel.py
@@ -1,0 +1,91 @@
+"""Bench harness for the cluster orchestration kernel prototype.
+
+Spec: docs/superpowers/specs/2026-05-30-cluster-orchestration-kernel-spec.md
+
+Measures the Python build_clusters loop vs the native build_clusters_native
+kernel on a synthetic shape that mirrors the QIS 10M bench's cluster wall
+(2M clusters x ~5 members each, ~20M scored pairs).
+
+Run locally once the native module is built:
+    .venv/Scripts/python.exe scripts/bench_native_cluster_kernel.py
+
+Skipped when the native module isn't available -- there's nothing to compare.
+"""
+from __future__ import annotations
+
+import random
+import time
+
+try:
+    import goldenmatch._native as native_mod  # type: ignore[import-not-found]
+except ImportError:
+    raise SystemExit("goldenmatch._native not built; run scripts/build_native.py")  # noqa: B904
+
+if not hasattr(native_mod, "build_clusters_native"):
+    raise SystemExit(
+        "native module loaded but build_clusters_native not exposed -- rebuild"
+    )
+
+from goldenmatch.core.cluster import build_clusters as py_build_clusters
+
+
+def gen_workload(n_records: int, n_pairs: int, seed: int = 42):
+    """Generate a synthetic (pairs, all_ids) tuple that produces ~n_records/5
+    multi-record clusters at full pair count."""
+    rng = random.Random(seed)
+    all_ids = list(range(n_records))
+    pairs: list[tuple[int, int, float]] = []
+    seen: set[tuple[int, int]] = set()
+    while len(pairs) < n_pairs:
+        a = rng.randint(0, n_records - 1)
+        b = rng.randint(0, n_records - 1)
+        if a == b:
+            continue
+        key = (min(a, b), max(a, b))
+        if key in seen:
+            continue
+        seen.add(key)
+        pairs.append((key[0], key[1], rng.random() * 0.4 + 0.6))
+    return pairs, all_ids
+
+
+def time_python(pairs, all_ids):
+    t0 = time.perf_counter()
+    result = py_build_clusters(
+        pairs, all_ids, max_cluster_size=1000, auto_split=False,
+    )
+    return time.perf_counter() - t0, result
+
+
+def time_native(pairs, all_ids):
+    t0 = time.perf_counter()
+    result = native_mod.build_clusters_native(pairs, all_ids, 1000)
+    return time.perf_counter() - t0, result
+
+
+def main():
+    # Three shapes: small (smoke test), medium (interactive run), large (closer
+    # to QIS 10M bucket-realistic shape). Scale down the largest if running on
+    # a memory-constrained box.
+    shapes = [
+        ("smoke",  10_000,    50_000),
+        ("medium", 100_000,   500_000),
+        ("large",  500_000, 2_000_000),
+    ]
+    print(f"{'shape':>8} {'records':>10} {'pairs':>10} "
+          f"{'py s':>8} {'rs s':>8} {'speedup':>8}")
+    for label, n_records, n_pairs in shapes:
+        pairs, all_ids = gen_workload(n_records, n_pairs)
+        py_s, py_result = time_python(pairs, all_ids)
+        rs_s, rs_result = time_native(pairs, all_ids)
+        speedup = py_s / rs_s if rs_s > 0 else float("inf")
+        print(f"{label:>8} {n_records:>10,} {n_pairs:>10,} "
+              f"{py_s:>8.2f} {rs_s:>8.2f} {speedup:>7.2f}x")
+        # Sanity: both paths should produce the same number of clusters.
+        if len(py_result) != len(rs_result):
+            print(f"  WARNING: cluster count diverges -- py={len(py_result)} "
+                  f"rs={len(rs_result)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Prototype Rust kernel for the cluster orchestration hotpath. Spec: `docs/superpowers/specs/2026-05-30-cluster-orchestration-kernel-spec.md` (gitignored). Subsumes 70-75% of cluster's 75s wall at 10M (connected_components -> compute_confidence). Does NOT wire it into build_clusters yet -- the bench script in scripts/bench_native_cluster_kernel.py measures the FFI-vs-compute split first. If py-vs-rs speedup is < 2x, the dict-construction floor dominates and wiring won't help. Parity tests lock down the contract.