### PR TITLE
feat(backends): DataFusion spike + Ray cluster infra fixes

### DIFF
--- a/.github/workflows/bench-datafusion-vs-bucket.yml
+++ b/.github/workflows/bench-datafusion-vs-bucket.yml
@@ -1,0 +1,112 @@
+# Bench: DataFusion vs bucket vs parallel at 10K + 100K, Day-3 gate.
+#
+# workflow_dispatch only. Runs scripts/bench_datafusion_vs_bucket.py
+# on large-new-64GB (16c / 64GB) -- the same baseline the bucket
+# 25M-on-one-node numbers were measured on. Uploads the JSON
+# artifact and posts the markdown summary to the step summary.
+#
+# Decision gate (replicated in the bench script, surfaced here for
+# visibility): at n=100K, if datafusion_wall / bucket_wall > 2.0,
+# the bench exits non-zero and we stop the spike to triage before
+# pushing to Day 4 (1M).
+#
+# Spec:
+#   docs/superpowers/specs/2026-05-30-datafusion-backend-spike-design.md
+#   (gitignored)
+#
+# IMPORTANT: this bench must NOT run locally on the dev box -- the
+# 100K controller-iteration shape OOMed Ben's Windows machine
+# (2026-05-30). All heavy compute lives in GH Actions per
+# memory/feedback_avoid_full_suite_oom.
+
+name: bench-datafusion-vs-bucket
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: large-new-64GB
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Editable install goldenmatch[datafusion]
+        # The [datafusion] extra pulls datafusion>=44 (~38 MB wheel).
+        # Editable so the bench picks up the spike branch's
+        # backends/datafusion_backend.py without re-syncing.
+        run: uv pip install -e "packages/python/goldenmatch[datafusion]"
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build native module
+        # bucket and datafusion backends both REQUIRE the native
+        # module -- bucket for its inner score_block_pairs_arrow
+        # kernel, datafusion for the jaro_winkler / levenshtein /
+        # token_sort UDFs. Without native, the bench short-circuits
+        # to a meaningless result.
+        run: .venv/bin/python scripts/build_native.py
+
+      - name: Verify native loaded for both backends
+        run: |
+          .venv/bin/python -c "
+          import goldenmatch._native as n
+          for fn in ('jaro_winkler_similarity', 'levenshtein_similarity',
+                     'token_sort_ratio', 'score_block_pairs_arrow'):
+              assert hasattr(n, fn), f'native missing {fn}'
+          print('native loaded with all required kernels')
+          "
+
+      - name: Run Day-3 bench (10K + 100K, 3 iters each, 3 backends)
+        # The script writes its own JSON to .profile_tmp/datafusion-bench/.
+        # It also prints a markdown table that we re-capture into
+        # GITHUB_STEP_SUMMARY below. Non-zero exit means the Day-3
+        # decision gate failed (datafusion >2x slower than bucket at 100K).
+        run: |
+          set -euo pipefail
+          mkdir -p .profile_tmp/datafusion-bench
+          # Tee stdout so we can post the markdown table from it.
+          .venv/bin/python packages/python/goldenmatch/scripts/bench_datafusion_vs_bucket.py \
+            2>&1 | tee .profile_tmp/datafusion-bench/day3_stdout.txt
+
+      - name: Post markdown summary
+        if: always()
+        run: |
+          STDOUT=.profile_tmp/datafusion-bench/day3_stdout.txt
+          if [ ! -f "$STDOUT" ]; then
+            echo "no stdout captured -- earlier step failed" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## bench-datafusion-vs-bucket (Day 3)"
+            echo ""
+            echo "Spec gate: at n=100K, ratio = datafusion_wall / bucket_wall must be <= 2.0 to continue to Day 4 (1M)."
+            echo ""
+            # Pull only the markdown table + the GATE line from the
+            # bench script output. Anything outside that range is
+            # per-iter logging noise.
+            awk '/^## Bench summary/,/^GATE @/' "$STDOUT"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload bench artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: datafusion-vs-bucket-day3
+          path: .profile_tmp/datafusion-bench/
+          if-no-files-found: warn

--- a/.github/workflows/bench-ray-cluster.yml
+++ b/.github/workflows/bench-ray-cluster.yml
@@ -159,10 +159,34 @@ jobs:
         # `ray submit` ships the script to the head node and runs it.
         # The script writes its JSON output to /tmp on the head; we
         # rsync it back via `ray rsync_down` after the run.
+        #
+        # We background a `ray status` poller (every 30s) so the GH
+        # live log shows head/worker resource use and per-node state
+        # interleaved with bench stdout. Without this, the only
+        # signal mid-run is autoscaler "Resized to N CPUs" lines and
+        # whatever the bench script chooses to print.
         run: |
           set -euo pipefail
           mkdir -p .profile_tmp/qis
           OUT_REMOTE="/tmp/qis_${{ inputs.label }}.json"
+
+          # Background poller. Runs in a subshell so we can trap-kill
+          # it cleanly on bench completion regardless of exit code.
+          (
+            while true; do
+              echo "===== ray status @ $(date -u +%H:%M:%S) ====="
+              ray exec .ray/cluster-gce.yaml "ray status" 2>&1 \
+                | grep -E "Node status|Active|Pending|Recent|Resources|CPU|memory|object_store|Healthy|Unhealthy" \
+                || echo "ray status poll failed (transient SSH/docker issue)"
+              echo ""
+              sleep 30
+            done
+          ) &
+          POLLER_PID=$!
+          # Trap fires on script exit (success OR failure) to release
+          # the poller PID and its SSH control-master connections.
+          trap "kill $POLLER_PID 2>/dev/null || true" EXIT
+
           ray submit .ray/cluster-gce.yaml \
             scripts/quality_invariant_scale.py \
             -- --rows ${{ inputs.rows }} \

--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -104,10 +104,14 @@ available_node_types:
           initializeParams:
             diskSizeGb: 100
             sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts
-      # Preemptible (spot) workers are 60-80% cheaper. Phase 5 streaming
-      # is partition-resumable so preemption is tolerable at this scale.
-      # Flip to false if you see preemption-driven retries dominating wall.
+      # On-demand workers. We started on preemptible (60-80% cheaper) but
+      # n2-standard-16 spot capacity in us-central1-a was intermittent --
+      # v44l / v45 saw workers either fail to launch or get preempted
+      # within seconds, while the on-demand head provisioned cleanly.
+      # On-demand costs ~4x per worker but is the right call until the
+      # cluster path is proven end-to-end. Flip back once we've shown
+      # the Ray code path works at this scale.
       scheduling:
-        - preemptible: true
+        - preemptible: false
 
 head_node_type: ray_head_default

--- a/.ray/cluster-gce.yaml
+++ b/.ray/cluster-gce.yaml
@@ -46,7 +46,13 @@ docker:
   container_name: "ray_container"
   pull_before_run: true
 
-initialization_commands: []
+initialization_commands:
+  # Ubuntu LTS base doesn't ship Docker; Ray's container runtime
+  # needs it. Idempotent: skips if docker is already present.
+  - "command -v docker >/dev/null || (curl -fsSL https://get.docker.com | sudo sh)"
+  # Ray SSHes as the `ubuntu` user; add it to the docker group so
+  # later docker invocations don't need sudo.
+  - "sudo usermod -aG docker ubuntu"
 
 # Install goldenmatch from the repo's tag. The bench workflow stamps
 # this from the commit SHA so reruns hit identical code.

--- a/packages/python/goldenmatch/goldenmatch/backends/datafusion_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/datafusion_backend.py
@@ -1,0 +1,287 @@
+"""DataFusion block-scoring backend.
+
+Spike — see ``docs/superpowers/specs/2026-05-30-datafusion-backend-spike-design.md``
+(gitignored). Routes block scoring through Apache DataFusion's columnar
+query engine, with native scorers wrapped as vectorized Arrow-batch
+Python UDFs that delegate to ``goldenmatch._native``.
+
+Day 2 scope: single-field ``weighted`` matchkey, scorer in
+``{"jaro_winkler", "levenshtein", "token_sort"}``. Anything outside
+that scope raises ``NotImplementedError`` — the spike does NOT yet
+cover multi-field weighted, exact, probabilistic, or embedding
+scorers; falling back to the parallel scorer for those is the
+caller's responsibility.
+
+Opt-in via ``config.backend="datafusion"``. The optional extra is
+``goldenmatch[datafusion]`` (pulls ``datafusion>=44``).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pyarrow as pa
+
+logger = logging.getLogger(__name__)
+
+
+# Scorers supported in the Day-2 spike. Each maps to a callable that
+# takes two strings and returns a float in [0, 1]. The native module
+# is required — bench numbers from the parallel path with jellyfish
+# fallback would be misleading.
+_SUPPORTED_SCORERS = ("jaro_winkler", "levenshtein", "token_sort")
+
+
+def _ensure_datafusion():
+    """Lazy import so the optional extra stays truly optional."""
+    try:
+        import datafusion
+        return datafusion
+    except ImportError as e:
+        raise ImportError(
+            "DataFusion backend requires datafusion. Install with:\n"
+            "    pip install goldenmatch[datafusion]"
+        ) from e
+
+
+def _ensure_native():
+    """Hard-require the native module. The whole premise of the
+    DataFusion backend is native scoring inside DataFusion's planner;
+    falling back to jellyfish would invalidate any bench result."""
+    try:
+        import goldenmatch._native as native
+        return native
+    except ImportError as e:
+        raise ImportError(
+            "DataFusion backend requires the compiled native module. "
+            "Build it with: python scripts/build_native.py\n"
+            "(Then re-install: pip install -e packages/python/goldenmatch)"
+        ) from e
+
+
+def _validate_matchkey(mk: Any) -> tuple[str, str, float]:
+    """Validate that ``mk`` is in the spike-supported subset, and
+    return ``(field_name, scorer_name, threshold)``.
+
+    Raises:
+        NotImplementedError if the matchkey shape is outside the
+        spike scope. Callers should treat this as a signal to fall
+        back to the parallel backend, not as a bug.
+    """
+    if getattr(mk, "type", None) != "weighted":
+        raise NotImplementedError(
+            f"DataFusion backend (spike) only supports type='weighted' "
+            f"matchkeys; got type={mk.type!r}. Use a different backend."
+        )
+
+    fields = list(getattr(mk, "fields", []) or [])
+    if len(fields) != 1:
+        raise NotImplementedError(
+            f"DataFusion backend (spike) only supports single-field "
+            f"weighted matchkeys; got {len(fields)} fields. "
+            f"Multi-field is a follow-up."
+        )
+
+    field = fields[0]
+    scorer_name = getattr(field, "scorer", None)
+    if scorer_name not in _SUPPORTED_SCORERS:
+        raise NotImplementedError(
+            f"DataFusion backend (spike) only supports scorers "
+            f"{_SUPPORTED_SCORERS}; got scorer={scorer_name!r}."
+        )
+
+    field_name = field.resolved_field if hasattr(field, "resolved_field") else field.field
+    threshold = mk.fuzzy_threshold if hasattr(mk, "fuzzy_threshold") else mk.threshold
+    if threshold is None:
+        raise ValueError(
+            "DataFusion backend requires a non-None matchkey threshold "
+            "(weighted matchkeys must set threshold per the schema validator)."
+        )
+    return field_name, scorer_name, float(threshold)
+
+
+def _make_score_udf(scorer_name: str, datafusion_mod, native_mod):
+    """Build a vectorized Arrow-batch UDF that calls into the native
+    scorer once per record batch.
+
+    Note on Path B1 vs B2: this is B1 (vectorized Python wrapper around
+    pyo3 native). Python pays per-batch overhead (~1 call per ~8K rows
+    depending on DataFusion's batch size). If Day-3 cProfile shows that
+    overhead is material, we drop to B2 — a true Rust ScalarUDF
+    registered via datafusion-python's PyCapsule FFI. The
+    PyCapsule path is documented in ``datafusion.udf`` itself.
+    """
+    if scorer_name == "jaro_winkler":
+        scorer = native_mod.jaro_winkler_similarity
+    elif scorer_name == "levenshtein":
+        scorer = native_mod.levenshtein_similarity
+    elif scorer_name == "token_sort":
+        # native token_sort_ratio returns 0-100; normalize to 0-1 here
+        # to match jellyfish/rapidfuzz convention used elsewhere.
+        _raw = native_mod.token_sort_ratio
+        def scorer(a: str, b: str) -> float:
+            return _raw(a, b) / 100.0
+    else:  # defensive; _validate_matchkey already gates this
+        raise NotImplementedError(scorer_name)
+
+    def _batch_fn(left: pa.Array, right: pa.Array) -> pa.Array:
+        lefts = left.to_pylist()
+        rights = right.to_pylist()
+        out = [scorer(a or "", b or "") for a, b in zip(lefts, rights, strict=True)]
+        return pa.array(out, type=pa.float64())
+
+    return datafusion_mod.udf(
+        _batch_fn,
+        input_fields=[pa.string(), pa.string()],
+        return_field=pa.float64(),
+        volatility="immutable",
+        name=f"_gm_score_{scorer_name}",
+    )
+
+
+def _score_one_block_datafusion(
+    block: Any,
+    field_name: str,
+    udf_callable_name: str,
+    threshold: float,
+    exclude_pairs: set[tuple[int, int]] | frozenset[tuple[int, int]],
+    ctx,
+    across_files_only: bool = False,
+    source_lookup: dict[int, str] | None = None,
+) -> list[tuple[int, int, float]]:
+    """Score one block via DataFusion. Returns canonicalized
+    ``(min_id, max_id, score)`` tuples above threshold.
+    """
+    block_df = block.df.collect()
+    if block_df.height < 2:
+        return []
+
+    if across_files_only and source_lookup:
+        sources_in_block = block_df["__source__"].unique().to_list()
+        if len(sources_in_block) < 2:
+            return []
+
+    # Build a 2-column Arrow table: __row_id__ (int64), <field> (string).
+    # We deliberately don't ship the whole block_df into DataFusion --
+    # the only columns the spike's scoring SQL needs are the row id
+    # and the field being scored. Extra columns would inflate
+    # serialization cost without affecting the result.
+    import polars as _pl  # local import keeps optional-extra purity
+    row_ids = block_df["__row_id__"].cast(_pl.Int64).to_arrow()
+    values = block_df[field_name].cast(_pl.Utf8).to_arrow()
+    table = pa.table({"__row_id__": row_ids, field_name: values})
+
+    # Per-block table name keeps blocks isolated; we deregister at end
+    # of the call to free DataFusion's internal state.
+    table_name = f"_gm_block_{id(block)}"
+    ctx.register_record_batches(table_name, [table.to_batches()])
+    try:
+        # Self-join on (a.id < b.id) for canonical pair ordering,
+        # score, threshold filter. DataFusion's planner picks the
+        # join strategy (hash vs nested-loop) -- our spike just hands
+        # it the SQL and inspects the result.
+        sql = f"""
+            SELECT
+                a.__row_id__ AS id_a,
+                b.__row_id__ AS id_b,
+                {udf_callable_name}(a.{field_name}, b.{field_name}) AS score
+            FROM {table_name} a
+            JOIN {table_name} b ON a.__row_id__ < b.__row_id__
+            WHERE {udf_callable_name}(a.{field_name}, b.{field_name}) >= {threshold}
+        """
+        df = ctx.sql(sql)
+        result_table = df.to_arrow_table()
+    finally:
+        try:
+            ctx.deregister_table(table_name)
+        except Exception:  # noqa: BLE001 -- best-effort cleanup
+            pass
+
+    if result_table.num_rows == 0:
+        return []
+
+    id_a_arr = result_table.column("id_a").to_pylist()
+    id_b_arr = result_table.column("id_b").to_pylist()
+    score_arr = result_table.column("score").to_pylist()
+
+    pairs: list[tuple[int, int, float]] = []
+    for a, b, s in zip(id_a_arr, id_b_arr, score_arr, strict=True):
+        a_i = int(a)
+        b_i = int(b)
+        key = (a_i, b_i) if a_i < b_i else (b_i, a_i)
+        if key in exclude_pairs:
+            continue
+        if across_files_only and source_lookup:
+            if source_lookup.get(a_i) == source_lookup.get(b_i):
+                continue
+        pairs.append((key[0], key[1], float(s)))
+    return pairs
+
+
+def score_blocks_datafusion(
+    blocks: list,
+    mk: Any,
+    matched_pairs: set[tuple[int, int]],
+    across_files_only: bool = False,
+    source_lookup: dict[int, str] | None = None,
+    target_ids: set[int] | None = None,
+) -> list[tuple[int, int, float]]:
+    """Score all blocks via DataFusion. Drop-in for
+    ``score_blocks_parallel`` modulo the spike-scope constraints in
+    ``_validate_matchkey`` (single-field weighted, supported scorer).
+
+    See module docstring for spike scope. Anything outside that scope
+    raises ``NotImplementedError`` so callers can route to a
+    different backend without silent fallback (which would taint
+    bench numbers).
+    """
+    if not blocks:
+        return []
+
+    field_name, scorer_name, threshold = _validate_matchkey(mk)
+    datafusion_mod = _ensure_datafusion()
+    native_mod = _ensure_native()
+
+    # One SessionContext + one UDF registration per call. SessionContext
+    # is cheap to create (no daemon, no warm-up), and reusing one across
+    # all blocks of this call lets DataFusion amortize any internal
+    # caches across blocks. Day-3 bench should confirm this isn't a
+    # bottleneck; if it is, the next architectural step is "one
+    # SessionContext, one big Arrow table with all blocks tagged by
+    # __block_key__, one GROUP BY query" -- which is the shape
+    # DataFusion is actually designed for and the spec's secondary
+    # architectural lever.
+    ctx = datafusion_mod.SessionContext()
+    udf = _make_score_udf(scorer_name, datafusion_mod, native_mod)
+    ctx.register_udf(udf)
+    udf_callable_name = f"_gm_score_{scorer_name}"
+
+    exclude_frozen = frozenset(matched_pairs)
+
+    all_pairs: list[tuple[int, int, float]] = []
+    for block in blocks:
+        block_pairs = _score_one_block_datafusion(
+            block,
+            field_name=field_name,
+            udf_callable_name=udf_callable_name,
+            threshold=threshold,
+            exclude_pairs=exclude_frozen,
+            ctx=ctx,
+            across_files_only=across_files_only,
+            source_lookup=source_lookup,
+        )
+        if target_ids is not None:
+            block_pairs = [
+                (a, b, s) for a, b, s in block_pairs
+                if (a in target_ids) != (b in target_ids)
+            ]
+        all_pairs.extend(block_pairs)
+        for a, b, _s in block_pairs:
+            matched_pairs.add((a, b))
+
+    logger.info(
+        "DataFusion backend: scored %d block(s), emitted %d pair(s) "
+        "above threshold %.3f using scorer=%s field=%s",
+        len(blocks), len(all_pairs), threshold, scorer_name, field_name,
+    )
+    return all_pairs

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -100,6 +100,21 @@ def _get_block_scorer(config: GoldenMatchConfig):
         # connector branch existed.
         from goldenmatch.backends.score_duckdb import score_blocks_duckdb
         return score_blocks_duckdb
+    if backend == "datafusion":
+        # Experimental backend (spike: docs/superpowers/specs/
+        # 2026-05-30-datafusion-backend-spike-design.md). Routes block
+        # scoring through Apache DataFusion with native scorers wrapped
+        # as vectorized Arrow-batch UDFs. Day-2 scope: single-field
+        # weighted matchkey with one of {jaro_winkler, levenshtein,
+        # token_sort}; raises NotImplementedError outside that scope
+        # (callers must NOT catch + silently fall back -- the spike
+        # depends on deterministic routing to produce interpretable
+        # bench numbers). Requires goldenmatch[datafusion] + the
+        # compiled goldenmatch._native module.
+        from goldenmatch.backends.datafusion_backend import (
+            score_blocks_datafusion,
+        )
+        return score_blocks_datafusion
     return score_blocks_parallel
 from goldenmatch.core.cluster import build_clusters
 from goldenmatch.core.golden import (

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -120,6 +120,13 @@ duckdb = [
 ray = [
     "ray>=2.0",
 ]
+# Experimental DataFusion backend (spike: docs/superpowers/specs/
+# 2026-05-30-datafusion-backend-spike-design.md). Opt-in via
+# config.backend="datafusion". Apache Arrow query engine; pairs with
+# goldenmatch-native for zero-Python-loop scoring.
+datafusion = [
+    "datafusion>=44",
+]
 agent = [
     "aiohttp>=3.9",
 ]

--- a/packages/python/goldenmatch/scripts/bench_datafusion_vs_bucket.py
+++ b/packages/python/goldenmatch/scripts/bench_datafusion_vs_bucket.py
@@ -39,8 +39,6 @@ import psutil
 # regression tests -- per memory/feedback_synthetic_surname_fixtures.md
 # this is the shape that doesn't hang blocking+scoring for hours.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests"))
-from test_autoconfig_regressions import _person_df  # noqa: E402
-
 from goldenmatch import dedupe_df  # noqa: E402
 from goldenmatch.config.schemas import (  # noqa: E402
     BlockingConfig,
@@ -49,6 +47,7 @@ from goldenmatch.config.schemas import (  # noqa: E402
     MatchkeyConfig,
     MatchkeyField,
 )
+from test_autoconfig_regressions import _person_df  # noqa: E402
 
 
 # Spike scope: single-field weighted jaro_winkler on last_name. Matches

--- a/packages/python/goldenmatch/scripts/bench_datafusion_vs_bucket.py
+++ b/packages/python/goldenmatch/scripts/bench_datafusion_vs_bucket.py
@@ -1,0 +1,254 @@
+"""Day-3 bench: DataFusion vs bucket vs parallel on the same fixture.
+
+Spike: docs/superpowers/specs/2026-05-30-datafusion-backend-spike-design.md
+(gitignored)
+
+Drives the full ``dedupe_df`` pipeline three times per N with
+different ``config.backend`` values:
+
+    parallel    — score_blocks_parallel (default, ThreadPoolExecutor + rapidfuzz cdist)
+    bucket      — score_buckets (bypasses build_blocks; the production winner today)
+    datafusion  — score_blocks_datafusion (this spike's contribution)
+
+Same input frame, same matchkey, same blocking. Each backend runs 3
+iterations; reports median wall + peak RSS + pair count.
+
+Shape check (per spec Day 3): if 100K's datafusion wall is >2x
+bucket's, stop and triage. If competitive, push to Day 4 (1M).
+
+Run::
+
+    pip install -e packages/python/goldenmatch[datafusion]
+    python scripts/build_native.py   # required for datafusion + bucket native
+    python packages/python/goldenmatch/scripts/bench_datafusion_vs_bucket.py
+"""
+from __future__ import annotations
+
+import gc
+import json
+import statistics
+import sys
+import threading
+import time
+from pathlib import Path
+
+import polars as pl
+import psutil
+
+# Reuse the surname-distributed person fixture from the autoconfig
+# regression tests -- per memory/feedback_synthetic_surname_fixtures.md
+# this is the shape that doesn't hang blocking+scoring for hours.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests"))
+from test_autoconfig_regressions import _person_df  # noqa: E402
+
+from goldenmatch import dedupe_df  # noqa: E402
+from goldenmatch.config.schemas import (  # noqa: E402
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+
+
+# Spike scope: single-field weighted jaro_winkler on last_name. Matches
+# what the datafusion backend supports per
+# datafusion_backend._validate_matchkey; the parallel + bucket
+# backends accept it too, so all three measure the same workload.
+def _make_config(backend: str) -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="last_name_fuzzy",
+                type="weighted",
+                fields=[MatchkeyField(field="last_name", scorer="jaro_winkler", weight=1.0)],
+                threshold=0.85,
+            )
+        ],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["last_name"], transforms=["soundex"])],
+        ),
+        backend=backend,
+    )
+
+
+class _RSSWatcher:
+    """Background thread sampling process RSS every 50ms. Captures
+    peak between ``start`` and ``stop``.
+
+    Windows note: psutil's ``memory_info().rss`` returns the working
+    set, which is the Windows equivalent of Linux RSS. Same metric
+    across platforms for our purposes.
+    """
+
+    def __init__(self, interval_s: float = 0.05) -> None:
+        self._interval = interval_s
+        self._proc = psutil.Process()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.peak_bytes: int = 0
+
+    def start(self) -> None:
+        self.peak_bytes = self._proc.memory_info().rss
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                rss = self._proc.memory_info().rss
+                if rss > self.peak_bytes:
+                    self.peak_bytes = rss
+            except psutil.Error:
+                break
+            self._stop.wait(self._interval)
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+
+
+def _run_once(df: pl.DataFrame, backend: str) -> dict:
+    """Single dedupe call. Returns wall + peak RSS + pair/cluster counts."""
+    cfg = _make_config(backend)
+    gc.collect()
+    watcher = _RSSWatcher()
+    watcher.start()
+    t0 = time.perf_counter()
+    try:
+        result = dedupe_df(df, config=cfg)
+        wall = time.perf_counter() - t0
+    except NotImplementedError as e:
+        watcher.stop()
+        return {"backend": backend, "error": f"NotImplementedError: {e}"}
+    except Exception as e:  # noqa: BLE001 -- bench script wants to see ALL backend failures
+        watcher.stop()
+        return {"backend": backend, "error": f"{type(e).__name__}: {e}"}
+    finally:
+        watcher.stop()
+
+    n_dupes = result.dupes.height if result.dupes is not None else 0
+    n_clusters = len(result.clusters) if result.clusters else 0
+
+    return {
+        "backend": backend,
+        "wall_s": wall,
+        "peak_rss_mb": watcher.peak_bytes / (1024 * 1024),
+        "duplicates": n_dupes,
+        "clusters": n_clusters,
+    }
+
+
+def _bench_one_shape(n: int, n_iters: int = 3) -> dict:
+    """For a given N, run all three backends n_iters times each."""
+    print(f"\n=== n={n:,} (iters={n_iters} per backend) ===")
+    df = _person_df(n)
+    print(f"  fixture: height={df.height}, distinct_last_names={df['last_name'].n_unique()}")
+
+    results: dict[str, list[dict]] = {}
+    for backend in ("parallel", "bucket", "datafusion"):
+        runs: list[dict] = []
+        for i in range(n_iters):
+            r = _run_once(df, backend)
+            if "error" in r:
+                print(f"  {backend}[{i}]: ERROR -- {r['error']}")
+                runs.append(r)
+                # Skip remaining iters of this backend -- they'll fail the same way
+                break
+            print(
+                f"  {backend}[{i}]: wall={r['wall_s']:.3f}s  "
+                f"peak_rss={r['peak_rss_mb']:.0f}MB  "
+                f"dupes={r['duplicates']}  clusters={r['clusters']}"
+            )
+            runs.append(r)
+        results[backend] = runs
+    return {"n": n, "results": results}
+
+
+def _summarize(shape: dict) -> dict:
+    """Median wall + max peak RSS + pair-count consistency check."""
+    summary: dict[str, dict] = {}
+    for backend, runs in shape["results"].items():
+        ok_runs = [r for r in runs if "error" not in r]
+        if not ok_runs:
+            summary[backend] = {"status": "FAILED", "error": runs[0].get("error")}
+            continue
+        walls = [r["wall_s"] for r in ok_runs]
+        rsses = [r["peak_rss_mb"] for r in ok_runs]
+        dupes = {r["duplicates"] for r in ok_runs}
+        summary[backend] = {
+            "status": "OK",
+            "wall_median_s": statistics.median(walls),
+            "peak_rss_mb": max(rsses),
+            "duplicates": ok_runs[0]["duplicates"],
+            "duplicates_consistent": len(dupes) == 1,
+        }
+    return summary
+
+
+def _print_markdown_table(per_shape: list[dict]) -> None:
+    print("\n\n## Bench summary\n")
+    print("| n | backend | wall_median_s | peak_rss_MB | duplicates | status |")
+    print("|---:|---|---:|---:|---:|---|")
+    for shape in per_shape:
+        n = shape["n"]
+        for backend, s in shape["summary"].items():
+            if s["status"] == "OK":
+                print(
+                    f"| {n:,} | {backend} | {s['wall_median_s']:.3f} | "
+                    f"{s['peak_rss_mb']:.0f} | {s['duplicates']} | "
+                    f"{'OK' if s['duplicates_consistent'] else 'INCONSISTENT'} |"
+                )
+            else:
+                print(f"| {n:,} | {backend} | — | — | — | {s['status']} |")
+
+
+def _decision_gate(per_shape: list[dict]) -> int:
+    """Day-3 gate: at n=100K, if datafusion wall > 2x bucket wall,
+    print a STOP recommendation and exit non-zero so CI can gate on
+    it. Otherwise green-light Day 4 (1M)."""
+    for shape in per_shape:
+        if shape["n"] != 100_000:
+            continue
+        bucket = shape["summary"].get("bucket", {})
+        df = shape["summary"].get("datafusion", {})
+        if bucket.get("status") != "OK" or df.get("status") != "OK":
+            print("\nGATE: at least one of bucket/datafusion failed at 100K. See errors above.")
+            return 1
+        ratio = df["wall_median_s"] / bucket["wall_median_s"]
+        print(
+            f"\nGATE @ 100K: datafusion_wall / bucket_wall = {ratio:.2f}x "
+            f"(threshold for Day-3 continue: <= 2.0x)"
+        )
+        if ratio > 2.0:
+            print("STOP: datafusion is >2x slower than bucket at 100K. "
+                  "Triage before pushing to 1M (Day 4).")
+            return 1
+        print("CONTINUE: datafusion is within 2x of bucket. Push to Day 4 (1M).")
+        return 0
+    return 0
+
+
+def main() -> int:
+    per_shape: list[dict] = []
+    for n in (10_000, 100_000):
+        shape = _bench_one_shape(n, n_iters=3)
+        shape["summary"] = _summarize(shape)
+        per_shape.append(shape)
+
+    _print_markdown_table(per_shape)
+
+    out_dir = Path(__file__).resolve().parents[3] / ".profile_tmp" / "datafusion-bench"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "day3_results.json"
+    out_path.write_text(json.dumps(per_shape, indent=2))
+    print(f"\nJSON saved: {out_path}")
+
+    return _decision_gate(per_shape)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/scripts/datafusion_smoke.py
+++ b/packages/python/goldenmatch/scripts/datafusion_smoke.py
@@ -44,7 +44,9 @@ except ImportError:
 # prove-out works even without a built native module. The benchmark
 # itself (Day 3) will assert native is loaded.
 try:
-    from goldenmatch._native import jaro_winkler_similarity as _native_jw  # type: ignore[import-not-found]
+    from goldenmatch._native import (
+        jaro_winkler_similarity as _native_jw,  # type: ignore[import-not-found]
+    )
     _IMPL = "native"
 except ImportError:
     import jellyfish

--- a/packages/python/goldenmatch/scripts/datafusion_smoke.py
+++ b/packages/python/goldenmatch/scripts/datafusion_smoke.py
@@ -1,0 +1,143 @@
+"""Day-1 prove-out for the DataFusion backend spike.
+
+Goal: get ONE block scored end-to-end via DataFusion using a
+vectorized Arrow-batch Python UDF that delegates to the existing
+``goldenmatch._native.jaro_winkler_similarity`` Rust kernel.
+
+This is NOT a benchmark. It exercises plumbing:
+- can we import datafusion alongside the existing stack
+- can we register a Python UDF that processes Arrow batches
+- can we call into the native pyo3 scorer from the UDF without
+  pickling, threading, or marshalling cost beyond per-batch overhead
+- does the result set look right on a hand-crafted fixture
+
+Run::
+
+    pip install -e packages/python/goldenmatch[datafusion]
+    python packages/python/goldenmatch/scripts/datafusion_smoke.py
+
+Expected output: ~3-5 pair rows, scores in [0.85, 1.0], no errors.
+If native isn't built, falls back to per-row jellyfish (slower; the
+prove-out still works so the FFI shape is what we're validating).
+
+Spec:
+    docs/superpowers/specs/2026-05-30-datafusion-backend-spike-design.md
+"""
+from __future__ import annotations
+
+import sys
+
+import pyarrow as pa
+
+try:
+    import datafusion
+except ImportError:
+    print(
+        "ERROR: datafusion not installed. Install with:\n"
+        "    pip install -e packages/python/goldenmatch[datafusion]",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+# Try the native kernel first; fall back to jellyfish so the plumbing
+# prove-out works even without a built native module. The benchmark
+# itself (Day 3) will assert native is loaded.
+try:
+    from goldenmatch._native import jaro_winkler_similarity as _native_jw  # type: ignore[import-not-found]
+    _IMPL = "native"
+except ImportError:
+    import jellyfish
+    _native_jw = jellyfish.jaro_winkler_similarity
+    _IMPL = "jellyfish-fallback"
+
+
+def _jw_batch(left: pa.Array, right: pa.Array) -> pa.Array:
+    """Vectorized scoring UDF. Called once per record batch.
+
+    DataFusion passes two Arrow string arrays; we iterate the
+    decoded values, call the per-pair scorer, and return a Float64
+    array of the same length. The for-loop is in Python but each
+    iteration's WORK is in Rust (native path) -- Python overhead is
+    constant per batch, not per pair.
+
+    A future iteration replaces this with a true Rust UDF registered
+    via datafusion-python's Rust FFI (spec tier B2).
+    """
+    lefts = left.to_pylist()
+    rights = right.to_pylist()
+    scores = [_native_jw(a or "", b or "") for a, b in zip(lefts, rights, strict=True)]
+    return pa.array(scores, type=pa.float64())
+
+
+def main() -> int:
+    print(f"datafusion {datafusion.__version__} -- scorer impl: {_IMPL}")
+
+    # Tiny hand-crafted "block": 5 records, all in one block. We'll
+    # join the table to itself, filter to (id_a < id_b) to canonicalize
+    # pairs, score, and threshold.
+    records = pa.table({
+        "id": pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+        "name": pa.array(
+            ["John Smith", "Jon Smith", "Jane Smith", "John Smyth", "Bob Jones"],
+            type=pa.string(),
+        ),
+    })
+
+    ctx = datafusion.SessionContext()
+    ctx.register_record_batches("records", [records.to_batches()])
+
+    # Register the vectorized scorer. datafusion-python's UDF wrapper
+    # treats Python callables as batch-in/batch-out by default when the
+    # input/output types are arrays -- that's the path we want. (If we
+    # used .udf(volatility="immutable") with scalar types, it'd be
+    # per-row and the FFI cost would dominate.)
+    # datafusion 53+ API: input_fields / return_field (DataType is
+    # accepted as shorthand for "nullable field, no metadata"). Earlier
+    # versions used input_types / return_type.
+    score_udf = datafusion.udf(
+        _jw_batch,
+        input_fields=[pa.string(), pa.string()],
+        return_field=pa.float64(),
+        volatility="immutable",
+    )
+    ctx.register_udf(score_udf)
+
+    # SQL prove-out: self-join with id_a < id_b canonicalization,
+    # score, threshold at 0.85. Matches the contract of the bucket
+    # backend's per-block scoring.
+    result = ctx.sql(
+        """
+        SELECT
+            a.id AS id_a,
+            b.id AS id_b,
+            _jw_batch(a.name, b.name) AS score
+        FROM records a
+        JOIN records b ON a.id < b.id
+        WHERE _jw_batch(a.name, b.name) >= 0.85
+        ORDER BY score DESC
+        """
+    ).to_pandas()
+
+    print(f"\n{len(result)} pair(s) above threshold:")
+    print(result.to_string(index=False))
+
+    # Sanity checks: the high-similarity pairs must be present.
+    pairs_set = {(int(r.id_a), int(r.id_b)) for r in result.itertuples()}
+    expected_present = [
+        (1, 2),  # John Smith / Jon Smith     ~0.97
+        (1, 4),  # John Smith / John Smyth    ~0.94
+        (2, 4),  # Jon Smith  / John Smyth    ~0.93
+    ]
+    missing = [p for p in expected_present if p not in pairs_set]
+    if missing:
+        print(f"\nFAIL: expected pairs missing: {missing}", file=sys.stderr)
+        return 1
+
+    print(f"\nOK: {len(expected_present)} high-similarity pairs present, "
+          f"end-to-end DataFusion->native FFI works.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/tests/backends/test_datafusion_parity.py
+++ b/packages/python/goldenmatch/tests/backends/test_datafusion_parity.py
@@ -22,7 +22,6 @@ datafusion = pytest.importorskip("datafusion")
 native = pytest.importorskip("goldenmatch._native")
 
 import polars as pl
-
 from goldenmatch.backends.datafusion_backend import score_blocks_datafusion
 from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
 from goldenmatch.core.blocker import BlockResult

--- a/packages/python/goldenmatch/tests/backends/test_datafusion_parity.py
+++ b/packages/python/goldenmatch/tests/backends/test_datafusion_parity.py
@@ -1,0 +1,222 @@
+"""Parity test: DataFusion backend vs parallel backend.
+
+Spike Day 2 deliverable from
+``docs/superpowers/specs/2026-05-30-datafusion-backend-spike-design.md``.
+
+Both backends must produce the IDENTICAL pair set (Jaccard == 1.0)
+on the spike's supported matchkey shape: single-field weighted with
+scorer in {jaro_winkler, levenshtein, token_sort}. Scores may differ
+by float-tolerance epsilon; pair membership and threshold filtering
+must match exactly.
+
+Skipped when ``datafusion`` or ``goldenmatch._native`` aren't
+installed -- the spike requires both. Surfacing as skip rather than
+fail keeps default CI green; the dedicated bench job will hard-fail
+if either is missing.
+"""
+from __future__ import annotations
+
+import pytest
+
+datafusion = pytest.importorskip("datafusion")
+native = pytest.importorskip("goldenmatch._native")
+
+import polars as pl
+
+from goldenmatch.backends.datafusion_backend import score_blocks_datafusion
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.blocker import BlockResult
+from goldenmatch.core.scorer import score_blocks_parallel
+
+
+def _make_block(records: list[tuple[int, str]], block_key: str = "k0") -> BlockResult:
+    """Build a single BlockResult from (row_id, name) tuples."""
+    df = pl.LazyFrame({
+        "__row_id__": [r[0] for r in records],
+        "__source__": ["fixture"] * len(records),
+        "name": [r[1] for r in records],
+    })
+    return BlockResult(block_key=block_key, df=df)
+
+
+def _make_mk(scorer: str = "jaro_winkler", threshold: float = 0.85) -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="test_mk",
+        type="weighted",
+        fields=[MatchkeyField(field="name", scorer=scorer, weight=1.0)],
+        threshold=threshold,
+    )
+
+
+def _canonical_pairs(pairs: list[tuple[int, int, float]]) -> set[tuple[int, int]]:
+    """Strip scores, canonicalize as (min, max)."""
+    return {(min(a, b), max(a, b)) for a, b, _ in pairs}
+
+
+# ---------------------------------------------------------------------------
+# Pair-set parity (the gate the spike depends on)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("scorer", ["jaro_winkler", "levenshtein", "token_sort"])
+def test_pair_set_parity_single_block(scorer):
+    """Single block, mixed similarity. Pair set must match exactly."""
+    records = [
+        (1, "John Smith"),
+        (2, "Jon Smith"),     # ~0.97 jw vs 1
+        (3, "Jane Smith"),    # ~0.91 jw vs 1
+        (4, "John Smyth"),    # ~0.96 jw vs 1
+        (5, "Bob Jones"),     # low vs all
+        (6, "John Smith"),    # exact dup of 1
+    ]
+    block = _make_block(records)
+    mk = _make_mk(scorer=scorer, threshold=0.85)
+
+    par_pairs = score_blocks_parallel([block], mk, matched_pairs=set())
+    df_pairs = score_blocks_datafusion([block], mk, matched_pairs=set())
+
+    par_set = _canonical_pairs(par_pairs)
+    df_set = _canonical_pairs(df_pairs)
+
+    assert df_set == par_set, (
+        f"scorer={scorer}: pair sets differ. "
+        f"parallel-only={par_set - df_set}, datafusion-only={df_set - par_set}"
+    )
+
+
+def test_pair_set_parity_multi_block():
+    """Multiple blocks, scored independently. Verifies the
+    per-block iteration shape doesn't drop pairs at block boundaries."""
+    block_a = _make_block(
+        [(10, "Alice Anderson"), (11, "Alice Andersen"), (12, "Bob Brown")],
+        block_key="block_a",
+    )
+    block_b = _make_block(
+        [(20, "Charlie Chen"), (21, "Charlie Chan"), (22, "Diane Day")],
+        block_key="block_b",
+    )
+    mk = _make_mk(threshold=0.85)
+
+    par_pairs = score_blocks_parallel([block_a, block_b], mk, matched_pairs=set())
+    df_pairs = score_blocks_datafusion([block_a, block_b], mk, matched_pairs=set())
+
+    assert _canonical_pairs(df_pairs) == _canonical_pairs(par_pairs)
+
+
+def test_pair_set_parity_with_excluded():
+    """``matched_pairs`` exclude must hide pairs identically."""
+    records = [
+        (1, "John Smith"),
+        (2, "Jon Smith"),
+        (3, "John Smyth"),
+    ]
+    block = _make_block(records)
+    mk = _make_mk(threshold=0.85)
+
+    # Pre-exclude pair (1, 2). Both backends must omit it.
+    par_pairs = score_blocks_parallel([block], mk, matched_pairs={(1, 2)})
+    df_pairs = score_blocks_datafusion([block], mk, matched_pairs={(1, 2)})
+
+    par_set = _canonical_pairs(par_pairs)
+    df_set = _canonical_pairs(df_pairs)
+    assert (1, 2) not in par_set, "parallel should respect matched_pairs"
+    assert (1, 2) not in df_set, "datafusion should respect matched_pairs"
+    assert df_set == par_set
+
+
+def test_empty_blocks_returns_empty():
+    """Empty input is a contract, not a degenerate case."""
+    mk = _make_mk()
+    assert score_blocks_datafusion([], mk, matched_pairs=set()) == []
+
+
+def test_single_record_block_returns_empty():
+    """Block with one record can't produce any pairs."""
+    block = _make_block([(1, "John Smith")])
+    mk = _make_mk()
+    assert score_blocks_datafusion([block], mk, matched_pairs=set()) == []
+
+
+# ---------------------------------------------------------------------------
+# Score-value parity (float-tolerance — same kernel, should be exact)
+# ---------------------------------------------------------------------------
+
+
+def test_score_values_within_tolerance():
+    """For each shared pair, the score must agree within f32-precision
+    tolerance.
+
+    Both backends use the same underlying jaro_winkler math, but the
+    storage precision differs: the parallel scorer routes through
+    ``rapidfuzz.cdist`` which returns f32 columns, while the
+    DataFusion path calls ``_native.jaro_winkler_similarity`` per pair
+    and gets f64 back. 1e-6 catches any genuine math drift while
+    accepting the f32 quantization on parallel's side.
+    """
+    records = [(1, "John Smith"), (2, "Jon Smith"), (3, "John Smyth")]
+    block = _make_block(records)
+    mk = _make_mk()
+
+    par_by_pair = {
+        (min(a, b), max(a, b)): s
+        for a, b, s in score_blocks_parallel([block], mk, matched_pairs=set())
+    }
+    df_by_pair = {
+        (min(a, b), max(a, b)): s
+        for a, b, s in score_blocks_datafusion([block], mk, matched_pairs=set())
+    }
+
+    assert set(par_by_pair) == set(df_by_pair), "different pair sets"
+    for pair, par_score in par_by_pair.items():
+        df_score = df_by_pair[pair]
+        assert abs(par_score - df_score) < 1e-6, (
+            f"score drift on {pair}: parallel={par_score}, datafusion={df_score}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Out-of-spike-scope shapes must raise (NOT silently fall back)
+# ---------------------------------------------------------------------------
+
+
+def test_multi_field_matchkey_raises_not_implemented():
+    """Spike covers single-field only. Multi-field weighted must
+    raise so callers route to a different backend deliberately."""
+    block = _make_block([(1, "John"), (2, "Jon")])
+    mk = MatchkeyConfig(
+        name="multi",
+        type="weighted",
+        fields=[
+            MatchkeyField(field="name", scorer="jaro_winkler", weight=0.5),
+            MatchkeyField(field="name", scorer="levenshtein", weight=0.5),
+        ],
+        threshold=0.85,
+    )
+    with pytest.raises(NotImplementedError, match="single-field"):
+        score_blocks_datafusion([block], mk, matched_pairs=set())
+
+
+def test_unsupported_scorer_raises_not_implemented():
+    """Embedding / record_embedding / ensemble are out of scope."""
+    block = _make_block([(1, "John"), (2, "Jon")])
+    mk = MatchkeyConfig(
+        name="emb",
+        type="weighted",
+        fields=[MatchkeyField(field="name", scorer="ensemble", weight=1.0)],
+        threshold=0.85,
+    )
+    with pytest.raises(NotImplementedError, match="scorers"):
+        score_blocks_datafusion([block], mk, matched_pairs=set())
+
+
+def test_exact_matchkey_raises_not_implemented():
+    """Spike covers weighted only; exact matchkeys go through a
+    different scoring path entirely (find_exact_matches)."""
+    block = _make_block([(1, "John"), (2, "John")])
+    mk = MatchkeyConfig(
+        name="ex",
+        type="exact",
+        fields=[MatchkeyField(field="name")],
+    )
+    with pytest.raises(NotImplementedError, match="weighted"):
+        score_blocks_datafusion([block], mk, matched_pairs=set())


### PR DESCRIPTION
## Summary

Two parallel workstreams from the 2026-05-30 session:

### DataFusion backend spike (Day 1-3)

Adds experimental `backend=\"datafusion\"` that routes block scoring through Apache DataFusion with native scorers wrapped as vectorized Arrow-batch UDFs. Day 1-3 deliverables of the spike (spec gitignored at \`docs/superpowers/specs/2026-05-30-datafusion-backend-spike-design.md\`):

- **Day 1**: \`[datafusion]\` extra + \`scripts/datafusion_smoke.py\` proves DataFusion → native FFI end-to-end on a 5-record fixture.
- **Day 2**: \`backends/datafusion_backend.py\` + 11/11 PASS parity test (\`tests/backends/test_datafusion_parity.py\`). Pair-set Jaccard = 1.0 vs \`score_blocks_parallel\` across all 3 supported scorers. Raises \`NotImplementedError\` outside spike scope (multi-field / unsupported scorer / exact) -- no silent fallback that would taint bench numbers.
- **Day 3**: \`scripts/bench_datafusion_vs_bucket.py\` + \`bench-datafusion-vs-bucket.yml\` workflow. Runs 10K + 100K, 3 iters per backend (parallel / bucket / datafusion) on large-new-64GB. Decision gate at 100K: ratio \`datafusion_wall / bucket_wall <= 2.0\` to continue to Day 4 (1M).

Scope: single-field weighted matchkey, scorer in {jaro_winkler, levenshtein, token_sort}. Out-of-scope shapes hard-fail.

### Ray cluster infra fixes

- Bumped \`CPUS_ALL_REGIONS\` quota (32 → 96) on golden-490919 -- prior \"Failed to launch\" autoscaler messages were quota errors swallowed by Ray's GCE provider.
- Flipped GCE workers to on-demand (\`preemptible: false\`) -- spot capacity in us-central1-a was intermittent.
- Added 30s \`ray status\` poller during Submit bench step for live cluster visibility in GH logs.

## Test plan

- [x] \`tests/backends/test_datafusion_parity.py\` -- 11/11 PASS locally
- [ ] CI green on this PR
- [ ] Dispatch \`bench-datafusion-vs-bucket\` workflow after merge -- watch for Day-3 gate result
- [ ] If gate passes, push spike to Day 4 (1M bench) on a follow-up branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)