### PR TITLE
perf(cluster): native Rust kernel for the MST oversized-split path

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -162,33 +162,34 @@ def split_oversized_cluster(
         return [{"members": sorted(members), "size": len(members),
                  "oversized": False, "pair_scores": pair_scores}]
 
-    if native_enabled("clustering"):
+    if native_enabled("clustering"):  # pragma: no cover - exercised by the native CI lane (test_native_parity), not the no-ext python lane
         # Native kernel does MST (Kruskal) + weakest-edge removal + re-union
         # and returns the post-split subcluster member lists. Edges are passed
         # in pair_scores iteration order so the native stable score-desc sort
         # and first-minimum tie-break reproduce the Python path exactly. An
-        # empty return means the MST was empty -> unsplittable (mirrors the
-        # pure-Python `if not mst` early return below).
+        # empty return means the MST was empty -> unsplittable (handled by the
+        # shared guard below, mirroring the pure-Python `if not mst`).
         edges = [(a, b, s) for (a, b), s in pair_scores.items()]
         subclusters: list = native_module().mst_split_components(members, edges)
-        if not subclusters:
-            return [{"members": sorted(members), "size": len(members),
-                     "oversized": False, "pair_scores": pair_scores}]
     else:
         mst = _build_mst(members, pair_scores)
         if not mst:
-            return [{"members": sorted(members), "size": len(members),
-                     "oversized": False, "pair_scores": pair_scores}]
+            subclusters = []
+        else:
+            weakest = min(mst, key=lambda e: e[2])
+            remaining = [(a, b, s) for a, b, s in mst if (a, b, s) != weakest]
 
-        weakest = min(mst, key=lambda e: e[2])
-        remaining = [(a, b, s) for a, b, s in mst if (a, b, s) != weakest]
+            uf = UnionFind()
+            uf.add_many(members)
+            for a, b, _s in remaining:
+                uf.union(a, b)
 
-        uf = UnionFind()
-        uf.add_many(members)
-        for a, b, _s in remaining:
-            uf.union(a, b)
+            subclusters = uf.get_clusters()
 
-        subclusters = uf.get_clusters()
+    if not subclusters:
+        # Native MST empty or Python cluster unsplittable -> leave intact.
+        return [{"members": sorted(members), "size": len(members),
+                 "oversized": False, "pair_scores": pair_scores}]
     # Partition pair_scores across the post-split subclusters in a SINGLE
     # pass. The previous shape rebuilt each subcluster's pair dict with a
     # comprehension that re-scanned the FULL pair_scores per subcluster

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -162,20 +162,33 @@ def split_oversized_cluster(
         return [{"members": sorted(members), "size": len(members),
                  "oversized": False, "pair_scores": pair_scores}]
 
-    mst = _build_mst(members, pair_scores)
-    if not mst:
-        return [{"members": sorted(members), "size": len(members),
-                 "oversized": False, "pair_scores": pair_scores}]
+    if native_enabled("clustering"):
+        # Native kernel does MST (Kruskal) + weakest-edge removal + re-union
+        # and returns the post-split subcluster member lists. Edges are passed
+        # in pair_scores iteration order so the native stable score-desc sort
+        # and first-minimum tie-break reproduce the Python path exactly. An
+        # empty return means the MST was empty -> unsplittable (mirrors the
+        # pure-Python `if not mst` early return below).
+        edges = [(a, b, s) for (a, b), s in pair_scores.items()]
+        subclusters: list = native_module().mst_split_components(members, edges)
+        if not subclusters:
+            return [{"members": sorted(members), "size": len(members),
+                     "oversized": False, "pair_scores": pair_scores}]
+    else:
+        mst = _build_mst(members, pair_scores)
+        if not mst:
+            return [{"members": sorted(members), "size": len(members),
+                     "oversized": False, "pair_scores": pair_scores}]
 
-    weakest = min(mst, key=lambda e: e[2])
-    remaining = [(a, b, s) for a, b, s in mst if (a, b, s) != weakest]
+        weakest = min(mst, key=lambda e: e[2])
+        remaining = [(a, b, s) for a, b, s in mst if (a, b, s) != weakest]
 
-    uf = UnionFind()
-    uf.add_many(members)
-    for a, b, _s in remaining:
-        uf.union(a, b)
+        uf = UnionFind()
+        uf.add_many(members)
+        for a, b, _s in remaining:
+            uf.union(a, b)
 
-    subclusters = uf.get_clusters()
+        subclusters = uf.get_clusters()
     # Partition pair_scores across the post-split subclusters in a SINGLE
     # pass. The previous shape rebuilt each subcluster's pair dict with a
     # comprehension that re-scanned the FULL pair_scores per subcluster

--- a/packages/python/goldenmatch/tests/test_cluster.py
+++ b/packages/python/goldenmatch/tests/test_cluster.py
@@ -61,7 +61,10 @@ class TestBuildClusters:
         assert len(result) == 2
         # Find the cluster containing member 1
         cluster_with_1 = [c for c in result.values() if 1 in c["members"]][0]
-        assert cluster_with_1["members"] == [1, 2, 3]
+        # Member ORDER is not a contract (build_clusters keeps whatever order
+        # the UF kernel returns -- Python dict-insertion vs native hash order
+        # differ; see the v34 note in cluster.py). Assert membership only.
+        assert sorted(cluster_with_1["members"]) == [1, 2, 3]
         assert cluster_with_1["size"] == 3
         assert cluster_with_1["oversized"] is False
         # pair_scores should contain the pairs
@@ -102,13 +105,15 @@ class TestBuildClusters:
         assert cluster["pair_scores"][(10, 20)] == 0.85
         assert cluster["pair_scores"][(20, 30)] == 0.77
 
-    def test_members_sorted(self):
-        """Members list is sorted."""
+    def test_members_complete(self):
+        """A cluster contains exactly its connected members (order-agnostic:
+        build_clusters does not guarantee member order -- native hash order vs
+        Python insertion order differ; readers treat members as a set)."""
         pairs = [(5, 3, 0.9), (3, 1, 0.9)]
         all_ids = [5, 3, 1]
         result = build_clusters(pairs, all_ids)
         cluster_with_all = [c for c in result.values() if c["size"] == 3][0]
-        assert cluster_with_all["members"] == [1, 3, 5]
+        assert sorted(cluster_with_all["members"]) == [1, 3, 5]
 
 
 def test_auto_split_oversized():

--- a/packages/python/goldenmatch/tests/test_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_parity.py
@@ -571,3 +571,50 @@ def test_auto_uses_native_only_for_gated_components(monkeypatch):
 def test_native_required_mode_uses_native(monkeypatch):
     monkeypatch.setenv("GOLDENMATCH_NATIVE", "1")
     assert _native_loader.native_enabled("clustering") is True
+
+
+# --- split_oversized_cluster (native mst_split_components kernel) parity ---
+
+# (members, pair_scores) fixtures: clean chain, tie-scored weakest edges
+# (stresses the first-minimum tie-break), dense clique with a non-MST intra
+# edge that must survive the split, and a star.
+_SPLIT_FIXTURES = [
+    ([0, 1, 2, 3], {(0, 1): 0.9, (1, 2): 0.5, (2, 3): 0.8}),
+    ([0, 1, 2, 3], {(0, 1): 0.9, (0, 2): 0.85, (1, 2): 0.88, (2, 3): 0.3}),
+    # Multiple MST edges tie at the minimum score -> tie-break must match.
+    ([0, 1, 2, 3, 4], {(0, 1): 0.7, (1, 2): 0.7, (2, 3): 0.7, (3, 4): 0.9}),
+    # Two dense triangles bridged by one weak edge.
+    (
+        [0, 1, 2, 3, 4, 5],
+        {(0, 1): 0.95, (0, 2): 0.92, (1, 2): 0.9, (3, 4): 0.95,
+         (3, 5): 0.92, (4, 5): 0.9, (2, 3): 0.4},
+    ),
+    ([0, 1, 2, 3, 4], {(0, i): 0.8 for i in range(1, 5)}),  # star
+]
+
+
+def _normalize_split(result: list) -> dict:
+    """Key subclusters by member set so native/Python ordering is irrelevant;
+    value carries the fields the split must preserve identically."""
+    return {
+        frozenset(c["members"]): (
+            c["size"],
+            c["oversized"],
+            tuple(sorted(c["pair_scores"].items())),
+            c.get("bottleneck_pair"),
+            c.get("confidence"),
+        )
+        for c in result
+    }
+
+
+@pytest.mark.parametrize("members,pair_scores", _SPLIT_FIXTURES)
+def test_split_oversized_cluster_parity(monkeypatch, members, pair_scores):
+    from goldenmatch.core.cluster import split_oversized_cluster
+
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    py = split_oversized_cluster(list(members), dict(pair_scores))
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "1")
+    native = split_oversized_cluster(list(members), dict(pair_scores))
+
+    assert _normalize_split(py) == _normalize_split(native)

--- a/packages/rust/extensions/native/src/cluster.rs
+++ b/packages/rust/extensions/native/src/cluster.rs
@@ -68,6 +68,85 @@ pub fn connected_components(
     groups.into_values().collect()
 }
 
+/// Max-weight spanning tree (Kruskal), then drop the single weakest MST edge
+/// and return the resulting components. Behavior-exact mirror of `_build_mst`
+/// + weakest-edge removal + re-union + `get_clusters` in cluster.py's
+/// `split_oversized_cluster`.
+///
+/// `edges` MUST arrive in `pair_scores` iteration order: the stable
+/// score-descending sort then reproduces Python's Kruskal edge selection, and
+/// the first-minimum scan reproduces `min(mst, key=score)`'s tie-break
+/// (Python `min` keeps the first element achieving the minimum). Component
+/// membership is independent of union strategy, so naive union here matches
+/// the Python union-by-rank grouping. Returns `[]` when the MST is empty
+/// (caller treats that as "unsplittable", same as Python's `if not mst`).
+#[pyfunction]
+pub fn mst_split_components(
+    members: Vec<i64>,
+    edges: Vec<(i64, i64, f64)>,
+) -> Vec<Vec<i64>> {
+    // Kruskal over a max-weight ordering. Vec::sort_by is stable, so equal
+    // scores keep pair_scores insertion order -- matching Python's stable sort.
+    let mut sorted = edges;
+    sorted.sort_by(|a, b| {
+        b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let need = members.len().saturating_sub(1);
+    let mut parent: HashMap<i64, i64> = HashMap::with_capacity(members.len());
+    for &m in &members {
+        parent.entry(m).or_insert(m);
+    }
+    let mut mst: Vec<(i64, i64, f64)> = Vec::with_capacity(need);
+    for &(a, b, s) in &sorted {
+        let ra = find(&mut parent, a);
+        let rb = find(&mut parent, b);
+        if ra != rb {
+            parent.insert(ra, rb);
+            mst.push((a, b, s));
+            if mst.len() == need {
+                break;
+            }
+        }
+    }
+    if mst.is_empty() {
+        return Vec::new();
+    }
+
+    // weakest = first MST edge achieving the minimum score (strict `<` keeps
+    // the first on ties, mirroring Python `min`).
+    let mut weakest = 0usize;
+    for i in 1..mst.len() {
+        if mst[i].2 < mst[weakest].2 {
+            weakest = i;
+        }
+    }
+
+    // Re-union every MST edge except the weakest, over the full member set, so
+    // isolated members surface as singleton components (mirrors add_many).
+    let mut parent2: HashMap<i64, i64> = HashMap::with_capacity(members.len());
+    for &m in &members {
+        parent2.entry(m).or_insert(m);
+    }
+    for (i, &(a, b, _s)) in mst.iter().enumerate() {
+        if i == weakest {
+            continue;
+        }
+        let ra = find(&mut parent2, a);
+        let rb = find(&mut parent2, b);
+        if ra != rb {
+            parent2.insert(ra, rb);
+        }
+    }
+    let keys: Vec<i64> = parent2.keys().copied().collect();
+    let mut groups: HashMap<i64, Vec<i64>> = HashMap::new();
+    for k in keys {
+        let r = find(&mut parent2, k);
+        groups.entry(r).or_default().push(k);
+    }
+    groups.into_values().collect()
+}
+
 /// Count edges whose removal splits the cluster into two >= 2-node components
 /// (the "merged by one weak link" pathology). Behavior-exact mirror of
 /// `_severe_bridge_count` in cluster.py:168-200. `edges` are the cluster's

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -17,6 +17,7 @@ mod score;
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_function(wrap_pyfunction!(cluster::connected_components, m)?)?;
+    m.add_function(wrap_pyfunction!(cluster::mst_split_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::severe_bridge_count, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::cluster_confidence, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::build_clusters_native, m)?)?;


### PR DESCRIPTION
## Summary

Follow-up to #647/#648, continuing the hotspot loop. After #648 the cluster path is at its pure-Python floor; the remaining **always-pure-Python** hotspot is `split_oversized_cluster` → `_build_mst` (Kruskal sort + Union-Find), which has no native kernel even when `goldenmatch._native` is built (`connected_components`/`cluster_confidence` already do).

Adds `cluster::mst_split_components` to the native crate: max-weight spanning tree (Kruskal) → drop the single weakest MST edge → re-union the rest → return the components. `split_oversized_cluster` calls it under `native_enabled("clustering")` and keeps the pure-Python path as the fallback; the O(pairs) `pair_scores` partition + confidence tail from #648 is shared by both paths.

## Behavior-exact parity

- Edges are passed in `pair_scores` iteration order, so the native **stable** score-descending sort reproduces Python's Kruskal edge selection.
- The first-minimum scan reproduces `min(mst, key=score)`'s tie-break (Python `min` keeps the first element achieving the minimum).
- Component membership is independent of union strategy, so naive union in Rust matches the Python union-by-rank grouping (same invariant `connected_components` already relies on).
- An empty MST returns `[]` → caller treats it as unsplittable, mirroring the pure-Python `if not mst` early return.

## Test plan

- [x] `tests/test_native_parity.py` gains 5 `split_oversized_cluster` fixtures (chain, non-MST intra edge, **tie-scored weakest edges**, bridged triangles, star) asserting native == Python on member partition, per-subcluster `pair_scores`, `bottleneck_pair`, and `confidence`.
- [x] Full goldenmatch suite **3360 passed / 0 failed** with the ext absent (the `python (goldenmatch)` lane).
- [x] `test_native_parity.py` **66 passed** with the ext built (the `native` lane's target).
- [x] `cargo clippy` clean on the native crate (pinned 1.94.1 toolchain).
- [ ] Re-dispatch `profile-hotspots` post-merge with the ext built to quantify the split-path cumtime drop at 1M.

## Notes

- Pure-Python default is unchanged; native runs only when the ext is importable and `clustering` is gated on (it is).
- Two `build_clusters` unit tests that asserted a specific member **order** are made order-agnostic — member order is not a contract (native hash order vs Python insertion order differ; see the v34 note in `cluster.py`), so the cluster suite no longer falsely fails when the ext is built locally.
- Out of scope (flagged, not fixed here): with the ext built, `test_native_cluster_orchestration_parity` / `test_native_field_matrix_parity` / `test_native_bulk_fingerprint_parity` show pre-existing native-vs-Python drift in the `cluster_confidence` / `field_matrix` / `fingerprint` kernels (unrelated to this change; those files aren't in the `native` lane's run list). Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiKj934B5YrmFGUMoMVok5)_