### PR TITLE
fix(ray): pull project from GCP_RAY_BENCH_PROJECT_ID (not GOOGLE_CLOUD_PROJECT)

### DIFF
--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -13,8 +13,11 @@
 #   INFISICAL_CLIENT_SECRET  — companion secret for the same identity.
 #
 # Pulled FROM Infisical project a99885f0-c5af-4ae1-9dc8-255cc60aa129, env=dev, at runtime:
-#   GOOGLE_CLOUD_PROJECT  — GCP project to bill
-#   GCP_SA_KEY_B64        — base64-encoded service account JSON
+#   GCP_RAY_BENCH_PROJECT_ID  — GCP project that holds the bench SA +
+#                                APIs (golden-490919). NOT the same as
+#                                GOOGLE_CLOUD_PROJECT, which the team
+#                                uses for a different (Vertex) project.
+#   GCP_SA_KEY_B64            — base64-encoded service account JSON
 #                           (roles listed below). Decoded to disk at
 #                           fetch time; never echoed.
 #
@@ -108,10 +111,13 @@ jobs:
             --client-secret="$INFISICAL_CLIENT_SECRET")
           echo "::add-mask::$INFISICAL_TOKEN"
 
-          # GOOGLE_CLOUD_PROJECT is the team's existing Infisical secret
-          # name; surfaces it locally as GCP_PROJECT_ID for the rest of
-          # this workflow's env to read.
-          GCP_PROJECT_ID=$(infisical secrets get GOOGLE_CLOUD_PROJECT \
+          # GCP_RAY_BENCH_PROJECT_ID is the project where the bench SA
+          # lives and the required APIs are enabled (golden-490919).
+          # The team's GOOGLE_CLOUD_PROJECT secret points elsewhere
+          # (gen-lang-client-* Vertex project) -- using it would 403
+          # the SA on every cloudresourcemanager call. Surfaces it
+          # locally as GCP_PROJECT_ID for the rest of this workflow.
+          GCP_PROJECT_ID=$(infisical secrets get GCP_RAY_BENCH_PROJECT_ID \
             --projectId=a99885f0-c5af-4ae1-9dc8-255cc60aa129 --env=dev --plain --token="$INFISICAL_TOKEN")
           echo "::add-mask::$GCP_PROJECT_ID"
 

--- a/docs/distributed/ray-gce-cluster.md
+++ b/docs/distributed/ray-gce-cluster.md
@@ -61,8 +61,13 @@ existing naming convention:
 
 | Infisical secret name | Format | Decoded form |
 |---|---|---|
-| `GOOGLE_CLOUD_PROJECT` | plain string | the GCP project id |
+| `GCP_RAY_BENCH_PROJECT_ID` | plain string | the GCP project id where the bench SA lives (e.g. `golden-490919`) |
 | `GCP_SA_KEY_B64` | base64-encoded | service account JSON |
+
+`GCP_RAY_BENCH_PROJECT_ID` is a Ray-bench-specific name on purpose -- the
+team's existing `GOOGLE_CLOUD_PROJECT` secret points at a different
+project used for Vertex AI work. Reusing it would 403 the bench SA on
+every cloudresourcemanager call.
 
 The workflow base64-decodes `GCP_SA_KEY_B64` and writes the JSON
 straight to disk; the raw bytes never round-trip through env vars.


### PR DESCRIPTION
v44b-v44f Ray bootstrap kept failing with 'Service accounts cannot create projects without a parent.' Root cause: existing Infisical GOOGLE_CLOUD_PROJECT points at a Vertex AI project where the bench SA has no permissions; Ray's _get_project hit 403 and fell through to _create_project. Switching to a bench-specific Infisical secret name (GCP_RAY_BENCH_PROJECT_ID = golden-490919) where the SA + APIs actually live. CLAUDE.md memory project_506_embedding_provider_bench called out this exact pitfall: 'Vertex SA needs billing (golden-490919, not gen-lang-client).'