### PR TITLE
feat(native): Rust Arrow C kernel for build_clusters (Phase 3, #625)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -1088,3 +1088,123 @@ def build_clusters_v2_columnar(
         auto_split=auto_split,
     )
     return cluster_dict_to_frames(legacy)
+
+
+# ---------------------------------------------------------------------------
+# Arrow-native roadmap Phase 3 (#625): build_clusters via Rust Arrow kernel
+# ---------------------------------------------------------------------------
+#
+# Reads pair stream + all_ids as Arrow buffers (zero-copy from Polars),
+# runs Union-Find in Rust, returns ClusterFrames-shaped output without
+# the dict/list intermediate that capped build_clusters_native at 1.09x.
+#
+# Third Rust Arrow kernel in the Phase 3 series after dedup_pairs_arrow
+# (#643) and record_fingerprints_batch_arrow (#644). Same strategic
+# pattern: kernels with Arrow IO unblock DataFusion B2 via PyCapsule
+# ScalarUDFs.
+#
+# v1 scope: Union-Find + cluster_id assignment + confidence/bottleneck/
+# oversized metadata. Auto-split (oversized -> MST split) and weak-
+# cluster downgrades (cluster_quality=weak) are NOT in this kernel --
+# callers wrap and post-process for those. The output's ``quality``
+# column is always ``"strong"`` and ``auto_split`` is ignored;
+# build_clusters_v2_columnar can re-apply downstream filters when
+# needed.
+
+
+def build_clusters_arrow_native(
+    pairs_df,  # pl.DataFrame with PAIR_STREAM_SCHEMA columns
+    all_ids: list[int] | None = None,
+    max_cluster_size: int = 100,
+) -> ClusterFrames:
+    """Rust Arrow native cluster builder. Reads the pair stream's Arrow
+    buffers directly via the C Data Interface, runs Union-Find in Rust,
+    emits two ClusterFrames-shaped Arrow buffer sets.
+
+    Phase 3 deliverable per the Arrow-native roadmap (#625). The
+    dict-shaped ``build_clusters_native`` Rust kernel benched at 1.09x
+    (capped by per-cluster PyDict construction); this Arrow path
+    bypasses the dict construction entirely.
+
+    Falls back to ``build_clusters_v2_columnar`` (Polars columnar +
+    legacy build_clusters) when the native ``clustering`` component
+    is disabled or the Arrow kernel isn't built -- graceful degrade
+    with identical output shape.
+
+    Args:
+        pairs_df: ``PAIR_STREAM_SCHEMA`` DataFrame.
+        all_ids: Optional explicit ID list (defaults to derived from
+            pair endpoints).
+        max_cluster_size: Threshold for the ``oversized`` flag on
+            metadata.
+
+    Returns:
+        ``ClusterFrames`` with the canonical (assignments, metadata)
+        shape. ``quality`` column is always ``"strong"`` in v1 --
+        weak-cluster downgrades and auto-split happen via the legacy
+        post-processor path; callers can chain that as needed.
+    """
+    from goldenmatch.core._native_loader import native_enabled, native_module
+
+    # Fall back when native isn't enabled or the kernel isn't exposed.
+    if not native_enabled("clustering"):
+        return build_clusters_v2_columnar(
+            pairs_df, all_ids=all_ids, max_cluster_size=max_cluster_size,
+        )
+    native = native_module()
+    arrow_fn = getattr(native, "build_clusters_arrow", None)
+    if arrow_fn is None:
+        return build_clusters_v2_columnar(
+            pairs_df, all_ids=all_ids, max_cluster_size=max_cluster_size,
+        )
+
+    import polars as _pl
+
+    if all_ids is None:
+        # Vectorized derive: concat id_a/id_b and uniq. Polars handles
+        # this without materializing a Python list.
+        if pairs_df.is_empty():
+            all_ids = []
+        else:
+            ids_series = _pl.concat(
+                [pairs_df["id_a"], pairs_df["id_b"]],
+            ).unique()
+            all_ids = [int(i) for i in ids_series.to_list()]
+
+    a_arrow = pairs_df["id_a"].to_arrow() if not pairs_df.is_empty() \
+        else _pl.Series("id_a", [], dtype=_pl.Int64).to_arrow()
+    b_arrow = pairs_df["id_b"].to_arrow() if not pairs_df.is_empty() \
+        else _pl.Series("id_b", [], dtype=_pl.Int64).to_arrow()
+    s_arrow = pairs_df["score"].to_arrow() if not pairs_df.is_empty() \
+        else _pl.Series("score", [], dtype=_pl.Float64).to_arrow()
+    all_ids_arrow = _pl.Series("__ids__", all_ids, dtype=_pl.Int64).to_arrow()
+
+    (
+        a_cid, a_mid,
+        m_cid, m_size, m_conf, m_over, m_bot_a, m_bot_b,
+    ) = arrow_fn(a_arrow, b_arrow, s_arrow, all_ids_arrow, max_cluster_size)
+
+    assignments = _pl.DataFrame({
+        "cluster_id": _pl.from_arrow(a_cid),
+        "member_id":  _pl.from_arrow(a_mid),
+    })
+    metadata = _pl.DataFrame({
+        "cluster_id":       _pl.from_arrow(m_cid),
+        "size":             _pl.from_arrow(m_size),
+        "confidence":       _pl.from_arrow(m_conf),
+        "quality":          _pl.Series(
+            "quality", ["strong"] * metadata_height(m_cid), dtype=_pl.Utf8,
+        ),
+        "oversized":        _pl.from_arrow(m_over),
+        "bottleneck_pair_a": _pl.from_arrow(m_bot_a),
+        "bottleneck_pair_b": _pl.from_arrow(m_bot_b),
+    })
+    return ClusterFrames(assignments=assignments, metadata=metadata)
+
+
+def metadata_height(arrow_array) -> int:
+    """Tiny helper -- get row count from a PyArrow ArrayData/Array
+    without materializing the values. Used for the ``quality`` column
+    construction in ``build_clusters_arrow_native``."""
+    # PyArrow arrays expose ``__len__``.
+    return len(arrow_array)

--- a/packages/python/goldenmatch/tests/test_build_clusters_arrow_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_build_clusters_arrow_native_parity.py
@@ -1,0 +1,164 @@
+"""Phase 3 (Rust): ``build_clusters_arrow_native`` matches
+``build_clusters_v2_columnar`` on the canonical partition.
+
+GH issue #625 (Arrow-native roadmap Phase 3).
+
+The Arrow kernel must produce the same cluster partition (member ->
+co-members mapping) as the legacy dict-shaped builder. Cluster_id
+numbering and metadata field values (confidence, oversized, etc.)
+must also match.
+
+Skipped when ``goldenmatch._native`` isn't built or doesn't yet
+expose ``build_clusters_arrow``.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+native = pytest.importorskip("goldenmatch._native")
+if not hasattr(native, "build_clusters_arrow"):
+    pytest.skip(
+        "native module loaded but build_clusters_arrow not exposed; "
+        "Rust kernel needs to be rebuilt against the Phase 3 PR.",
+        allow_module_level=True,
+    )
+
+from goldenmatch.core.cluster import (
+    ClusterFrames,
+    build_clusters_arrow_native,
+    build_clusters_v2_columnar,
+)
+from goldenmatch.core.scorer import pairs_list_to_df
+
+
+def _partition_from_frames(frames: ClusterFrames) -> frozenset[frozenset[int]]:
+    if frames.assignments.is_empty():
+        return frozenset()
+    by_cid: dict[int, set[int]] = {}
+    for cid, mid in zip(
+        frames.assignments["cluster_id"].to_list(),
+        frames.assignments["member_id"].to_list(),
+        strict=True,
+    ):
+        by_cid.setdefault(int(cid), set()).add(int(mid))
+    return frozenset(frozenset(members) for members in by_cid.values())
+
+
+class TestPartitionParity:
+    def test_simple_clusters_partition_matches_legacy(self):
+        pairs = [(1, 2, 0.95), (2, 3, 0.92), (5, 6, 0.88)]
+        all_ids = [1, 2, 3, 4, 5, 6, 7]
+        df = pairs_list_to_df(pairs)
+
+        rust = build_clusters_arrow_native(df, all_ids=all_ids)
+        legacy = build_clusters_v2_columnar(df, all_ids=all_ids)
+
+        # Same partition (members co-grouped identically). Cluster IDs
+        # may differ in absolute numbering -- compare via the partition
+        # equivalence relation.
+        assert _partition_from_frames(rust) == _partition_from_frames(legacy)
+
+    def test_no_pairs_emits_singletons(self):
+        df = pairs_list_to_df([])
+        all_ids = [1, 2, 3]
+        rust = build_clusters_arrow_native(df, all_ids=all_ids)
+        legacy = build_clusters_v2_columnar(df, all_ids=all_ids)
+        assert _partition_from_frames(rust) == _partition_from_frames(legacy)
+        # Singletons: each id its own cluster.
+        assert _partition_from_frames(rust) == frozenset({
+            frozenset({1}), frozenset({2}), frozenset({3}),
+        })
+
+    def test_transitive_closure(self):
+        """1-2 and 2-3 should put {1,2,3} in the same cluster."""
+        pairs = [(1, 2, 0.9), (2, 3, 0.85)]
+        df = pairs_list_to_df(pairs)
+        rust = build_clusters_arrow_native(df, all_ids=[1, 2, 3])
+        partition = _partition_from_frames(rust)
+        assert partition == frozenset({frozenset({1, 2, 3})})
+
+
+class TestMetadata:
+    def test_size_matches_member_count(self):
+        pairs = [(1, 2, 0.9), (2, 3, 0.85), (5, 6, 0.95)]
+        df = pairs_list_to_df(pairs)
+        rust = build_clusters_arrow_native(df, all_ids=[1, 2, 3, 4, 5, 6])
+        # Per cluster, metadata.size must equal the row count in
+        # assignments for that cluster_id.
+        meta_size = dict(zip(
+            rust.metadata["cluster_id"].to_list(),
+            rust.metadata["size"].to_list(),
+            strict=True,
+        ))
+        actual_size = (
+            rust.assignments
+            .group_by("cluster_id")
+            .agg(pl.len().alias("n"))
+        )
+        for cid, n in zip(
+            actual_size["cluster_id"].to_list(),
+            actual_size["n"].to_list(),
+            strict=True,
+        ):
+            assert meta_size[int(cid)] == int(n)
+
+    def test_oversized_flag(self):
+        # 5 members in one cluster; max_cluster_size=3 -> oversized.
+        pairs = [(1, 2, 0.9), (2, 3, 0.9), (3, 4, 0.9), (4, 5, 0.9)]
+        df = pairs_list_to_df(pairs)
+        rust = build_clusters_arrow_native(
+            df, all_ids=[1, 2, 3, 4, 5], max_cluster_size=3,
+        )
+        # Find the cluster with size > 3 and verify it's flagged.
+        for cid, size, oversized in zip(
+            rust.metadata["cluster_id"].to_list(),
+            rust.metadata["size"].to_list(),
+            rust.metadata["oversized"].to_list(),
+            strict=True,
+        ):
+            if size > 3:
+                assert oversized, f"cluster {cid} size {size} not marked oversized"
+            else:
+                assert not oversized
+
+    def test_confidence_present(self):
+        """Multi-member clusters should have a non-zero confidence
+        value (the actual algorithm: 0.4*min + 0.3*avg + 0.3*conn)."""
+        pairs = [(1, 2, 0.95), (2, 3, 0.92), (1, 3, 0.90)]
+        df = pairs_list_to_df(pairs)
+        rust = build_clusters_arrow_native(df, all_ids=[1, 2, 3])
+        # All members in one cluster, fully connected triangle.
+        # confidence should be > 0.
+        for size, conf in zip(
+            rust.metadata["size"].to_list(),
+            rust.metadata["confidence"].to_list(),
+            strict=True,
+        ):
+            if size > 1:
+                assert conf > 0.0, (
+                    f"multi-member cluster has zero confidence: size={size}"
+                )
+
+
+class TestClusterFramesContract:
+    def test_returns_cluster_frames(self):
+        df = pairs_list_to_df([(1, 2, 0.9)])
+        rust = build_clusters_arrow_native(df, all_ids=[1, 2])
+        assert isinstance(rust, ClusterFrames)
+
+    def test_schemas(self):
+        df = pairs_list_to_df([(1, 2, 0.9)])
+        rust = build_clusters_arrow_native(df, all_ids=[1, 2])
+        assert set(rust.assignments.columns) == {"cluster_id", "member_id"}
+        assert set(rust.metadata.columns) == {
+            "cluster_id", "size", "confidence", "quality",
+            "oversized", "bottleneck_pair_a", "bottleneck_pair_b",
+        }
+
+    def test_empty_input(self):
+        """Empty pair stream + empty all_ids -> empty frames."""
+        df = pairs_list_to_df([])
+        rust = build_clusters_arrow_native(df, all_ids=[])
+        assert rust.assignments.is_empty()
+        assert rust.metadata.is_empty()

--- a/packages/rust/extensions/native/src/cluster.rs
+++ b/packages/rust/extensions/native/src/cluster.rs
@@ -2,6 +2,10 @@
 //! in `goldenmatch/core/cluster.py`.
 use std::collections::{HashMap, HashSet};
 
+use arrow::array::{Array, ArrayData, BooleanArray, Float64Array, Int64Array};
+use arrow::datatypes::DataType;
+use arrow::pyarrow::PyArrowType;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 /// `(min_edge, avg_edge, connectivity, bottleneck_pair, confidence)` — mirrors
@@ -275,4 +279,191 @@ pub fn build_clusters_native<'py>(
     }
 
     Ok(out)
+}
+
+/// Type alias for the Arrow build_clusters_arrow result tuple. Eight
+/// PyArrowType<ArrayData> fields keep clippy::type_complexity quiet.
+type BuildClustersArrowResult = (
+    PyArrowType<ArrayData>, // assignments.cluster_id
+    PyArrowType<ArrayData>, // assignments.member_id
+    PyArrowType<ArrayData>, // metadata.cluster_id
+    PyArrowType<ArrayData>, // metadata.size
+    PyArrowType<ArrayData>, // metadata.confidence
+    PyArrowType<ArrayData>, // metadata.oversized
+    PyArrowType<ArrayData>, // metadata.bottleneck_pair_a
+    PyArrowType<ArrayData>, // metadata.bottleneck_pair_b
+);
+
+/// Arrow-native roadmap Phase 3 (#625): `build_clusters` over Arrow
+/// pair arrays. Emits two ClusterFrames-shaped Arrow buffer sets:
+/// assignments (cluster_id, member_id) and metadata (cluster_id,
+/// size, confidence, oversized, bottleneck_pair_a, bottleneck_pair_b).
+///
+/// Reuses the existing find() helper + same Union-Find pattern as
+/// `build_clusters_native` (1-based cluster ids, sorted by
+/// min(member)). Confidence + bottleneck via `cluster_confidence`.
+/// Cluster quality and auto-split logic are NOT in this kernel --
+/// callers wrap and post-process for those (matches the Phase 2a
+/// ClusterFrames shape which has a fixed `quality="strong"` until the
+/// downstream weak-cluster downgrade fires).
+///
+/// Output shape matches the Phase 2a ClusterFrames spec exactly so
+/// the Python wrapper just hands the arrays to pl.DataFrame.
+#[pyfunction]
+pub fn build_clusters_arrow(
+    id_a: PyArrowType<ArrayData>,
+    id_b: PyArrowType<ArrayData>,
+    score: PyArrowType<ArrayData>,
+    all_ids: PyArrowType<ArrayData>,
+    max_cluster_size: usize,
+) -> PyResult<BuildClustersArrowResult> {
+    // ---- Type validation. -------------------------------------------------
+    let id_a_data = id_a.0;
+    let id_b_data = id_b.0;
+    let score_data = score.0;
+    let all_ids_data = all_ids.0;
+    for (name, dt, expected) in [
+        ("id_a", id_a_data.data_type(), DataType::Int64),
+        ("id_b", id_b_data.data_type(), DataType::Int64),
+        ("score", score_data.data_type(), DataType::Float64),
+        ("all_ids", all_ids_data.data_type(), DataType::Int64),
+    ] {
+        if dt != &expected {
+            return Err(PyValueError::new_err(format!(
+                "build_clusters_arrow: column {name:?} must be {expected:?}, got {dt:?}"
+            )));
+        }
+    }
+    let id_a = Int64Array::from(id_a_data);
+    let id_b = Int64Array::from(id_b_data);
+    let score = Float64Array::from(score_data);
+    let all_ids = Int64Array::from(all_ids_data);
+
+    let n_pairs = id_a.len();
+    if id_b.len() != n_pairs || score.len() != n_pairs {
+        return Err(PyValueError::new_err(format!(
+            "build_clusters_arrow: pair-stream column lengths differ -- \
+             id_a={}, id_b={}, score={}",
+            n_pairs, id_b.len(), score.len(),
+        )));
+    }
+
+    // ---- Union-Find on Arrow ids (same algorithm as build_clusters_native). -
+    let mut parent: HashMap<i64, i64> = HashMap::with_capacity(
+        all_ids.len() + n_pairs * 2,
+    );
+    for i in 0..all_ids.len() {
+        if !all_ids.is_null(i) {
+            let id = all_ids.value(i);
+            parent.entry(id).or_insert(id);
+        }
+    }
+    for i in 0..n_pairs {
+        let a = id_a.value(i);
+        let b = id_b.value(i);
+        parent.entry(a).or_insert(a);
+        parent.entry(b).or_insert(b);
+    }
+    for i in 0..n_pairs {
+        let a = id_a.value(i);
+        let b = id_b.value(i);
+        let ra = find(&mut parent, a);
+        let rb = find(&mut parent, b);
+        if ra != rb {
+            parent.insert(ra, rb);
+        }
+    }
+
+    // ---- Group + 1-based cluster_id assignment by sort-by-min-member. -------
+    let keys: Vec<i64> = parent.keys().copied().collect();
+    let mut root_to_members: HashMap<i64, Vec<i64>> = HashMap::new();
+    for k in keys {
+        let r = find(&mut parent, k);
+        root_to_members.entry(r).or_default().push(k);
+    }
+    let mut clusters: Vec<Vec<i64>> = root_to_members.into_values().collect();
+    clusters.sort_by_key(|c| *c.iter().min().expect("non-empty by construction"));
+
+    let mut member_to_cid: HashMap<i64, i64> =
+        HashMap::with_capacity(parent.len());
+    for (idx, members) in clusters.iter().enumerate() {
+        let cid = (idx + 1) as i64;
+        for &m in members {
+            member_to_cid.insert(m, cid);
+        }
+    }
+
+    // ---- Bucket input edges per cluster (preserve input order for confidence
+    //      bottleneck tie-break invariant). -----------------------------------
+    let n_clusters = clusters.len();
+    let mut per_cluster_edges: Vec<Vec<(i64, i64, f64)>> = vec![Vec::new(); n_clusters];
+    for i in 0..n_pairs {
+        let a = id_a.value(i);
+        let s = score.value(i);
+        if let Some(&cid) = member_to_cid.get(&a) {
+            // cid is 1-based; per_cluster_edges is 0-indexed.
+            per_cluster_edges[(cid - 1) as usize].push((a, id_b.value(i), s));
+        }
+    }
+
+    // ---- Assemble Arrow output arrays. --------------------------------------
+    // Assignments: long form, one row per (cluster_id, member_id).
+    let total_members: usize = clusters.iter().map(|c| c.len()).sum();
+    let mut a_cid: Vec<i64> = Vec::with_capacity(total_members);
+    let mut a_mid: Vec<i64> = Vec::with_capacity(total_members);
+    for (idx, members) in clusters.iter().enumerate() {
+        let cid = (idx + 1) as i64;
+        for &m in members {
+            a_cid.push(cid);
+            a_mid.push(m);
+        }
+    }
+
+    // Metadata: one row per cluster.
+    let mut m_cid: Vec<i64> = Vec::with_capacity(n_clusters);
+    let mut m_size: Vec<i64> = Vec::with_capacity(n_clusters);
+    let mut m_conf: Vec<f64> = Vec::with_capacity(n_clusters);
+    let mut m_over: Vec<bool> = Vec::with_capacity(n_clusters);
+    let mut m_bot_a: Vec<i64> = Vec::with_capacity(n_clusters);
+    let mut m_bot_b: Vec<i64> = Vec::with_capacity(n_clusters);
+    for (idx, members) in clusters.iter().enumerate() {
+        let cid = (idx + 1) as i64;
+        let size = members.len();
+        let edges = &per_cluster_edges[idx];
+        let (_min_e, _avg_e, _conn, bn, conf) = cluster_confidence(edges.clone(), size);
+        m_cid.push(cid);
+        m_size.push(size as i64);
+        m_conf.push(conf);
+        m_over.push(size > max_cluster_size);
+        match bn {
+            Some((a, b)) => {
+                m_bot_a.push(a);
+                m_bot_b.push(b);
+            }
+            None => {
+                m_bot_a.push(0);
+                m_bot_b.push(0);
+            }
+        }
+    }
+
+    let assignments_cid = Int64Array::from(a_cid);
+    let assignments_mid = Int64Array::from(a_mid);
+    let metadata_cid = Int64Array::from(m_cid);
+    let metadata_size = Int64Array::from(m_size);
+    let metadata_conf = Float64Array::from(m_conf);
+    let metadata_over = BooleanArray::from(m_over);
+    let metadata_bot_a = Int64Array::from(m_bot_a);
+    let metadata_bot_b = Int64Array::from(m_bot_b);
+
+    Ok((
+        PyArrowType(assignments_cid.to_data()),
+        PyArrowType(assignments_mid.to_data()),
+        PyArrowType(metadata_cid.to_data()),
+        PyArrowType(metadata_size.to_data()),
+        PyArrowType(metadata_conf.to_data()),
+        PyArrowType(metadata_over.to_data()),
+        PyArrowType(metadata_bot_a.to_data()),
+        PyArrowType(metadata_bot_b.to_data()),
+    ))
 }

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -20,6 +20,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cluster::severe_bridge_count, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::cluster_confidence, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::build_clusters_native, m)?)?;
+    m.add_function(wrap_pyfunction!(cluster::build_clusters_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::canonicalize_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::dedup_pairs_max_score, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::dedup_pairs_arrow, m)?)?;


### PR DESCRIPTION
Third Phase 3 Rust Arrow kernel. Union-Find over Arrow pair arrays + all_ids; emits ClusterFrames-shaped output as eight Arrow buffers. Bypasses per-cluster PyDict construction that capped build_clusters_native at 1.09x. v1: confidence + oversized; auto_split + cluster_quality downgrade stay in the Python wrapper layer.