### PR TITLE
feat(native): Rust Arrow C kernel for dedup_pairs (Arrow Phase 3, #625)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pairs.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pairs.py
@@ -185,3 +185,49 @@ def dedup_pairs_max_score_columnar(pairs_df):  # pl.DataFrame -> pl.DataFrame
         .rename({"__a__": "id_a", "__b__": "id_b"})
         .select(["id_a", "id_b", "score"])
     )
+
+
+def dedup_pairs_max_score_arrow(pairs_df):  # pl.DataFrame -> pl.DataFrame
+    """Rust-Arrow native dedup. Reads the DataFrame's Arrow buffers
+    directly via the C Data Interface, runs the BTreeMap reduction in
+    Rust, returns the result as a new DataFrame.
+
+    Phase 3 deliverable per the Arrow-native roadmap (#625). The
+    dict-shaped ``dedup_pairs_max_score`` Rust kernel benched at 1.19x
+    (capped by per-tuple pyo3 marshalling); this Arrow path bypasses
+    the marshalling floor entirely -- the i64/f64 arrays are read in
+    place from the Polars frame's Arrow buffers, the BTreeMap reduces
+    them, and the output emits back as Arrow arrays.
+
+    Falls back to ``dedup_pairs_max_score_columnar`` (the Polars
+    expression path) when the native ``pairs`` component is disabled
+    or unavailable, so callers always get a working result.
+
+    Bit-exact contract with the dict-shaped kernel: same canonical
+    ``(min, max)`` orientation, same first-occurrence-wins tie
+    semantics (output values identical regardless).
+    """
+    import polars as _pl
+
+    from goldenmatch.core.scorer import PAIR_STREAM_SCHEMA
+
+    if not native_enabled("pairs"):
+        return dedup_pairs_max_score_columnar(pairs_df)
+    if pairs_df.is_empty():
+        return _pl.DataFrame(schema=PAIR_STREAM_SCHEMA)
+
+    native = native_module()
+    if not hasattr(native, "dedup_pairs_arrow"):
+        # Older native build doesn't have the Arrow kernel yet; degrade
+        # to the Polars columnar path (same correctness, no perf claim).
+        return dedup_pairs_max_score_columnar(pairs_df)
+
+    a_arrow = pairs_df["id_a"].to_arrow()
+    b_arrow = pairs_df["id_b"].to_arrow()
+    s_arrow = pairs_df["score"].to_arrow()
+    a_out, b_out, s_out = native.dedup_pairs_arrow(a_arrow, b_arrow, s_arrow)
+    return _pl.DataFrame({
+        "id_a": _pl.from_arrow(a_out),
+        "id_b": _pl.from_arrow(b_out),
+        "score": _pl.from_arrow(s_out),
+    })

--- a/packages/python/goldenmatch/tests/test_dedup_pairs_arrow_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_dedup_pairs_arrow_native_parity.py
@@ -1,0 +1,125 @@
+"""Phase 3 (Rust): ``dedup_pairs_max_score_arrow`` matches both the
+list-path and the columnar-path kernels.
+
+GH issue #625 (Arrow-native roadmap Phase 3).
+
+The Rust Arrow kernel must produce bit-identical output to the
+existing dict-shaped kernel (``dedup_pairs_max_score``) and the
+Polars columnar kernel (``dedup_pairs_max_score_columnar``) on
+identical input.
+
+Skipped when ``goldenmatch._native`` isn't built or doesn't yet
+expose ``dedup_pairs_arrow`` -- the Polars fallback covers the
+correctness contract in that case.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+native = pytest.importorskip("goldenmatch._native")
+if not hasattr(native, "dedup_pairs_arrow"):
+    pytest.skip(
+        "native module loaded but dedup_pairs_arrow not exposed; "
+        "Rust kernel needs to be rebuilt against the Phase 3 PR.",
+        allow_module_level=True,
+    )
+
+
+from goldenmatch.core.pairs import (
+    Pair,
+    dedup_pairs_max_score,
+    dedup_pairs_max_score_arrow,
+    dedup_pairs_max_score_columnar,
+)
+from goldenmatch.core.scorer import PAIR_STREAM_SCHEMA, pairs_list_to_df
+
+
+def _df(pairs: list[Pair]) -> pl.DataFrame:
+    return pairs_list_to_df(pairs)
+
+
+def _to_list(df: pl.DataFrame) -> list[Pair]:
+    return [
+        (int(a), int(b), float(s))
+        for a, b, s in zip(
+            df["id_a"].to_list(),
+            df["id_b"].to_list(),
+            df["score"].to_list(),
+            strict=True,
+        )
+    ]
+
+
+class TestRustArrowParity:
+    def test_simple_dedup_matches_legacy(self):
+        pairs = [(1, 2, 0.9), (2, 1, 0.8), (3, 4, 0.95)]
+        legacy = dedup_pairs_max_score(pairs)
+        rust_arrow = _to_list(dedup_pairs_max_score_arrow(_df(pairs)))
+        assert rust_arrow == legacy
+
+    def test_multiple_duplicates_max_wins(self):
+        pairs = [
+            (1, 2, 0.5),
+            (1, 2, 0.9),
+            (1, 2, 0.7),
+            (2, 1, 0.8),
+        ]
+        result = _to_list(dedup_pairs_max_score_arrow(_df(pairs)))
+        assert result == [(1, 2, 0.9)]
+
+    def test_sort_ascending_by_a_then_b(self):
+        pairs = [
+            (5, 6, 0.5),
+            (1, 9, 0.6),
+            (1, 2, 0.7),
+            (3, 4, 0.8),
+        ]
+        result = _to_list(dedup_pairs_max_score_arrow(_df(pairs)))
+        ids = [(a, b) for a, b, _ in result]
+        assert ids == sorted(ids)
+
+    def test_matches_polars_columnar_path(self):
+        """Three-way parity: Rust Arrow == Polars columnar == legacy."""
+        pairs = [
+            (10, 20, 0.95), (20, 10, 0.96),
+            (10, 30, 0.80),
+            (30, 10, 0.85),
+            (5,  5,  1.00),
+            (1, 100, 0.50), (100, 1, 0.50),
+            (1,  2, 0.99),
+        ]
+        legacy = dedup_pairs_max_score(pairs)
+        polars_path = _to_list(dedup_pairs_max_score_columnar(_df(pairs)))
+        rust_path = _to_list(dedup_pairs_max_score_arrow(_df(pairs)))
+        assert rust_path == legacy
+        assert rust_path == polars_path
+
+    def test_empty_input(self):
+        empty = pl.DataFrame(schema=PAIR_STREAM_SCHEMA)
+        result = dedup_pairs_max_score_arrow(empty)
+        assert result.is_empty()
+        assert result.schema == PAIR_STREAM_SCHEMA
+
+    def test_self_loops_preserved(self):
+        """Pair (5, 5) is canonically (5, 5); the Arrow kernel must
+        handle id_a == id_b without dropping or duplicating."""
+        pairs = [(5, 5, 0.8), (5, 5, 0.9), (5, 5, 0.7)]
+        result = _to_list(dedup_pairs_max_score_arrow(_df(pairs)))
+        assert result == [(5, 5, 0.9)]
+
+    def test_large_workload_matches(self):
+        """100-pair workload exercising more of the BTreeMap reduce
+        path. Ensures the Arrow buffer reads + reduction stay correct
+        at non-trivial sizes."""
+        import random
+        rng = random.Random(42)
+        pairs = []
+        for _ in range(100):
+            a = rng.randint(1, 30)
+            b = rng.randint(1, 30)
+            s = rng.random()
+            pairs.append((a, b, s))
+        legacy = dedup_pairs_max_score(pairs)
+        rust_arrow = _to_list(dedup_pairs_max_score_arrow(_df(pairs)))
+        assert rust_arrow == legacy

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -22,6 +22,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cluster::build_clusters_native, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::canonicalize_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::dedup_pairs_max_score, m)?)?;
+    m.add_function(wrap_pyfunction!(pairs::dedup_pairs_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::candidate_pair_count, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::block_histogram, m)?)?;
     m.add_function(wrap_pyfunction!(featurize::char_ngram_features, m)?)?;

--- a/packages/rust/extensions/native/src/pairs.rs
+++ b/packages/rust/extensions/native/src/pairs.rs
@@ -8,6 +8,10 @@
 //! default once the parity test passes.
 use std::collections::BTreeMap;
 
+use arrow::array::{Array, ArrayData, Float64Array, Int64Array};
+use arrow::datatypes::DataType;
+use arrow::pyarrow::PyArrowType;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 /// Canonicalize each pair to `(min, max, score)`, preserving input order and
@@ -53,6 +57,107 @@ pub fn candidate_pair_count(block_sizes: Vec<i64>) -> i64 {
         }
     }
     total as i64
+}
+
+/// Arrow-native roadmap Phase 3 (#625): `dedup_pairs_max_score` over
+/// Arrow C Data Interface arrays.
+///
+/// Reads `id_a`, `id_b` (Int64) and `score` (Float64) directly from the
+/// PyArrow array buffers -- no per-tuple pyo3 marshalling. The same
+/// `BTreeMap<(i64, i64), f64>` reduction as the dict-shaped kernel,
+/// emitted back as three Arrow arrays sorted ascending by `(a, b)`.
+///
+/// The dict-shaped kernel benched at 1.19x speedup vs the Python loop
+/// (capped by per-tuple marshalling); this Arrow path bypasses that
+/// floor entirely. At 200M-pair / 5M-row reference shapes the dict
+/// kernel paid ~80 bytes Python overhead per pair; this path reads the
+/// raw Arrow i64/f64 buffers and pays only the BTreeMap update.
+///
+/// Pairs with `NULL` in any column are silently dropped (defensive --
+/// the upstream pair stream shouldn't contain nulls; we don't want a
+/// null to crash the reduce loop).
+#[pyfunction]
+pub fn dedup_pairs_arrow(
+    id_a: PyArrowType<ArrayData>,
+    id_b: PyArrowType<ArrayData>,
+    score: PyArrowType<ArrayData>,
+) -> PyResult<(PyArrowType<ArrayData>, PyArrowType<ArrayData>, PyArrowType<ArrayData>)> {
+    let id_a_data = id_a.0;
+    let id_b_data = id_b.0;
+    let score_data = score.0;
+
+    if id_a_data.data_type() != &DataType::Int64 {
+        return Err(PyValueError::new_err(format!(
+            "dedup_pairs_arrow: id_a must be int64, got {:?}",
+            id_a_data.data_type()
+        )));
+    }
+    if id_b_data.data_type() != &DataType::Int64 {
+        return Err(PyValueError::new_err(format!(
+            "dedup_pairs_arrow: id_b must be int64, got {:?}",
+            id_b_data.data_type()
+        )));
+    }
+    if score_data.data_type() != &DataType::Float64 {
+        return Err(PyValueError::new_err(format!(
+            "dedup_pairs_arrow: score must be float64, got {:?}",
+            score_data.data_type()
+        )));
+    }
+
+    let id_a = Int64Array::from(id_a_data);
+    let id_b = Int64Array::from(id_b_data);
+    let score = Float64Array::from(score_data);
+
+    let n = id_a.len();
+    if id_b.len() != n || score.len() != n {
+        return Err(PyValueError::new_err(format!(
+            "dedup_pairs_arrow: array lengths differ -- id_a={}, id_b={}, score={}",
+            n, id_b.len(), score.len(),
+        )));
+    }
+
+    // Reduce: same algorithm as dedup_pairs_max_score. Strict `>`
+    // first-occurrence-wins on ties keeps it bit-identical with the
+    // dict-shaped kernel at the output value layer.
+    let mut best: BTreeMap<(i64, i64), f64> = BTreeMap::new();
+    for i in 0..n {
+        if id_a.is_null(i) || id_b.is_null(i) || score.is_null(i) {
+            continue;
+        }
+        let a = id_a.value(i);
+        let b = id_b.value(i);
+        let s = score.value(i);
+        let key = if a <= b { (a, b) } else { (b, a) };
+        match best.get(&key) {
+            Some(&cur) if s <= cur => {}
+            _ => {
+                best.insert(key, s);
+            }
+        }
+    }
+
+    // Emit sorted output as three Arrow arrays. BTreeMap iter yields
+    // ascending key order, so the result is already sorted by (a, b).
+    let n_out = best.len();
+    let mut out_a: Vec<i64> = Vec::with_capacity(n_out);
+    let mut out_b: Vec<i64> = Vec::with_capacity(n_out);
+    let mut out_s: Vec<f64> = Vec::with_capacity(n_out);
+    for ((a, b), s) in best {
+        out_a.push(a);
+        out_b.push(b);
+        out_s.push(s);
+    }
+
+    let a_array = Int64Array::from(out_a);
+    let b_array = Int64Array::from(out_b);
+    let s_array = Float64Array::from(out_s);
+
+    Ok((
+        PyArrowType(a_array.to_data()),
+        PyArrowType(b_array.to_data()),
+        PyArrowType(s_array.to_data()),
+    ))
 }
 
 /// `(count, total_records, max, p50, p95, p99)` over the block-size


### PR DESCRIPTION
Phase 3 Rust kernel — reads pair-stream Arrow buffers directly via PyArrow C Data Interface, runs BTreeMap reduction in Rust, emits Arrow arrays. Bypasses per-tuple pyo3 marshalling floor that capped the dict-shaped kernel at 1.19x. Strategic unblock for DataFusion B2 (Phase 7). 7 parity tests (3-way: Rust Arrow == Polars columnar == legacy list). Gracefully degrades when native not built.