### PR TITLE
feat(golden): consume ClusterFrames directly (Arrow Phase 4, #626)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -1015,3 +1015,117 @@ def build_golden_record_with_provenance(
 
     golden_df = pl.DataFrame(golden_rows) if golden_rows else pl.DataFrame()
     return GoldenRecordResult(df=golden_df, provenance=provenance_list)
+
+
+# ---------------------------------------------------------------------------
+# Arrow-native roadmap Phase 4 (#626): golden consumes columnar input
+# ---------------------------------------------------------------------------
+#
+# Sibling function to ``build_golden_records_batch`` that accepts the
+# Phase 2 two-frame cluster representation (``ClusterFrames``)
+# directly, instead of requiring the caller to pre-build a
+# ``multi_df`` with a ``__cluster_id__`` column. Today's
+# implementation joins ``cluster_assignments`` against the source
+# frame via a vectorized Polars expression and delegates to
+# ``build_golden_records_batch`` -- same correctness contract, no perf
+# regression (the join replaces a manual loop the caller would
+# otherwise write).
+#
+# Why this phase exists: the existing ``build_golden_records_batch``
+# requires its caller to materialize the per-cluster row assignment
+# as a ``__cluster_id__`` column on the multi-member source slice. In
+# the distributed identity / Splink-Spark Phase 5 path that means the
+# driver must collect the cluster assignments via
+# ``materialize_cluster_dict`` (the ~3 GB / 25M cheat-line). Phase 4
+# gives the caller a single function: hand it the ``ClusterFrames``
+# and the source df, get golden records out -- no manual cluster_id
+# attachment, ready to consume directly from Phase 2's columnar
+# shape.
+#
+# Spec: docs/superpowers/specs/2026-05-31-arrow-native-roadmap.md
+# (gitignored).
+
+
+def build_golden_records_from_frames(
+    source_df: pl.DataFrame,
+    frames,  # cluster.ClusterFrames; imported lazily to keep golden.py independent
+    rules: GoldenRulesConfig,
+    quality_scores: dict[tuple[int, str], float] | None = None,
+    provenance: bool = False,
+) -> list[dict]:
+    """Phase 4 entry point: build golden records from a Phase-2
+    ``ClusterFrames`` plus the source DataFrame.
+
+    Args:
+        source_df: Original source data with a ``__row_id__`` column.
+            Rows NOT referenced by ``frames.assignments.member_id`` are
+            silently dropped (they're singletons; golden only operates
+            on multi-member clusters).
+        frames: ``ClusterFrames`` from
+            ``cluster.build_clusters_v2_columnar`` (or equivalent). The
+            ``assignments`` frame must have ``cluster_id`` (i64) and
+            ``member_id`` (i64) columns. The ``metadata`` frame is read
+            to filter singletons via the ``size`` column.
+        rules: forwarded to ``build_golden_records_batch`` unchanged.
+        quality_scores, provenance: forwarded unchanged.
+
+    Returns:
+        Same shape as ``build_golden_records_batch`` -- list of golden
+        record dicts, one per multi-member cluster, sorted by
+        ``__cluster_id__``.
+
+    Empty cases:
+        - empty ``source_df`` -> ``[]``.
+        - empty ``assignments`` -> ``[]``.
+        - assignments contains member_ids absent from ``source_df`` ->
+          those clusters are silently dropped (consistent with how the
+          existing pipeline drops rows whose __row_id__ isn't in the
+          source).
+    """
+    if source_df.height == 0 or frames.assignments.is_empty():
+        return []
+
+    if "__row_id__" not in source_df.columns:
+        raise ValueError(
+            "build_golden_records_from_frames: source_df must contain a "
+            "__row_id__ column. Use "
+            "source_df.with_row_index(name='__row_id__') if your input "
+            "frame doesn't have one.",
+        )
+
+    # Drop singleton clusters via the metadata.size filter -- golden
+    # only processes multi-member clusters per the existing
+    # ``build_golden_records_batch`` contract. This filter is cheap
+    # (Polars filter on a small metadata frame) and avoids feeding
+    # singleton clusters through the per-column group_by pipeline.
+    multi_cluster_ids = (
+        frames.metadata
+        .filter(pl.col("size") > 1)
+        .select("cluster_id")
+    )
+
+    # Vectorized join: attach __cluster_id__ to each source row whose
+    # __row_id__ appears in the assignments frame. ``inner`` join
+    # drops rows that aren't members of any multi-member cluster (the
+    # "rows NOT referenced ... are silently dropped" contract above).
+    assignments_multi = frames.assignments.join(
+        multi_cluster_ids, on="cluster_id", how="inner",
+    ).rename({"cluster_id": "__cluster_id__"})
+
+    multi_df = source_df.join(
+        assignments_multi,
+        left_on="__row_id__",
+        right_on="member_id",
+        how="inner",
+    )
+
+    if multi_df.height == 0:
+        return []
+
+    return build_golden_records_batch(
+        multi_df,
+        rules,
+        quality_scores=quality_scores,
+        provenance=provenance,
+    )
+

--- a/packages/python/goldenmatch/tests/test_golden_from_frames_parity.py
+++ b/packages/python/goldenmatch/tests/test_golden_from_frames_parity.py
@@ -1,0 +1,174 @@
+"""Phase 4 parity: build_golden_records_from_frames matches the
+manual __cluster_id__-on-multi_df path.
+
+GH issue #626 (Arrow-native roadmap Phase 4).
+
+Asserts that ``build_golden_records_from_frames`` produces the SAME
+golden records as building the ``multi_df`` manually and calling
+``build_golden_records_batch`` directly. The new function is a thin
+sibling that does the cluster-assignments join in a vectorized
+Polars expression; the parity test locks the contract that the
+implicit join produces the same shape as the explicit one.
+
+Tests use tiny hand-built fixtures (≤ 20 rows). No ``dedupe_df``
+calls.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.config.schemas import GoldenRulesConfig
+from goldenmatch.core.cluster import ClusterFrames
+from goldenmatch.core.golden import (
+    build_golden_records_batch,
+    build_golden_records_from_frames,
+)
+
+
+def _make_source() -> pl.DataFrame:
+    """Tiny 6-row people frame; 2 multi-member clusters + 1 singleton."""
+    return pl.DataFrame({
+        "__row_id__": [1, 2, 3, 4, 5, 6],
+        "first_name": ["John", "Jon", "John", "Bob", "Bobby", "Alice"],
+        "last_name": ["Smith", "Smith", "Smyth", "Brown", "Brown", "Cooper"],
+        "zip": ["10001", "10001", "10001", "20002", "20002", "30003"],
+    })
+
+
+def _make_frames() -> ClusterFrames:
+    """ClusterFrames for the _make_source() shape.
+
+    cluster 100: members 1, 2, 3 (three Smith variants)
+    cluster 101: members 4, 5    (two Brown variants)
+    cluster 102: member  6       (Alice, singleton)
+    """
+    assignments = pl.DataFrame({
+        "cluster_id": pl.Series([100, 100, 100, 101, 101, 102], dtype=pl.Int64),
+        "member_id":  pl.Series([1, 2, 3, 4, 5, 6], dtype=pl.Int64),
+    })
+    metadata = pl.DataFrame({
+        "cluster_id": pl.Series([100, 101, 102], dtype=pl.Int64),
+        "size":       pl.Series([3, 2, 1], dtype=pl.Int64),
+        "confidence": pl.Series([0.95, 0.88, 1.0], dtype=pl.Float64),
+        "quality":    pl.Series(["strong", "strong", "strong"], dtype=pl.Utf8),
+        "oversized":  pl.Series([False, False, False], dtype=pl.Boolean),
+        "bottleneck_pair_a": pl.Series([1, 4, 0], dtype=pl.Int64),
+        "bottleneck_pair_b": pl.Series([3, 5, 0], dtype=pl.Int64),
+    })
+    return ClusterFrames(assignments=assignments, metadata=metadata)
+
+
+def _manual_multi_df(source: pl.DataFrame, frames: ClusterFrames) -> pl.DataFrame:
+    """The explicit join that callers would otherwise write."""
+    multi_cluster_ids = (
+        frames.metadata.filter(pl.col("size") > 1).select("cluster_id")
+    )
+    assignments_multi = frames.assignments.join(
+        multi_cluster_ids, on="cluster_id", how="inner",
+    ).rename({"cluster_id": "__cluster_id__"})
+    return source.join(
+        assignments_multi,
+        left_on="__row_id__",
+        right_on="member_id",
+        how="inner",
+    )
+
+
+class TestGoldenFromFramesParity:
+    def test_records_match_manual_join(self):
+        source = _make_source()
+        frames = _make_frames()
+        rules = GoldenRulesConfig(default_strategy="most_complete")
+
+        new = build_golden_records_from_frames(source, frames, rules)
+        old = build_golden_records_batch(
+            _manual_multi_df(source, frames), rules,
+        )
+
+        # Same number of golden records (one per multi-member cluster)
+        assert len(new) == len(old), (
+            f"record count differs: new={len(new)}, old={len(old)}"
+        )
+        # Same set of __cluster_id__ values
+        new_cids = sorted(r["__cluster_id__"] for r in new)
+        old_cids = sorted(r["__cluster_id__"] for r in old)
+        assert new_cids == old_cids, (
+            f"cluster ids differ: new={new_cids}, old={old_cids}"
+        )
+
+    def test_singleton_clusters_dropped(self):
+        """The metadata.size > 1 filter must drop singleton clusters
+        (cluster 102 / Alice in this fixture)."""
+        source = _make_source()
+        frames = _make_frames()
+        rules = GoldenRulesConfig(default_strategy="most_complete")
+
+        new = build_golden_records_from_frames(source, frames, rules)
+        cids = {r["__cluster_id__"] for r in new}
+
+        assert 100 in cids
+        assert 101 in cids
+        assert 102 not in cids, (
+            "singleton cluster 102 leaked into golden output; "
+            "metadata.size > 1 filter is broken"
+        )
+
+    def test_empty_source(self):
+        empty_source = pl.DataFrame({
+            "__row_id__": pl.Series([], dtype=pl.Int64),
+            "first_name": pl.Series([], dtype=pl.Utf8),
+        })
+        frames = _make_frames()
+        rules = GoldenRulesConfig(default_strategy="most_complete")
+        assert build_golden_records_from_frames(empty_source, frames, rules) == []
+
+    def test_empty_assignments(self):
+        source = _make_source()
+        empty_frames = ClusterFrames(
+            assignments=pl.DataFrame({
+                "cluster_id": pl.Series([], dtype=pl.Int64),
+                "member_id":  pl.Series([], dtype=pl.Int64),
+            }),
+            metadata=pl.DataFrame({
+                "cluster_id": pl.Series([], dtype=pl.Int64),
+                "size":       pl.Series([], dtype=pl.Int64),
+                "confidence": pl.Series([], dtype=pl.Float64),
+                "quality":    pl.Series([], dtype=pl.Utf8),
+                "oversized":  pl.Series([], dtype=pl.Boolean),
+                "bottleneck_pair_a": pl.Series([], dtype=pl.Int64),
+                "bottleneck_pair_b": pl.Series([], dtype=pl.Int64),
+            }),
+        )
+        rules = GoldenRulesConfig(default_strategy="most_complete")
+        assert build_golden_records_from_frames(source, empty_frames, rules) == []
+
+    def test_missing_row_id_raises(self):
+        source_no_rowid = pl.DataFrame({
+            "first_name": ["John"],
+            "last_name": ["Smith"],
+        })
+        frames = _make_frames()
+        rules = GoldenRulesConfig(default_strategy="most_complete")
+        try:
+            build_golden_records_from_frames(source_no_rowid, frames, rules)
+        except ValueError as e:
+            assert "__row_id__" in str(e)
+        else:
+            raise AssertionError("expected ValueError for missing __row_id__")
+
+    def test_member_id_not_in_source_silently_dropped(self):
+        """If assignments references a member_id that isn't in
+        source_df, that cluster is silently dropped (consistent with
+        the existing pipeline)."""
+        source = _make_source().head(3)  # only rows 1, 2, 3
+        # Frames reference 1-6; only 100 has all members in source
+        frames = _make_frames()
+        rules = GoldenRulesConfig(default_strategy="most_complete")
+
+        new = build_golden_records_from_frames(source, frames, rules)
+        cids = {r["__cluster_id__"] for r in new}
+
+        # Cluster 100 (1, 2, 3) is fully present -> included
+        assert 100 in cids
+        # Cluster 101 (4, 5) has no members in source -> empty multi_df
+        # for that group -> dropped by the join
+        assert 101 not in cids


### PR DESCRIPTION
Phase 4 sibling `build_golden_records_from_frames` — takes ClusterFrames + source df, joins via Polars, delegates to existing batch builder. 6/6 parity tests. Unblocks the distributed identity path from `materialize_cluster_dict`.