### PR TITLE
feat(cluster): two-frame cluster representation (Arrow roadmap Phase 2a, #624)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -868,3 +868,179 @@ def build_clusters_columnar(
         weak_cluster_threshold=weak_cluster_threshold,
         auto_split=auto_split,
     )
+
+
+# ---------------------------------------------------------------------------
+# Arrow-native roadmap Phase 2a (#624): cluster representation columnar
+# ---------------------------------------------------------------------------
+#
+# Sibling function that returns the Phase-2 two-frame cluster shape:
+# - assignments: pl.DataFrame({"cluster_id": i64, "member_id": i64}) long form
+# - metadata:    pl.DataFrame({"cluster_id": i64, "size": i64,
+#                              "confidence": f64, "quality": Utf8,
+#                              "oversized": bool,
+#                              "bottleneck_pair_a": i64,
+#                              "bottleneck_pair_b": i64})
+#
+# This is Phase 2a (additive sibling); Phase 2b migrates consumers
+# (identity, web preview, MCP, REST) one at a time; Phase 2c removes
+# the dict-returning build_clusters once all consumers are migrated.
+#
+# Today's implementation delegates to build_clusters and converts the
+# dict to the two-frame shape at the boundary. Same correctness contract
+# as Phase 1a wrappers (the inner clustering math is byte-identical;
+# only the return shape changes).
+#
+# Why the two-frame shape: it eliminates the ~3 GB cluster dict that
+# materialize_cluster_dict collects driver-side at 25M scale, AND it
+# lets distributed identity resolve (Phase 5 / Splink-Spark roadmap
+# Phase 6) run true map_batches over partitions of cluster_assignments
+# instead of collecting everything to the driver.
+#
+# Spec: docs/superpowers/specs/2026-05-31-arrow-native-roadmap.md
+# (gitignored).
+
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ClusterFrames:
+    """Two-frame cluster representation (Phase 2a output).
+
+    ``assignments`` is long form: one row per (cluster, member) pair.
+    Iterate via ``df.group_by("cluster_id")`` for per-cluster work, or
+    use as input to a join with the source frame for golden record
+    build (Phase 4).
+
+    ``metadata`` is one row per cluster: size, confidence, quality
+    ("strong" / "weak" / "split"), oversized flag, and the bottleneck
+    pair (the weakest edge inside the cluster — used by unmerge).
+
+    The two frames share ``cluster_id`` as the key. Phase 2c will make
+    this the canonical return shape; today it's an additive sibling.
+    """
+    assignments: object  # pl.DataFrame; not typed to keep this module Polars-lazy at import time
+    metadata: object  # pl.DataFrame
+
+
+def cluster_dict_to_frames(clusters: dict[int, dict]) -> ClusterFrames:
+    """Adapter: legacy ``dict[int, dict]`` cluster shape -> two-frame
+    Phase-2 representation. Lossless modulo ``pair_scores`` (which
+    moves to a lazy view computed from the pair stream in Phase 2b).
+    """
+    import polars as _pl
+
+    if not clusters:
+        return ClusterFrames(
+            assignments=_pl.DataFrame(schema={
+                "cluster_id": _pl.Int64(), "member_id": _pl.Int64(),
+            }),
+            metadata=_pl.DataFrame(schema={
+                "cluster_id": _pl.Int64(),
+                "size": _pl.Int64(),
+                "confidence": _pl.Float64(),
+                "quality": _pl.Utf8(),
+                "oversized": _pl.Boolean(),
+                "bottleneck_pair_a": _pl.Int64(),
+                "bottleneck_pair_b": _pl.Int64(),
+            }),
+        )
+
+    assign_rows: list[tuple[int, int]] = []
+    meta_rows: list[dict] = []
+    for cid, cluster in clusters.items():
+        members = cluster.get("members", [])
+        for m in members:
+            assign_rows.append((int(cid), int(m)))
+        bottleneck = cluster.get("bottleneck_pair") or (0, 0)
+        meta_rows.append({
+            "cluster_id": int(cid),
+            "size": int(cluster.get("size", len(members))),
+            "confidence": float(cluster.get("confidence", 0.0)),
+            "quality": str(cluster.get("cluster_quality", "strong")),
+            "oversized": bool(cluster.get("oversized", False)),
+            "bottleneck_pair_a": int(bottleneck[0]) if bottleneck else 0,
+            "bottleneck_pair_b": int(bottleneck[1]) if bottleneck else 0,
+        })
+
+    assignments = _pl.DataFrame(
+        assign_rows,
+        schema={"cluster_id": _pl.Int64(), "member_id": _pl.Int64()},
+        orient="row",
+    )
+    metadata = _pl.DataFrame(meta_rows)
+    return ClusterFrames(assignments=assignments, metadata=metadata)
+
+
+def cluster_frames_to_dict(frames: ClusterFrames) -> dict[int, dict]:
+    """Adapter: two-frame Phase-2 representation -> legacy
+    ``dict[int, dict]`` shape. For migrating consumers during Phase 2b.
+
+    NOTE: ``pair_scores`` is NOT reconstructed (it doesn't live on the
+    cluster frame). Consumers that need pair_scores must look it up via
+    the lazy view against the Phase-1 pair stream — Phase 2b will wire
+    that helper.
+    """
+    assignments = frames.assignments
+    metadata = frames.metadata
+    if assignments.is_empty():
+        return {}
+
+    # Build member lists by cluster_id from the assignments frame.
+    by_cid: dict[int, list[int]] = {}
+    for cid, mid in zip(
+        assignments["cluster_id"].to_list(),
+        assignments["member_id"].to_list(),
+        strict=True,
+    ):
+        by_cid.setdefault(int(cid), []).append(int(mid))
+
+    out: dict[int, dict] = {}
+    for row in metadata.iter_rows(named=True):
+        cid = int(row["cluster_id"])
+        bot = (row["bottleneck_pair_a"], row["bottleneck_pair_b"])
+        out[cid] = {
+            "members": by_cid.get(cid, []),
+            "size": int(row["size"]),
+            "confidence": float(row["confidence"]),
+            "cluster_quality": str(row["quality"]),
+            "oversized": bool(row["oversized"]),
+            "bottleneck_pair": bot if bot != (0, 0) else None,
+            # pair_scores omitted -- consumers that need it use the lazy
+            # view against the Phase-1 pair stream (Phase 2b deliverable).
+            "pair_scores": {},
+        }
+    return out
+
+
+def build_clusters_v2_columnar(
+    pairs_df,  # pl.DataFrame with PAIR_STREAM_SCHEMA columns
+    all_ids: list[int] | None = None,
+    max_cluster_size: int = 100,
+    weak_cluster_threshold: float = 0.3,
+    auto_split: bool = True,
+) -> ClusterFrames:
+    """Phase 2a entry point. Returns the canonical two-frame cluster
+    shape (``ClusterFrames``) instead of the legacy ``dict[int, dict]``.
+
+    Same clustering math as ``build_clusters`` / ``build_clusters_columnar``;
+    only the return shape differs. Phase 2c will make this canonical.
+
+    Args:
+        pairs_df: ``PAIR_STREAM_SCHEMA`` DataFrame (from
+            ``score_blocks_columnar`` etc.).
+        all_ids, max_cluster_size, weak_cluster_threshold, auto_split:
+            Forwarded to ``build_clusters`` unchanged.
+
+    Returns:
+        ``ClusterFrames(assignments, metadata)``.
+    """
+    legacy = build_clusters_columnar(
+        pairs_df,
+        all_ids=all_ids,
+        max_cluster_size=max_cluster_size,
+        weak_cluster_threshold=weak_cluster_threshold,
+        auto_split=auto_split,
+    )
+    return cluster_dict_to_frames(legacy)

--- a/packages/python/goldenmatch/tests/test_cluster_columnar_parity.py
+++ b/packages/python/goldenmatch/tests/test_cluster_columnar_parity.py
@@ -1,0 +1,177 @@
+"""Phase 2a parity tests for the two-frame cluster representation.
+
+GH issue #624 (Arrow-native roadmap Phase 2).
+
+Asserts ``cluster_dict_to_frames`` and ``cluster_frames_to_dict`` are
+lossless round-trips, and that ``build_clusters_v2_columnar`` produces
+the same partition (member-to-cluster mapping) as
+``build_clusters_columnar`` (and therefore as ``build_clusters``,
+transitively verified in test_pair_stream_columnar_parity.py).
+
+Note: ``pair_scores`` is intentionally omitted from the round-trip —
+it doesn't live on the cluster frame in Phase 2 (consumers compute it
+via a lazy view against the Phase-1 pair stream, Phase 2b deliverable).
+Tests assert this is the only diff between input and round-tripped
+dict.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.core.cluster import (
+    ClusterFrames,
+    build_clusters,
+    build_clusters_v2_columnar,
+    cluster_dict_to_frames,
+    cluster_frames_to_dict,
+)
+from goldenmatch.core.scorer import PAIR_STREAM_SCHEMA, pairs_list_to_df
+
+# ── Adapter round-trip ──────────────────────────────────────────────
+
+
+class TestAdapterRoundtrip:
+    def test_empty_clusters_to_frames(self):
+        frames = cluster_dict_to_frames({})
+        assert isinstance(frames, ClusterFrames)
+        assert frames.assignments.is_empty()
+        assert frames.metadata.is_empty()
+        assert frames.assignments.schema == {
+            "cluster_id": pl.Int64(), "member_id": pl.Int64(),
+        }
+
+    def test_empty_frames_to_clusters(self):
+        frames = cluster_dict_to_frames({})
+        assert cluster_frames_to_dict(frames) == {}
+
+    def test_roundtrip_simple(self):
+        clusters = {
+            0: {
+                "members": [1, 2, 3],
+                "size": 3,
+                "confidence": 0.95,
+                "cluster_quality": "strong",
+                "oversized": False,
+                "bottleneck_pair": (1, 2),
+                "pair_scores": {(1, 2): 0.95, (2, 3): 0.93, (1, 3): 0.90},
+            },
+            1: {
+                "members": [5, 6],
+                "size": 2,
+                "confidence": 0.88,
+                "cluster_quality": "weak",
+                "oversized": False,
+                "bottleneck_pair": (5, 6),
+                "pair_scores": {(5, 6): 0.88},
+            },
+        }
+        frames = cluster_dict_to_frames(clusters)
+        back = cluster_frames_to_dict(frames)
+
+        # Members lists match (modulo order — assert as sets).
+        for cid in clusters:
+            assert set(back[cid]["members"]) == set(clusters[cid]["members"])
+            assert back[cid]["size"] == clusters[cid]["size"]
+            assert back[cid]["confidence"] == clusters[cid]["confidence"]
+            assert back[cid]["cluster_quality"] == clusters[cid]["cluster_quality"]
+            assert back[cid]["oversized"] == clusters[cid]["oversized"]
+            assert back[cid]["bottleneck_pair"] == clusters[cid]["bottleneck_pair"]
+            # pair_scores intentionally NOT round-tripped (Phase 2b deliverable)
+            assert back[cid]["pair_scores"] == {}
+
+    def test_roundtrip_oversized_cluster(self):
+        clusters = {
+            42: {
+                "members": list(range(101)),
+                "size": 101,
+                "confidence": 0.5,
+                "cluster_quality": "split",
+                "oversized": True,
+                "bottleneck_pair": (10, 50),
+                "pair_scores": {},
+            },
+        }
+        frames = cluster_dict_to_frames(clusters)
+        back = cluster_frames_to_dict(frames)
+        assert back[42]["oversized"] is True
+        assert back[42]["cluster_quality"] == "split"
+        assert len(back[42]["members"]) == 101
+
+
+# ── End-to-end: build_clusters_v2_columnar partition parity ────────
+
+
+class TestBuildClustersV2Parity:
+    def test_simple_clusters_partition_matches_legacy(self):
+        pairs = [(1, 2, 0.95), (2, 3, 0.92), (5, 6, 0.88)]
+        all_ids = [1, 2, 3, 4, 5, 6, 7]
+
+        legacy = build_clusters(pairs, all_ids=all_ids)
+        v2 = build_clusters_v2_columnar(
+            pairs_list_to_df(pairs),
+            all_ids=all_ids,
+        )
+
+        # Compare partitions (member -> set of co-members) — invariant
+        # under cluster_id relabeling.
+        legacy_partition = _partition_from_dict(legacy)
+        v2_partition = _partition_from_frames(v2)
+        assert legacy_partition == v2_partition
+
+    def test_metadata_size_matches_member_count(self):
+        pairs = [(1, 2, 0.9), (3, 4, 0.85), (5, 6, 0.9), (5, 7, 0.85)]
+        v2 = build_clusters_v2_columnar(pairs_list_to_df(pairs))
+
+        # Each metadata row's size must equal the assignments row count
+        # for the same cluster_id. Phase 2 invariant.
+        meta_size = dict(zip(
+            v2.metadata["cluster_id"].to_list(),
+            v2.metadata["size"].to_list(),
+            strict=True,
+        ))
+        actual_size = (
+            v2.assignments.group_by("cluster_id").agg(pl.len().alias("n"))
+        )
+        for cid, n in zip(
+            actual_size["cluster_id"].to_list(),
+            actual_size["n"].to_list(),
+            strict=True,
+        ):
+            assert meta_size[int(cid)] == int(n), (
+                f"metadata.size mismatch for cluster {cid}: "
+                f"metadata says {meta_size[int(cid)]}, "
+                f"assignments has {n} members"
+            )
+
+    def test_empty_pair_stream_v2(self):
+        v2 = build_clusters_v2_columnar(
+            pl.DataFrame(schema=PAIR_STREAM_SCHEMA),
+            all_ids=[1, 2, 3],
+        )
+        # 3 singleton clusters expected (one per all_ids entry).
+        n_clusters = v2.metadata.height
+        assert n_clusters == 3
+        # Each cluster has exactly one member.
+        assert v2.assignments.height == 3
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _partition_from_dict(clusters: dict[int, dict]) -> frozenset[frozenset[int]]:
+    return frozenset(
+        frozenset(c.get("members", []))
+        for c in clusters.values()
+    )
+
+
+def _partition_from_frames(frames: ClusterFrames) -> frozenset[frozenset[int]]:
+    if frames.assignments.is_empty():
+        return frozenset()
+    by_cid: dict[int, list[int]] = {}
+    for cid, mid in zip(
+        frames.assignments["cluster_id"].to_list(),
+        frames.assignments["member_id"].to_list(),
+        strict=True,
+    ):
+        by_cid.setdefault(int(cid), []).append(int(mid))
+    return frozenset(frozenset(members) for members in by_cid.values())


### PR DESCRIPTION
Refs #624. **Draft, stacked on #631** (which is stacked on #630). Will be retargeted to \`main\` and taken out of draft as each parent merges.

## Summary

Arrow-native roadmap Phase 2a: introduces the canonical two-frame cluster representation (\`ClusterFrames\` = \`(assignments, metadata)\`) as sibling functions. Zero risk to existing dict-consuming callers; Phase 2b migrates consumers; Phase 2c inverts the relationship.

## New surface

- \`cluster.ClusterFrames\` dataclass
- \`cluster.build_clusters_v2_columnar(pairs_df, ...)\` -> ClusterFrames
- \`cluster.cluster_dict_to_frames\` / \`cluster_frames_to_dict\` adapters

## Phase 2 motivation

Today's \`materialize_cluster_dict\` at 25M scale collects ~17M cluster aggregates to ~3 GB driver-side (Splink-Spark Phase 6 cheat-line per CLAUDE.md). The two-frame shape eliminates the collection — distributed identity resolve can \`map_batches\` over partitions of \`cluster_assignments\` directly.

## Test plan

- [x] 7 Phase 2a parity tests PASS locally (combined with 14 Phase 1a = 21/21 PASS)
- [ ] CI green
- [ ] After all 3 stacked PRs merge (#630 -> #631 -> this): start Phase 1b (migrate canonical callers to use the columnar functions) in a new branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)