### PR TITLE
perf(cluster): one-pass pair partition + itemgetter keys in oversized-split path

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import operator
 import os
 import uuid
 from collections import defaultdict
@@ -137,7 +138,10 @@ def _build_mst(
 ) -> list[tuple[int, int, float]]:
     """Build max-weight spanning tree using Kruskal's algorithm."""
     edges = [(a, b, s) for (a, b), s in pair_scores.items()]
-    edges.sort(key=lambda e: e[2], reverse=True)
+    # operator.itemgetter(2) is a C-level key extractor; the equivalent
+    # `lambda e: e[2]` invokes a Python frame per comparison-key fetch and
+    # showed up as a hotspot in the profile-hotspots cProfile run.
+    edges.sort(key=operator.itemgetter(2), reverse=True)
     uf = UnionFind()
     uf.add_many(members)
     mst: list[tuple[int, int, float]] = []
@@ -171,11 +175,30 @@ def split_oversized_cluster(
     for a, b, _s in remaining:
         uf.union(a, b)
 
+    subclusters = uf.get_clusters()
+    # Partition pair_scores across the post-split subclusters in a SINGLE
+    # pass. The previous shape rebuilt each subcluster's pair dict with a
+    # comprehension that re-scanned the FULL pair_scores per subcluster
+    # (O(pairs * subclusters)); on dense oversized clusters that was a
+    # measured hotspot. A member -> subcluster-index map lets us bucket
+    # each pair exactly once (O(pairs)). A pair whose endpoints landed in
+    # different subclusters (the removed weakest edge, plus any cross-cut
+    # edge) belongs to neither bucket -- identical to the old `a in
+    # sc_members and b in sc_members` filter.
+    member_to_sub: dict[int, int] = {}
+    for idx, sc_members in enumerate(subclusters):
+        for m in sc_members:
+            member_to_sub[m] = idx
+    sub_pairs: list[dict[tuple[int, int], float]] = [{} for _ in subclusters]
+    for (a, b), s in pair_scores.items():
+        ia = member_to_sub.get(a)
+        if ia is not None and ia == member_to_sub.get(b):
+            sub_pairs[ia][(a, b)] = s
+
     result = []
-    for sc_members in uf.get_clusters():
+    for idx, sc_members in enumerate(subclusters):
         sc_list = sorted(sc_members)
-        sc_pairs = {(a, b): s for (a, b), s in pair_scores.items()
-                    if a in sc_members and b in sc_members}
+        sc_pairs = sub_pairs[idx]
         size = len(sc_list)
         conf = compute_cluster_confidence(sc_pairs, size)
         result.append({
@@ -526,7 +549,11 @@ def compute_cluster_confidence(
     avg_edge = sum(scores) / len(scores)
     max_possible_edges = size * (size - 1) / 2
     connectivity = len(pair_scores) / max_possible_edges if max_possible_edges > 0 else 0.0
-    bottleneck_pair = min(pair_scores, key=lambda p: pair_scores[p])
+    # `min(pair_scores, key=lambda p: pair_scores[p])` invoked a Python lambda
+    # AND a dict lookup per pair (a profiled hotspot at ~2.9M lambda calls).
+    # Scanning items() with a C-level itemgetter key avoids both; ties resolve
+    # to the same first-minimum key because items() preserves dict order.
+    bottleneck_pair = min(pair_scores.items(), key=operator.itemgetter(1))[0]
 
     # Weighted confidence: weakest link matters most
     confidence = 0.4 * min_edge + 0.3 * avg_edge + 0.3 * connectivity

--- a/packages/python/goldenmatch/tests/test_cluster.py
+++ b/packages/python/goldenmatch/tests/test_cluster.py
@@ -189,6 +189,30 @@ def test_split_chain():
     assert {2, 3} in member_sets
 
 
+def test_split_partitions_pair_scores_correctly():
+    """After splitting, each subcluster keeps EVERY original pair whose two
+    endpoints landed in that subcluster -- including non-MST edges -- and the
+    cut edge appears in no subcluster. Locks the one-pass partition refactor
+    (member -> subcluster map) against the old per-subcluster rescan."""
+    # Triangle {0,1,2} (dense) + weak bridge 2-3. MST keeps 0-1, 1-2, 2-3;
+    # weakest MST edge 2-3 (0.3) is removed -> {0,1,2} and {3}. The non-MST
+    # edge 0-2 (0.85) is WITHIN {0,1,2} and must be retained.
+    pair_scores = {(0, 1): 0.9, (0, 2): 0.85, (1, 2): 0.88, (2, 3): 0.3}
+    result = split_oversized_cluster([0, 1, 2, 3], pair_scores)
+
+    by_members = {frozenset(c["members"]): c for c in result}
+    assert set(by_members) == {frozenset({0, 1, 2}), frozenset({3})}
+
+    triangle = by_members[frozenset({0, 1, 2})]
+    # All three intra-subcluster edges retained (incl. the non-MST 0-2).
+    assert set(triangle["pair_scores"]) == {(0, 1), (0, 2), (1, 2)}
+    # The removed cross-cut edge is dropped from every subcluster.
+    assert all((2, 3) not in c["pair_scores"] for c in result)
+    # bottleneck is the weakest intra-subcluster edge (0,2)=0.85.
+    assert triangle["bottleneck_pair"] == (0, 2)
+    assert by_members[frozenset({3})]["pair_scores"] == {}
+
+
 def test_was_split_not_in_output():
     """_was_split sentinel must not leak into final cluster dicts."""
     pairs = [(0, 1, 0.9), (1, 2, 0.5), (2, 3, 0.8)]


### PR DESCRIPTION
## Summary

Follow-up to #647, completing its open test-plan item ("re-dispatch profile-hotspots to identify the new top hotspot"). I re-ran the `profile-hotspots` harness (100K columnar, cProfile) against post-#647 `main`. With the `pairs_df_to_list` conversion already optimized, `build_clusters_columnar`'s next addressable Python cost is the **oversized-cluster split path** — `split_oversized_cluster` → `_build_mst`, plus `compute_cluster_confidence`'s per-pair bottleneck scan. (`score_blocks_columnar`'s remaining time is rapidfuzz thread-wait — real parallel work, not Python-addressable.)

Three behavior-preserving changes in `core/cluster.py`:

1. **`split_oversized_cluster` — O(pairs × subclusters) → O(pairs).** It rebuilt each subcluster's `pair_scores` with a comprehension that re-scanned the **full** `pair_scores` once *per subcluster*. A `member → subcluster-index` map buckets every pair exactly once. Cross-cut edges (the removed weakest MST edge + any other) land in no bucket — identical to the old `a in sc_members and b in sc_members` filter.
2. **`compute_cluster_confidence` bottleneck scan.** `min(pair_scores, key=lambda p: pair_scores[p])` invoked a Python lambda **and** a dict lookup per pair (~2.9M lambda calls in the profile). `min(pair_scores.items(), key=operator.itemgetter(1))[0]` is C-level and drops the lookup; ties resolve identically (`items()` preserves dict order, `min` returns the first minimum).
3. **`_build_mst`** edge-sort key lambda → `operator.itemgetter(2)`.

## Measurements (100K `realistic_person`)

| metric | main | this PR |
|---|---:|---:|
| `build_clusters_columnar` median wall, no profiler (median of 7) | 4415 ms | **4168 ms (~6%)** |
| `build_clusters_columnar` cumtime, cProfile | 11.66 s | **8.73 s** |
| `compute_cluster_confidence` | top-10 hotspot | dropped out of top-10 |

cProfile shows a larger drop because it amplifies the Python-call overhead removed here; the residual wall is C-bound Union-Find + dict work this change doesn't touch. Relative gain grows with subcluster count and pair-density per oversized cluster. The native `compute_cluster_confidence` path is unchanged.

## Test plan

- [x] New `test_split_partitions_pair_scores_correctly` locks the partition: non-MST intra-subcluster edges retained, cut edge dropped, `bottleneck_pair` unchanged
- [x] 24 cluster + 53 columnar-parity tests pass
- [x] ruff clean
- [x] Full goldenmatch suite: 3360 passed / 0 failed (CI-faithful local run)
- [ ] Re-dispatch `profile-hotspots` post-merge to confirm the cumtime shift at 1M and surface the next hotspot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiKj934B5YrmFGUMoMVok5)_