### PR TITLE
feat(scorer): columnar pair-stream entry points (Arrow roadmap Phase 1a, #623)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -797,3 +797,72 @@ def unmerge_cluster(
         next_cid += 1
 
     return clusters
+
+
+# ---------------------------------------------------------------------------
+# Arrow-native roadmap Phase 1a (#623): columnar pair-stream entry point
+# ---------------------------------------------------------------------------
+#
+# Sibling function to ``build_clusters`` that accepts a ``pl.DataFrame``
+# pair stream (the Phase 1a output of ``score_blocks_columnar`` /
+# ``find_fuzzy_matches_columnar``) instead of the legacy list of tuples.
+#
+# Today's implementation converts the DataFrame to the list shape at the
+# boundary and delegates to ``build_clusters`` — same correctness contract
+# as the Phase 1a scorer wrappers. Phase 1c will invert: the columnar
+# function becomes canonical, the list version becomes a shim.
+#
+# Spec: docs/superpowers/specs/2026-05-31-arrow-native-roadmap.md
+# (gitignored).
+
+
+def build_clusters_columnar(
+    pairs_df,  # pl.DataFrame with PAIR_STREAM_SCHEMA columns
+    all_ids: list[int] | None = None,
+    max_cluster_size: int = 100,
+    weak_cluster_threshold: float = 0.3,
+    auto_split: bool = True,
+) -> dict[int, dict]:
+    """Columnar wrapper around :func:`build_clusters`.
+
+    Accepts a Polars DataFrame ``(id_a, id_b, score)`` (canonical
+    ``PAIR_STREAM_SCHEMA`` from ``scorer.pairs_list_to_df``). Returns the
+    same ``dict[int, dict]`` cluster shape as ``build_clusters``; Phase 2
+    will change the return shape to the two-frame ``(assignments,
+    metadata)`` layout. For Phase 1a the goal is JUST to accept the
+    columnar input.
+
+    Args:
+        pairs_df: Polars DataFrame with int64 ``id_a``, int64 ``id_b``,
+            float64 ``score`` columns. ``PAIR_STREAM_SCHEMA``-shaped.
+        all_ids: Optional explicit ID list; if None, derived from the
+            ``id_a`` + ``id_b`` columns via ``.unique()``.
+        max_cluster_size, weak_cluster_threshold, auto_split:
+            Forwarded to ``build_clusters`` unchanged.
+
+    Returns:
+        Same ``dict[int, dict]`` as ``build_clusters``. Phase 2 changes
+        this to the columnar two-frame shape.
+    """
+    import polars as _pl
+
+    from goldenmatch.core.scorer import pairs_df_to_list
+
+    if all_ids is None and not pairs_df.is_empty():
+        # Derive all_ids from the DataFrame via Polars expressions instead
+        # of iterating tuples (the slow path in build_clusters' own derive
+        # branch). Phase 2 lifts this to a fully vectorized columnar
+        # derive in the canonical implementation.
+        ids_series = _pl.concat(
+            [pairs_df["id_a"], pairs_df["id_b"]],
+        ).unique()
+        all_ids = [int(i) for i in ids_series.to_list()]
+
+    pairs = pairs_df_to_list(pairs_df)
+    return build_clusters(
+        pairs,
+        all_ids=all_ids,
+        max_cluster_size=max_cluster_size,
+        weak_cluster_threshold=weak_cluster_threshold,
+        auto_split=auto_split,
+    )

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -16,6 +16,8 @@ from goldenmatch.core.complexity_profile import ClusterProfile
 from goldenmatch.core.profile_emitter import _emitter_stack, current_emitter
 
 if TYPE_CHECKING:
+    import polars as pl
+
     from goldenmatch.core.memory.store import MemoryStore
 
 _log = logging.getLogger("goldenmatch.memory")
@@ -817,7 +819,7 @@ def unmerge_cluster(
 
 
 def build_clusters_columnar(
-    pairs_df,  # pl.DataFrame with PAIR_STREAM_SCHEMA columns
+    pairs_df: pl.DataFrame,
     all_ids: list[int] | None = None,
     max_cluster_size: int = 100,
     weak_cluster_threshold: float = 0.3,

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -1144,3 +1144,112 @@ def rerank_top_pairs(
         len(result), len(pairs),
     )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Arrow-native roadmap Phase 1a (#623): columnar pair-stream entry points
+# ---------------------------------------------------------------------------
+#
+# Sibling functions to the list-returning scorers above. Same inputs, same
+# scoring math, but return ``pl.DataFrame`` instead of ``list[tuple]``. Let
+# Phase 1b callers (build_clusters, web preview, lineage, identity edge
+# ingestion, MCP/REST surfaces) migrate piecewise without breaking any
+# existing list-based consumer.
+#
+# Phase 1c will invert the relationship: the columnar functions become the
+# canonical implementation and the list versions become thin
+# ``.to_pairs_list()`` shims, eventually removed entirely.
+#
+# Today's implementation is a wrap-and-convert: the list path runs, then we
+# build the DataFrame from the result. That carries Phase 1a's correctness
+# guarantee (the inner scoring is byte-identical) at the cost of a single
+# Python -> Arrow conversion per call. The conversion is O(N_pairs); at the
+# 200M-pair / 5M-row reference shape that's ~10s of overhead, recovered in
+# Phase 1c. Spec: docs/superpowers/specs/2026-05-31-arrow-native-roadmap.md
+# (gitignored).
+
+PAIR_STREAM_SCHEMA: dict[str, pl.DataType] = {
+    "id_a": pl.Int64(),
+    "id_b": pl.Int64(),
+    "score": pl.Float64(),
+}
+"""Canonical pair-stream schema. ``id_a < id_b`` invariant maintained by the
+caller (legacy scorers already canonicalize via ``(min, max)``)."""
+
+
+def pairs_list_to_df(pairs: list[tuple[int, int, float]]) -> pl.DataFrame:
+    """Adapter: legacy ``(id_a, id_b, score)`` list -> typed DataFrame.
+
+    Empty input returns a zero-row frame with the canonical schema so
+    downstream Polars expressions (joins, group_by, with_columns) work
+    without an ``if df.is_empty()`` guard at every call site.
+    """
+    if not pairs:
+        return pl.DataFrame(schema=PAIR_STREAM_SCHEMA)
+    return pl.DataFrame(pairs, schema=PAIR_STREAM_SCHEMA, orient="row")
+
+
+def pairs_df_to_list(df: pl.DataFrame) -> list[tuple[int, int, float]]:
+    """Adapter: DataFrame pair stream -> legacy list shape.
+
+    For migrating call sites that need the list shape during the Phase 1b
+    window. Removed in Phase 1c.
+    """
+    if df.is_empty():
+        return []
+    return [
+        (int(a), int(b), float(s))
+        for a, b, s in zip(
+            df["id_a"].to_list(),
+            df["id_b"].to_list(),
+            df["score"].to_list(),
+            strict=True,
+        )
+    ]
+
+
+def find_fuzzy_matches_columnar(
+    block_df: pl.DataFrame,
+    mk: MatchkeyConfig,
+    exclude_pairs: set[tuple[int, int]] | frozenset[tuple[int, int]] | None = None,
+    pre_scored_pairs: list[tuple[int, int, float]] | None = None,
+) -> pl.DataFrame:
+    """Columnar wrapper around :func:`find_fuzzy_matches`.
+
+    Returns a typed Polars DataFrame ``(id_a, id_b, score)`` with the
+    ``PAIR_STREAM_SCHEMA`` shape. Behavior identical to the list version
+    (same scoring math, same canonicalization, same threshold filter);
+    only the return shape differs.
+
+    See module docstring section on Phase 1a for context.
+    """
+    pairs = find_fuzzy_matches(block_df, mk, exclude_pairs, pre_scored_pairs)
+    return pairs_list_to_df(pairs)
+
+
+def score_blocks_columnar(
+    blocks: list,
+    mk: MatchkeyConfig,
+    matched_pairs: set[tuple[int, int]],
+    max_workers: int | None = None,
+    across_files_only: bool = False,
+    source_lookup: dict[int, str] | None = None,
+    target_ids: set[int] | None = None,
+) -> pl.DataFrame:
+    """Columnar wrapper around :func:`score_blocks_parallel`.
+
+    Returns the same ``PAIR_STREAM_SCHEMA`` DataFrame. ``matched_pairs``
+    is mutated in place exactly as the list version does (the side effect
+    is part of the contract — callers rely on it to deduplicate pairs
+    across blocking passes).
+    """
+    pairs = score_blocks_parallel(
+        blocks,
+        mk,
+        matched_pairs,
+        max_workers=max_workers,
+        across_files_only=across_files_only,
+        source_lookup=source_lookup,
+        target_ids=target_ids,
+    )
+    return pairs_list_to_df(pairs)

--- a/packages/python/goldenmatch/tests/test_pair_stream_columnar_parity.py
+++ b/packages/python/goldenmatch/tests/test_pair_stream_columnar_parity.py
@@ -17,8 +17,6 @@ harness, not unit tests.
 from __future__ import annotations
 
 import polars as pl
-import pytest
-
 from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
 from goldenmatch.core.blocker import BlockResult
 from goldenmatch.core.cluster import build_clusters, build_clusters_columnar
@@ -31,7 +29,6 @@ from goldenmatch.core.scorer import (
     score_blocks_columnar,
     score_blocks_parallel,
 )
-
 
 # ── Fixtures ─────────────────────────────────────────────────────────
 

--- a/packages/python/goldenmatch/tests/test_pair_stream_columnar_parity.py
+++ b/packages/python/goldenmatch/tests/test_pair_stream_columnar_parity.py
@@ -1,0 +1,232 @@
+"""Phase 1a parity tests for columnar pair-stream functions.
+
+GH issue #623 (Arrow-native roadmap Phase 1).
+
+Asserts that the columnar entry points (``find_fuzzy_matches_columnar``,
+``score_blocks_columnar``, ``build_clusters_columnar``) produce
+byte-identical output to their list-based predecessors when the same
+fixture, matchkey, and parameters are used. Phase 1a is purely a
+shape change — same scoring, same canonicalization, same clustering.
+Any drift here is a bug in the columnar wrappers, not a design
+trade-off.
+
+Tests use tiny hand-built fixtures (≤ 20 rows). NO ``dedupe_df``
+calls, NO ``realistic_person_df`` calls — those are for the bench
+harness, not unit tests.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.blocker import BlockResult
+from goldenmatch.core.cluster import build_clusters, build_clusters_columnar
+from goldenmatch.core.scorer import (
+    PAIR_STREAM_SCHEMA,
+    find_fuzzy_matches,
+    find_fuzzy_matches_columnar,
+    pairs_df_to_list,
+    pairs_list_to_df,
+    score_blocks_columnar,
+    score_blocks_parallel,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+def _block_df(records: list[tuple[int, str]]) -> pl.DataFrame:
+    return pl.DataFrame({
+        "__row_id__": [r[0] for r in records],
+        "__source__": ["fixture"] * len(records),
+        "name": [r[1] for r in records],
+    })
+
+
+def _block(records: list[tuple[int, str]], block_key: str = "k") -> BlockResult:
+    return BlockResult(block_key=block_key, df=_block_df(records).lazy())
+
+
+def _mk() -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="test",
+        type="weighted",
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+        threshold=0.85,
+    )
+
+
+# ── Adapter round-trip ──────────────────────────────────────────────
+
+
+class TestAdapterRoundtrip:
+    def test_empty_list_to_df_returns_empty_schema(self):
+        df = pairs_list_to_df([])
+        assert df.is_empty()
+        assert df.schema == PAIR_STREAM_SCHEMA
+
+    def test_empty_df_to_list_returns_empty(self):
+        df = pl.DataFrame(schema=PAIR_STREAM_SCHEMA)
+        assert pairs_df_to_list(df) == []
+
+    def test_roundtrip_preserves_pairs(self):
+        original = [(1, 2, 0.95), (3, 4, 0.87), (5, 6, 1.0)]
+        df = pairs_list_to_df(original)
+        back = pairs_df_to_list(df)
+        assert back == original
+
+    def test_df_schema_is_canonical(self):
+        df = pairs_list_to_df([(1, 2, 0.9)])
+        assert df.schema == PAIR_STREAM_SCHEMA
+        assert df.height == 1
+
+
+# ── find_fuzzy_matches parity ───────────────────────────────────────
+
+
+class TestFindFuzzyMatchesParity:
+    def test_single_block_parity(self):
+        records = [
+            (1, "John Smith"),
+            (2, "Jon Smith"),
+            (3, "Jane Smith"),
+            (4, "John Smyth"),
+            (5, "Bob Jones"),
+        ]
+        block_df = _block_df(records)
+        mk = _mk()
+
+        list_pairs = find_fuzzy_matches(block_df, mk)
+        df_pairs = find_fuzzy_matches_columnar(block_df, mk)
+
+        # Same pair set, same scores.
+        assert pairs_df_to_list(df_pairs) == list_pairs
+
+    def test_exclude_pairs_parity(self):
+        records = [(1, "John Smith"), (2, "Jon Smith"), (3, "John Smyth")]
+        block_df = _block_df(records)
+        mk = _mk()
+        exclude = {(1, 2)}
+
+        list_pairs = find_fuzzy_matches(block_df, mk, exclude_pairs=exclude)
+        df_pairs = find_fuzzy_matches_columnar(block_df, mk, exclude_pairs=exclude)
+
+        assert pairs_df_to_list(df_pairs) == list_pairs
+
+    def test_empty_block_returns_empty(self):
+        block_df = _block_df([(1, "alone")])
+        mk = _mk()
+        df_pairs = find_fuzzy_matches_columnar(block_df, mk)
+        assert df_pairs.is_empty()
+        assert df_pairs.schema == PAIR_STREAM_SCHEMA
+
+
+# ── score_blocks parity ──────────────────────────────────────────────
+
+
+class TestScoreBlocksParity:
+    def test_single_block_parity(self):
+        records = [
+            (1, "John Smith"),
+            (2, "Jon Smith"),
+            (3, "Jane Smith"),
+            (4, "John Smyth"),
+        ]
+        b = _block(records)
+        mk = _mk()
+
+        list_pairs = score_blocks_parallel([b], mk, matched_pairs=set())
+        df_pairs = score_blocks_columnar([b], mk, matched_pairs=set())
+
+        assert pairs_df_to_list(df_pairs) == list_pairs
+
+    def test_multi_block_parity(self):
+        b1 = _block([(10, "Alice Anderson"), (11, "Alice Andersen")], "ba")
+        b2 = _block([(20, "Bob Brown"), (21, "Bob Browne")], "bb")
+        mk = _mk()
+
+        list_pairs = score_blocks_parallel([b1, b2], mk, matched_pairs=set())
+        df_pairs = score_blocks_columnar([b1, b2], mk, matched_pairs=set())
+
+        # Convert both to canonical sorted sets for order-independent compare
+        # (score_blocks_parallel doesn't guarantee block iteration order
+        # affects the output list order — DataFrame round-trip preserves it
+        # exactly, but assert as sets to be safe).
+        assert sorted(pairs_df_to_list(df_pairs)) == sorted(list_pairs)
+
+    def test_empty_blocks_returns_empty(self):
+        mk = _mk()
+        df = score_blocks_columnar([], mk, matched_pairs=set())
+        assert df.is_empty()
+        assert df.schema == PAIR_STREAM_SCHEMA
+
+    def test_matched_pairs_mutation_parity(self):
+        """``score_blocks_parallel`` mutates ``matched_pairs`` in place
+        as a side effect (existing contract). The columnar wrapper must
+        preserve that exactly — callers across blocking passes rely on
+        it."""
+        records = [(1, "John Smith"), (2, "Jon Smith"), (3, "John Smyth")]
+        b = _block(records)
+        mk = _mk()
+
+        list_matched = set()
+        score_blocks_parallel([b], mk, matched_pairs=list_matched)
+
+        df_matched = set()
+        score_blocks_columnar([b], mk, matched_pairs=df_matched)
+
+        assert df_matched == list_matched, (
+            "columnar wrapper failed to preserve matched_pairs side effect; "
+            f"list_path={list_matched}, df_path={df_matched}"
+        )
+
+
+# ── build_clusters parity ────────────────────────────────────────────
+
+
+class TestBuildClustersParity:
+    def test_simple_clusters_parity(self):
+        pairs = [(1, 2, 0.95), (2, 3, 0.92), (5, 6, 0.88)]
+        all_ids = [1, 2, 3, 4, 5, 6, 7]
+
+        legacy = build_clusters(pairs, all_ids=all_ids)
+        columnar = build_clusters_columnar(
+            pairs_list_to_df(pairs),
+            all_ids=all_ids,
+        )
+
+        # Cluster dicts may differ in cluster_id ordering, but the
+        # partition (mapping member_id -> set of members in same cluster)
+        # must be identical.
+        assert _partition(legacy) == _partition(columnar), (
+            f"cluster partitions differ; legacy={_partition(legacy)}, "
+            f"columnar={_partition(columnar)}"
+        )
+
+    def test_all_ids_derived_when_not_provided(self):
+        pairs = [(1, 2, 0.9), (3, 4, 0.85)]
+        # Both paths should infer the same all_ids from the pair stream.
+        legacy = build_clusters(pairs)
+        columnar = build_clusters_columnar(pairs_list_to_df(pairs))
+        assert _partition(legacy) == _partition(columnar)
+
+    def test_empty_pair_stream(self):
+        legacy = build_clusters([], all_ids=[1, 2, 3])
+        columnar = build_clusters_columnar(
+            pl.DataFrame(schema=PAIR_STREAM_SCHEMA),
+            all_ids=[1, 2, 3],
+        )
+        assert _partition(legacy) == _partition(columnar)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _partition(clusters: dict[int, dict]) -> frozenset[frozenset[int]]:
+    """Convert cluster dict to a partition (set of frozensets of members)
+    that's invariant under cluster_id relabeling."""
+    return frozenset(
+        frozenset(c.get("members", []))
+        for c in clusters.values()
+    )


### PR DESCRIPTION
Refs #623. **Draft** — stacked on top of #630 (Phase 0). Will be moved out of draft once #630 merges and this rebases cleanly onto main.

## Summary

Arrow-native roadmap Phase 1a: introduces sibling columnar pair-stream entry points. The legacy list-based functions are untouched, so this is zero-risk additive for existing callers. Phase 1b will migrate callers piecewise; Phase 1c will invert the relationship (columnar canonical, list as thin shim).

## New surface

- \`scorer.find_fuzzy_matches_columnar()\` -> pl.DataFrame
- \`scorer.score_blocks_columnar()\` -> pl.DataFrame
- \`cluster.build_clusters_columnar()\` -> dict[int, dict] (Phase 2 changes the return shape)
- \`scorer.PAIR_STREAM_SCHEMA\` (canonical id_a: i64, id_b: i64, score: f64)
- \`scorer.pairs_list_to_df\` / \`scorer.pairs_df_to_list\` adapters

## Test plan

- [x] 14/14 parity tests PASS locally on tiny fixtures (no \`dedupe_df\` calls)
- [ ] CI green
- [ ] After merge: dispatch the Phase 1 bench (\`bench_pair_stream_columnar\` — Phase 1b deliverable, separate PR) to measure the kill criterion at 5M

🤖 Generated with [Claude Code](https://claude.com/claude-code)