### PR TITLE
feat(native): record_fingerprints_batch prototype + decision-gate bench

### DIFF
--- a/.github/workflows/bench-native-bulk-fingerprint.yml
+++ b/.github/workflows/bench-native-bulk-fingerprint.yml
@@ -1,0 +1,95 @@
+# Bench: per-record loop vs bulk record_fingerprints_batch.
+#
+# workflow_dispatch only. Builds the native module, runs
+# scripts/bench_native_bulk_fingerprint.py at three shapes
+# (smoke / medium / large = 10K / 100K / 1M records), posts the
+# py-vs-rs speedup table to the step summary.
+#
+# Decision gate: large-shape speedup >= 2x ships the wire-up PR
+# (identity/resolve.py refactor to collect payloads + call bulk once
+# + zip back). Below that the per-record Python pre-pass is the
+# floor and wiring won't move the identity-resolve wall enough.
+# Spec:
+# docs/superpowers/specs/2026-05-30-bulk-record-fingerprint-kernel-spec.md
+# (gitignored; local design notes).
+
+name: bench-native-bulk-fingerprint
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Editable install goldenmatch (defensive shadow guard)
+        run: uv pip install -e packages/python/goldenmatch
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build native module
+        run: .venv/bin/python scripts/build_native.py
+
+      - name: Verify native loaded + record_fingerprints_batch exposed
+        run: |
+          .venv/bin/python -c "
+          import goldenmatch._native as n
+          assert hasattr(n, 'record_fingerprints_batch'), (
+              'kernel not exposed -- this PR may have failed to land '
+              'or the rebuild missed hash.rs'
+          )
+          print('native loaded; record_fingerprints_batch present')
+          "
+
+      - name: Run bulk fingerprint bench
+        run: |
+          set -euo pipefail
+          mkdir -p .profile_tmp/native-bench
+          .venv/bin/python scripts/bench_native_bulk_fingerprint.py \
+            | tee .profile_tmp/native-bench/bulk_fingerprint.txt
+
+      - name: Post bench output to step summary
+        if: always()
+        run: |
+          if [ ! -f .profile_tmp/native-bench/bulk_fingerprint.txt ]; then
+            echo "no bench output -- earlier step failed" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          {
+            echo "## record_fingerprint: per-record loop vs bulk kernel"
+            echo ""
+            echo "Decision gate: ship the wire-up follow-up PR"
+            echo "(identity/resolve.py refactor) iff the large-shape"
+            echo "speedup is >= 2x. Below that the per-record Python"
+            echo "pre-pass dominates and wiring won't meaningfully"
+            echo "reduce identity-resolve wall."
+            echo ""
+            echo '```'
+            cat .profile_tmp/native-bench/bulk_fingerprint.txt
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload raw bench output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-bulk-fingerprint-bench
+          path: .profile_tmp/native-bench/bulk_fingerprint.txt
+          if-no-files-found: warn

--- a/packages/python/goldenmatch/goldenmatch/core/_hashing.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_hashing.py
@@ -76,3 +76,25 @@ def record_fingerprint(record: dict[str, Any]) -> str:
     if native_enabled("hashing"):
         return native_module().record_fingerprint(record)
     return _fingerprint_py(record)
+
+
+def record_fingerprints_batch(records: list[dict[str, Any]]) -> list[str]:
+    """Bulk variant of ``record_fingerprint`` -- one hex string per input
+    record, in order. Identical per-record semantics; the kernel amortizes
+    Python-interpreter overhead across the batch and parallelizes SHA-256 via
+    rayon under ``py.allow_threads``. Falls back to a per-record loop when
+    the native module isn't loaded or the bulk kernel isn't exposed.
+
+    Realistic benefit only on the identity-resolve hot path
+    (``identity/resolve.py:_record_id_candidates``) when ``config.identity.
+    enabled`` is True. Decision-gate spec:
+    docs/superpowers/specs/2026-05-30-bulk-record-fingerprint-kernel-spec.md
+    (local, gitignored)."""
+    if native_enabled("hashing"):
+        native = native_module()
+        bulk = getattr(native, "record_fingerprints_batch", None)
+        if bulk is not None:
+            return bulk(records)
+    # Fallback: per-record loop. Same shape as the existing single-record
+    # path, just iterated.
+    return [record_fingerprint(r) for r in records]

--- a/packages/python/goldenmatch/tests/test_native_bulk_fingerprint_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_bulk_fingerprint_parity.py
@@ -1,0 +1,112 @@
+"""Parity: native record_fingerprints_batch vs the per-record loop.
+
+Locks down the contract for the bulk kernel before the wire-up PR. The
+bulk kernel must produce byte-identical output to calling
+``record_fingerprint`` N times in sequence.
+
+Skipped when the native module isn't built.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+native = pytest.importorskip("goldenmatch._native")
+if not hasattr(native, "record_fingerprints_batch"):
+    pytest.skip(
+        "native module loaded but record_fingerprints_batch not exposed",
+        allow_module_level=True,
+    )
+
+from goldenmatch.core._hashing import record_fingerprint, record_fingerprints_batch
+
+
+def _single_loop(records: list[dict]) -> list[str]:
+    """Per-record single-call loop (the reference behavior the bulk kernel
+    must reproduce byte-for-byte)."""
+    return [record_fingerprint(r) for r in records]
+
+
+class TestSingleRecord:
+    def test_empty_batch(self):
+        assert record_fingerprints_batch([]) == []
+
+    def test_single_record(self):
+        records = [{"name": "alice", "zip": "10001"}]
+        assert record_fingerprints_batch(records) == _single_loop(records)
+
+
+class TestSmallBatches:
+    def test_two_distinct_records(self):
+        records = [
+            {"name": "alice", "zip": "10001"},
+            {"name": "bob",   "zip": "10002"},
+        ]
+        assert record_fingerprints_batch(records) == _single_loop(records)
+
+    def test_duplicate_records_same_hash(self):
+        records = [
+            {"name": "alice", "zip": "10001"},
+            {"name": "alice", "zip": "10001"},
+        ]
+        out = record_fingerprints_batch(records)
+        assert out[0] == out[1]
+        assert out == _single_loop(records)
+
+    def test_field_order_irrelevant(self):
+        a = {"name": "alice", "zip": "10001"}
+        b = {"zip": "10001", "name": "alice"}
+        out = record_fingerprints_batch([a, b])
+        assert out[0] == out[1]
+
+
+class TestTypeCoverage:
+    """All primitives the v1 canonical spec accepts."""
+
+    def test_mixed_primitives(self):
+        records = [
+            {"s": "hello", "i": 42, "f": 3.14, "b": True, "n": None, "by": b"raw"},
+            {"s": "world", "i": -1,  "f": 0.0,  "b": False,"n": None, "by": b""},
+        ]
+        assert record_fingerprints_batch(records) == _single_loop(records)
+
+    def test_double_underscore_keys_dropped(self):
+        # __row_id__, __source__ etc. must NOT contribute to the hash.
+        a = {"name": "alice"}
+        b = {"name": "alice", "__row_id__": 7, "__source__": "test"}
+        out = record_fingerprints_batch([a, b])
+        assert out[0] == out[1]
+
+
+class TestErrorPropagation:
+    def test_first_bad_record_raises(self):
+        records = [
+            {"name": "alice"},
+            {"name": "bob", "bad": math.inf},  # non-finite float -> ValueError
+            {"name": "carol"},
+        ]
+        with pytest.raises(ValueError, match="non-finite"):
+            record_fingerprints_batch(records)
+
+    def test_non_string_key_raises(self):
+        records: list[dict] = [{"name": "alice"}, {1: "bob"}]
+        with pytest.raises(TypeError, match="field names must be strings"):
+            record_fingerprints_batch(records)
+
+
+class TestScale:
+    """Synthetic batch large enough to exercise the rayon parallel path."""
+
+    def test_10k_records_parity(self):
+        import random
+        rng = random.Random(7)
+        records = [
+            {
+                "first": rng.choice(["alice", "bob", "carol"]),
+                "last":  rng.choice(["smith", "jones", "doe"]),
+                "zip":   str(10000 + rng.randint(0, 89999)),
+            }
+            for _ in range(10_000)
+        ]
+        assert record_fingerprints_batch(records) == _single_loop(records)

--- a/packages/rust/extensions/native/src/hash.rs
+++ b/packages/rust/extensions/native/src/hash.rs
@@ -15,6 +15,7 @@ use goldenmatch_fingerprint_core::{fingerprint_fields, fingerprint_json, FpValue
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyString};
+use rayon::prelude::*;
 
 fn py_to_fpvalue(name: &str, value: &Bound<'_, PyAny>) -> PyResult<FpValue> {
     if value.is_none() {
@@ -68,6 +69,55 @@ pub fn record_fingerprint(record: &Bound<'_, PyDict>) -> PyResult<String> {
         fields.push((name, fv));
     }
     fingerprint_fields(fields).map_err(PyValueError::new_err)
+}
+
+/// Bulk canonical SHA-256 fingerprints for N records.
+///
+/// Identical per-record semantics to `record_fingerprint`. Returns one hex
+/// string per input record, in order. Errors propagate from the FIRST
+/// failing record (matches the per-record loop callers wrote before this
+/// kernel landed).
+///
+/// Two phases:
+///   1. Sequential pyo3 extraction — convert each `dict[str, scalar]` to a
+///      `Vec<(String, FpValue)>`. Holds the GIL; cannot parallelize.
+///   2. GIL-released SHA-256 + hex via rayon. Per-record work is independent
+///      so par_iter is correct.
+///
+/// Spec:
+/// docs/superpowers/specs/2026-05-30-bulk-record-fingerprint-kernel-spec.md
+/// (gitignored; local design notes).
+#[pyfunction]
+pub fn record_fingerprints_batch(
+    py: Python<'_>,
+    records: Vec<Bound<'_, PyDict>>,
+) -> PyResult<Vec<String>> {
+    // ---- Phase 1: extract all records to FpValue field lists (GIL-held). --
+    let mut extracted: Vec<Vec<(String, FpValue)>> = Vec::with_capacity(records.len());
+    for record in &records {
+        let mut fields: Vec<(String, FpValue)> = Vec::with_capacity(record.len());
+        for (k, v) in record.iter() {
+            let name: String = k
+                .extract()
+                .map_err(|_| PyTypeError::new_err("record field names must be strings"))?;
+            if name.starts_with("__") {
+                continue;
+            }
+            let fv = py_to_fpvalue(&name, &v)?;
+            fields.push((name, fv));
+        }
+        extracted.push(fields);
+    }
+
+    // ---- Phase 2: par_iter SHA-256 + hex (GIL released). -------------------
+    // Errors in fingerprint_fields are theoretically possible (canonicalization
+    // edge cases) -- collect into Result<Vec, String> via try_fold-equivalent.
+    py.allow_threads(|| {
+        extracted
+            .into_par_iter()
+            .map(|fields| fingerprint_fields(fields).map_err(PyValueError::new_err))
+            .collect::<PyResult<Vec<String>>>()
+    })
 }
 
 /// C ABI: canonical record fingerprint over a JSON object string.

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -35,5 +35,6 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score::build_exclude_set, m)?)?;
     m.add_class::<score::ExcludeSet>()?;
     m.add_function(wrap_pyfunction!(hash::record_fingerprint, m)?)?;
+    m.add_function(wrap_pyfunction!(hash::record_fingerprints_batch, m)?)?;
     Ok(())
 }

--- a/scripts/bench_native_bulk_fingerprint.py
+++ b/scripts/bench_native_bulk_fingerprint.py
@@ -1,0 +1,89 @@
+"""Bench harness for the bulk record fingerprint kernel prototype.
+
+Spec: docs/superpowers/specs/2026-05-30-bulk-record-fingerprint-kernel-spec.md
+
+Compares the per-record Python loop (single-record `record_fingerprint`
+called N times) vs the bulk `record_fingerprints_batch` kernel on three
+shapes that mirror identity-resolve hot loops.
+
+Decision gate (large shape, 1M records): >= 2x speedup ships the wire-up
+PR. Below that the per-record Python pre-pass is the floor.
+
+Run locally once the native module is built:
+    .venv/Scripts/python.exe scripts/bench_native_bulk_fingerprint.py
+"""
+from __future__ import annotations
+
+import random
+import time
+
+try:
+    import goldenmatch._native as native_mod  # type: ignore[import-not-found]
+except ImportError:
+    raise SystemExit("goldenmatch._native not built; run scripts/build_native.py")  # noqa: B904
+
+if not hasattr(native_mod, "record_fingerprints_batch"):
+    raise SystemExit(
+        "native module loaded but record_fingerprints_batch not exposed -- rebuild"
+    )
+
+from goldenmatch.core._hashing import record_fingerprint
+
+
+def gen_records(n: int, seed: int = 42) -> list[dict]:
+    """Generate N realistic identity-shaped records: first/last name + zip +
+    email + birth_year. Five fields per record matches the QIS shape."""
+    rng = random.Random(seed)
+    first_names = ["alice", "bob", "carol", "david", "eve", "frank", "grace", "heidi"]
+    last_names = ["smith", "jones", "doe", "brown", "wilson", "moore"]
+    records = []
+    for i in range(n):
+        records.append({
+            "first_name": rng.choice(first_names),
+            "last_name": rng.choice(last_names),
+            "zip": str(10000 + rng.randint(0, 89999)),
+            "email": f"user{i}@example.com",
+            "birth_year": 1950 + rng.randint(0, 60),
+        })
+    return records
+
+
+def time_python_loop(records: list[dict]) -> tuple[float, list[str]]:
+    """Per-record single-call loop -- what identity/resolve.py does today."""
+    t0 = time.perf_counter()
+    result = [record_fingerprint(r) for r in records]
+    return time.perf_counter() - t0, result
+
+
+def time_bulk(records: list[dict]) -> tuple[float, list[str]]:
+    """Bulk kernel: one FFI hop, rayon-parallel inside."""
+    t0 = time.perf_counter()
+    result = native_mod.record_fingerprints_batch(records)
+    return time.perf_counter() - t0, result
+
+
+def main() -> None:
+    # Three shapes: smoke for sanity, medium for interactive runs, large
+    # for the decision gate. 1M records is the realistic identity-resolve
+    # hot-loop scale (QIS realistic = ~2M but pre-PK split usually halves it).
+    shapes = [
+        ("smoke",   10_000),
+        ("medium", 100_000),
+        ("large", 1_000_000),
+    ]
+    print(f"{'shape':>8} {'records':>10} {'py s':>8} {'rs s':>8} {'speedup':>8}")
+    for label, n in shapes:
+        records = gen_records(n)
+        py_s, py_out = time_python_loop(records)
+        rs_s, rs_out = time_bulk(records)
+        speedup = py_s / rs_s if rs_s > 0 else float("inf")
+        print(f"{label:>8} {n:>10,} {py_s:>8.2f} {rs_s:>8.2f} {speedup:>7.2f}x")
+        # Sanity: each (py, rs) pair must agree -- the bulk kernel is supposed
+        # to be byte-equivalent to the per-record loop.
+        if py_out != rs_out:
+            mismatches = sum(1 for a, b in zip(py_out, rs_out) if a != b)
+            print(f"  WARNING: {mismatches} bytes diverge -- parity broken")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Bulk variant of record_fingerprint -- identical per-record semantics but processes N records in one FFI hop with rayon-parallel SHA-256 under py.allow_threads. Returns list[str] (no dict-construction floor; cluster kernel learning carried forward). Adds parity tests + bench script + workflow. Decision gate: large-shape (1M records) speedup >= 2x ships the wire-up PR (identity/resolve.py refactor). Spec: docs/superpowers/specs/2026-05-30-bulk-record-fingerprint-kernel-spec.md (gitignored).