### PR TITLE
perf(scorer): hot-path direct DataFrame emit (Arrow Phase 1c, #623)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -920,8 +920,12 @@ class ClusterFrames:
     The two frames share ``cluster_id`` as the key. Phase 2c will make
     this the canonical return shape; today it's an additive sibling.
     """
-    assignments: object  # pl.DataFrame; not typed to keep this module Polars-lazy at import time
-    metadata: object  # pl.DataFrame
+    # Both fields are pl.DataFrame at runtime. Annotated as string
+    # forward refs against the TYPE_CHECKING-only ``pl`` import so the
+    # module stays Polars-lazy at import time, while pyright narrows
+    # ``frames.assignments.is_empty()`` etc. correctly.
+    assignments: pl.DataFrame
+    metadata: pl.DataFrame
 
 
 def cluster_dict_to_frames(clusters: dict[int, dict]) -> ClusterFrames:
@@ -1015,7 +1019,7 @@ def cluster_frames_to_dict(frames: ClusterFrames) -> dict[int, dict]:
 
 
 def build_clusters_v2_columnar(
-    pairs_df,  # pl.DataFrame with PAIR_STREAM_SCHEMA columns
+    pairs_df: pl.DataFrame,
     all_ids: list[int] | None = None,
     max_cluster_size: int = 100,
     weak_cluster_threshold: float = 0.3,

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -620,7 +620,9 @@ def find_fuzzy_matches(
     mk: MatchkeyConfig,
     exclude_pairs: set[tuple[int, int]] | frozenset[tuple[int, int]] | None = None,
     pre_scored_pairs: list[tuple[int, int, float]] | None = None,
-) -> list[tuple[int, int, float]]:
+    *,
+    _emit_dataframe: bool = False,
+) -> list[tuple[int, int, float]] | pl.DataFrame:
     """Find fuzzy matches within a block DataFrame.
 
     Uses vectorized rapidfuzz cdist for batch scoring, with early termination
@@ -632,9 +634,23 @@ def find_fuzzy_matches(
         exclude_pairs: Optional set of (min_id, max_id) pairs to skip.
         pre_scored_pairs: Optional pre-computed (id_a, id_b, score) pairs
             from ANN blocking. When set, skip NxN scoring.
+        _emit_dataframe: Arrow-native roadmap Phase 1c hot-path opt-in.
+            When True AND the call is on the hot path (no NE, no
+            ``exclude_pairs``, no ``pre_scored_pairs``), emit a
+            ``pl.DataFrame`` directly from numpy arrays instead of
+            constructing a Python list of tuples. Zero per-pair Python
+            overhead at scale (the bottleneck for 200M-pair / 5M-row runs
+            per the Phase 1 spec). Non-hot-path branches still return
+            ``list[tuple]`` even when True; ``find_fuzzy_matches_columnar``
+            wraps those at the boundary. Default False keeps the existing
+            list contract for backward compat. The arg is positional-only
+            via the ``*`` marker so legacy callers don't accidentally pass
+            it.
 
     Returns:
-        List of (row_id_a, row_id_b, score) tuples above threshold.
+        ``list[tuple[int, int, float]]`` by default (legacy contract).
+        ``pl.DataFrame`` with ``PAIR_STREAM_SCHEMA`` columns when
+        ``_emit_dataframe=True`` AND the call hits the hot path.
     """
     # find_fuzzy_matches requires mk.threshold + field weights/scorers set;
     # upstream config validation enforces this. Pyright sees the schema-level
@@ -850,6 +866,19 @@ def find_fuzzy_matches(
                 results.append((int(a), int(b), float(s)))
         return results
 
+    # HOT PATH: no NE, no exclude_pairs, no pre_scored_pairs. ~99% of
+    # production block-scoring calls land here. The Phase 1c
+    # _emit_dataframe opt-in (#623) bypasses the list-of-tuples
+    # construction by building a Polars DataFrame directly from the
+    # numpy arrays. List comprehension at 200M pairs (5M-row reference
+    # shape) is the per-pair Python overhead the Arrow-native roadmap
+    # exists to remove; this is where it lands.
+    if _emit_dataframe:
+        return pl.DataFrame({
+            "id_a": ids_a if hasattr(ids_a, "astype") else np.asarray(ids_a, dtype=np.int64),
+            "id_b": ids_b if hasattr(ids_b, "astype") else np.asarray(ids_b, dtype=np.int64),
+            "score": scores if hasattr(scores, "astype") else np.asarray(scores, dtype=np.float64),
+        }, schema=PAIR_STREAM_SCHEMA)
     return [(int(a), int(b), float(s)) for a, b, s in zip(ids_a, ids_b, scores)]
 
 
@@ -1221,9 +1250,34 @@ def find_fuzzy_matches_columnar(
     (same scoring math, same canonicalization, same threshold filter);
     only the return shape differs.
 
-    See module docstring section on Phase 1a for context.
+    Phase 1c hot-path optimization (#623): when the call hits the hot
+    path (no NE, no exclude_pairs, no pre_scored_pairs), we pass
+    ``_emit_dataframe=True`` so ``find_fuzzy_matches`` emits the
+    DataFrame directly from its numpy arrays — bypassing the
+    list-of-tuples construction that dominates the wall at 200M-pair
+    scale. Non-hot-path branches still wrap-and-convert (rare in
+    production: NE is opt-in, exclude_pairs is empty for first-pass
+    blocking).
     """
+    is_hot_path = (
+        not mk.negative_evidence
+        and (exclude_pairs is None or len(exclude_pairs) == 0)
+        and pre_scored_pairs is None
+    )
+    if is_hot_path:
+        result = find_fuzzy_matches(
+            block_df, mk, exclude_pairs, pre_scored_pairs,
+            _emit_dataframe=True,
+        )
+        # On the hot path the emission branch returns a DataFrame, but
+        # the n < 2 / total_weight == 0 early returns above the hot
+        # path always return ``[]`` regardless of the flag (they
+        # short-circuit before knowing about it). Wrap defensively.
+        if isinstance(result, pl.DataFrame):
+            return result
+        return pairs_list_to_df(result)
     pairs = find_fuzzy_matches(block_df, mk, exclude_pairs, pre_scored_pairs)
+    assert isinstance(pairs, list)
     return pairs_list_to_df(pairs)
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -906,6 +906,11 @@ def _score_one_block(
         exclude_pairs=exclude_pairs,
         pre_scored_pairs=block.pre_scored_pairs,
     )
+    # _score_one_block never opts into the Phase-1c DataFrame emit
+    # (_emit_dataframe defaults to False); the return is always a list.
+    # Narrow for pyright now that the find_fuzzy_matches return type
+    # includes pl.DataFrame as a union.
+    assert isinstance(pairs, list)
 
     if across_files_only and source_lookup:
         pairs = [

--- a/packages/python/goldenmatch/tests/test_pair_stream_columnar_parity.py
+++ b/packages/python/goldenmatch/tests/test_pair_stream_columnar_parity.py
@@ -54,6 +54,64 @@ def _mk() -> MatchkeyConfig:
     )
 
 
+# ── Phase 1c hot-path direct-emit (#623) ────────────────────────────
+
+
+class TestHotPathDirectEmit:
+    """Phase 1c: ``find_fuzzy_matches(..., _emit_dataframe=True)`` must
+    emit a ``pl.DataFrame`` directly from numpy arrays on the hot path
+    (no NE, no exclude_pairs, no pre_scored_pairs), bypassing the
+    list-of-tuples construction that dominates wall at 200M-pair scale.
+    """
+
+    def test_hot_path_returns_dataframe(self):
+        block_df = _block_df([(1, "John Smith"), (2, "Jon Smith"), (3, "John Smyth")])
+        result = find_fuzzy_matches(
+            block_df, _mk(),
+            exclude_pairs=None, pre_scored_pairs=None,
+            _emit_dataframe=True,
+        )
+        assert isinstance(result, pl.DataFrame), (
+            f"hot path with _emit_dataframe=True must return DataFrame, "
+            f"got {type(result).__name__}"
+        )
+        from goldenmatch.core.scorer import PAIR_STREAM_SCHEMA
+        assert result.schema == PAIR_STREAM_SCHEMA
+
+    def test_hot_path_matches_list_path(self):
+        """DataFrame-emit output must match list-emit output as
+        canonical-pair sets."""
+        block_df = _block_df([
+            (1, "John Smith"), (2, "Jon Smith"), (3, "Jane Smith"),
+            (4, "John Smyth"), (5, "Bob Jones"),
+        ])
+        list_pairs = find_fuzzy_matches(block_df, _mk())
+        df_pairs = find_fuzzy_matches(block_df, _mk(), _emit_dataframe=True)
+        assert isinstance(df_pairs, pl.DataFrame)
+
+        list_set = {(min(a, b), max(a, b)) for a, b, _ in list_pairs}
+        df_set = {
+            (min(int(a), int(b)), max(int(a), int(b)))
+            for a, b in zip(
+                df_pairs["id_a"].to_list(),
+                df_pairs["id_b"].to_list(),
+                strict=True,
+            )
+        }
+        assert df_set == list_set
+
+    def test_exclude_pairs_path_falls_back_to_list(self):
+        """When ``exclude_pairs`` is non-empty, the function takes a
+        list-building branch above the hot-path emission; the flag is
+        not honored there. ``find_fuzzy_matches_columnar`` handles this
+        via the defensive wrap. Locks the contract."""
+        block_df = _block_df([(1, "John"), (2, "Jon")])
+        result = find_fuzzy_matches(
+            block_df, _mk(), exclude_pairs={(1, 2)}, _emit_dataframe=True,
+        )
+        assert isinstance(result, list)
+
+
 # ── Adapter round-trip ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
Hot-path optimization in `find_fuzzy_matches` — `_emit_dataframe=True` builds DataFrame directly from numpy arrays, bypassing list-of-tuples construction. `find_fuzzy_matches_columnar` uses it on the hot path. Existing list callers unchanged. 17/17 parity tests pass.