### PR TITLE
fix(native-parity): correct cluster-confidence + soundex/exact parity tests, add hashing key-type guard

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/_hashing.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_hashing.py
@@ -59,6 +59,15 @@ def _value_bytes(name: str, value: Any) -> bytes:
 
 def _fingerprint_py(record: dict[str, Any]) -> str:
     """Pure-Python reference implementation of canonicalization v1."""
+    # Validate key types up front so a non-string field name raises the same
+    # TypeError the native kernel does (hash.rs: "record field names must be
+    # strings"). Without this, the `k.startswith("__")` filter below raises a
+    # confusing AttributeError ('int' object has no attribute 'startswith')
+    # and sorting mixed-type keys would also fail -- neither matches the spec'd
+    # contract the native kernel enforces.
+    for k in record:
+        if not isinstance(k, str):
+            raise TypeError("record field names must be strings")
     buf = bytearray()
     for name in sorted(k for k in record if not k.startswith("__")):
         buf += name.encode("utf-8")

--- a/packages/python/goldenmatch/tests/test_native_cluster_orchestration_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_cluster_orchestration_parity.py
@@ -20,6 +20,7 @@ if not hasattr(native, "build_clusters_native"):
     )
 
 from goldenmatch.core.cluster import build_clusters as py_build_clusters
+from goldenmatch.core.cluster import compute_cluster_confidence
 
 
 def _canon_pair_scores(d):
@@ -59,7 +60,22 @@ def _assert_clusters_equal(py_result, rs_result, *, with_quality_fields=False):
         assert _canon_pair_scores(py_info["pair_scores"]) == _canon_pair_scores(
             rs_info["pair_scores"]
         )
-        assert py_info["confidence"] == pytest.approx(rs_info["confidence"], abs=1e-9)
+        # The native kernel subsumes the loop "through compute_cluster_confidence"
+        # (its docstring) -- i.e. RAW confidence. It deliberately does NOT apply
+        # build_clusters' post-hoc weak-cluster confidence downgrade (a separate
+        # Python step that runs after compute_cluster_confidence and only fires
+        # for weak clusters). So compare the kernel against the RAW formula, not
+        # py_build_clusters' (possibly downgraded) value -- otherwise weak-link
+        # inputs falsely diverge (0.494 raw vs 0.3458 downgraded). For non-weak
+        # clusters the two are identical, so existing cases are unaffected.
+        raw_conf = compute_cluster_confidence(
+            dict(rs_info["pair_scores"]), rs_info["size"],
+        )["confidence"]
+        # abs=1e-5: the kernel accumulates the avg_edge sum in f32, so on large
+        # clusters it diverges from Python's f64 sum by a few 1e-6 (same f32
+        # precision class as the field-matrix kernels' 1e-4 band). Tight enough
+        # to catch a real formula divergence, loose enough for f32 rounding.
+        assert rs_info["confidence"] == pytest.approx(raw_conf, abs=1e-5)
         # bottleneck_pair: either ordering valid (Python's min() is "first min wins";
         # the kernel mirrors the same iteration order, but the BOTTLENECK ITSELF
         # has only one canonical answer per cluster).

--- a/packages/python/goldenmatch/tests/test_native_field_matrix_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_field_matrix_parity.py
@@ -60,6 +60,21 @@ def test_native_field_matrix_matches_rapidfuzz(scorer_name: str):
     np.testing.assert_allclose(rs_mat, py_mat, atol=1e-4)
 
 
+def _offdiag(m: np.ndarray) -> np.ndarray:
+    """Zero the diagonal so parity is asserted only on cells the pipeline reads.
+
+    The exact/soundex match matrices diverge ONLY on the diagonal: the native
+    kernel reports self-match = 1.0, while Python's `_exact_score_matrix` only
+    sets 1.0 for hash-groups of size > 1, leaving a singleton value's diagonal
+    at 0.0. That divergence is a documented don't-care -- every consumer
+    extracts pairs via `np.triu(combined, k=1)` (scorer.py), which discards the
+    diagonal before any pair is emitted. Compare the off-diagonal contract.
+    """
+    out = m.astype(np.float64).copy()
+    np.fill_diagonal(out, 0.0)
+    return out
+
+
 def test_native_soundex_matches_jellyfish():
     py_mat = scorer._exact_score_matrix(
         [scorer.jellyfish.soundex(v) if v else None for v in _VALUES]
@@ -67,15 +82,16 @@ def test_native_soundex_matches_jellyfish():
     rs_mat = _native_field_matrix(_VALUES, "soundex_match")
     assert rs_mat is not None
     assert rs_mat.shape == py_mat.shape
-    # soundex is binary 0/1; no tolerance band needed.
-    np.testing.assert_array_equal(rs_mat.astype(np.float64), py_mat)
+    # soundex is binary 0/1; no tolerance band needed. Diagonal excluded
+    # (self-match don't-care; see _offdiag).
+    np.testing.assert_array_equal(_offdiag(rs_mat), _offdiag(py_mat))
 
 
 def test_native_exact_matches_hash_path():
     py_mat = scorer._exact_score_matrix(_VALUES)
     rs_mat = _native_field_matrix(_VALUES, "exact")
     assert rs_mat is not None
-    np.testing.assert_array_equal(rs_mat.astype(np.float64), py_mat)
+    np.testing.assert_array_equal(_offdiag(rs_mat), _offdiag(py_mat))
 
 
 def test_symmetric_self_cdist():


### PR DESCRIPTION
## Summary

Fixes the three `test_native_*_parity.py` files that fail when `goldenmatch._native` is built (surfaced while building the ext for #649). These files aren't in CI's `native` lane run-list, so the mismatches were invisible to CI. **Two are test-baseline bugs (the native kernels are correct); one is a real Python-reference validation gap.**

### 1. `test_native_cluster_orchestration_parity` — confidence (test fix)
The unwired `build_clusters_native` prototype computes **raw** confidence (its docstring: subsumes the loop "through `compute_cluster_confidence`"). The test compared it against full `py_build_clusters`, which applies a **weak-cluster confidence downgrade afterward** (0.494 raw → 0.3458 for the weak-link chain). Now compares the kernel against raw `compute_cluster_confidence`, with `abs=1e-5` tolerance (the kernel sums `avg_edge` in f32, so large clusters diverge by a few 1e-6 — same precision class as the field-matrix kernels' existing `1e-4` band). Non-weak clusters are unaffected.

### 2. `test_native_field_matrix_parity` — soundex + exact (test fix)
Native and Python agree on **every off-diagonal cell**; they differ only on the **diagonal** — native reports self-match `1.0`, while `_exact_score_matrix` leaves a *singleton* value's diagonal at `0.0` (it sets `1.0` only for hash-groups > 1). That cell is a documented don't-care: every consumer extracts pairs via `np.triu(combined, k=1)` (scorer.py), zeroing the diagonal before emitting. Now asserts parity on the off-diagonal.

### 3. `_hashing.py` — non-string key (real fix)
`_fingerprint_py` did `k.startswith("__")` over keys, so a non-string field name raised `AttributeError ('int' object has no attribute 'startswith')` instead of the spec'd `TypeError` the native kernel raises (`hash.rs`: `"record field names must be strings"`). Added an up-front key-type guard so both surfaces raise the same `TypeError`. `record_fingerprint` is Phase-1 default-OFF infra (nothing calls it yet); **no behavior change for valid input**.

## Test plan
- [x] All three parity files pass with the ext built (26 tests)
- [x] `test_record_fingerprint` + `test_native_parity` pass with the ext built (121)
- [x] Full goldenmatch suite **3360 passed / 0 failed** with the ext absent (python lane)
- [x] ruff clean

## Notes
- No production behavior change: #1 and #2 are test-only; #3 only changes the *exception type* for invalid (non-string-key) input on unwired Phase-1 hashing infra.
- This makes the native-parity suite fully green with the ext built, but those three files still aren't in CI's `native` lane — adding them to the lane's run-list is a sensible separate follow-up so future drift is caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiKj934B5YrmFGUMoMVok5)_