### PR TITLE
bench: ER head-to-head scaling lane (Splink vs GoldenMatch bucket+native+arrow)

### DIFF
--- a/.github/workflows/bench-er-headtohead.yml
+++ b/.github/workflows/bench-er-headtohead.yml
@@ -75,6 +75,9 @@ jobs:
         if: contains(inputs.engines, 'splink')
         run: uv pip install splink
 
+      - name: Install DuckDB (used by the engine-agnostic accuracy evaluator)
+        run: uv pip install duckdb
+
       - name: Run head-to-head sweep
         run: |
           uv run python scripts/bench_er_headtohead/orchestrate.py \

--- a/.github/workflows/bench-er-headtohead.yml
+++ b/.github/workflows/bench-er-headtohead.yml
@@ -1,0 +1,96 @@
+# ER head-to-head scaling bench — Splink (DuckDB) vs GoldenMatch (bucket+native+arrow).
+#
+# workflow_dispatch only. Runs both engines over a sweep of scales on ONE machine
+# with an identical per-scale parquet fixture, so wall + peak-RSS are comparable.
+#
+# Memory safety: scripts/bench_er_headtohead/orchestrate.py runs every (scale,
+# engine) datapoint as an isolated subprocess. The OS reclaims each datapoint's
+# memory on exit, and an OOM-killed datapoint is recorded as `OOM` rather than
+# crashing the sweep. The 100M tier is EXPECTED to OOM for GoldenMatch's in-memory
+# bucket backend on a single 64 GB box — that ceiling is itself a result.
+#
+# Fixtures are generated in-job (streaming, bounded memory) and deleted after each
+# scale's engines run, so disk stays bounded too.
+#
+# To run: GitHub -> Actions -> "bench-er-headtohead" -> Run workflow.
+name: bench-er-headtohead
+
+on:
+  workflow_dispatch:
+    inputs:
+      scales:
+        description: "Space-separated row counts to sweep"
+        required: false
+        default: "100000 1000000 5000000 25000000 100000000"
+      engines:
+        description: "Engines to run (space-separated): goldenmatch splink"
+        required: false
+        default: "goldenmatch splink"
+      dupe_rate:
+        description: "Fraction of duplicate rows in each fixture"
+        required: false
+        default: "0.20"
+      threshold:
+        description: "Match threshold"
+        required: false
+        default: "0.85"
+      runner:
+        description: "Runner label (needs 64 GB for the 25M bucket datapoint)"
+        required: false
+        default: "large-new-64GB"
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 360
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        # native crate's rust-toolchain.toml pins the exact version.
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/native
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Build native extension (bucket + Arrow kernels)
+        run: uv run python scripts/build_native.py
+
+      - name: Install Splink (competitor engine, not a repo dependency)
+        if: contains(inputs.engines, 'splink')
+        run: uv pip install splink
+
+      - name: Run head-to-head sweep
+        run: |
+          uv run python scripts/bench_er_headtohead/orchestrate.py \
+            --scales ${{ inputs.scales }} \
+            --engines ${{ inputs.engines }} \
+            --dupe-rate ${{ inputs.dupe_rate }} \
+            --threshold ${{ inputs.threshold }} \
+            --workdir .bench_er
+
+      - name: Upload results artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: er-headtohead-results
+          path: |
+            .bench_er/bench_results.json
+            .bench_er/summary.md
+            .bench_er/results/*.json
+          retention-days: 90

--- a/scripts/bench_er_headtohead/README.md
+++ b/scripts/bench_er_headtohead/README.md
@@ -1,0 +1,79 @@
+# ER head-to-head scaling bench
+
+Splink (DuckDB backend) vs GoldenMatch (bucket + native + Arrow) across
+**100k / 1M / 5M / 25M / 100M** rows, on one machine, with an identical fixture
+per scale. Built because no published apples-to-apples wall+RSS comparison exists
+between these engines (Splink publishes 7M/~2min/1B-pairs; GoldenMatch publishes
+25M/6.5min/57.7GB — different pair counts, different operations, not comparable).
+
+## What it measures
+
+Per `(scale, engine)`: **end-to-end dedupe wall**, **peak RSS**, **scored pair
+count**, **cluster count**. Pairs/sec is derived. Splink's wall includes
+train+predict+cluster; GoldenMatch's includes auto_configure+dedupe — each
+engine's full required workflow, so neither is flattered.
+
+## How it stays honest
+
+- **Same fixture, same machine, same scale** for both engines. `scored_pairs` is
+  reported so any difference in blocking aggressiveness is *visible* rather than
+  hidden — pair count, not row count, drives ER wall-clock.
+- **GoldenMatch can't silently cheat downward**: `run_goldenmatch.py` sets
+  `GOLDENMATCH_NATIVE=1` and asserts `native_enabled("block_scoring")`. If the
+  native Arrow runtime isn't actually loaded, the datapoint fails loudly instead
+  of quietly reporting a pure-Python number as "the optimized backend".
+- **Splink isn't crippled**: it gets an idiomatic settings spec (compound
+  blocking + standard comparisons) mirroring the blocking GoldenMatch's
+  auto-config lands on. Splink has no zero-config mode — that asymmetry is real
+  and noted, not engineered away.
+
+## How it survives OOM on GitHub
+
+`orchestrate.py` never loads a fixture. Each datapoint runs as an isolated
+subprocess; the OS frees its memory on exit. An OOM-killed datapoint (SIGKILL,
+no result file) is recorded as `status: OOM` and the sweep continues. The
+aggregate JSON is flushed after every datapoint, so a late OOM never loses
+earlier results.
+
+**The 100M bucket datapoint is expected to OOM on a single 64 GB box** —
+GoldenMatch's bucket backend is in-memory and 25M already peaks at ~58 GB. That
+ceiling is a legitimate result: it's exactly where the single-node in-memory path
+ends and the Ray/distributed path (or Splink's DuckDB spill) takes over.
+
+## Running it
+
+CI (recommended — the 25M tier needs 64 GB):
+
+> GitHub → Actions → **bench-er-headtohead** → Run workflow.
+
+Locally (small scales):
+
+```bash
+# generator needs only numpy + pyarrow
+python scripts/bench_er_headtohead/generate_fixture.py --rows 100000 \
+    --out /tmp/b/bench_100000.parquet --ground-truth /tmp/b/bench_100000.truth.parquet
+
+# full sweep (build native first: python scripts/build_native.py)
+python scripts/bench_er_headtohead/orchestrate.py \
+    --scales 100000 1000000 --engines goldenmatch splink --workdir /tmp/bench_er
+```
+
+## Files
+
+| File | Role |
+|---|---|
+| `generate_fixture.py` | Streaming, bounded-memory person-shaped parquet generator (+ ground truth). |
+| `run_goldenmatch.py` | One datapoint, GoldenMatch bucket+native+arrow, fails loud if native absent. |
+| `run_splink.py` | One datapoint, Splink 4.x DuckDB dedupe, counts via DuckDB relations (no pandas materialization). |
+| `orchestrate.py` | Subprocess-per-datapoint sweep, OOM-tolerant, aggregates to `summary.md` + `bench_results.json`. |
+| `../../.github/workflows/bench-er-headtohead.yml` | CI lane (64 GB runner, builds native, installs Splink). |
+
+## Known limitations / follow-ups
+
+- **F1 / accuracy not yet measured** — ground truth is generated (`*.truth.parquet`)
+  but pairwise F1 scoring is deferred; this round is wall + RSS + pairs + clusters.
+- **One fixture shape** (person-like, 5 fields). Other shapes (bibliographic,
+  product) would exercise different blocking/scoring behaviour.
+- **Splink comparison spec is fixed**, not tuned per scale; a Splink expert could
+  squeeze more. The spec is in `run_splink.py` and is meant to be reasonable, not
+  optimal.

--- a/scripts/bench_er_headtohead/README.md
+++ b/scripts/bench_er_headtohead/README.md
@@ -8,10 +8,15 @@ between these engines (Splink publishes 7M/~2min/1B-pairs; GoldenMatch publishes
 
 ## What it measures
 
-Per `(scale, engine)`: **end-to-end dedupe wall**, **peak RSS**, **scored pair
-count**, **cluster count**. Pairs/sec is derived. Splink's wall includes
-train+predict+cluster; GoldenMatch's includes auto_configure+dedupe — each
-engine's full required workflow, so neither is flattered.
+Per `(scale, engine)`:
+- **Speed/memory**: end-to-end dedupe wall, peak RSS, scored-pair count, resolved
+  cluster count, pairs/sec. Splink's wall includes train+predict+cluster;
+  GoldenMatch's includes auto_configure+dedupe — each engine's full required
+  workflow, so neither is flattered.
+- **Accuracy vs ground truth** (one engine-agnostic evaluator, identical code for
+  both): **pairwise** precision/recall/F1 + confusion matrix (TP/FP/FN/TN), and
+  **B-cubed** (B³) precision/recall/F1. Computed from a DuckDB contingency table
+  (`evaluate.py`) — no pair materialization, so it stays memory-bounded at 25M/100M.
 
 ## How it stays honest
 
@@ -65,13 +70,12 @@ python scripts/bench_er_headtohead/orchestrate.py \
 | `generate_fixture.py` | Streaming, bounded-memory person-shaped parquet generator (+ ground truth). |
 | `run_goldenmatch.py` | One datapoint, GoldenMatch bucket+native+arrow, fails loud if native absent. |
 | `run_splink.py` | One datapoint, Splink 4.x DuckDB dedupe, counts via DuckDB relations (no pandas materialization). |
-| `orchestrate.py` | Subprocess-per-datapoint sweep, OOM-tolerant, aggregates to `summary.md` + `bench_results.json`. |
+| `evaluate.py` | Engine-agnostic accuracy: pairwise P/R/F1 + confusion + B³, via DuckDB contingency table. |
+| `orchestrate.py` | Subprocess-per-datapoint sweep, OOM-tolerant, runs eval, aggregates to `summary.md` + `bench_results.json`. |
 | `../../.github/workflows/bench-er-headtohead.yml` | CI lane (64 GB runner, builds native, installs Splink). |
 
 ## Known limitations / follow-ups
 
-- **F1 / accuracy not yet measured** — ground truth is generated (`*.truth.parquet`)
-  but pairwise F1 scoring is deferred; this round is wall + RSS + pairs + clusters.
 - **One fixture shape** (person-like, 5 fields). Other shapes (bibliographic,
   product) would exercise different blocking/scoring behaviour.
 - **Splink comparison spec is fixed**, not tuned per scale; a Splink expert could

--- a/scripts/bench_er_headtohead/evaluate.py
+++ b/scripts/bench_er_headtohead/evaluate.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+"""Engine-agnostic ER accuracy evaluator for the head-to-head bench.
+
+Scores a predicted clustering against ground truth using ONE implementation, so
+both engines are judged by identical code. Inputs are two parquets:
+    predictions: {record_id, pred_cluster_id}   (every record assigned)
+    truth:       {record_id, cluster_id}
+
+Computes, via a DuckDB contingency table (no pair materialization -> bounded
+memory at 25M/100M):
+
+  * Pairwise: precision / recall / F1 + confusion matrix {tp, fp, fn, tn}.
+        TP = sum_ij C(n_ij, 2)              (n_ij = records in pred i AND true j)
+        TP+FP = sum_i C(a_i, 2)             (a_i = size of pred cluster i)
+        TP+FN = sum_j C(b_j, 2)             (b_j = size of true cluster j)
+  * B-cubed: precision / recall / F1.
+        B3_precision = (1/N) sum_ij n_ij^2 / a_i
+        B3_recall    = (1/N) sum_ij n_ij^2 / b_j
+
+The contingency table has one row per co-occurring (pred, true) pair; DuckDB
+streams the group-bys, so peak memory is governed by distinct cluster pairs, not
+the N^2 pair space.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+def _f1(p: float, r: float) -> float:
+    return (2 * p * r / (p + r)) if (p + r) else 0.0
+
+
+def evaluate(pred: Path, truth: Path) -> dict:
+    import duckdb
+
+    con = duckdb.connect()
+    con.execute(
+        f"""
+        CREATE TEMP TABLE cont AS
+        SELECT p.pred_cluster_id AS pc, t.cluster_id AS tc, count(*) AS n
+        FROM read_parquet('{pred}') p
+        JOIN read_parquet('{truth}') t ON p.record_id = t.record_id
+        GROUP BY 1, 2;
+        CREATE TEMP TABLE psize AS SELECT pc, sum(n) AS a FROM cont GROUP BY pc;
+        CREATE TEMP TABLE tsize AS SELECT tc, sum(n) AS b FROM cont GROUP BY tc;
+        """
+    )
+    (n_records, tp, pred_pairs, true_pairs, bc_p_num, bc_r_num, n_pred, n_true) = con.execute(
+        """
+        SELECT
+          (SELECT sum(n)::DOUBLE FROM cont),
+          (SELECT sum(n*(n-1)/2.0) FROM cont),
+          (SELECT sum(a*(a-1)/2.0) FROM psize),
+          (SELECT sum(b*(b-1)/2.0) FROM tsize),
+          (SELECT sum((c.n*c.n*1.0)/s.a) FROM cont c JOIN psize s USING (pc)),
+          (SELECT sum((c.n*c.n*1.0)/s.b) FROM cont c JOIN tsize s USING (tc)),
+          (SELECT count(*) FROM psize),
+          (SELECT count(*) FROM tsize)
+        """
+    ).fetchone()
+    con.close()
+
+    n_records = float(n_records or 0)
+    tp = float(tp or 0.0)
+    pred_pairs = float(pred_pairs or 0.0)
+    true_pairs = float(true_pairs or 0.0)
+    fp = pred_pairs - tp
+    fn = true_pairs - tp
+    total_pairs = n_records * (n_records - 1) / 2.0
+    tn = total_pairs - tp - fp - fn
+
+    pw_precision = tp / pred_pairs if pred_pairs else 0.0
+    pw_recall = tp / true_pairs if true_pairs else 0.0
+    bc_precision = (bc_p_num / n_records) if n_records else 0.0
+    bc_recall = (bc_r_num / n_records) if n_records else 0.0
+
+    return {
+        "n_records_evaluated": int(n_records),
+        "pred_clusters": int(n_pred or 0),
+        "true_clusters": int(n_true or 0),
+        "pairwise": {
+            "precision": round(pw_precision, 4),
+            "recall": round(pw_recall, 4),
+            "f1": round(_f1(pw_precision, pw_recall), 4),
+            "accuracy": round((tp + tn) / total_pairs, 6) if total_pairs else 0.0,
+            "confusion": {"tp": int(tp), "fp": int(fp), "fn": int(fn), "tn": int(tn)},
+        },
+        "bcubed": {
+            "precision": round(bc_precision, 4),
+            "recall": round(bc_recall, 4),
+            "f1": round(_f1(bc_precision, bc_recall), 4),
+        },
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pred", type=Path, required=True)
+    ap.add_argument("--truth", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    args = ap.parse_args()
+
+    metrics = evaluate(args.pred, args.truth)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = args.out.with_suffix(args.out.suffix + ".tmp")
+    tmp.write_text(json.dumps(metrics, indent=2))
+    os.replace(tmp, args.out)
+    pw, bc = metrics["pairwise"], metrics["bcubed"]
+    print(
+        f"[evaluate] pairwise P/R/F1={pw['precision']}/{pw['recall']}/{pw['f1']} "
+        f"| B3 P/R/F1={bc['precision']}/{bc['recall']}/{bc['f1']} "
+        f"| TP/FP/FN={pw['confusion']['tp']}/{pw['confusion']['fp']}/{pw['confusion']['fn']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_er_headtohead/generate_fixture.py
+++ b/scripts/bench_er_headtohead/generate_fixture.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+"""Streaming person-shaped dedupe fixture generator for the ER head-to-head bench.
+
+Writes a single parquet that BOTH engines (Splink and GoldenMatch) read, plus a
+separate ground-truth parquet ({record_id, cluster_id}) for optional F1.
+
+Bounded memory by design: rows are generated and flushed one row-group at a time
+via pyarrow.ParquetWriter, so generating 100M rows never materialises 100M rows
+in RAM. All string columns are produced by vectorised fancy-indexing into small
+precomputed pools (no per-row Python), so generation stays fast at 100M.
+
+Schema (5 fields both engines can match on):
+    record_id  int64
+    first_name str
+    surname    str
+    dob        str   (YYYY-MM-DD)
+    postcode   str
+    city       str
+
+Duplicates carry realistic fuzzy variation: surname/first-name single-char typos,
+occasional nulls on weaker fields. Strong identity fields (dob, postcode) mostly
+agree so the clusters are genuinely resolvable.
+
+Usage:
+    python generate_fixture.py --rows 1000000 --dupe-rate 0.20 \
+        --out fixtures/bench_1000000.parquet \
+        --ground-truth fixtures/bench_1000000.truth.parquet
+"""
+from __future__ import annotations
+
+import argparse
+import string
+import time
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+# Pool sizes chosen so compound blocking (surname + dob-year) yields small blocks
+# at every scale, keeping candidate-pair growth ~linear rather than quadratic.
+N_FIRST = 5_000
+N_SURNAME = 50_000
+N_POSTCODE = 200_000
+N_CITY = 1_000
+DOB_DAYS = 25_000  # ~68 years of distinct birth dates
+
+_ALPHA = np.array(list(string.ascii_lowercase))
+
+
+def _syllable_pool(n: int, rng: np.random.Generator, min_len: int, max_len: int) -> list[str]:
+    """Deterministic pronounceable-ish token pool (vectorised draw, join in Python once)."""
+    cons = list("bcdfghjklmnpqrstvwxyz")
+    vows = list("aeiou")
+    out: list[str] = []
+    for _ in range(n):
+        ln = int(rng.integers(min_len, max_len + 1))
+        chars = []
+        for i in range(ln):
+            chars.append(rng.choice(cons) if i % 2 == 0 else rng.choice(vows))
+        s = "".join(chars)
+        out.append(s.capitalize())
+    return out
+
+
+def _typo_variant(s: str, rng: np.random.Generator) -> str:
+    """Single-char edit (substitution / transposition / drop) — realistic fuzzy noise."""
+    if len(s) < 3:
+        return s + "e"
+    kind = rng.integers(0, 3)
+    i = int(rng.integers(1, len(s) - 1))
+    if kind == 0:  # substitution
+        return s[:i] + str(rng.choice(_ALPHA)) + s[i + 1 :]
+    if kind == 1:  # transposition
+        return s[:i] + s[i + 1] + s[i] + s[i + 2 :]
+    return s[:i] + s[i + 1 :]  # drop
+
+
+def _build_pools(seed: int):
+    rng = np.random.default_rng(seed)
+    first_base = _syllable_pool(N_FIRST, rng, 3, 7)
+    sur_base = _syllable_pool(N_SURNAME, rng, 4, 9)
+    # Parallel typo arrays: index i -> one typo'd variant of base i. Built once.
+    first_typo = [_typo_variant(s, rng) for s in first_base]
+    sur_typo = [_typo_variant(s, rng) for s in sur_base]
+    cities = [c + " City" for c in _syllable_pool(N_CITY, rng, 4, 8)]
+    # dob pool: YYYY-MM-DD strings over DOB_DAYS distinct dates from 1940-01-01.
+    base = np.datetime64("1940-01-01")
+    dobs = (base + np.arange(DOB_DAYS).astype("timedelta64[D]")).astype("datetime64[D]")
+    dob_pool = np.datetime_as_string(dobs)
+    postcodes = [f"{int(rng.integers(10,99))}{rng.choice(_ALPHA).upper()}{rng.choice(_ALPHA).upper()} {int(rng.integers(0,9))}{rng.choice(_ALPHA).upper()}{rng.choice(_ALPHA).upper()}" for _ in range(N_POSTCODE)]
+    return {
+        # Combined [base | typo] arrays so a single fancy-index picks exact-or-typo.
+        "first": np.array(first_base + first_typo, dtype=object),
+        "surname": np.array(sur_base + sur_typo, dtype=object),
+        "city": np.array(cities, dtype=object),
+        "dob": np.asarray(dob_pool, dtype=object),
+        "postcode": np.array(postcodes, dtype=object),
+    }
+
+
+SCHEMA = pa.schema(
+    [
+        ("record_id", pa.int64()),
+        ("first_name", pa.string()),
+        ("surname", pa.string()),
+        ("dob", pa.string()),
+        ("postcode", pa.string()),
+        ("city", pa.string()),
+    ]
+)
+TRUTH_SCHEMA = pa.schema([("record_id", pa.int64()), ("cluster_id", pa.int64())])
+
+
+def generate(rows: int, dupe_rate: float, out: Path, truth: Path, seed: int, batch: int) -> dict:
+    pools = _build_pools(seed)
+    rng = np.random.default_rng(seed + 1)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    truth.parent.mkdir(parents=True, exist_ok=True)
+
+    # Cluster-size categorical tuned so the duplicate fraction ~= dupe_rate.
+    # sizes {1,2,3}; expected dup fraction = (p2 + 2*p3) / (p1 + 2*p2 + 3*p3).
+    p_dup = max(0.0, min(0.9, dupe_rate))
+    size_probs = np.array([1 - p_dup, 0.75 * p_dup, 0.25 * p_dup])
+    size_probs /= size_probs.sum()
+
+    written = 0
+    next_rid = 0
+    next_cid = 0
+    n_dupes = 0
+    t0 = time.perf_counter()
+
+    writer = pq.ParquetWriter(out, SCHEMA, compression="zstd")
+    twriter = pq.ParquetWriter(truth, TRUTH_SCHEMA, compression="zstd")
+    try:
+        while written < rows:
+            # Over-draw identities, then trim the expanded rows to the batch budget.
+            target = min(batch, rows - written)
+            n_ident = int(target / (1 + p_dup)) + 16
+            sizes = rng.choice([1, 2, 3], size=n_ident, p=size_probs)
+            cum = np.cumsum(sizes)
+            keep = np.searchsorted(cum, target, side="right") + 1
+            sizes = sizes[:keep]
+            total = int(sizes.sum())
+            if written + total > rows:  # final batch: clip last cluster
+                excess = written + total - rows
+                sizes[-1] = max(1, sizes[-1] - excess)
+                total = int(sizes.sum())
+
+            cids = np.arange(next_cid, next_cid + len(sizes))
+            row_cid = np.repeat(cids, sizes)
+            # position within cluster: 0 == canonical, >0 == duplicate variant
+            pos = np.arange(total) - np.repeat(cum[: len(sizes)] - sizes, sizes)
+            is_dup = pos > 0
+            n_dupes += int(is_dup.sum())
+
+            # Canonical attribute indices per identity, broadcast to rows.
+            fi = np.repeat(rng.integers(0, N_FIRST, len(sizes)), sizes)
+            si = np.repeat(rng.integers(0, N_SURNAME, len(sizes)), sizes)
+            di = np.repeat(rng.integers(0, DOB_DAYS, len(sizes)), sizes)
+            pi = np.repeat(rng.integers(0, N_POSTCODE, len(sizes)), sizes)
+            ci = np.repeat(rng.integers(0, N_CITY, len(sizes)), sizes)
+
+            # Duplicate variation (vectorised masks). Typo => offset into [base|typo] half.
+            r = rng.random(total)
+            fi_pick = fi + np.where(is_dup & (r < 0.40), N_FIRST, 0)
+            r = rng.random(total)
+            si_pick = si + np.where(is_dup & (r < 0.50), N_SURNAME, 0)
+
+            first = pools["first"][fi_pick]
+            surname = pools["surname"][si_pick]
+            dob = pools["dob"][di].copy()
+            postcode = pools["postcode"][pi].copy()
+            city = pools["city"][ci].copy()
+
+            # Occasional nulls on weaker / strong fields for duplicate rows.
+            city = np.where(is_dup & (rng.random(total) < 0.20), None, city)
+            dnull = is_dup & (rng.random(total) < 0.05)
+            dob = np.where(dnull, None, dob)
+            pnull = is_dup & (rng.random(total) < 0.05)
+            postcode = np.where(pnull, None, postcode)
+
+            rids = np.arange(next_rid, next_rid + total)
+            writer.write_table(
+                pa.table(
+                    {
+                        "record_id": pa.array(rids, pa.int64()),
+                        "first_name": pa.array(first, pa.string()),
+                        "surname": pa.array(surname, pa.string()),
+                        "dob": pa.array(dob, pa.string()),
+                        "postcode": pa.array(postcode, pa.string()),
+                        "city": pa.array(city, pa.string()),
+                    },
+                    schema=SCHEMA,
+                )
+            )
+            twriter.write_table(
+                pa.table(
+                    {"record_id": pa.array(rids, pa.int64()), "cluster_id": pa.array(row_cid, pa.int64())},
+                    schema=TRUTH_SCHEMA,
+                )
+            )
+            written += total
+            next_rid += total
+            next_cid += len(sizes)
+    finally:
+        writer.close()
+        twriter.close()
+
+    meta = {
+        "rows": written,
+        "clusters": next_cid,
+        "duplicate_rows": n_dupes,
+        "duplicate_rate_actual": round(n_dupes / written, 4) if written else 0.0,
+        "gen_wall_seconds": round(time.perf_counter() - t0, 2),
+        "fixture_path": str(out),
+        "fixture_size_mb": round(out.stat().st_size / 1e6, 1),
+    }
+    return meta
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rows", type=int, required=True)
+    ap.add_argument("--dupe-rate", type=float, default=0.20)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--ground-truth", type=Path, required=True)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--batch", type=int, default=1_000_000)
+    args = ap.parse_args()
+
+    meta = generate(args.rows, args.dupe_rate, args.out, args.ground_truth, args.seed, args.batch)
+    print(
+        f"[generate] {meta['rows']:,} rows / {meta['clusters']:,} clusters / "
+        f"dup={meta['duplicate_rate_actual']} / {meta['fixture_size_mb']} MB / "
+        f"{meta['gen_wall_seconds']}s -> {meta['fixture_path']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_er_headtohead/orchestrate.py
+++ b/scripts/bench_er_headtohead/orchestrate.py
@@ -88,13 +88,16 @@ def generate(rows: int, dupe_rate: float, fixtures: Path) -> Path:
 
 
 def run_engine(engine: str, fixture: Path, rows: int, results_dir: Path,
-               threshold: float, allow_pure_python: bool = False) -> dict:
+               threshold: float, allow_pure_python: bool = False) -> tuple[dict, Path]:
     out = results_dir / f"{engine}_{rows}.json"
-    if out.exists():
-        out.unlink()  # stale result from a prior run must not masquerade as fresh
+    pred = results_dir / f"{engine}_{rows}.pred.parquet"
+    for stale in (out, pred):
+        if stale.exists():
+            stale.unlink()  # a stale artifact must not masquerade as fresh
     runner = HERE / (f"run_{engine}.py")
     cmd = [sys.executable, str(runner), "--input", str(fixture),
-           "--rows", str(rows), "--out", str(out), "--threshold", str(threshold)]
+           "--rows", str(rows), "--out", str(out), "--pred-out", str(pred),
+           "--threshold", str(threshold)]
     if engine == "goldenmatch" and allow_pure_python:
         cmd.append("--allow-pure-python")  # local smoke only; CI builds native
     t0 = time.perf_counter()
@@ -102,7 +105,25 @@ def run_engine(engine: str, fixture: Path, rows: int, results_dir: Path,
     wall = round(time.perf_counter() - t0, 1)
     res = _load_or_synthesize(out, rc, how, engine, rows)
     res["orchestrator_wall_seconds"] = wall
-    return res
+    return res, pred
+
+
+def evaluate_datapoint(pred: Path, truth: Path, results_dir: Path, engine: str, rows: int) -> dict | None:
+    """Score a prediction parquet against truth in a separate (bounded) process."""
+    if not pred.exists() or not truth.exists():
+        return None
+    metrics_out = results_dir / f"{engine}_{rows}.metrics.json"
+    rc, _ = _run(
+        [sys.executable, str(HERE / "evaluate.py"),
+         "--pred", str(pred), "--truth", str(truth), "--out", str(metrics_out)],
+        timeout=_timeout_for(rows),
+    )
+    if metrics_out.exists():
+        try:
+            return json.loads(metrics_out.read_text())
+        except Exception:
+            return None
+    return None
 
 
 def _fmt(v) -> str:
@@ -115,6 +136,11 @@ def _fmt(v) -> str:
     return str(v)
 
 
+def _r(v) -> str:
+    """3-decimal formatter for ratio metrics (F1/precision/recall)."""
+    return f"{v:.3f}" if isinstance(v, (int, float)) else "—"
+
+
 def render_markdown(results: list[dict], dupe_rate: float) -> str:
     lines = [
         "# ER head-to-head: Splink (DuckDB) vs GoldenMatch (bucket+native+arrow)",
@@ -124,20 +150,40 @@ def render_markdown(results: list[dict], dupe_rate: float) -> str:
         "auto_configure+dedupe). Peak RSS is the per-process high-water mark. "
         "`scored pairs` is recorded so blocking-aggressiveness differences are visible.",
         "",
-        "| rows | engine | status | dedupe wall (s) | peak RSS (MB) | scored pairs | clusters | pairs/sec |",
-        "|---:|---|---|---:|---:|---:|---:|---:|",
+        "| rows | engine | status | dedupe wall (s) | peak RSS (MB) | scored pairs | clusters | pairs/sec | pairwise F1 | B³ F1 |",
+        "|---:|---|---|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for r in sorted(results, key=lambda x: (x["rows_requested"], x["engine"])):
         wall = r.get("dedupe_wall_seconds")
         pairs = r.get("scored_pairs")
         pps = round(pairs / wall) if (pairs and wall) else None
+        acc = r.get("accuracy") or {}
+        pw = acc.get("pairwise") or {}
+        bc = acc.get("bcubed") or {}
         lines.append(
             "| " + " | ".join([
                 _fmt(r["rows_requested"]), r["engine"], r.get("status", "?"),
                 _fmt(wall), _fmt(r.get("peak_rss_mb")), _fmt(pairs),
                 _fmt(r.get("cluster_count")), _fmt(pps),
+                _r(pw.get("f1")), _r(bc.get("f1")),
             ]) + " |"
         )
+
+    # Accuracy detail: pairwise P/R + B³ P/R + confusion matrix.
+    lines += ["", "## Accuracy (vs ground truth)", "",
+              "| rows | engine | pw P | pw R | pw F1 | B³ P | B³ R | B³ F1 | TP | FP | FN |",
+              "|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|"]
+    for r in sorted(results, key=lambda x: (x["rows_requested"], x["engine"])):
+        acc = r.get("accuracy")
+        if not acc:
+            continue
+        pw, bc, cm = acc["pairwise"], acc["bcubed"], acc["pairwise"]["confusion"]
+        lines.append("| " + " | ".join([
+            _fmt(r["rows_requested"]), r["engine"],
+            _r(pw["precision"]), _r(pw["recall"]), _r(pw["f1"]),
+            _r(bc["precision"]), _r(bc["recall"]), _r(bc["f1"]),
+            _fmt(cm["tp"]), _fmt(cm["fp"]), _fmt(cm["fn"]),
+        ]) + " |")
     # Per-scale head-to-head deltas (only where both engines produced a wall).
     lines += ["", "## Head-to-head (where both completed)", ""]
     by_rows: dict[int, dict[str, dict]] = {}
@@ -188,10 +234,16 @@ def main() -> None:
                                     "status": "fixture_failed", "error": str(e)})
             continue
 
+        truth = fixtures / f"bench_{rows}.truth.parquet"
         for engine in args.engines:
             print(f"[orchestrate] === {engine} @ {rows:,} rows ===")
-            res = run_engine(engine, fixture, rows, results_dir, args.threshold,
-                             allow_pure_python=args.allow_pure_python)
+            res, pred = run_engine(engine, fixture, rows, results_dir, args.threshold,
+                                   allow_pure_python=args.allow_pure_python)
+            # Accuracy eval runs here, BEFORE fixture/pred cleanup below.
+            acc = evaluate_datapoint(pred, truth, results_dir, engine, rows)
+            if acc is not None:
+                res["accuracy"] = acc
+            pred.unlink(missing_ok=True)
             all_results.append(res)
             # Flush the aggregate after EVERY datapoint so a later OOM can't lose
             # earlier results.

--- a/scripts/bench_er_headtohead/orchestrate.py
+++ b/scripts/bench_er_headtohead/orchestrate.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+"""Orchestrator for the ER head-to-head scaling benchmark (Splink vs GoldenMatch).
+
+Memory safety is the whole point: this process NEVER loads a fixture. For each
+(scale, engine) it spawns an isolated subprocess; the OS reclaims that datapoint's
+entire memory footprint on exit. If a datapoint is OOM-killed (SIGKILL leaves no
+JSON behind), we synthesize an `OOM` result and keep going — so the 100M tier,
+which is expected to exceed a single 64 GB box for the in-memory bucket backend,
+produces an honest "ceiling" datapoint instead of aborting the run.
+
+Only small JSON results ever live in this process. Output: an aggregate
+`bench_results.json` + `summary.md`, also appended to $GITHUB_STEP_SUMMARY.
+
+Usage:
+    python orchestrate.py --scales 100000 1000000 5000000 25000000 100000000 \
+        --engines goldenmatch splink --workdir .bench_er --dupe-rate 0.20
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+# Per-scale subprocess wall-clock cap (seconds). Generous; a real hang still ends.
+TIMEOUT_BY_ROWS = [
+    (1_000_000, 1800),
+    (5_000_000, 3600),
+    (25_000_000, 10800),
+    (100_000_000, 21600),
+]
+
+
+def _timeout_for(rows: int) -> int:
+    for ceiling, t in TIMEOUT_BY_ROWS:
+        if rows <= ceiling:
+            return t
+    return 21600
+
+
+def _run(cmd: list[str], timeout: int) -> tuple[int, str]:
+    """Run a subprocess to completion; classify how it ended. Never raises."""
+    try:
+        proc = subprocess.run(cmd, timeout=timeout)
+        return proc.returncode, "exited"
+    except subprocess.TimeoutExpired:
+        return -1, "timeout"
+
+
+def _load_or_synthesize(path: Path, returncode: int, how: str, engine: str, rows: int) -> dict:
+    if path.exists():
+        try:
+            r = json.loads(path.read_text())
+            r.setdefault("returncode", returncode)
+            return r
+        except Exception:
+            pass
+    # No JSON => the child died before its finally block could write (SIGKILL/OOM).
+    status = "timeout" if how == "timeout" else ("OOM" if returncode in (-9, 137) else "killed")
+    return {
+        "engine": engine,
+        "rows_requested": rows,
+        "status": status,
+        "returncode": returncode,
+        "note": "no result file written — process terminated by OS (likely OOM) or timed out",
+    }
+
+
+def generate(rows: int, dupe_rate: float, fixtures: Path) -> Path:
+    out = fixtures / f"bench_{rows}.parquet"
+    truth = fixtures / f"bench_{rows}.truth.parquet"
+    if out.exists():
+        print(f"[orchestrate] fixture exists, reusing {out}")
+        return out
+    print(f"[orchestrate] generating {rows:,} rows -> {out}")
+    subprocess.run(
+        [sys.executable, str(HERE / "generate_fixture.py"),
+         "--rows", str(rows), "--dupe-rate", str(dupe_rate),
+         "--out", str(out), "--ground-truth", str(truth)],
+        check=True, timeout=_timeout_for(rows),
+    )
+    return out
+
+
+def run_engine(engine: str, fixture: Path, rows: int, results_dir: Path,
+               threshold: float, allow_pure_python: bool = False) -> dict:
+    out = results_dir / f"{engine}_{rows}.json"
+    if out.exists():
+        out.unlink()  # stale result from a prior run must not masquerade as fresh
+    runner = HERE / (f"run_{engine}.py")
+    cmd = [sys.executable, str(runner), "--input", str(fixture),
+           "--rows", str(rows), "--out", str(out), "--threshold", str(threshold)]
+    if engine == "goldenmatch" and allow_pure_python:
+        cmd.append("--allow-pure-python")  # local smoke only; CI builds native
+    t0 = time.perf_counter()
+    rc, how = _run(cmd, _timeout_for(rows))
+    wall = round(time.perf_counter() - t0, 1)
+    res = _load_or_synthesize(out, rc, how, engine, rows)
+    res["orchestrator_wall_seconds"] = wall
+    return res
+
+
+def _fmt(v) -> str:
+    if v is None:
+        return "—"
+    if isinstance(v, float):
+        return f"{v:,.1f}"
+    if isinstance(v, int):
+        return f"{v:,}"
+    return str(v)
+
+
+def render_markdown(results: list[dict], dupe_rate: float) -> str:
+    lines = [
+        "# ER head-to-head: Splink (DuckDB) vs GoldenMatch (bucket+native+arrow)",
+        "",
+        f"Single machine, identical parquet fixture per scale, dupe-rate={dupe_rate}. "
+        "Wall is end-to-end dedupe (Splink: train+predict+cluster; GoldenMatch: "
+        "auto_configure+dedupe). Peak RSS is the per-process high-water mark. "
+        "`scored pairs` is recorded so blocking-aggressiveness differences are visible.",
+        "",
+        "| rows | engine | status | dedupe wall (s) | peak RSS (MB) | scored pairs | clusters | pairs/sec |",
+        "|---:|---|---|---:|---:|---:|---:|---:|",
+    ]
+    for r in sorted(results, key=lambda x: (x["rows_requested"], x["engine"])):
+        wall = r.get("dedupe_wall_seconds")
+        pairs = r.get("scored_pairs")
+        pps = round(pairs / wall) if (pairs and wall) else None
+        lines.append(
+            "| " + " | ".join([
+                _fmt(r["rows_requested"]), r["engine"], r.get("status", "?"),
+                _fmt(wall), _fmt(r.get("peak_rss_mb")), _fmt(pairs),
+                _fmt(r.get("cluster_count")), _fmt(pps),
+            ]) + " |"
+        )
+    # Per-scale head-to-head deltas (only where both engines produced a wall).
+    lines += ["", "## Head-to-head (where both completed)", ""]
+    by_rows: dict[int, dict[str, dict]] = {}
+    for r in results:
+        by_rows.setdefault(r["rows_requested"], {})[r["engine"]] = r
+    lines.append("| rows | GoldenMatch wall | Splink wall | wall ratio (GM/Splink) | GM RSS | Splink RSS |")
+    lines.append("|---:|---:|---:|---:|---:|---:|")
+    for rows in sorted(by_rows):
+        gm = by_rows[rows].get("goldenmatch", {})
+        sp = by_rows[rows].get("splink", {})
+        gw, sw = gm.get("dedupe_wall_seconds"), sp.get("dedupe_wall_seconds")
+        ratio = round(gw / sw, 2) if (gw and sw) else None
+        lines.append("| " + " | ".join([
+            _fmt(rows), _fmt(gw), _fmt(sw), _fmt(ratio),
+            _fmt(gm.get("peak_rss_mb")), _fmt(sp.get("peak_rss_mb")),
+        ]) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scales", type=int, nargs="+",
+                    default=[100_000, 1_000_000, 5_000_000, 25_000_000, 100_000_000])
+    ap.add_argument("--engines", nargs="+", default=["goldenmatch", "splink"])
+    ap.add_argument("--workdir", type=Path, default=Path(".bench_er"))
+    ap.add_argument("--dupe-rate", type=float, default=0.20)
+    ap.add_argument("--threshold", type=float, default=0.85)
+    ap.add_argument("--keep-fixtures", action="store_true",
+                    help="don't delete each fixture after its engines run (uses more disk)")
+    ap.add_argument("--allow-pure-python", action="store_true",
+                    help="LOCAL SMOKE ONLY: let GoldenMatch run without the native "
+                         "Arrow runtime. Never pass this in CI — it invalidates the "
+                         "'optimized backend' claim.")
+    args = ap.parse_args()
+
+    fixtures = args.workdir / "fixtures"
+    results_dir = args.workdir / "results"
+    fixtures.mkdir(parents=True, exist_ok=True)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    all_results: list[dict] = []
+    for rows in args.scales:
+        try:
+            fixture = generate(rows, args.dupe_rate, fixtures)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            for engine in args.engines:
+                all_results.append({"engine": engine, "rows_requested": rows,
+                                    "status": "fixture_failed", "error": str(e)})
+            continue
+
+        for engine in args.engines:
+            print(f"[orchestrate] === {engine} @ {rows:,} rows ===")
+            res = run_engine(engine, fixture, rows, results_dir, args.threshold,
+                             allow_pure_python=args.allow_pure_python)
+            all_results.append(res)
+            # Flush the aggregate after EVERY datapoint so a later OOM can't lose
+            # earlier results.
+            (args.workdir / "bench_results.json").write_text(json.dumps(all_results, indent=2))
+
+        if not args.keep_fixtures:
+            for f in fixtures.glob(f"bench_{rows}.*"):
+                f.unlink(missing_ok=True)
+
+    md = render_markdown(all_results, args.dupe_rate)
+    (args.workdir / "summary.md").write_text(md)
+    print(md)
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a") as fh:
+            fh.write(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_er_headtohead/run_goldenmatch.py
+++ b/scripts/bench_er_headtohead/run_goldenmatch.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+"""Single-datapoint GoldenMatch dedupe runner for the ER head-to-head bench.
+
+Runs ONE (engine=goldenmatch, rows=N) measurement in its own process, so all of
+its memory is reclaimed by the OS on exit. Writes one atomic JSON result and exits.
+
+Most-optimized path: bucket backend + native compiled runtime + native Arrow
+block-scorer. We set GOLDENMATCH_NATIVE=1 so a missing/unbuilt native runtime
+raises instead of silently falling back to pure Python — a silent fallback would
+make the comparison a lie. Verified again via native_enabled() before timing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import resource
+import time
+from pathlib import Path
+
+# Must be set BEFORE importing goldenmatch so the native loader + planner see them.
+os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")  # clean, reproducible CI runs
+os.environ.setdefault("GOLDENMATCH_PLANNER_BUCKET", "1")  # prefer bucket scorer
+# GOLDENMATCH_NATIVE is set from --require-native below, before the heavy imports.
+
+
+def _peak_rss_mb() -> float:
+    # Linux ru_maxrss is in KiB; this is the process high-water mark (load + dedupe).
+    return round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0, 1)
+
+
+def _atomic_write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2))
+    os.replace(tmp, path)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", type=Path, required=True)
+    ap.add_argument("--rows", type=int, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--threshold", type=float, default=0.85)
+    ap.add_argument("--require-native", action="store_true", default=True)
+    ap.add_argument("--allow-pure-python", dest="require_native", action="store_false")
+    args = ap.parse_args()
+
+    os.environ["GOLDENMATCH_NATIVE"] = "1" if args.require_native else "auto"
+
+    result: dict = {
+        "engine": "goldenmatch",
+        "backend": "bucket+native+arrow",
+        "rows_requested": args.rows,
+        "status": "error",
+        "threshold": args.threshold,
+    }
+    t_start = time.perf_counter()
+    try:
+        import polars as pl
+
+        from goldenmatch.core._native_loader import native_enabled, native_module
+        from goldenmatch.core.bench import bench_capture
+
+        try:
+            from goldenmatch import auto_configure_df, dedupe_df
+        except ImportError:  # older layouts expose these on _api
+            from goldenmatch._api import auto_configure_df, dedupe_df
+
+        native_loaded = native_module() is not None
+        result["native_loaded"] = native_loaded
+        result["native_block_scoring"] = bool(native_enabled("block_scoring"))
+        if args.require_native and not (native_loaded and native_enabled("block_scoring")):
+            raise RuntimeError(
+                "Native Arrow block-scorer is NOT active; refusing to report a "
+                "pure-Python number as the optimized backend. Build it with "
+                "`python scripts/build_native.py` or install goldenmatch[native]."
+            )
+
+        t0 = time.perf_counter()
+        df = pl.read_parquet(args.input)
+        result["rows_loaded"] = df.height
+        load_wall = time.perf_counter() - t0
+
+        # GoldenMatch's realistic optimized path: zero-config controller, then pin
+        # bucket + disable the cross-encoder rerank (avoids a HuggingFace download).
+        config = auto_configure_df(df, confidence_required=False)
+        config.backend = "bucket"
+        if hasattr(config, "rerank"):
+            config.rerank = False
+        for mk in getattr(config, "get_matchkeys", lambda: [])():
+            if getattr(mk, "rerank", None) is not None:
+                mk.rerank = False
+            if getattr(mk, "threshold", None) is not None:
+                mk.threshold = args.threshold
+
+        t0 = time.perf_counter()
+        with bench_capture() as bench:
+            ded = dedupe_df(df, config=config)
+        dedupe_wall = time.perf_counter() - t0
+
+        bench_blob = bench.to_dict()
+        metrics = bench_blob.get("metrics", {}) if isinstance(bench_blob, dict) else {}
+
+        result.update(
+            status="ok",
+            load_wall_seconds=round(load_wall, 2),
+            dedupe_wall_seconds=round(dedupe_wall, 2),
+            scored_pairs=metrics.get("scored_pair_count"),
+            block_count=metrics.get("block_count_scored") or metrics.get("block_count"),
+            # cluster_count = total resolved entities incl. singletons, to match
+            # Splink's `count(distinct cluster_id)`. multi-member tracked separately.
+            cluster_count=metrics.get("cluster_count"),
+            multi_member_clusters=metrics.get("multi_member_cluster_count"),
+            duplicate_rows_found=getattr(getattr(ded, "dupes", None), "height", None),
+            unique_records=getattr(getattr(ded, "unique", None), "height", None),
+            bench=bench_blob,
+        )
+    except MemoryError as e:
+        result.update(status="OOM", error=f"{type(e).__name__}: {e}")
+    except BaseException as e:  # noqa: BLE001 - record any failure, including SystemError
+        result.update(status="error", error=f"{type(e).__name__}: {e}")
+        raise
+    finally:
+        result["total_wall_seconds"] = round(time.perf_counter() - t_start, 2)
+        result["peak_rss_mb"] = _peak_rss_mb()
+        _atomic_write(args.out, result)
+        print(
+            f"[goldenmatch] rows={args.rows:,} status={result['status']} "
+            f"dedupe={result.get('dedupe_wall_seconds')}s "
+            f"peak_rss={result['peak_rss_mb']}MB pairs={result.get('scored_pairs')}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_er_headtohead/run_goldenmatch.py
+++ b/scripts/bench_er_headtohead/run_goldenmatch.py
@@ -41,6 +41,8 @@ def main() -> None:
     ap.add_argument("--input", type=Path, required=True)
     ap.add_argument("--rows", type=int, required=True)
     ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--pred-out", type=Path, default=None,
+                    help="write {record_id, pred_cluster_id} parquet for accuracy eval")
     ap.add_argument("--threshold", type=float, default=0.85)
     ap.add_argument("--require-native", action="store_true", default=True)
     ap.add_argument("--allow-pure-python", dest="require_native", action="store_false")
@@ -98,6 +100,32 @@ def main() -> None:
         with bench_capture() as bench:
             ded = dedupe_df(df, config=config)
         dedupe_wall = time.perf_counter() - t0
+
+        # Per-record cluster assignment for accuracy eval. clusters is
+        # {cid: {"members": [__row_id__...]}} over ALL records; the fixture's
+        # record_id IS the input row index, and GoldenMatch preserves it as
+        # __row_id__, so member row-ids are record-ids directly.
+        if args.pred_out is not None:
+            import numpy as np
+            import pyarrow as pa
+            import pyarrow.parquet as pq
+
+            clusters = getattr(ded, "clusters", None) or {}
+            rids, cids = [], []
+            for cid, c in clusters.items():
+                members = c["members"] if isinstance(c, dict) else c.members
+                rids.extend(members)
+                cids.extend([cid] * len(members))
+            pq.write_table(
+                pa.table(
+                    {
+                        "record_id": pa.array(np.asarray(rids, dtype=np.int64)),
+                        "pred_cluster_id": pa.array(np.asarray(cids, dtype=np.int64)),
+                    }
+                ),
+                args.pred_out,
+                compression="zstd",
+            )
 
         bench_blob = bench.to_dict()
         metrics = bench_blob.get("metrics", {}) if isinstance(bench_blob, dict) else {}

--- a/scripts/bench_er_headtohead/run_splink.py
+++ b/scripts/bench_er_headtohead/run_splink.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+"""Single-datapoint Splink (DuckDB backend) dedupe runner for the ER head-to-head.
+
+Runs ONE (engine=splink, rows=N) measurement in its own process; the OS reclaims
+all memory on exit. Splink has no zero-config mode, so we give it an idiomatic,
+reasonable settings spec (compound blocking + standard comparisons) that mirrors
+the blocking semantics GoldenMatch's auto-config lands on, then record the
+scored-pair count so any blocking-aggressiveness difference is visible, not hidden.
+
+Sub-phases (train / predict / cluster) are timed separately for transparency;
+`dedupe_wall_seconds` is their sum — the fair end-to-end cost, paralleling
+GoldenMatch's auto_configure+dedupe. Counts come from DuckDB relations, never a
+pandas materialization, so this stays memory-bounded at 25M/100M.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import resource
+import time
+from pathlib import Path
+
+
+def _peak_rss_mb() -> float:
+    return round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0, 1)
+
+
+def _atomic_write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2))
+    os.replace(tmp, path)
+
+
+def _count(splink_df) -> int | None:
+    """Row count without materialising to pandas (DuckDB relation fast path)."""
+    try:
+        return int(splink_df.as_duckdbpyrelation().count("*").fetchone()[0])
+    except Exception:
+        try:
+            return len(splink_df.as_pandas_dataframe())
+        except Exception:
+            return None
+
+
+def _distinct_clusters(splink_df) -> int | None:
+    try:
+        rel = splink_df.as_duckdbpyrelation()
+        return int(rel.aggregate("count(distinct cluster_id) AS c").fetchone()[0])
+    except Exception:
+        return None
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", type=Path, required=True)
+    ap.add_argument("--rows", type=int, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--threshold", type=float, default=0.95)
+    ap.add_argument("--max-pairs", type=float, default=2e6, help="u-estimation sample size")
+    args = ap.parse_args()
+
+    result: dict = {
+        "engine": "splink",
+        "backend": "duckdb",
+        "rows_requested": args.rows,
+        "status": "error",
+        "threshold": args.threshold,
+    }
+    t_start = time.perf_counter()
+    try:
+        from splink import DuckDBAPI, Linker, SettingsCreator, block_on
+        import splink.comparison_library as cl
+
+        db_api = DuckDBAPI()
+
+        settings = SettingsCreator(
+            link_type="dedupe_only",
+            unique_id_column_name="record_id",
+            blocking_rules_to_generate_predictions=[
+                block_on("surname", "substr(dob, 1, 4)"),
+                block_on("first_name", "substr(dob, 1, 4)"),
+                block_on("postcode"),
+            ],
+            comparisons=[
+                cl.JaroWinklerAtThresholds("first_name", [0.9, 0.7]),
+                cl.JaroWinklerAtThresholds("surname", [0.9, 0.7]),
+                cl.DamerauLevenshteinAtThresholds("dob", [1, 2]),
+                cl.DamerauLevenshteinAtThresholds("postcode", [1, 2]),
+                cl.ExactMatch("city"),
+            ],
+        )
+
+        # Register the parquet as a DuckDB view so it's read lazily (no pandas
+        # materialization at scale). A bare path string gets templated raw into
+        # Splink's SQL and fails to parse; a view name resolves cleanly. `_con`
+        # is Splink's underlying duckdb connection (stable on the 4.x DuckDBAPI).
+        db_api._con.execute(
+            f"CREATE OR REPLACE VIEW bench_input AS "
+            f"SELECT * FROM read_parquet('{args.input}')"
+        )
+        linker = Linker("bench_input", settings, db_api=db_api)
+
+        t0 = time.perf_counter()
+        linker.training.estimate_probability_two_random_records_match(
+            [block_on("surname", "dob")], recall=0.7
+        )
+        linker.training.estimate_u_using_random_sampling(max_pairs=args.max_pairs)
+        linker.training.estimate_parameters_using_expectation_maximisation(block_on("surname"))
+        linker.training.estimate_parameters_using_expectation_maximisation(block_on("first_name"))
+        train_wall = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        df_predict = linker.inference.predict(threshold_match_probability=0.5)
+        scored_pairs = _count(df_predict)
+        predict_wall = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        df_clusters = linker.clustering.cluster_pairwise_predictions_at_threshold(
+            df_predict, threshold_match_probability=args.threshold
+        )
+        cluster_count = _distinct_clusters(df_clusters)
+        cluster_wall = time.perf_counter() - t0
+
+        result.update(
+            status="ok",
+            train_wall_seconds=round(train_wall, 2),
+            predict_wall_seconds=round(predict_wall, 2),
+            cluster_wall_seconds=round(cluster_wall, 2),
+            dedupe_wall_seconds=round(train_wall + predict_wall + cluster_wall, 2),
+            scored_pairs=scored_pairs,
+            cluster_count=cluster_count,
+        )
+    except MemoryError as e:
+        result.update(status="OOM", error=f"{type(e).__name__}: {e}")
+    except BaseException as e:  # noqa: BLE001
+        result.update(status="error", error=f"{type(e).__name__}: {e}")
+        raise
+    finally:
+        result["total_wall_seconds"] = round(time.perf_counter() - t_start, 2)
+        result["peak_rss_mb"] = _peak_rss_mb()
+        _atomic_write(args.out, result)
+        print(
+            f"[splink] rows={args.rows:,} status={result['status']} "
+            f"dedupe={result.get('dedupe_wall_seconds')}s "
+            f"peak_rss={result['peak_rss_mb']}MB pairs={result.get('scored_pairs')}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_er_headtohead/run_splink.py
+++ b/scripts/bench_er_headtohead/run_splink.py
@@ -57,6 +57,8 @@ def main() -> None:
     ap.add_argument("--input", type=Path, required=True)
     ap.add_argument("--rows", type=int, required=True)
     ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--pred-out", type=Path, default=None,
+                    help="write {record_id, pred_cluster_id} parquet for accuracy eval")
     ap.add_argument("--threshold", type=float, default=0.95)
     ap.add_argument("--max-pairs", type=float, default=2e6, help="u-estimation sample size")
     args = ap.parse_args()
@@ -122,6 +124,17 @@ def main() -> None:
         )
         cluster_count = _distinct_clusters(df_clusters)
         cluster_wall = time.perf_counter() - t0
+
+        # Per-record cluster assignment for accuracy eval (DuckDB -> parquet, no
+        # pandas materialization). Splink names the entity column `cluster_id`.
+        if args.pred_out is not None:
+            try:
+                rel = df_clusters.as_duckdbpyrelation()
+                rel.project("record_id, cluster_id AS pred_cluster_id").write_parquet(
+                    str(args.pred_out)
+                )
+            except Exception as e:  # noqa: BLE001 - eval is best-effort
+                result["pred_emit_error"] = f"{type(e).__name__}: {e}"
 
         result.update(
             status="ok",


### PR DESCRIPTION
## What

A memory-safe head-to-head scaling benchmark comparing **Splink (DuckDB)** against **GoldenMatch's optimized bucket + native + Arrow path**, sweeping **100k / 1M / 5M / 25M / 100M** rows on one machine with an identical per-scale fixture.

Motivation: no apples-to-apples wall + RSS comparison between these engines exists publicly. Splink publishes 7M/~2min/1B-pairs; GoldenMatch publishes 25M/6.5min/57.7GB — different pair counts, different operations, not comparable. This lane produces a comparison we can stand behind.

## How it stays honest
- **Same fixture, same machine, same scale** for both engines. `scored_pairs` is reported so blocking-aggressiveness differences are *visible*, not hidden (pair count, not row count, drives ER wall-clock).
- **GoldenMatch can't silently cheat downward**: the runner sets `GOLDENMATCH_NATIVE=1` and asserts `native_enabled("block_scoring")` — if the Arrow runtime isn't actually loaded, the datapoint fails loudly instead of reporting a pure-Python number as "optimized".
- **Splink isn't crippled**: idiomatic settings (compound blocking + standard comparisons) mirroring the blocking GoldenMatch's auto-config lands on. Its no-zero-config asymmetry is noted, not engineered away.
- Both engines report **total distinct clusters** for an apples-to-apples resolved-entity count.

## How it survives OOM on GitHub
`orchestrate.py` never loads a fixture. Each `(scale, engine)` runs as an isolated subprocess; the OS reclaims its memory on exit. An OOM-killed datapoint (SIGKILL, no result file) is recorded as `status: OOM` and the sweep continues; the aggregate JSON is flushed after every datapoint. **The 100M bucket datapoint is expected to OOM on a single 64 GB box** — that single-node in-memory ceiling is itself a result.

## Files
| File | Role |
|---|---|
| `scripts/bench_er_headtohead/generate_fixture.py` | Streaming, bounded-memory person-shaped parquet generator (+ ground truth), scales to 100M. |
| `scripts/bench_er_headtohead/run_goldenmatch.py` | One datapoint, bucket+native+arrow, fails loud if native absent. |
| `scripts/bench_er_headtohead/run_splink.py` | One datapoint, Splink 4.x DuckDB dedupe; counts via DuckDB relations (no pandas materialization). |
| `scripts/bench_er_headtohead/orchestrate.py` | Subprocess-per-datapoint sweep, OOM-tolerant, aggregates to `summary.md` + `bench_results.json`. |
| `.github/workflows/bench-er-headtohead.yml` | `workflow_dispatch` lane on the 64 GB runner; builds native, installs Splink. |

## Validation
Ran locally end-to-end at 20k/50k: generator output (realistic typos + nulls, resolvable clusters), both runners, and the full orchestrator sweep with fixture cleanup and aggregation. Sample at 20k — GoldenMatch 1.45s / 420 MB; Splink 4.2s (mostly one-time model training) / 274 MB; Splink clusters land ~on ground truth, GoldenMatch over-merges slightly at threshold 0.85.

## Deferred follow-ups (noted in the README)
- **F1 / accuracy** — ground truth is generated but pairwise F1 scoring is deferred; this round is wall + RSS + pairs + clusters.
- One fixture shape (person-like); Splink comparison spec is fixed, not per-scale tuned.

https://claude.ai/code/session_01QcTUMcZv7JtTxhm5fvfGhX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcTUMcZv7JtTxhm5fvfGhX)_