### PR TITLE
docs(ray): runbook enables cloudresourcemanager + iamcredentials APIs

### DIFF
--- a/docs/distributed/ray-gce-cluster.md
+++ b/docs/distributed/ray-gce-cluster.md
@@ -25,7 +25,11 @@ leak: ~$1/hr if both teardown steps fail.
 ```sh
 gcloud projects create goldenmatch-ray-bench --name="goldenmatch ray bench"
 gcloud config set project goldenmatch-ray-bench
-gcloud services enable compute.googleapis.com iam.googleapis.com
+gcloud services enable \
+    compute.googleapis.com \
+    iam.googleapis.com \
+    cloudresourcemanager.googleapis.com \
+    iamcredentials.googleapis.com
 ```
 
 The project ID becomes the `GCP_PROJECT_ID` GitHub secret.


### PR DESCRIPTION
v44c hit a 403 from Ray Cluster Launcher because Cloud Resource Manager API wasn't enabled. One-line docs fix.