### PR TITLE
feat(arrow-phase1): scorer DataFrame contract + build_clusters columnar ingest (Waves 1-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,18 +271,31 @@ jobs:
           #
           # For goldenmatch only: also produce coverage.xml in this same
           # pytest run so the floor check (next step) has the artifact
-          # without re-executing the suite. Coverage instrumentation adds
-          # ~30% wall vs ~4x for a second serial pytest pass (pre-2026-05-16
-          # this lane was 105s plain + 406s with cov; combining drops total
-          # to ~140s for the goldenmatch matrix entry).
-          COV_ARGS=""
+          # without re-executing the suite.
+          COV=""
+          COV_REPORT=""
+          SERIAL_HEAVY=""
           if [ "${{ matrix.pkg }}" = "goldenmatch" ]; then
-            COV_ARGS="--cov=goldenmatch --cov-report=xml:packages/python/goldenmatch/coverage.xml --cov-report=term"
+            COV="--cov=goldenmatch"
+            COV_REPORT="--cov-report=xml:packages/python/goldenmatch/coverage.xml --cov-report=term"
+            # test_controller_adaptive_e2e runs the FULL real auto-config
+            # iteration loop -- the suite's heaviest test. Under `-n auto` +
+            # coverage on a 16GB runner its peak OOM-kills an xdist worker
+            # (silent "node down: Not properly terminated", no traceback). Run
+            # it SERIALLY (full runner memory, no worker contention) and combine
+            # coverage via --cov-append so the floor check still sees its lines.
+            SERIAL_HEAVY="packages/python/goldenmatch/tests/test_controller_adaptive_e2e.py"
           fi
-          # --durations=20 surfaces the slowest tests in the CI log so
-          # we can target wall-time investigation (#433). Negligible
-          # cost; only adds a summary block at the end of the pytest run.
-          uv run pytest packages/python/${{ matrix.pkg }} -n auto --timeout=120 --timeout-method=thread --durations=20 $COV_ARGS $IGNORE
+          # --durations=20 surfaces the slowest tests in the CI log (#433).
+          if [ -n "$SERIAL_HEAVY" ]; then
+            # Parallel run: everything except the heavy file. Collect coverage
+            # data only; the serial run below appends and writes the xml.
+            uv run pytest packages/python/${{ matrix.pkg }} -n auto --timeout=120 --timeout-method=thread --durations=20 $COV $IGNORE --ignore="$SERIAL_HEAVY"
+            # Serial run for the heavy file: full runner memory, no xdist.
+            uv run pytest "$SERIAL_HEAVY" --timeout=120 --timeout-method=thread --durations=20 $COV --cov-append $COV_REPORT
+          else
+            uv run pytest packages/python/${{ matrix.pkg }} -n auto --timeout=120 --timeout-method=thread --durations=20 $COV $COV_REPORT $IGNORE
+          fi
       # Per-module coverage gate (goldenmatch only — other packages don't yet
       # have floors defined). Reads the coverage.xml produced by the pytest
       # step above. Fails CI if any tracked module regresses below its floor

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -379,6 +379,21 @@ def build_clusters(
         )
         return materialize_cluster_dict(clusters_ds, pairs)
 
+    # Arrow Phase 1 (Wave 2): accept a columnar pair stream as a first-class
+    # input. A Polars DataFrame (PAIR_STREAM_SCHEMA: id_a, id_b, score) is
+    # converted via the numpy path -- NOT a Python list comprehension -- to the
+    # list[(int, int, float)] the Union-Find / pair_scores path below consumes.
+    # The return shape is unchanged (dict[int, dict]); Phase 2 changes it to
+    # the two-frame ClusterFrames layout. The list[tuple] branch below stays
+    # for the deprecation window.
+    if _is_pairs_dataframe(pairs):
+        if all_ids is None and not pairs.is_empty():
+            import numpy as _np
+            a_np = pairs["id_a"].to_numpy()
+            b_np = pairs["id_b"].to_numpy()
+            all_ids = _np.unique(_np.concatenate([a_np, b_np])).tolist()
+        pairs = _pairs_df_to_list_numpy(pairs)
+
     # Derive all_ids from pairs when not provided explicitly
     if all_ids is None:
         seen: set[int] = set()
@@ -915,6 +930,20 @@ def build_clusters_columnar(
         weak_cluster_threshold=weak_cluster_threshold,
         auto_split=auto_split,
     )
+
+
+def _is_pairs_dataframe(pairs: Any) -> bool:
+    """True when ``pairs`` is a Polars DataFrame (the columnar pair stream).
+
+    polars is a hard dependency of goldenmatch but is imported lazily here so
+    cluster.py stays import-light for the list path. A cheap duck-type guard
+    (``columns`` attr + ``is_empty``) avoids importing polars when the input is
+    obviously a list; the isinstance check confirms it.
+    """
+    if not hasattr(pairs, "is_empty"):
+        return False
+    import polars as pl
+    return isinstance(pairs, pl.DataFrame)
 
 
 def _pairs_df_to_list_numpy(df) -> list[tuple[int, int, float]]:

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -946,7 +946,7 @@ def build_clusters_columnar(
     )
 
 
-def _pairs_df_to_list_numpy(df) -> list[tuple[int, int, float]]:
+def _pairs_df_to_list_numpy(df: pl.DataFrame) -> list[tuple[int, int, float]]:
     """Faster DataFrame -> list[Pair] via numpy.tolist().
 
     The legacy ``scorer.pairs_df_to_list`` uses Polars' Series.to_list()
@@ -1214,7 +1214,7 @@ def build_clusters_v2_columnar(
 
 
 def build_clusters_arrow_native(
-    pairs_df,  # pl.DataFrame with PAIR_STREAM_SCHEMA columns
+    pairs_df: pl.DataFrame,  # PAIR_STREAM_SCHEMA columns
     all_ids: list[int] | None = None,
     max_cluster_size: int = 100,
 ) -> ClusterFrames:
@@ -1303,7 +1303,7 @@ def build_clusters_arrow_native(
     return ClusterFrames(assignments=assignments, metadata=metadata)
 
 
-def metadata_height(arrow_array) -> int:
+def metadata_height(arrow_array: Any) -> int:
     """Tiny helper -- get row count from a PyArrow ArrayData/Array
     without materializing the values. Used for the ``quality`` column
     construction in ``build_clusters_arrow_native``."""

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -344,8 +344,22 @@ def _emit_cluster_profile(clusters: dict[int, dict]) -> None:
     current_emitter().set_cluster(profile)
 
 
+def _is_pairs_dataframe(pairs: Any) -> bool:
+    """True when ``pairs`` is a Polars DataFrame (the columnar pair stream).
+
+    polars is a hard dependency of goldenmatch but is imported lazily here so
+    cluster.py stays import-light for the list path. The cheap ``is_empty``
+    duck-type check short-circuits the common list input before importing
+    polars; the isinstance check is the actual gate.
+    """
+    if not hasattr(pairs, "is_empty"):
+        return False
+    import polars as pl
+    return isinstance(pairs, pl.DataFrame)
+
+
 def build_clusters(
-    pairs: Any,  # list[tuple[int, int, float]] | ray.data.Dataset
+    pairs: Any,  # list[tuple[int, int, float]] | pl.DataFrame | ray.data.Dataset
     all_ids: list[int] | None = None,
     max_cluster_size: int = 100,
     weak_cluster_threshold: float = 0.3,
@@ -930,20 +944,6 @@ def build_clusters_columnar(
         weak_cluster_threshold=weak_cluster_threshold,
         auto_split=auto_split,
     )
-
-
-def _is_pairs_dataframe(pairs: Any) -> bool:
-    """True when ``pairs`` is a Polars DataFrame (the columnar pair stream).
-
-    polars is a hard dependency of goldenmatch but is imported lazily here so
-    cluster.py stays import-light for the list path. A cheap duck-type guard
-    (``columns`` attr + ``is_empty``) avoids importing polars when the input is
-    obviously a list; the isinstance check confirms it.
-    """
-    if not hasattr(pairs, "is_empty"):
-        return False
-    import polars as pl
-    return isinstance(pairs, pl.DataFrame)
 
 
 def _pairs_df_to_list_numpy(df) -> list[tuple[int, int, float]]:

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -924,6 +924,11 @@ def _score_one_block(
     Polars ``.filter()`` on the frame rather than a Python list
     comprehension. Default False keeps the legacy list contract for the
     deprecation window.
+
+    NOTE (Wave 3 convergence): the ``_emit_dataframe=True`` path duplicates the
+    across-files Polars-filter logic in ``_score_one_block_columnar`` below. They
+    are byte-identical today; if you change one, mirror the other until Wave 3
+    retires ``_score_one_block_columnar``.
     """
     block_df = block.df.collect()
 
@@ -1326,10 +1331,10 @@ def find_fuzzy_matches_columnar(
             block_df, mk, exclude_pairs, pre_scored_pairs,
             _emit_dataframe=True,
         )
-        # On the hot path the emission branch returns a DataFrame, but
-        # the n < 2 / total_weight == 0 early returns above the hot
-        # path always return ``[]`` regardless of the flag (they
-        # short-circuit before knowing about it). Wrap defensively.
+        # Post Phase-1 Wave 1, find_fuzzy_matches honours _emit_dataframe on
+        # ALL branches (incl. the n<2 / total_weight==0 early returns), so this
+        # is always a DataFrame. The isinstance wrap is a belt-and-suspenders
+        # no-op kept against any future branch that forgets the flag.
         if isinstance(result, pl.DataFrame):
             return result
         return pairs_list_to_df(result)
@@ -1353,6 +1358,10 @@ def _score_one_block_columnar(
     Skips the list-of-tuples accumulation that ``_score_one_block``
     pays before its caller would re-convert. Across-files filtering is
     applied as a Polars expression on the result frame, vectorized.
+
+    NOTE (Wave 3 convergence): the across-files Polars-filter logic here is
+    byte-identical to ``_score_one_block(..., _emit_dataframe=True)``. Mirror any
+    change to both until Wave 3 retires this twin.
     """
     block_df = block.df.collect()
 

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -634,29 +634,47 @@ def find_fuzzy_matches(
         exclude_pairs: Optional set of (min_id, max_id) pairs to skip.
         pre_scored_pairs: Optional pre-computed (id_a, id_b, score) pairs
             from ANN blocking. When set, skip NxN scoring.
-        _emit_dataframe: Arrow-native roadmap Phase 1c hot-path opt-in.
-            When True AND the call is on the hot path (no NE, no
-            ``exclude_pairs``, no ``pre_scored_pairs``), emit a
-            ``pl.DataFrame`` directly from numpy arrays instead of
-            constructing a Python list of tuples. Zero per-pair Python
-            overhead at scale (the bottleneck for 200M-pair / 5M-row runs
-            per the Phase 1 spec). Non-hot-path branches still return
-            ``list[tuple]`` even when True; ``find_fuzzy_matches_columnar``
-            wraps those at the boundary. Default False keeps the existing
-            list contract for backward compat. The arg is positional-only
-            via the ``*`` marker so legacy callers don't accidentally pass
-            it.
+        _emit_dataframe: Arrow-native roadmap Phase 1 opt-in. When True,
+            EVERY return branch (early-empty, ``pre_scored_pairs``,
+            negative-evidence penalty, ``exclude_pairs``, and the hot
+            path) emits a ``pl.DataFrame`` with ``PAIR_STREAM_SCHEMA``
+            instead of a Python list of tuples. On the hot path the
+            frame is built directly from numpy arrays (zero per-pair
+            Python overhead — the bottleneck for 200M-pair / 5M-row runs
+            per the Phase 1 spec); the non-hot branches build their
+            filtered result list then convert once at the boundary via
+            ``pairs_list_to_df`` (Task 1.1, #623). Default False keeps
+            the legacy ``list[tuple]`` contract for the one-release
+            deprecation window. The arg is keyword-only via the ``*``
+            marker so legacy callers don't accidentally pass it.
 
     Returns:
         ``list[tuple[int, int, float]]`` by default (legacy contract).
-        ``pl.DataFrame`` with ``PAIR_STREAM_SCHEMA`` columns when
-        ``_emit_dataframe=True`` AND the call hits the hot path.
+        ``pl.DataFrame`` with ``PAIR_STREAM_SCHEMA`` columns from ALL
+        branches when ``_emit_dataframe=True``.
     """
     # find_fuzzy_matches requires mk.threshold + field weights/scorers set;
     # upstream config validation enforces this. Pyright sees the schema-level
     # Optional, so we narrow once here for clarity.
     assert mk.threshold is not None, "find_fuzzy_matches requires mk.threshold"
     mk_threshold: float = mk.threshold
+
+    # Task 1.1 (#623): emit a uniform return shape across ALL branches.
+    # When ``_emit_dataframe`` is True every branch (early-empty,
+    # pre_scored_pairs, NE-penalty, exclude_pairs, hot path) returns a
+    # ``pl.DataFrame`` with ``PAIR_STREAM_SCHEMA``; otherwise the legacy
+    # ``list[tuple]`` (deprecation window). These two helpers keep the
+    # branch bodies readable and the conversion in one place.
+    def _emit_empty() -> list[tuple[int, int, float]] | pl.DataFrame:
+        return pl.DataFrame(schema=PAIR_STREAM_SCHEMA) if _emit_dataframe else []
+
+    def _emit_results(
+        results: list[tuple[int, int, float]],
+    ) -> list[tuple[int, int, float]] | pl.DataFrame:
+        if not _emit_dataframe:
+            return results
+        return pairs_list_to_df(results)
+
     # Fast path: pre-scored pairs from ANN (skip NxN scoring)
     if pre_scored_pairs is not None:
         results = []
@@ -666,11 +684,11 @@ def find_fuzzy_matches(
                 if exclude_pairs and pair_key in exclude_pairs:
                     continue
                 results.append((pair_key[0], pair_key[1], score))
-        return results
+        return _emit_results(results)
 
     n = block_df.height
     if n < 2:
-        return []
+        return _emit_empty()
 
     row_ids = block_df["__row_id__"].to_list()
 
@@ -690,7 +708,7 @@ def find_fuzzy_matches(
 
     total_weight = sum(_w(f) for f in mk.fields)
     if total_weight == 0.0:
-        return []
+        return _emit_empty()
 
     # Phase 1: Score cheap fields (exact + soundex) and build null masks.
     #
@@ -825,7 +843,7 @@ def find_fuzzy_matches(
     rows_idx, cols_idx = np.where(upper >= mk_threshold)
 
     if len(rows_idx) == 0:
-        return []
+        return _emit_empty()
 
     row_id_arr = np.array(row_ids)
     ids_a = row_id_arr[rows_idx]
@@ -854,9 +872,11 @@ def find_fuzzy_matches(
                 pair_key = (min(int(a), int(b)), max(int(a), int(b)))
                 if pair_key not in exclude_pairs:
                     results.append((int(a), int(b), float(s)))
-            return results
-        return [(int(a), int(b), float(s)) for a, b, s in zip(ids_a, ids_b, scores)
-                if s >= mk_threshold]
+            return _emit_results(results)
+        return _emit_results(
+            [(int(a), int(b), float(s)) for a, b, s in zip(ids_a, ids_b, scores)
+             if s >= mk_threshold]
+        )
 
     if exclude_pairs is not None and len(exclude_pairs) > 0:
         results = []
@@ -864,7 +884,7 @@ def find_fuzzy_matches(
             pair_key = (min(int(a), int(b)), max(int(a), int(b)))
             if pair_key not in exclude_pairs:
                 results.append((int(a), int(b), float(s)))
-        return results
+        return _emit_results(results)
 
     # HOT PATH: no NE, no exclude_pairs, no pre_scored_pairs. ~99% of
     # production block-scoring calls land here. The Phase 1c

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -912,24 +912,56 @@ def _score_one_block(
     exclude_pairs: set[tuple[int, int]] | frozenset[tuple[int, int]],
     across_files_only: bool = False,
     source_lookup: dict[int, str] | None = None,
-) -> list[tuple[int, int, float]]:
-    """Score a single block — safe to call from a thread."""
+    *,
+    _emit_dataframe: bool = False,
+) -> list[tuple[int, int, float]] | pl.DataFrame:
+    """Score a single block — safe to call from a thread.
+
+    Task 1.2 (#623): ``_emit_dataframe`` threads through to
+    ``find_fuzzy_matches`` so the block scorer can be DataFrame-canonical.
+    When True the return is a ``pl.DataFrame`` (``PAIR_STREAM_SCHEMA``)
+    and the ``across_files_only`` cross-source filter is applied via a
+    Polars ``.filter()`` on the frame rather than a Python list
+    comprehension. Default False keeps the legacy list contract for the
+    deprecation window.
+    """
     block_df = block.df.collect()
 
     if across_files_only and source_lookup:
         sources_in_block = block_df["__source__"].unique().to_list()
         if len(sources_in_block) < 2:
-            return []
+            return pl.DataFrame(schema=PAIR_STREAM_SCHEMA) if _emit_dataframe else []
 
     pairs = find_fuzzy_matches(
         block_df, mk,
         exclude_pairs=exclude_pairs,
         pre_scored_pairs=block.pre_scored_pairs,
+        _emit_dataframe=_emit_dataframe,
     )
-    # _score_one_block never opts into the Phase-1c DataFrame emit
-    # (_emit_dataframe defaults to False); the return is always a list.
-    # Narrow for pyright now that the find_fuzzy_matches return type
-    # includes pl.DataFrame as a union.
+
+    if _emit_dataframe:
+        # find_fuzzy_matches emits a frame in every branch under the flag.
+        assert isinstance(pairs, pl.DataFrame)
+        if across_files_only and source_lookup and not pairs.is_empty():
+            # Vectorized cross-source filter: join row_id -> source on
+            # both endpoints, keep pairs whose sources differ. Avoids the
+            # per-pair Python dict lookup the list path does.
+            src_map = pl.DataFrame({
+                "__row_id__": list(source_lookup.keys()),
+                "__src__": list(source_lookup.values()),
+            })
+            pairs = (
+                pairs
+                .join(src_map.rename({"__row_id__": "id_a", "__src__": "src_a"}),
+                      on="id_a", how="left")
+                .join(src_map.rename({"__row_id__": "id_b", "__src__": "src_b"}),
+                      on="id_b", how="left")
+                .filter(pl.col("src_a") != pl.col("src_b"))
+                .drop(["src_a", "src_b"])
+            )
+        return pairs
+
+    # Legacy list path (deprecation window).
     assert isinstance(pairs, list)
 
     if across_files_only and source_lookup:

--- a/packages/python/goldenmatch/tests/test_cluster.py
+++ b/packages/python/goldenmatch/tests/test_cluster.py
@@ -272,3 +272,101 @@ def test_union_find_nodes_returns_added_members():
     uf.union(1, 2)
     nodes = sorted(uf.nodes())
     assert nodes == [1, 2, 3]
+
+
+def _canonical_clusters(result: dict[int, dict]) -> dict:
+    """Re-key a build_clusters result by sorted-member frozenset so the
+    comparison is independent of cluster-id numbering and member order
+    (neither is a contract -- see the v34 note in cluster.py). pair_scores
+    keys are canonicalized to (min, max) tuples and sorted for stable compare.
+    """
+    canon: dict = {}
+    for cinfo in result.values():
+        key = frozenset(cinfo["members"])
+        pair_scores = {
+            (min(a, b), max(a, b)): s for (a, b), s in cinfo["pair_scores"].items()
+        }
+        canon[key] = {
+            "size": cinfo["size"],
+            "oversized": cinfo["oversized"],
+            "confidence": cinfo["confidence"],
+            "cluster_quality": cinfo["cluster_quality"],
+            "bottleneck_pair": (
+                tuple(sorted(cinfo["bottleneck_pair"]))
+                if cinfo["bottleneck_pair"] is not None
+                else None
+            ),
+            "pair_scores": dict(sorted(pair_scores.items())),
+        }
+    return canon
+
+
+class TestBuildClustersColumnar:
+    """Wave 2 (Arrow Phase 1): build_clusters accepts a pl.DataFrame pair stream."""
+
+    def _fixture_pairs(self):
+        # Two multi-member clusters + one singleton:
+        #   {1,2,3} (chain), {10,11,12,13} (mixed-strength), 99 singleton.
+        return [
+            (1, 2, 0.95),
+            (2, 3, 0.88),
+            (10, 11, 0.91),
+            (11, 12, 0.55),
+            (12, 13, 0.93),
+            (10, 13, 0.80),
+        ]
+
+    def _all_ids(self):
+        return [1, 2, 3, 10, 11, 12, 13, 99]
+
+    def test_dataframe_input_matches_list_input(self):
+        """build_clusters(pairs_df) == build_clusters(pairs_list), same content."""
+        import polars as pl
+        from goldenmatch.core.scorer import PAIR_STREAM_SCHEMA
+
+        pairs = self._fixture_pairs()
+        all_ids = self._all_ids()
+
+        pairs_df = pl.DataFrame(
+            {
+                "id_a": [p[0] for p in pairs],
+                "id_b": [p[1] for p in pairs],
+                "score": [p[2] for p in pairs],
+            },
+            schema=PAIR_STREAM_SCHEMA,
+        )
+
+        from_list = build_clusters(pairs, all_ids)
+        from_df = build_clusters(pairs_df, all_ids)
+
+        assert _canonical_clusters(from_df) == _canonical_clusters(from_list)
+
+    def test_dataframe_input_derives_all_ids(self):
+        """all_ids=None path works for DataFrame input too (matches list path)."""
+        import polars as pl
+        from goldenmatch.core.scorer import PAIR_STREAM_SCHEMA
+
+        pairs = self._fixture_pairs()
+        pairs_df = pl.DataFrame(
+            {
+                "id_a": [p[0] for p in pairs],
+                "id_b": [p[1] for p in pairs],
+                "score": [p[2] for p in pairs],
+            },
+            schema=PAIR_STREAM_SCHEMA,
+        )
+
+        from_list = build_clusters(pairs)  # all_ids derived from pairs
+        from_df = build_clusters(pairs_df)
+
+        assert _canonical_clusters(from_df) == _canonical_clusters(from_list)
+
+    def test_empty_dataframe_input(self):
+        """An empty pair DataFrame yields no clusters (matches empty list)."""
+        import polars as pl
+        from goldenmatch.core.scorer import PAIR_STREAM_SCHEMA
+
+        empty_df = pl.DataFrame(schema=PAIR_STREAM_SCHEMA)
+        from_df = build_clusters(empty_df)
+        from_list = build_clusters([])
+        assert _canonical_clusters(from_df) == _canonical_clusters(from_list)

--- a/packages/python/goldenmatch/tests/test_pair_stream_columnar_parity.py
+++ b/packages/python/goldenmatch/tests/test_pair_stream_columnar_parity.py
@@ -26,6 +26,7 @@ from goldenmatch.core.blocker import BlockResult
 from goldenmatch.core.cluster import build_clusters, build_clusters_columnar
 from goldenmatch.core.scorer import (
     PAIR_STREAM_SCHEMA,
+    _score_one_block,
     find_fuzzy_matches,
     find_fuzzy_matches_columnar,
     pairs_df_to_list,
@@ -47,6 +48,22 @@ def _block_df(records: list[tuple[int, str]]) -> pl.DataFrame:
 
 def _block(records: list[tuple[int, str]], block_key: str = "k") -> BlockResult:
     return BlockResult(block_key=block_key, df=_block_df(records).lazy())
+
+
+def _block_df_multi(records: list[tuple[int, str, str]]) -> pl.DataFrame:
+    """Block frame with explicit per-row source labels (for the
+    across_files_only / cross-source filter tests)."""
+    return pl.DataFrame({
+        "__row_id__": [r[0] for r in records],
+        "__source__": [r[1] for r in records],
+        "name": [r[2] for r in records],
+    })
+
+
+def _block_multi(
+    records: list[tuple[int, str, str]], block_key: str = "k",
+) -> BlockResult:
+    return BlockResult(block_key=block_key, df=_block_df_multi(records).lazy())
 
 
 def _mk() -> MatchkeyConfig:
@@ -337,6 +354,95 @@ class TestScoreBlocksParity:
             "columnar wrapper failed to preserve matched_pairs side effect; "
             f"list_path={list_matched}, df_path={df_matched}"
         )
+
+    def test_across_files_only_parity(self):
+        """The cross-source (``across_files_only``) filter must produce
+        identical pairs via the columnar path vs the list path. The
+        list path filters via a Python comprehension on
+        ``source_lookup``; the columnar path applies a Polars filter on
+        the frame. Both must agree."""
+        # Two sources; only cross-source pairs survive the filter.
+        records = [
+            (1, "src_a", "John Smith"),
+            (2, "src_b", "Jon Smith"),
+            (3, "src_a", "John Smyth"),
+            (4, "src_b", "Jane Smith"),
+        ]
+        b = _block_multi(records)
+        mk = _mk()
+        source_lookup = {r[0]: r[1] for r in records}
+
+        list_pairs = score_blocks_parallel(
+            [b], mk, matched_pairs=set(),
+            across_files_only=True, source_lookup=source_lookup,
+        )
+        df_pairs = score_blocks_columnar(
+            [b], mk, matched_pairs=set(),
+            across_files_only=True, source_lookup=source_lookup,
+        )
+        assert sorted(pairs_df_to_list(df_pairs)) == sorted(list_pairs)
+        # And the filter actually fired: no same-source pair survives.
+        for a, b_id, _s in pairs_df_to_list(df_pairs):
+            assert source_lookup[a] != source_lookup[b_id]
+
+
+# ── Task 1.2: _score_one_block DataFrame emit (#623) ─────────────────
+
+
+class TestScoreOneBlockEmit:
+    """Task 1.2 (#623): ``_score_one_block`` threads ``_emit_dataframe``
+    through to ``find_fuzzy_matches`` and applies the across-files
+    filter on the frame (not a Python comprehension) when emitting a
+    DataFrame. Parity is byte-for-byte against the list emit."""
+
+    def test_emit_dataframe_parity(self):
+        records = [(1, "John Smith"), (2, "Jon Smith"), (3, "John Smyth")]
+        b = _block(records)
+        mk = _mk()
+
+        as_list = _score_one_block(b, mk, exclude_pairs=set())
+        as_df = _score_one_block(b, mk, exclude_pairs=set(), _emit_dataframe=True)
+        assert isinstance(as_df, pl.DataFrame)
+        assert as_df.schema == PAIR_STREAM_SCHEMA
+        assert pairs_df_to_list(as_df) == as_list
+
+    def test_emit_dataframe_across_files_parity(self):
+        records = [
+            (1, "src_a", "John Smith"),
+            (2, "src_b", "Jon Smith"),
+            (3, "src_a", "John Smyth"),
+        ]
+        b = _block_multi(records)
+        mk = _mk()
+        source_lookup = {r[0]: r[1] for r in records}
+
+        as_list = _score_one_block(
+            b, mk, exclude_pairs=set(),
+            across_files_only=True, source_lookup=source_lookup,
+        )
+        as_df = _score_one_block(
+            b, mk, exclude_pairs=set(),
+            across_files_only=True, source_lookup=source_lookup,
+            _emit_dataframe=True,
+        )
+        assert isinstance(as_df, pl.DataFrame)
+        assert pairs_df_to_list(as_df) == as_list
+
+    def test_emit_dataframe_single_source_short_circuit(self):
+        # across_files_only with a single-source block -> empty frame.
+        records = [(1, "John Smith"), (2, "Jon Smith")]
+        b = _block(records)  # both "fixture" source
+        mk = _mk()
+        source_lookup = {1: "fixture", 2: "fixture"}
+
+        as_df = _score_one_block(
+            b, mk, exclude_pairs=set(),
+            across_files_only=True, source_lookup=source_lookup,
+            _emit_dataframe=True,
+        )
+        assert isinstance(as_df, pl.DataFrame)
+        assert as_df.is_empty()
+        assert as_df.schema == PAIR_STREAM_SCHEMA
 
 
 # ── build_clusters parity ────────────────────────────────────────────

--- a/packages/python/goldenmatch/tests/test_pair_stream_columnar_parity.py
+++ b/packages/python/goldenmatch/tests/test_pair_stream_columnar_parity.py
@@ -17,7 +17,11 @@ harness, not unit tests.
 from __future__ import annotations
 
 import polars as pl
-from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.config.schemas import (
+    MatchkeyConfig,
+    MatchkeyField,
+    NegativeEvidenceField,
+)
 from goldenmatch.core.blocker import BlockResult
 from goldenmatch.core.cluster import build_clusters, build_clusters_columnar
 from goldenmatch.core.scorer import (
@@ -100,16 +104,114 @@ class TestHotPathDirectEmit:
         }
         assert df_set == list_set
 
-    def test_exclude_pairs_path_falls_back_to_list(self):
-        """When ``exclude_pairs`` is non-empty, the function takes a
-        list-building branch above the hot-path emission; the flag is
-        not honored there. ``find_fuzzy_matches_columnar`` handles this
-        via the defensive wrap. Locks the contract."""
+    def test_exclude_pairs_path_emits_dataframe(self):
+        """Task 1.1 (#623): ALL branches honor ``_emit_dataframe=True``.
+        The ``exclude_pairs`` branch now emits a ``pl.DataFrame`` with
+        ``PAIR_STREAM_SCHEMA`` instead of a list. Default
+        (``_emit_dataframe=False``) keeps the list contract for the
+        deprecation window."""
         block_df = _block_df([(1, "John"), (2, "Jon")])
         result = find_fuzzy_matches(
             block_df, _mk(), exclude_pairs={(1, 2)}, _emit_dataframe=True,
         )
-        assert isinstance(result, list)
+        assert isinstance(result, pl.DataFrame)
+        assert result.schema == PAIR_STREAM_SCHEMA
+        # Default still returns a list (deprecation window).
+        as_list = find_fuzzy_matches(block_df, _mk(), exclude_pairs={(1, 2)})
+        assert isinstance(as_list, list)
+
+
+# ── Task 1.1: uniform DataFrame from non-hot branches (#623) ─────────
+
+
+class TestNonHotPathDirectEmit:
+    """Task 1.1 (#623): ``find_fuzzy_matches(..., _emit_dataframe=True)``
+    must emit a ``pl.DataFrame`` from ALL THREE branches (NE-penalty,
+    ``exclude_pairs``, hot path), not just the hot path. Parity is
+    asserted byte-for-byte against the list path via
+    ``pairs_df_to_list``."""
+
+    def test_exclude_pairs_branch_emits_dataframe(self):
+        records = [
+            (1, "John Smith"), (2, "Jon Smith"),
+            (3, "Jane Smith"), (4, "John Smyth"),
+        ]
+        block_df = _block_df(records)
+        mk = _mk()
+        excl = {(1, 2)}
+
+        as_list = find_fuzzy_matches(block_df, mk, exclude_pairs=excl)
+        as_df = find_fuzzy_matches(
+            block_df, mk, exclude_pairs=excl, _emit_dataframe=True,
+        )
+        assert isinstance(as_df, pl.DataFrame)
+        assert as_df.columns == ["id_a", "id_b", "score"]
+        assert pairs_df_to_list(as_df) == as_list
+
+    def test_ne_branch_emits_dataframe(self):
+        # name agrees (fuzzy weighted matchkey) but the NE field (city)
+        # disagrees -> NE-penalty branch is exercised.
+        block_df = pl.DataFrame({
+            "__row_id__": [1, 2, 3],
+            "__source__": ["fixture"] * 3,
+            "name": ["John Smith", "Jon Smith", "John Smith"],
+            "city": ["Boston", "Boston", "Seattle"],
+        })
+        mk = MatchkeyConfig(
+            name="test_ne",
+            type="weighted",
+            fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+            threshold=0.85,
+            negative_evidence=[
+                NegativeEvidenceField(
+                    field="city", scorer="exact", threshold=1.0, penalty=0.5,
+                ),
+            ],
+        )
+
+        as_list = find_fuzzy_matches(block_df, mk)
+        as_df = find_fuzzy_matches(block_df, mk, _emit_dataframe=True)
+        assert isinstance(as_df, pl.DataFrame)
+        assert as_df.schema == PAIR_STREAM_SCHEMA
+        assert pairs_df_to_list(as_df) == as_list
+
+    def test_ne_branch_with_exclude_emits_dataframe(self):
+        # NE-penalty AND exclude_pairs together (the nested exclude
+        # filter inside the NE branch).
+        block_df = pl.DataFrame({
+            "__row_id__": [1, 2, 3],
+            "__source__": ["fixture"] * 3,
+            "name": ["John Smith", "Jon Smith", "John Smyth"],
+            "city": ["Boston", "Boston", "Boston"],
+        })
+        mk = MatchkeyConfig(
+            name="test_ne",
+            type="weighted",
+            fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+            threshold=0.85,
+            negative_evidence=[
+                NegativeEvidenceField(
+                    field="city", scorer="exact", threshold=1.0, penalty=0.1,
+                ),
+            ],
+        )
+        excl = {(1, 2)}
+
+        as_list = find_fuzzy_matches(block_df, mk, exclude_pairs=excl)
+        as_df = find_fuzzy_matches(
+            block_df, mk, exclude_pairs=excl, _emit_dataframe=True,
+        )
+        assert isinstance(as_df, pl.DataFrame)
+        assert pairs_df_to_list(as_df) == as_list
+
+    def test_empty_result_emits_empty_dataframe(self):
+        # exclude_pairs removes the only candidate -> empty frame, not [].
+        block_df = _block_df([(1, "John"), (2, "Jon")])
+        as_df = find_fuzzy_matches(
+            block_df, _mk(), exclude_pairs={(1, 2)}, _emit_dataframe=True,
+        )
+        assert isinstance(as_df, pl.DataFrame)
+        assert as_df.schema == PAIR_STREAM_SCHEMA
 
 
 # ── Adapter round-trip ──────────────────────────────────────────────


### PR DESCRIPTION
Substrate for the Arrow Phase 1 cutover (#623, plan: docs/superpowers/plans/2026-06-01-arrow-phase1-cutover.md). **Purely additive, nothing flipped** — the scorer still returns `list[tuple]` by default (deprecation window). Waves 3-5 (consumer migration + default flip + gate) land in a follow-up PR.

## Wave 1 — scorer contract
`find_fuzzy_matches` / `_score_one_block` / `score_blocks_columnar` emit a uniform `pl.DataFrame` (`PAIR_STREAM_SCHEMA`) from ALL branches under `_emit_dataframe=True`; `_emit_dataframe=False` (default) keeps the list contract. `across_files_only` filter via Polars (not list comprehension). 25 parity tests (byte-identical via `pairs_df_to_list`).

## Wave 2 — build_clusters ingest
`build_clusters` accepts a `pl.DataFrame` pair stream (polymorphic on `pl.DataFrame | list[tuple]`) via the existing `_pairs_df_to_list_numpy` (numpy path, no tuple list). **Return shape unchanged** (`dict[int,dict]`; ClusterFrames is Phase 2). 27 cluster tests.

## Process
Built via subagent-driven execution; each wave passed spec-compliance + code-quality review (fixes folded in: stale-comment, twin-function cross-refs, forward-ref hoist).

## Out of scope (later)
Consumer migration, default flip, legacy deletion (N+1), pipeline-eligibility widening (Phase B/C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)