### PR TITLE
release: v1.25.0 — Arrow-native groundwork, perf, and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ npm install goldenmatch
 ```
 
 <!-- README-callouts:start  (auto-synced from packages/python/goldenmatch/CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
-> **🆕 v1.16.0 — 5M records in 9.94 min, 6.4 GB peak RSS, on one 16-core node** — the new `backend="bucket"` path is now the recommended 5M-on-one-node config. 5x wall reduction and 2x peak RSS reduction vs the v1.15 chunked baseline (~50 min, 11.9 GB), with rock-solid reliability on Linux runners where the chunked path was hanging at 63 GB plateau on the same fixture. PRs #310-#326.
+> **🆕 v1.25.0 — Arrow-native groundwork + leaner large-N runs** — columnar pair-stream / two-frame-cluster entry points and optional Rust/Arrow-C kernels (`build_clusters`, `dedup_pairs`, `record_fingerprints`, MST oversized-split) land behind the `goldenmatch._native` extension, purely additive with the pure-Python + Polars pipeline unchanged as the default and byte-for-byte reference. Plus single-node memory wins (golden -2.6 GB, bucket -3.8 GB peak at 10M; standardize ~25-30s off the prep wall) and fixes for a silently-dropped GoldenCheck quality scan and a prep-cache `id()`-recycle flake. PRs #588-#650.
+>
+> **v1.16.0 — 5M records in 9.94 min, 6.4 GB peak RSS, on one 16-core node** — the new `backend="bucket"` path is now the recommended 5M-on-one-node config. 5x wall reduction and 2x peak RSS reduction vs the v1.15 chunked baseline (~50 min, 11.9 GB), with rock-solid reliability on Linux runners where the chunked path was hanging at 63 GB plateau on the same fixture. PRs #310-#326.
 >
 > **v1.15.0 — 5M records in ~50 min on commodity hardware** — Chunked mode now actually delivers on its "1M to 100M+" promise. The streaming `scan_csv().slice()` reader + Polars-native cross-chunk join (B) + block-keyed bucketed index (C) + DuckDB pair-store backend (D) replace a broken eager-read + Python-double-loop path that OOM-killed at 3h+ on the pre-fix 5M dispatch. **Measured: 5M records, 50 min wall, 11.9 GB peak RSS, 618,817 multi-member clusters, no OOM** on a 4c/16GB GitHub runner. Pass `backend="chunked"` with an explicit blocking config. PRs #233/#234/#235.
->
-> **v1.12.0 — Negative evidence on exact matchkeys (Path Y)** — NE penalties now filter adversarial collision pairs at the `exact_email` level, not just inside the weighted matchkey scoring loop. DQbench composite **91.04** (was 66.99 at v1.11). T2 F1 69.0% → 97.5%, T3 F1 53.8% → 85.5%.
 <!-- README-callouts:end -->
 
 ---

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,75 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.25.0] - 2026-06-01
+
+<!-- README-callout
+**Arrow-native groundwork + leaner large-N runs** — columnar pair-stream / two-frame-cluster entry points and optional Rust/Arrow-C kernels (`build_clusters`, `dedup_pairs`, `record_fingerprints`, MST oversized-split) land behind the `goldenmatch._native` extension, purely additive with the pure-Python + Polars pipeline unchanged as the default and byte-for-byte reference. Plus single-node memory wins (golden -2.6 GB, bucket -3.8 GB peak at 10M; standardize ~25-30s off the prep wall) and fixes for a silently-dropped GoldenCheck quality scan and a prep-cache `id()`-recycle flake. PRs #588-#650.
+-->
+
+This release lands the **Arrow-native pipeline groundwork** (roadmap Phases 0-6), a
+batch of single-node memory/wall optimizations, an optional native Rust kernel for
+the cluster oversized-split path, and several user-facing bug fixes. All Arrow /
+native work is **additive and opt-in** — the default pure-Python + Polars pipeline is
+behavior-unchanged; the columnar entry points and `goldenmatch._native` kernels are
+exercised by the bench/profiler harnesses and wired in behind follow-up parity work.
+
+### Added
+
+- **Arrow-native pipeline groundwork (roadmap Phases 0-6).** Columnar pair-stream
+  scorer entry points (#631) with a native columnar inner loop for `score_blocks_columnar`
+  (#634, #639); a two-frame `ClusterFrames` cluster representation (#632) + numpy-backed
+  `cluster_dict_to_frames` (#635); golden (#636), identity (#638), and a hash-by-cluster_id
+  partitioner (#642) that consume `ClusterFrames` directly; columnar `dedup_pairs_max_score`
+  (#641). These are new entry points alongside the existing path, not a default swap.
+- **Native (Rust / Arrow-C) kernels** in the optional `goldenmatch._native` extension:
+  Arrow-C kernels for `build_clusters` (#645), `record_fingerprints` (#644), and
+  `dedup_pairs` (#643); a max-weight-spanning-tree oversized-split kernel (#649); and
+  `build_clusters_native` (#610) / `record_fingerprints_batch` (#612) prototypes. Pure
+  Python remains the default and the byte-for-byte reference; the kernels run only when
+  the extension is built and the relevant `native_enabled(...)` gate is on.
+- **Profiling + bench harnesses.** A GitHub Actions hotspot profiler (pyinstrument +
+  cProfile) over the pair-stream / cluster path (#646); a pair-stream columnar-vs-list
+  bench at 100K/1M/5M (#633); per-(shape, path) subprocess isolation (#637); and a
+  native-kernel decision-gate workflow (#611).
+- **`map_elements` justification lint** — prep-stage `map_elements` calls now require a
+  `# noqa: GM-MAP-ELEMENTS:` rationale comment, gating accidental per-row Python before
+  it ships (#640).
+- **Experimental backends/infra** (not on the default install path): a DataFusion backend
+  spike (#620, #621) and an ephemeral GCE Ray-cluster bench harness (#608-#619).
+
+### Performance
+
+- **Standardization native Polars chains.** `name_proper` (#601) and `address` (#602,
+  ~25-30s off the prep wall on the QIS shape) drop their per-row Python UDFs for
+  Polars-native chains.
+- **Golden + bucket memory slimming (default ON).** Slim `multi_df` before
+  `attach_cluster_id` (-2.6 GB, #595/#596); slim projection before `bucket_assign`
+  (-3.8 GB peak at 10M, #590); close the rechunk lane + free partition parents after
+  `partition_by` (#593); rechunk after `precompute_matchkey_transforms` (#591).
+- **Clustering.** Drop the non-load-bearing `sorted(members)` in `result_dict_init`
+  (#594); numpy-backed `pairs_df_to_list` in `build_clusters_columnar` (#647); one-pass
+  O(pairs) `pair_scores` partition + `operator.itemgetter` keys in the oversized-split
+  path (~6% on `build_clusters_columnar` at 100K, #648).
+
+### Fixed
+
+- **GoldenCheck quality scan silently dropped every finding** in the scan-only path
+  (`_scan_only`, used by the MCP `scan_quality` tool, the A2A quality skill, and the web
+  `/api/v1/quality` route): it read `Finding.rule_id` / `rows_affected` (the dataclass
+  exposes `check` / `affected_rows`) and the resulting `AttributeError` was swallowed as a
+  warning. Findings now serialize correctly, with `severity` as a lowercase string (it was
+  the raw `IntEnum`, which then broke the web consumer's `.lower()`) (#647).
+- **Prep-cache `id()` recycle.** The in-memory prep cache keyed on `id(df)` + schema, so a
+  garbage-collected frame's recycled address could serve a stale prepared frame to a
+  same-schema input (e.g. an empty DataFrame received a populated one — the
+  `test_dedupe_df_empty` `pytest -n auto` flake). The key now folds in `df.height` (#647).
+- **`record_fingerprint` raised `AttributeError` on a non-string field name** instead of
+  the spec'd `TypeError`; the pure-Python reference now validates key types up front,
+  matching the native kernel (#650).
+- **Native-vs-Python parity test baselines** corrected for cluster-confidence (raw vs
+  post-downgrade) and soundex/exact (diagonal don't-care) (#650).
+
 ## [1.24.0] - 2026-05-29
 
 ### Performance

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -48,11 +48,11 @@ npm install goldenmatch
 ```
 
 <!-- README-callouts:start  (auto-synced from CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
-> **🆕 v1.16.0 — 5M records in 9.94 min, 6.4 GB peak RSS, on one 16-core node** — the new `backend="bucket"` path is now the recommended 5M-on-one-node config. 5x wall reduction and 2x peak RSS reduction vs the v1.15 chunked baseline (~50 min, 11.9 GB), with rock-solid reliability on Linux runners where the chunked path was hanging at 63 GB plateau on the same fixture. PRs #310-#326.
+> **🆕 v1.25.0 — Arrow-native groundwork + leaner large-N runs** — columnar pair-stream / two-frame-cluster entry points and optional Rust/Arrow-C kernels (`build_clusters`, `dedup_pairs`, `record_fingerprints`, MST oversized-split) land behind the `goldenmatch._native` extension, purely additive with the pure-Python + Polars pipeline unchanged as the default and byte-for-byte reference. Plus single-node memory wins (golden -2.6 GB, bucket -3.8 GB peak at 10M; standardize ~25-30s off the prep wall) and fixes for a silently-dropped GoldenCheck quality scan and a prep-cache `id()`-recycle flake. PRs #588-#650.
+>
+> **v1.16.0 — 5M records in 9.94 min, 6.4 GB peak RSS, on one 16-core node** — the new `backend="bucket"` path is now the recommended 5M-on-one-node config. 5x wall reduction and 2x peak RSS reduction vs the v1.15 chunked baseline (~50 min, 11.9 GB), with rock-solid reliability on Linux runners where the chunked path was hanging at 63 GB plateau on the same fixture. PRs #310-#326.
 >
 > **v1.15.0 — 5M records in ~50 min on commodity hardware** — Chunked mode now actually delivers on its "1M to 100M+" promise. The streaming `scan_csv().slice()` reader + Polars-native cross-chunk join (B) + block-keyed bucketed index (C) + DuckDB pair-store backend (D) replace a broken eager-read + Python-double-loop path that OOM-killed at 3h+ on the pre-fix 5M dispatch. **Measured: 5M records, 50 min wall, 11.9 GB peak RSS, 618,817 multi-member clusters, no OOM** on a 4c/16GB GitHub runner. Pass `backend="chunked"` with an explicit blocking config. PRs #233/#234/#235.
->
-> **v1.12.0 — Negative evidence on exact matchkeys (Path Y)** — NE penalties now filter adversarial collision pairs at the `exact_email` level, not just inside the weighted matchkey scoring loop. DQbench composite **91.04** (was 66.99 at v1.11). T2 F1 69.0% → 97.5%, T3 F1 53.8% → 85.5%.
 <!-- README-callouts:end -->
 
 ---
@@ -159,6 +159,7 @@ npm install goldenmatch
 - **Chunked mode** — streaming `scan_csv().slice()` reader + vectorized cross-chunk join + block-keyed index. **Measured: 5M records in ~50 min on a 4c/16GB GitHub runner, 11.9 GB peak, no OOM** (PRs #233/#234/#235, 2026-05-14). Pass `backend="chunked"`. The bucket backend supersedes this for 16-core / 32+ GB Linux; chunked stays as the path for memory-constrained 4c/16GB shapes.
 - **DuckDB backend** — `config.backend="duckdb"` routes block scoring through a DuckDB-backed pair store that can spill to disk via `GOLDENMATCH_DUCKDB_SCORE_DB`. Doesn't replace in-memory scoring matrices yet; the value lands at 50M+ where pair counts hit 10⁸.
 - **Ray distributed backend** — `pip install goldenmatch[ray]` + pass `backend="ray"` explicitly OR set `GOLDENMATCH_ENABLE_DISTRIBUTED_RAY=1` to let the v3 planner pick it at 50M+ rows. As of v1.16.0 the planner no longer auto-picks ray after the Distributed Plan v1 stack failed the 5M kill criterion on the same workload where bucket succeeded at 6.4 GB peak RSS (PR #318).
+- **Native acceleration (optional, v1.25.0)** — `pip install goldenmatch[native]` pulls a compiled Rust/PyO3 abi3 kernel (`goldenmatch-native`) that strips Python-loop overhead from hot paths (record fingerprints, connected-components / cluster build, dedup-pairs, the MST oversized-split). Purely additive: the pure-Python + Polars pipeline stays the default and the byte-for-byte reference; the kernels engage only when the wheel is installed and the matching `native_enabled(...)` gate is on.
 - **dbt integration** — `dbt-goldenmatch` package for DuckDB-based ER in dbt pipelines
 
 ### Learning Memory (v1.6.0)

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.24.0"
+__version__ = "1.25.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.24.0"
+version = "1.25.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Cuts **v1.25.0**, releasing all work merged since the 1.24.0 boundary (PRs #588–#650). Single release PR: version bump (3 spots) + CHANGELOG + README/docs, per the agreed packaging.

### Version
- `pyproject.toml` + `goldenmatch/__init__.py`: **1.24.0 → 1.25.0** (minor — backward-compatible new functionality: the opt-in native kernels + columnar entry points, plus user-facing bug fixes).

### CHANGELOG `[1.25.0]`
- **Added** — Arrow-native pipeline groundwork (roadmap Phases 0–6: columnar pair-stream + `ClusterFrames` + columnar golden/identity/dedup_pairs); optional Rust/Arrow-C native kernels (`build_clusters`, `record_fingerprints`, `dedup_pairs`, MST oversized-split, prototypes); profiler + bench harnesses; `map_elements` justification lint; DataFusion/Ray-GCE bench infra.
- **Performance** — standardize native Polars chains (`name_proper`, `address` ~25–30s off prep); golden/bucket memory slimming (−2.6 GB / −3.8 GB peak at 10M, default ON); cluster split micro-opts (~6%).
- **Fixed** — GoldenCheck quality-scan findings silently dropped (`_scan_only` Finding attrs + `severity` serialization); prep-cache `id()`-recycle flake; `record_fingerprint` exception type; native-parity test baselines.

All Arrow/native work is **additive and opt-in** — the default pure-Python + Polars pipeline is behavior-unchanged.

### Docs
- Regenerated the README "what's new" callouts from the CHANGELOG via `scripts/sync_readme_callouts.py` (both READMEs; `--check` gate passes).
- Documented the previously-unlisted **`pip install goldenmatch[native]`** optional compiled runtime in the package README extras.
- Examples unchanged — no public API surface changed this release, so the 8 `examples/python/*` scripts still run as-is.

## Test plan
- [x] `goldenmatch.__version__ == "1.25.0"`; version test passes
- [x] `sync_readme_callouts.py --check` exits 0 (README matches CHANGELOG)
- [x] No test pins the old version; no stray `1.24.0` in package source
- [x] CHANGELOG entries cite real merged PRs; claims tied to commit-message / measured numbers

## After merge
Per our plan, I'll push the `v1.25.0` tag / cut the GitHub Release to fire `publish-goldenmatch.yml` → PyPI once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiKj934B5YrmFGUMoMVok5)_