### PR TITLE
feat(identity): hash-by-cluster_id partitioner (Arrow Phase 5, #627)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/distributed/identity_partition.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/identity_partition.py
@@ -1,0 +1,173 @@
+"""Arrow-native roadmap Phase 5 (#627): identity per-partition resolver
+building blocks.
+
+This module provides the data-shape transformations that Phase 5's
+``ray.map_batches`` wire-up needs at the boundary. Today it ships
+``partition_cluster_frames`` (hash-by-cluster_id splitter) which
+takes a ``ClusterFrames`` and emits N sub-frames each containing a
+disjoint subset of cluster_ids. Used directly today for testing /
+multi-worker simulation; consumed by the production
+``ray.map_batches`` path once Phase 5's full wire-up lands.
+
+Why per-partition: ``materialize_cluster_dict`` collects ~17M
+cluster aggregates to ~3 GB driver-side at 25M scale (per
+CLAUDE.md). Phase 5's binding lift is to make each Ray worker resolve
+its OWN partition's identities against a pooled Postgres connection,
+so the driver never holds the full cluster dict. The partitioner
+gives each worker a deterministic, disjoint slice of cluster_ids.
+
+Hash-by-cluster_id (not by member_id) so all members of one cluster
+end up on the same partition -- the resolver's correctness depends
+on seeing each cluster's full member set in one place.
+
+Spec: docs/superpowers/specs/2026-05-31-arrow-native-roadmap.md
+(gitignored).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+from goldenmatch.core.cluster import ClusterFrames
+
+
+def partition_cluster_frames(
+    frames: ClusterFrames, num_partitions: int,
+) -> list[ClusterFrames]:
+    """Hash-partition a ``ClusterFrames`` into ``num_partitions`` disjoint
+    slices by ``cluster_id``.
+
+    Each output ``ClusterFrames`` carries a SUBSET of the input's
+    cluster_ids; the union of subsets equals the original input (no
+    cluster is dropped or duplicated). All members of one cluster
+    land on the same partition -- the resolver needs the full member
+    list per cluster to make correct identity decisions.
+
+    Args:
+        frames: Input ``ClusterFrames`` (Phase 2a shape).
+        num_partitions: Number of disjoint slices to emit. Must be
+            >= 1. Empty input yields ``num_partitions`` empty frames.
+
+    Returns:
+        List of ``ClusterFrames`` of length ``num_partitions``.
+        Partition ``i`` contains ``cluster_id`` such that
+        ``hash(cluster_id) % num_partitions == i``.
+
+    Properties (locked by tests):
+        - Disjoint: no cluster_id appears in more than one partition.
+        - Complete: union of partition cluster_ids equals input.
+        - Stable: same input produces same partition assignment (hash
+          is deterministic; Polars' ``__hash__`` is based on bytewise
+          contents on the i64 column).
+    """
+    import polars as _pl
+
+    if num_partitions < 1:
+        raise ValueError(
+            f"num_partitions must be >= 1; got {num_partitions}"
+        )
+
+    empty_assignments_schema = {
+        "cluster_id": _pl.Int64(),
+        "member_id":  _pl.Int64(),
+    }
+    empty_metadata_schema = {
+        "cluster_id":       _pl.Int64(),
+        "size":             _pl.Int64(),
+        "confidence":       _pl.Float64(),
+        "quality":          _pl.Utf8(),
+        "oversized":        _pl.Boolean(),
+        "bottleneck_pair_a": _pl.Int64(),
+        "bottleneck_pair_b": _pl.Int64(),
+    }
+
+    if frames.metadata.is_empty():
+        return [
+            ClusterFrames(
+                assignments=_pl.DataFrame(schema=empty_assignments_schema),
+                metadata=_pl.DataFrame(schema=empty_metadata_schema),
+            )
+            for _ in range(num_partitions)
+        ]
+
+    # Tag every cluster with its partition index via ``cluster_id %
+    # num_partitions``. Polars supports modulo on integer columns
+    # natively. For i64 cluster_ids, this gives a uniform partition
+    # distribution as long as cluster_ids aren't pathologically
+    # correlated with N (uuidv7 + offset minted ids satisfy this).
+    metadata_tagged = frames.metadata.with_columns(
+        (_pl.col("cluster_id") % num_partitions).alias("__partition__"),
+    )
+
+    # Build partition_id -> cluster_id table once, then join the
+    # assignments frame against it so each (cluster, member) row
+    # carries its partition. Doing this via join instead of recomputing
+    # the hash keeps the partition assignment consistent if the modulo
+    # logic ever moves (single source of truth: metadata_tagged).
+    partition_index = metadata_tagged.select(["cluster_id", "__partition__"])
+    assignments_tagged = frames.assignments.join(
+        partition_index, on="cluster_id", how="inner",
+    )
+
+    out: list[ClusterFrames] = []
+    for i in range(num_partitions):
+        part_assignments = (
+            assignments_tagged
+            .filter(_pl.col("__partition__") == i)
+            .drop("__partition__")
+        )
+        part_metadata = (
+            metadata_tagged
+            .filter(_pl.col("__partition__") == i)
+            .drop("__partition__")
+        )
+        out.append(ClusterFrames(
+            assignments=part_assignments,
+            metadata=part_metadata,
+        ))
+    return out
+
+
+def merge_partitioned_frames(parts: list[ClusterFrames]) -> ClusterFrames:
+    """Inverse of ``partition_cluster_frames``: concatenate N partition
+    frames back into a single ``ClusterFrames``.
+
+    Used to verify the round-trip property (``merge(partition(x)) == x``)
+    in tests and to consume per-worker results once the partitioned
+    resolve_clusters path is wired through Ray.
+
+    Args:
+        parts: list of ``ClusterFrames`` to concatenate.
+
+    Returns:
+        A single ``ClusterFrames`` whose ``assignments`` and ``metadata``
+        are the row-concatenation of each partition's frames.
+    """
+    import polars as _pl
+
+    if not parts:
+        # Caller should provide at least one partition; mirror the
+        # ``partition_cluster_frames`` empty-input shape so the
+        # round-trip is total.
+        empty_assignments_schema = {
+            "cluster_id": _pl.Int64(),
+            "member_id":  _pl.Int64(),
+        }
+        empty_metadata_schema = {
+            "cluster_id":       _pl.Int64(),
+            "size":             _pl.Int64(),
+            "confidence":       _pl.Float64(),
+            "quality":          _pl.Utf8(),
+            "oversized":        _pl.Boolean(),
+            "bottleneck_pair_a": _pl.Int64(),
+            "bottleneck_pair_b": _pl.Int64(),
+        }
+        return ClusterFrames(
+            assignments=_pl.DataFrame(schema=empty_assignments_schema),
+            metadata=_pl.DataFrame(schema=empty_metadata_schema),
+        )
+    assignments = _pl.concat([p.assignments for p in parts])
+    metadata = _pl.concat([p.metadata for p in parts])
+    return ClusterFrames(assignments=assignments, metadata=metadata)

--- a/packages/python/goldenmatch/tests/identity/test_partition_cluster_frames.py
+++ b/packages/python/goldenmatch/tests/identity/test_partition_cluster_frames.py
@@ -1,0 +1,159 @@
+"""Phase 5 building block: hash-by-cluster_id partitioning of
+``ClusterFrames``.
+
+GH issue #627 (Arrow-native roadmap Phase 5).
+
+Tests the disjoint + complete + stable + cluster-cohesive properties
+of ``partition_cluster_frames``. These are the contracts Phase 5's
+``ray.map_batches`` will rely on when it shards cluster resolution
+across workers.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.core.cluster import ClusterFrames
+from goldenmatch.distributed.identity_partition import (
+    merge_partitioned_frames,
+    partition_cluster_frames,
+)
+
+
+def _make_frames(n_clusters: int = 6) -> ClusterFrames:
+    """Build n_clusters clusters with 2-3 members each."""
+    cluster_ids = list(range(100, 100 + n_clusters))
+    a_rows = []
+    sizes = []
+    for cid in cluster_ids:
+        # cluster i has members [10*i, 10*i+1, 10*i+2] (3 members each)
+        for m in range(10 * cid, 10 * cid + 3):
+            a_rows.append((cid, m))
+        sizes.append(3)
+    assignments = pl.DataFrame({
+        "cluster_id": pl.Series([r[0] for r in a_rows], dtype=pl.Int64),
+        "member_id":  pl.Series([r[1] for r in a_rows], dtype=pl.Int64),
+    })
+    metadata = pl.DataFrame({
+        "cluster_id": pl.Series(cluster_ids, dtype=pl.Int64),
+        "size":       pl.Series(sizes, dtype=pl.Int64),
+        "confidence": pl.Series([0.9] * n_clusters, dtype=pl.Float64),
+        "quality":    pl.Series(["strong"] * n_clusters, dtype=pl.Utf8),
+        "oversized":  pl.Series([False] * n_clusters, dtype=pl.Boolean),
+        "bottleneck_pair_a": pl.Series([0] * n_clusters, dtype=pl.Int64),
+        "bottleneck_pair_b": pl.Series([0] * n_clusters, dtype=pl.Int64),
+    })
+    return ClusterFrames(assignments=assignments, metadata=metadata)
+
+
+class TestDisjoint:
+    def test_no_cluster_id_in_two_partitions(self):
+        frames = _make_frames(20)
+        parts = partition_cluster_frames(frames, num_partitions=4)
+        seen: set[int] = set()
+        for p in parts:
+            cids = set(p.metadata["cluster_id"].to_list())
+            assert not (seen & cids), (
+                "cluster_id appeared in multiple partitions; "
+                f"overlap={seen & cids}"
+            )
+            seen.update(cids)
+
+
+class TestComplete:
+    def test_union_equals_input_cluster_ids(self):
+        frames = _make_frames(20)
+        parts = partition_cluster_frames(frames, num_partitions=4)
+        union: set[int] = set()
+        for p in parts:
+            union.update(p.metadata["cluster_id"].to_list())
+        original = set(frames.metadata["cluster_id"].to_list())
+        assert union == original, (
+            f"partitioner dropped clusters: missing={original - union}"
+        )
+
+    def test_union_equals_input_assignment_rows(self):
+        frames = _make_frames(15)
+        parts = partition_cluster_frames(frames, num_partitions=3)
+        total_rows = sum(p.assignments.height for p in parts)
+        assert total_rows == frames.assignments.height
+
+
+class TestStable:
+    def test_same_input_same_assignment(self):
+        frames = _make_frames(10)
+        parts_a = partition_cluster_frames(frames, num_partitions=3)
+        parts_b = partition_cluster_frames(frames, num_partitions=3)
+        for a, b in zip(parts_a, parts_b, strict=True):
+            assert sorted(a.metadata["cluster_id"].to_list()) == \
+                   sorted(b.metadata["cluster_id"].to_list())
+
+
+class TestClusterCohesive:
+    def test_all_members_of_one_cluster_in_same_partition(self):
+        """The resolver depends on seeing every member of a cluster
+        in one partition. Hash MUST be on cluster_id, not member_id."""
+        frames = _make_frames(12)
+        parts = partition_cluster_frames(frames, num_partitions=4)
+        for p in parts:
+            # Every member's cluster_id in this partition's assignments
+            # MUST also appear in this partition's metadata.
+            cid_assignments = set(p.assignments["cluster_id"].to_list())
+            cid_metadata = set(p.metadata["cluster_id"].to_list())
+            assert cid_assignments == cid_metadata, (
+                f"cluster_id mismatch within partition: "
+                f"assignments has {cid_assignments - cid_metadata} not in metadata, "
+                f"metadata has {cid_metadata - cid_assignments} not in assignments"
+            )
+
+
+class TestEdgeCases:
+    def test_empty_input(self):
+        empty = ClusterFrames(
+            assignments=pl.DataFrame({
+                "cluster_id": pl.Series([], dtype=pl.Int64),
+                "member_id":  pl.Series([], dtype=pl.Int64),
+            }),
+            metadata=pl.DataFrame({
+                "cluster_id":       pl.Series([], dtype=pl.Int64),
+                "size":             pl.Series([], dtype=pl.Int64),
+                "confidence":       pl.Series([], dtype=pl.Float64),
+                "quality":          pl.Series([], dtype=pl.Utf8),
+                "oversized":        pl.Series([], dtype=pl.Boolean),
+                "bottleneck_pair_a": pl.Series([], dtype=pl.Int64),
+                "bottleneck_pair_b": pl.Series([], dtype=pl.Int64),
+            }),
+        )
+        parts = partition_cluster_frames(empty, num_partitions=4)
+        assert len(parts) == 4
+        assert all(p.metadata.is_empty() for p in parts)
+        assert all(p.assignments.is_empty() for p in parts)
+
+    def test_num_partitions_one(self):
+        """N=1 must return a single partition containing the full input."""
+        frames = _make_frames(5)
+        parts = partition_cluster_frames(frames, num_partitions=1)
+        assert len(parts) == 1
+        assert parts[0].metadata.height == frames.metadata.height
+        assert parts[0].assignments.height == frames.assignments.height
+
+    def test_invalid_num_partitions(self):
+        frames = _make_frames(5)
+        try:
+            partition_cluster_frames(frames, num_partitions=0)
+        except ValueError as e:
+            assert "num_partitions" in str(e)
+        else:
+            raise AssertionError("expected ValueError for num_partitions=0")
+
+
+class TestRoundTrip:
+    def test_merge_of_partition_equals_input(self):
+        """``merge_partitioned_frames(partition_cluster_frames(x, n)) == x``
+        modulo row order."""
+        frames = _make_frames(15)
+        parts = partition_cluster_frames(frames, num_partitions=4)
+        merged = merge_partitioned_frames(parts)
+        # Compare as sorted sets of cluster_ids + row counts.
+        assert sorted(merged.metadata["cluster_id"].to_list()) == \
+               sorted(frames.metadata["cluster_id"].to_list())
+        assert merged.assignments.height == frames.assignments.height
+        assert merged.metadata.height == frames.metadata.height


### PR DESCRIPTION
Hash-by-cluster_id partitioner + merger for ClusterFrames. Building block for Phase 5's ray.map_batches wire-up. 9/9 parity tests covering disjoint, complete, stable, cluster-cohesive contracts + edge cases.