### PR TITLE
release: goldencheck 1.3.0, goldenflow 1.2.0, goldenpipe 1.2.1, infermap 0.5.0

### DIFF
--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [1.3.0] - 2026-06-01
+
+### Added
+- `scan_dataframe(df, ...)` top-level export: scan an in-memory Polars DataFrame directly, without a CSV round-trip.
+- Identity-safe primary-key preflight (`IdentitySafePkProfiler`): scans now emit a WARNING when a table has no stable primary-key candidate.
+
+### Security
+- SSRF guard on the `goldencheck serve` `/scan-url` endpoint (`_validate_remote_url`): rejects non-HTTP(S) schemes and private/internal IP addresses.
+
+### Changed
+- Scanner perf: cached `n_unique`/`null_count` and vectorized generalization in the column-profile loop (no behavioral change).
+- Repository and project URLs rebranded from `benzsevern` to `benseverndev-oss`.
+
 ## [1.1.0] - 2026-04-03
 
 ### Added

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 # Core: scanner + models
 from goldencheck.config.loader import load_config

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "1.2.0"
+version = "1.3.0"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.2.0 (2026-06-01)
+
+New `carceral` domain pack plus a native-Polars (expr-mode) perf migration of the
+transform library. The expr migration is output-preserving: existing test
+assertions are unchanged; only the internal call shape changed.
+
+### Added
+
+- `carceral` domain pack (U.S. prisons / jails / detention): `carceral_org_strip`,
+  `carceral_abbreviate`, `carceral_name_normalize`, and `latlng_pack`, plus the
+  `CARCERAL_OPERATOR_ORGS`, `CARCERAL_BOP_ABBREVIATIONS`, and
+  `CARCERAL_STATE_COMPLEX_ALIASES` constants. Registered as the `carceral` domain.
+
+### Performance
+
+- Native-Polars (expr-mode) rewrites of the currency, percentage, integer,
+  truncate, pad, html, url, emoji, line-ending, number-extract, address, and state
+  transforms. ASCII fast path for `normalize_unicode`; vectorized `date_iso8601`
+  for numeric and 4-digit-string year columns. Outputs are unchanged.
+
+### Changed
+
+- Repository and project URLs rebranded from `benzsevern` to `benseverndev-oss`.
+
 ## 1.1.6 (2026-05-13)
 
 Bug-fix release. Resolves a panic on large datasets surfaced by the

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.6"
+__version__ = "1.2.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.1.6"
+version = "1.2.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenpipe/CHANGELOG.md
+++ b/packages/python/goldenpipe/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.2.1 (2026-06-01)
+
+### Fixed
+
+- The `/validate` API route no longer returns the raw exception/traceback to
+  clients: it now logs the traceback server-side and returns only the first
+  error line, truncated to 200 chars.
+
+### Changed
+
+- Repository and project URLs rebranded from `benzsevern` to `benseverndev-oss`.
+
 ## 1.2.0 (2026-05-13)
 
 **Suite orchestration for Identity Graph.** GoldenPipe gains first-class

--- a/packages/python/goldenpipe/goldenpipe/__init__.py
+++ b/packages/python/goldenpipe/goldenpipe/__init__.py
@@ -1,5 +1,5 @@
 """GoldenPipe -- pluggable pipeline framework for data quality."""
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 from goldenpipe._api import run, run_df, run_stages
 from goldenpipe.config.loader import load_config

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldenpipe"
-version = "1.2.0"
+version = "1.2.1"
 description = "Pluggable pipeline framework for data quality workflows"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/python/goldenpipe/server.json
+++ b/packages/python/goldenpipe/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenPipe",
   "description": "One command to validate, transform, and deduplicate — chain GoldenCheck + Flow + Match.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenpipe/",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenpipe",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenpipe",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenpipe/tests/test_pipeline.py
+++ b/packages/python/goldenpipe/tests/test_pipeline.py
@@ -56,4 +56,4 @@ class TestImports:
         assert hasattr(gp, "PipeResult")
         assert hasattr(gp, "stage")
         assert hasattr(gp, "__version__")
-        assert gp.__version__ == "1.2.0"
+        assert gp.__version__ == "1.2.1"

--- a/packages/python/infermap/CHANGELOG.md
+++ b/packages/python/infermap/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-06-01
+
+### Added
+- Identity feeder: `write_aliases_from_mapping(...)` plus the `AliasWriteResult` dataclass, exported at top level. Writes per-record identity aliases into a GoldenMatch `IdentityStore` from an InferMap `MapResult`. Optional and goldenmatch-gated (lazy import; requires `goldenmatch>=1.15.0` only when called).
+- Newly public re-exports: `DomainPackTarget`, `detect_domain`, `detect_domain_detailed`.
+
+### Changed
+- Repository and project URLs rebranded from `benzsevern` to `benseverndev-oss`.
+
 ## [0.3.0] - 2026-04-10
 
 ### Added

--- a/packages/python/infermap/infermap/__init__.py
+++ b/packages/python/infermap/infermap/__init__.py
@@ -1,6 +1,6 @@
 """infermap — inference-driven schema mapping engine."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 from infermap.config import from_config
 from infermap.detect import detect_domain, detect_domain_detailed

--- a/packages/python/infermap/pyproject.toml
+++ b/packages/python/infermap/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "infermap"
-version = "0.4.0"
+version = "0.5.0"
 description = "Inference-driven schema mapping engine"
 readme = "README.md"
 license = "MIT"

--- a/packages/python/infermap/server.json
+++ b/packages/python/infermap/server.json
@@ -4,7 +4,7 @@
   "title": "InferMap",
   "description": "Map messy columns to a known schema — 7 scorers, domain dictionaries, F1 0.84. Zero config.",
   "websiteUrl": "https://benseverndev-oss.github.io/infermap/",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/infermap",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "infermap",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Cuts releases for the four packages whose MCP Registry listings were deleted during the benseverndev-oss namespace migration. Each needs a post-rename PyPI version so its README `mcp-name` marker matches the new `io.github.benseverndev-oss/<pkg>` server name (the registry's PyPI-ownership check rejects the sync otherwise).

## Bumps (version in pyproject.toml + __init__.py + server.json, plus CHANGELOG)
| Package | Bump | Highlights |
|---|---|---|
| goldencheck | 1.2.0 -> **1.3.0** (minor) | new `scan_dataframe` export; `IdentitySafePkProfiler` warning; `/scan-url` SSRF guard |
| goldenflow | 1.1.6 -> **1.2.0** (minor) | new `carceral` domain pack; output-preserving expr-mode transform perf migration |
| goldenpipe | 1.2.0 -> **1.2.1** (patch) | `/validate` no longer leaks tracebacks |
| infermap | 0.4.0 -> **0.5.0** (minor) | identity feeder (`write_aliases_from_mapping`, `AliasWriteResult`); widened public `__all__` |

Version scoping was reviewed per package against the diff since each last tag. Also updates the goldenpipe `__version__` assertion test to 1.2.1.

## After merge
Create 4 GitHub Releases (`goldencheck-v1.3.0`, `goldenflow-v1.2.0`, `goldenpipe-v1.2.1`, `infermap-v0.5.0`) -> PyPI publish -> `publish-mcp` (now PyPI-wait-gated, #654) re-lists each under `io.github.benseverndev-oss/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)