### PR TITLE
feat(ray): fetch GCP creds from Infisical at runtime (re-apply #609)

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -13,10 +13,12 @@
 #   INFISICAL_CLIENT_SECRET  — companion secret for the same identity.
 #
 # Pulled FROM Infisical project a99885f0-c5af-4ae1-9dc8-255cc60aa129, env=dev, at runtime:
-#   GCP_PROJECT_ID   — GCP project to bill
-#   GCP_SA_KEY       — service account JSON with the roles below
+#   GOOGLE_CLOUD_PROJECT  — GCP project to bill
+#   GCP_SA_KEY_B64        — base64-encoded service account JSON
+#                           (roles listed below). Decoded to disk at
+#                           fetch time; never echoed.
 #
-# Required GCP service account roles on GCP_PROJECT_ID:
+# Required GCP service account roles:
 #   - roles/compute.admin       (create/delete instances + disks)
 #   - roles/iam.serviceAccountUser (let Ray attach the SA to instances)
 #
@@ -106,15 +108,25 @@ jobs:
             --client-secret="$INFISICAL_CLIENT_SECRET")
           echo "::add-mask::$INFISICAL_TOKEN"
 
-          GCP_PROJECT_ID=$(infisical secrets get GCP_PROJECT_ID \
+          # GOOGLE_CLOUD_PROJECT is the team's existing Infisical secret
+          # name; surfaces it locally as GCP_PROJECT_ID for the rest of
+          # this workflow's env to read.
+          GCP_PROJECT_ID=$(infisical secrets get GOOGLE_CLOUD_PROJECT \
             --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$INFISICAL_TOKEN")
           echo "::add-mask::$GCP_PROJECT_ID"
 
-          # Multi-line SA JSON: write straight to disk; never echo.
-          infisical secrets get GCP_SA_KEY \
+          # SA key is stored base64-encoded under GCP_SA_KEY_B64. Decode
+          # straight to disk (never echo). base64 -d is GNU coreutils;
+          # uses --ignore-garbage to tolerate any leading whitespace
+          # the Infisical CLI might emit alongside the value.
+          infisical secrets get GCP_SA_KEY_B64 \
             --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$INFISICAL_TOKEN" \
-            > "$HOME/gcp-sa.json"
+            | base64 -d --ignore-garbage > "$HOME/gcp-sa.json"
           chmod 600 "$HOME/gcp-sa.json"
+
+          # Sanity: the decoded file must be a JSON object. Validates the
+          # base64 round-trip without echoing the contents.
+          python3 -c "import json; json.load(open('$HOME/gcp-sa.json'))"
 
           echo "GCP_PROJECT_ID=$GCP_PROJECT_ID" >> $GITHUB_ENV
           echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcp-sa.json" >> $GITHUB_ENV

--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -8,11 +8,11 @@
 # Required GitHub secrets (provision once per repo):
 #   INFISICAL_CLIENT_ID      — Universal Auth client id for a Machine
 #                              Identity scoped to the goldenmatch
-#                              Infisical project (a99885f0) with read
+#                              Infisical project (a99885f0-c5af-4ae1-9dc8-255cc60aa129) with read
 #                              access on the `dev` environment.
 #   INFISICAL_CLIENT_SECRET  — companion secret for the same identity.
 #
-# Pulled FROM Infisical project a99885f0, env=dev, at runtime:
+# Pulled FROM Infisical project a99885f0-c5af-4ae1-9dc8-255cc60aa129, env=dev, at runtime:
 #   GCP_PROJECT_ID   — GCP project to bill
 #   GCP_SA_KEY       — service account JSON with the roles below
 #
@@ -86,7 +86,7 @@ jobs:
       - name: Fetch GCP creds from Infisical
         # Authenticate the Machine Identity, then pull GCP_PROJECT_ID
         # and GCP_SA_KEY from the goldenmatch Infisical project
-        # (a99885f0, dev env). The values are masked in subsequent
+        # (a99885f0-c5af-4ae1-9dc8-255cc60aa129, dev env). The values are masked in subsequent
         # logs via ::add-mask::. The SA JSON is written to disk and
         # GOOGLE_APPLICATION_CREDENTIALS points at it; the project id
         # is exported as a job-scope env var so the render + sweep
@@ -107,12 +107,12 @@ jobs:
           echo "::add-mask::$INFISICAL_TOKEN"
 
           GCP_PROJECT_ID=$(infisical secrets get GCP_PROJECT_ID \
-            --projectId=a99885f0 --env=dev --plain --token="$INFISICAL_TOKEN")
+            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$INFISICAL_TOKEN")
           echo "::add-mask::$GCP_PROJECT_ID"
 
           # Multi-line SA JSON: write straight to disk; never echo.
           infisical secrets get GCP_SA_KEY \
-            --projectId=a99885f0 --env=dev --plain --token="$INFISICAL_TOKEN" \
+            --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$INFISICAL_TOKEN" \
             > "$HOME/gcp-sa.json"
           chmod 600 "$HOME/gcp-sa.json"
 

--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -5,14 +5,25 @@
 # config (1 head + 3 preemptible workers). The tear-down step runs in
 # `if: always()` so a failed bench still releases the instances.
 #
-# Required GitHub secrets (provision once per repo, see
-# docs/distributed/ray-gce-cluster.md for the gcloud commands):
+# Required GitHub secrets (provision once per repo):
+#   INFISICAL_CLIENT_ID      — Universal Auth client id for a Machine
+#                              Identity scoped to the goldenmatch
+#                              Infisical project (a99885f0) with read
+#                              access on the `dev` environment.
+#   INFISICAL_CLIENT_SECRET  — companion secret for the same identity.
+#
+# Pulled FROM Infisical project a99885f0, env=dev, at runtime:
 #   GCP_PROJECT_ID   — GCP project to bill
 #   GCP_SA_KEY       — service account JSON with the roles below
 #
-# Required service account roles on GCP_PROJECT_ID:
+# Required GCP service account roles on GCP_PROJECT_ID:
 #   - roles/compute.admin       (create/delete instances + disks)
 #   - roles/iam.serviceAccountUser (let Ray attach the SA to instances)
+#
+# Pattern: any future Infisical-backed secret reuses the same auth
+# pair instead of accumulating GH secrets. See
+# docs/distributed/ray-gce-cluster.md for the one-time Infisical
+# Machine Identity setup commands.
 
 name: bench-ray-cluster
 
@@ -57,39 +68,62 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install Ray + gcloud helpers
-        # Ray needs to be installed locally so the controller can drive
-        # `ray up` / `ray submit` / `ray down`. The version pin matches
-        # the cluster.yaml docker image.
+      - name: Install Ray + gcloud helpers + Infisical CLI
+        # Ray drives `ray up` / `ray submit` / `ray down` locally; the
+        # version pin matches the cluster.yaml docker image. Infisical
+        # CLI fetches GCP creds at runtime so the GCP secrets stay in
+        # one place instead of accumulating GH-Actions copies.
         run: |
           pip install --upgrade pip
           pip install "ray[default]==${{ env.RAY_RELEASE }}" "google-api-python-client"
           pip install pyyaml
+          # Infisical CLI: official apt repo. The 0.43.x series ships
+          # `infisical login --method=universal-auth` and
+          # `infisical secrets get --plain` which we both use.
+          curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
+          sudo apt-get update && sudo apt-get install -y infisical
 
-      - name: Auth to GCP
-        # Hydrate the service account JSON onto disk and set
-        # GOOGLE_APPLICATION_CREDENTIALS so gcloud/google-api-client
-        # pick it up. The JSON itself is never written to logs.
+      - name: Fetch GCP creds from Infisical
+        # Authenticate the Machine Identity, then pull GCP_PROJECT_ID
+        # and GCP_SA_KEY from the goldenmatch Infisical project
+        # (a99885f0, dev env). The values are masked in subsequent
+        # logs via ::add-mask::. The SA JSON is written to disk and
+        # GOOGLE_APPLICATION_CREDENTIALS points at it; the project id
+        # is exported as a job-scope env var so the render + sweep
+        # steps see it without ${{ secrets.* }}.
         env:
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+          INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
+          INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
         run: |
-          if [ -z "$GCP_SA_KEY" ]; then
-            echo "::error::GCP_SA_KEY secret not set; see docs/distributed/ray-gce-cluster.md"
+          set -euo pipefail
+          if [ -z "${INFISICAL_CLIENT_ID:-}" ] || [ -z "${INFISICAL_CLIENT_SECRET:-}" ]; then
+            echo "::error::INFISICAL_CLIENT_ID or INFISICAL_CLIENT_SECRET not set; see docs/distributed/ray-gce-cluster.md"
             exit 1
           fi
-          echo "$GCP_SA_KEY" > "$HOME/gcp-sa.json"
+          INFISICAL_TOKEN=$(infisical login --silent --plain \
+            --method=universal-auth \
+            --client-id="$INFISICAL_CLIENT_ID" \
+            --client-secret="$INFISICAL_CLIENT_SECRET")
+          echo "::add-mask::$INFISICAL_TOKEN"
+
+          GCP_PROJECT_ID=$(infisical secrets get GCP_PROJECT_ID \
+            --projectId=a99885f0 --env=dev --plain --token="$INFISICAL_TOKEN")
+          echo "::add-mask::$GCP_PROJECT_ID"
+
+          # Multi-line SA JSON: write straight to disk; never echo.
+          infisical secrets get GCP_SA_KEY \
+            --projectId=a99885f0 --env=dev --plain --token="$INFISICAL_TOKEN" \
+            > "$HOME/gcp-sa.json"
+          chmod 600 "$HOME/gcp-sa.json"
+
+          echo "GCP_PROJECT_ID=$GCP_PROJECT_ID" >> $GITHUB_ENV
           echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcp-sa.json" >> $GITHUB_ENV
 
       - name: Render cluster.yaml with project + git SHA
-        env:
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
-          if [ -z "$GCP_PROJECT_ID" ]; then
-            echo "::error::GCP_PROJECT_ID secret not set"
-            exit 1
-          fi
-          # Inject project_id, git SHA, cluster_name, and max_workers
-          # into the template. sed is fine; the placeholders are unique.
+          set -euo pipefail
+          # GCP_PROJECT_ID is in $GITHUB_ENV from the Infisical fetch
+          # step. Inject project_id, git SHA, cluster_name, max_workers.
           sed -i "s|GOLDENMATCH_GCP_PROJECT_PLACEHOLDER|$GCP_PROJECT_ID|g" .ray/cluster-gce.yaml
           sed -i "s|GOLDENMATCH_GIT_SHA_PLACEHOLDER|${{ github.sha }}|g" .ray/cluster-gce.yaml
           sed -i "s|cluster_name: goldenmatch-bench$|cluster_name: ${{ env.CLUSTER_NAME }}|" .ray/cluster-gce.yaml
@@ -143,16 +177,22 @@ jobs:
         # Suppress errors so the workflow doesn't itself fail here.
         if: always()
         run: |
+          # $GCP_PROJECT_ID + $GOOGLE_APPLICATION_CREDENTIALS were
+          # exported in $GITHUB_ENV by the Infisical fetch step.
+          if [ -z "${GCP_PROJECT_ID:-}" ]; then
+            echo "GCP_PROJECT_ID not in env -- earlier step failed before Infisical fetch; nothing to sweep."
+            exit 0
+          fi
           gcloud auth activate-service-account \
             --key-file="$GOOGLE_APPLICATION_CREDENTIALS" \
-            --project="${{ secrets.GCP_PROJECT_ID }}" || true
+            --project="$GCP_PROJECT_ID" || true
           gcloud compute instances list \
             --filter="labels.ray-cluster-name=${{ env.CLUSTER_NAME }}" \
-            --project="${{ secrets.GCP_PROJECT_ID }}" \
+            --project="$GCP_PROJECT_ID" \
             --format="value(name,zone)" 2>/dev/null | while read name zone; do
               if [ -n "$name" ]; then
                 gcloud compute instances delete "$name" \
-                  --zone="$zone" --project="${{ secrets.GCP_PROJECT_ID }}" \
+                  --zone="$zone" --project="$GCP_PROJECT_ID" \
                   --quiet || true
               fi
             done

--- a/docs/distributed/ray-gce-cluster.md
+++ b/docs/distributed/ray-gce-cluster.md
@@ -56,19 +56,19 @@ gcloud iam service-accounts keys create gm-ray-bench-key.json \
 ### 3. Store the GCP creds in Infisical
 
 The workflow pulls these at runtime from Infisical project
-`a99885f0`, env `dev`. Set them with `infisical secrets set` (use
+`a99885f0-c5af-4ae1-9dc8-255cc60aa129`, env `dev`. Set them with `infisical secrets set` (use
 `--silent` and redirect stdout so values don't echo into the
 terminal):
 
 ```powershell
 # Project id
 $projectId = (gcloud config get-value project)
-infisical.cmd secrets set --projectId a99885f0 --env dev `
+infisical.cmd secrets set --projectId a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env dev `
     GCP_PROJECT_ID=$projectId > $null
 
 # Service account JSON (multi-line; pass via env var to avoid quoting)
 $env:_GM_SA_JSON = Get-Content gm-ray-bench-key.json -Raw
-infisical.cmd secrets set --projectId a99885f0 --env dev `
+infisical.cmd secrets set --projectId a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env dev `
     GCP_SA_KEY=$env:_GM_SA_JSON > $null
 Remove-Item env:_GM_SA_JSON
 Remove-Item gm-ray-bench-key.json   # don't keep the JSON on disk
@@ -77,7 +77,7 @@ Remove-Item gm-ray-bench-key.json   # don't keep the JSON on disk
 Verify by name only (no values):
 
 ```powershell
-infisical.cmd secrets --projectId a99885f0 --env dev | Select-String GCP
+infisical.cmd secrets --projectId a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env dev | Select-String GCP
 ```
 
 ### 4. Create a Machine Identity for GitHub Actions

--- a/docs/distributed/ray-gce-cluster.md
+++ b/docs/distributed/ray-gce-cluster.md
@@ -53,21 +53,63 @@ gcloud iam service-accounts keys create gm-ray-bench-key.json \
     --iam-account="$SA_EMAIL"
 ```
 
-### 3. Set the GitHub secrets
+### 3. Store the GCP creds in Infisical
 
-```sh
-gh secret set GCP_PROJECT_ID \
-    --repo benseverndev-oss/goldenmatch \
-    --body "$(gcloud config get-value project)"
+The workflow pulls these at runtime from Infisical project
+`a99885f0`, env `dev`. Set them with `infisical secrets set` (use
+`--silent` and redirect stdout so values don't echo into the
+terminal):
 
-gh secret set GCP_SA_KEY \
-    --repo benseverndev-oss/goldenmatch \
-    --body "$(cat gm-ray-bench-key.json)"
+```powershell
+# Project id
+$projectId = (gcloud config get-value project)
+infisical.cmd secrets set --projectId a99885f0 --env dev `
+    GCP_PROJECT_ID=$projectId > $null
 
-rm gm-ray-bench-key.json   # don't keep the JSON on disk
+# Service account JSON (multi-line; pass via env var to avoid quoting)
+$env:_GM_SA_JSON = Get-Content gm-ray-bench-key.json -Raw
+infisical.cmd secrets set --projectId a99885f0 --env dev `
+    GCP_SA_KEY=$env:_GM_SA_JSON > $null
+Remove-Item env:_GM_SA_JSON
+Remove-Item gm-ray-bench-key.json   # don't keep the JSON on disk
 ```
 
-### 4. Dispatch the workflow
+Verify by name only (no values):
+
+```powershell
+infisical.cmd secrets --projectId a99885f0 --env dev | Select-String GCP
+```
+
+### 4. Create a Machine Identity for GitHub Actions
+
+The workflow authenticates to Infisical via a dedicated Machine
+Identity using Universal Auth (client id + secret pair):
+
+1. Infisical web UI → `goldenmatch` project → Access Control →
+   Machine Identities → Create.
+2. Name: `goldenmatch-bench-ray-cluster`. Auth method: **Universal
+   Auth**. Trusted IPs: `0.0.0.0/0` (Actions runners are dynamic;
+   restrict later if needed).
+3. Project permissions: read-only on env `dev`, paths `/GCP_*`.
+4. Copy the generated **Client ID** and **Client Secret**. The
+   secret is shown ONCE.
+
+### 5. Set the two GitHub Actions secrets
+
+```sh
+gh secret set INFISICAL_CLIENT_ID \
+    --repo benseverndev-oss/goldenmatch \
+    --body "<paste client id>"
+
+gh secret set INFISICAL_CLIENT_SECRET \
+    --repo benseverndev-oss/goldenmatch \
+    --body "<paste client secret>"
+```
+
+These two are the ONLY GH-Actions secrets the workflow needs. Future
+Infisical-backed secrets reuse the same auth pair.
+
+### 6. Dispatch the workflow
 
 ```sh
 gh workflow run bench-ray-cluster.yml \

--- a/docs/distributed/ray-gce-cluster.md
+++ b/docs/distributed/ray-gce-cluster.md
@@ -56,28 +56,38 @@ gcloud iam service-accounts keys create gm-ray-bench-key.json \
 ### 3. Store the GCP creds in Infisical
 
 The workflow pulls these at runtime from Infisical project
-`a99885f0-c5af-4ae1-9dc8-255cc60aa129`, env `dev`. Set them with `infisical secrets set` (use
-`--silent` and redirect stdout so values don't echo into the
-terminal):
+`a99885f0-c5af-4ae1-9dc8-255cc60aa129`, env `dev`, under the team's
+existing naming convention:
+
+| Infisical secret name | Format | Decoded form |
+|---|---|---|
+| `GOOGLE_CLOUD_PROJECT` | plain string | the GCP project id |
+| `GCP_SA_KEY_B64` | base64-encoded | service account JSON |
+
+The workflow base64-decodes `GCP_SA_KEY_B64` and writes the JSON
+straight to disk; the raw bytes never round-trip through env vars.
+
+Set them with `infisical secrets set` (redirect stdout to `$null` so
+values don't echo into the terminal):
 
 ```powershell
-# Project id
+# Project id (plain)
 $projectId = (gcloud config get-value project)
 infisical.cmd secrets set --projectId a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env dev `
-    GCP_PROJECT_ID=$projectId > $null
+    GOOGLE_CLOUD_PROJECT=$projectId > $null
 
-# Service account JSON (multi-line; pass via env var to avoid quoting)
-$env:_GM_SA_JSON = Get-Content gm-ray-bench-key.json -Raw
+# Service account JSON: base64-encode locally, store the encoded form
+$saB64 = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes("gm-ray-bench-key.json"))
 infisical.cmd secrets set --projectId a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env dev `
-    GCP_SA_KEY=$env:_GM_SA_JSON > $null
-Remove-Item env:_GM_SA_JSON
+    GCP_SA_KEY_B64=$saB64 > $null
+Remove-Variable saB64
 Remove-Item gm-ray-bench-key.json   # don't keep the JSON on disk
 ```
 
 Verify by name only (no values):
 
 ```powershell
-infisical.cmd secrets --projectId a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env dev | Select-String GCP
+infisical.cmd secrets --projectId a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env dev | Select-String "GOOGLE_CLOUD_PROJECT|GCP_SA_KEY_B64"
 ```
 
 ### 4. Create a Machine Identity for GitHub Actions
@@ -90,7 +100,9 @@ Identity using Universal Auth (client id + secret pair):
 2. Name: `goldenmatch-bench-ray-cluster`. Auth method: **Universal
    Auth**. Trusted IPs: `0.0.0.0/0` (Actions runners are dynamic;
    restrict later if needed).
-3. Project permissions: read-only on env `dev`, paths `/GCP_*`.
+3. Project permissions: read-only on env `dev` for
+   `GOOGLE_CLOUD_PROJECT` and `GCP_SA_KEY_B64` (the only two secrets
+   the workflow fetches).
 4. Copy the generated **Client ID** and **Client Secret**. The
    secret is shown ONCE.
 


### PR DESCRIPTION
Re-applies the Option B Infisical-fetch design from closed PR #609. The Machine Identity (INFISICAL_CLIENT_ID + INFISICAL_CLIENT_SECRET) was provisioned out-of-band; flipping back to the canonical pattern. Only two GH secrets required; GCP creds stay in Infisical project a99885f0 env dev.