### PR TITLE
fix(ray): bump pin 2.30.0 -> 2.43.0 (2.30 yanked from PyPI)

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -62,7 +62,7 @@ jobs:
       # (avoids collisions if two dispatches overlap) and the right
       # project_id + git SHA.
       CLUSTER_NAME: "goldenmatch-bench-${{ github.run_id }}"
-      RAY_RELEASE: "2.30.0"
+      RAY_RELEASE: "2.43.0"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 

--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -42,7 +42,7 @@ rsync_exclude:
 # series; the bench container layer installs goldenmatch on top via
 # pip.
 docker:
-  image: "rayproject/ray:2.30.0-py312"
+  image: "rayproject/ray:2.43.0-py312"
   container_name: "ray_container"
   pull_before_run: true
 


### PR DESCRIPTION
v44 failed installing ray==2.30.0 (no longer on PyPI; earliest now 2.31.0). Bump both the workflow pip pin and the cluster yaml docker image to 2.43.0.