### PR TITLE
perf(identity): Arrow-native batch fingerprinting in resolution (#663-A, gated)

### DIFF
--- a/.github/workflows/bench-identity-fingerprint.yml
+++ b/.github/workflows/bench-identity-fingerprint.yml
@@ -1,0 +1,47 @@
+name: bench-identity-fingerprint
+
+# Measure-first harness for the GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT gate.
+# Compares batch_fingerprints (Arrow kernel) vs per-row record_fingerprint loop
+# inside resolve_clusters at scale. Run this before flipping the gate default
+# to "1". Not part of PR gating.
+on:
+  workflow_dispatch:
+    inputs:
+      ns:
+        description: "Row counts to sweep (comma-separated)"
+        default: "1000000,5000000"
+      runs:
+        description: "Repetitions per measurement (median reported)"
+        default: "3"
+
+jobs:
+  bench:
+    # Beefy box so the profile is not starved (matches the suite bench default).
+    runs-on: large-new-64GB
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Build native extension (required for the Arrow fingerprint kernel)
+        # Without a fresh build the Arrow kernel is unavailable and the bench
+        # exercises only the dict-fallback path. The script reports
+        # native_available() so you can verify which path ran.
+        run: uv run python scripts/build_native.py
+      - name: Bench identity fingerprint (batch vs per-row)
+        run: |
+          uv run python packages/python/goldenmatch/scripts/bench_identity_fingerprint.py \
+            --ns "${{ inputs.ns }}" \
+            --runs "${{ inputs.runs }}" \
+            --output bench_identity_fingerprint.json
+      - name: Upload JSON artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-identity-fingerprint-results
+          path: bench_identity_fingerprint.json

--- a/docs/superpowers/plans/2026-06-01-identity-fingerprint-arrow.md
+++ b/docs/superpowers/plans/2026-06-01-identity-fingerprint-arrow.md
@@ -67,12 +67,15 @@ def _perrow(row: dict) -> str | None:
 
 
 def _adversarial_df() -> pl.DataFrame:
-    # Every routing-table case from the spec. Columns are record fields.
+    # The BATCHABLE + row-level-mask cases (no column-level-fallback dtypes here --
+    # a single bytes/Duration/Decimal column would force the WHOLE frame to per-row
+    # and this fixture would stop testing the batch path). Column-level-fallback
+    # dtypes get their own focused fixtures below.
     return pl.DataFrame({
         "s": ["alice", "bob", None, "x"],
         "i64": [1, 2, 3, 4],
         "f_finite": [1.5, 2.0, 3.25, 0.1],
-        "f_mixed": [1.5, float("nan"), float("inf"), -2.0],   # row-level fallback
+        "f_mixed": [1.5, float("nan"), float("inf"), -2.0],   # row-level mask
         "b": [True, False, None, True],
         "d": [dt.date(2020, 1, 2), dt.date(1999, 12, 31), None, dt.date(2000, 2, 29)],
         "dt_us": [dt.datetime(2020, 1, 2, 3, 4, 5, 123000),    # .123000 -> catches %.f bug
@@ -82,8 +85,11 @@ def _adversarial_df() -> pl.DataFrame:
         "i32": pl.Series([10, 20, 30, 40], dtype=pl.Int32),
         "f32": pl.Series([0.1, 0.2, 0.3, 0.4], dtype=pl.Float32),
         "allnull": pl.Series([None, None, None, None]),        # bare Null dtype
-        "dec": [Decimal("2.00"), Decimal("3.5"), None, Decimal("0")],
     })
+```
+
+(The `Decimal` import is still needed for the focused Decimal fixture below.)
+```python  # (focused single-column fixtures use the same _perrow reference)
 
 
 def test_batch_fingerprints_parity():
@@ -91,7 +97,7 @@ def test_batch_fingerprints_parity():
     assert batch_fingerprints(df) == [_perrow(r) for r in df.to_dicts()]
 ```
 
-Add separate focused fixtures + tests for the column-level fallback dtypes that need special construction: a `Duration` column, a `Time`-with-microseconds column, a tz-aware Datetime, a non-`us` (`ms`) Datetime, a `bytes` column, a `UInt64` column with a value `> 2**63`. Each asserts `batch_fingerprints(df) == [_perrow(r) for r in df.to_dicts()]`.
+Add separate focused fixtures + tests for the column-level fallback dtypes that need special construction: a `Duration` column, a `Time`-with-microseconds column, a tz-aware Datetime, a non-`us` (`ms`) Datetime, a `bytes` column, a `Decimal` column, and a `UInt64` column with a value `> 2**63`. Each asserts `batch_fingerprints(df) == [_perrow(r) for r in df.to_dicts()]`. (Note: `Decimal` columns normalize to one scale on construction -- `Decimal("3.5")` reads back as `Decimal("3.50")` if another cell has scale 2 -- which is fine since both sides read the normalized `to_dicts()`.) At least one of these single-column fixtures (e.g. the bytes or Duration column) MUST exercise the **all-rows-fallback** path where `canonicalize_records_df` returns `(None, [True]*height)` -- assert it still matches per-row, confirming the `batch_df is None` branch.
 
 - [ ] **Step 3: Run it — verify FAIL**
 
@@ -140,13 +146,27 @@ def batch_fingerprints(df) -> list:
     return out
 ```
 
-Key correctness points to get right (cite the spec): temporal recipe
-`dt.to_string("%Y-%m-%dT%H:%M:%S%.6f").str.replace(r"\.000000$", "")` (Date via
-`%Y-%m-%d`); `Float32->Float64`, `Int8/16/32`+`UInt8/16/32 -> Int64`; bare-`Null`
-dtype `cast(Utf8)`; row mask over EVERY float col's `is_finite` + UInt64>2**63;
-column-level fallback (return `(None, all-True)`) for bytes/Duration/tz/non-`us`
-Datetime/un-reproducible object. The `batch_df` rows MUST stay in original order so
-the scatter-back is a simple sequential fill.
+Key correctness points to get right (cite the spec):
+- **Temporal recipe** `dt.to_string("%Y-%m-%dT%H:%M:%S%.6f").str.replace(r"\.000000$", "")`
+  (Date via `%Y-%m-%d`).
+- **Up-casts** `Float32->Float64`, `Int8/16/32`+`UInt8/16/32 -> Int64`.
+- **bare-`Null` dtype** `cast(Utf8)`.
+- **Row-level masks** (mask only the offending rows, column stays in `batch_df`):
+  every Float col's `~is_finite` cells; UInt64 cells `> 2**63 - 1`. **ORDER MATTERS
+  for UInt64:** compute the overflow mask FIRST (`col > (2**63 - 1)`), exclude those
+  rows from `batch_df`, and cast Int64 only on the remaining rows -- casting a
+  UInt64 overflow cell raises `InvalidOperationError` which is NOT in
+  `except (TypeError, ValueError)` and would crash the whole batch.
+- **Column-level fallback** (return `(None, [True]*height)` -- the column is in
+  every row's hash and has no parity-preserving cast): bytes, `Duration`, `Time`,
+  tz-aware Datetime, non-`us` Datetime, **`Decimal`** (rejected by the kernel; a
+  Float64 cast would hash tag `f` not `s` and lose trailing zeros -- `str(Decimal(
+  "2.00"))=="2.00"`), and any un-reproducible object (list/struct/Array). For
+  Categorical/Enum, `cast(Utf8)` reproduces `str(value)` -- batchable; verify in the
+  fixture. (`Time` could in principle use the `%.6f` recipe but route it per-row for
+  simplicity -- the parity test gates either choice.)
+The `batch_df` rows MUST stay in original order so the scatter-back is a simple
+sequential fill.
 
 - [ ] **Step 5: Run the parity tests — verify PASS**
 
@@ -182,7 +202,17 @@ The candidate ordering + `_id_scheme()` logic is otherwise unchanged.
 
 - [ ] **Step 3: Batch-compute no-PK hashes in `resolve_clusters` + thread in**
 
-Behind the gate flag (Step 4), BEFORE the `for row in rows:` loop: build the no-PK subset (rows where `source_pk_col` is unset or the pk cell is null), call `batch_fingerprints` on `df` (or the no-PK sub-frame — keep row_id alignment), producing `h1_by_rowid: dict[int, str | None]`. In the loop, pass `precomputed_h1=h1_by_rowid.get(irid, _NOT_BATCHED)` (PK rows aren't in the dict -> `_NOT_BATCHED` -> unchanged path). When the gate is off, pass nothing (per-row path, byte-identical to today).
+Behind the gate flag (Step 4), BEFORE the `for row in rows:` loop: call
+`batch_fingerprints` on the **FULL `df`** (NOT a filtered sub-frame -- the output is
+mapped back positionally, so a sub-frame would misalign `hashes[row_index]` with
+`rows[row_index]` and silently move entity ids). The PK-vs-no-PK distinction is
+applied when POPULATING the dict, not when calling: only insert `h1_by_rowid[irid]`
+for no-PK rows (rows where `source_pk_col` is unset or the pk cell is null); PK rows
+are simply not inserted, so the loop's `.get(irid, _NOT_BATCHED)` leaves them on the
+unchanged path. (PK rows cost a wasted hash this way -- acceptable; correctness over
+the marginal waste.) Produce `h1_by_rowid: dict[int, str | None]`. In the loop, pass
+`precomputed_h1=h1_by_rowid.get(irid, _NOT_BATCHED)`. When the gate is off, pass
+nothing (per-row path, byte-identical to today).
 
 NOTE on alignment: `batch_fingerprints(df)` returns a list aligned to `df` rows in order; map it back to `__row_id__` via the same `rows` iteration so `h1_by_rowid[irid] = hashes[row_index]`. Only populate the dict for no-PK rows.
 
@@ -208,7 +238,7 @@ Commit: `feat(identity): wire batch_fingerprints into resolve_clusters behind GO
 
 - [ ] **Step 1: Bench script**
 
-`bench_identity_fingerprint.py`: generate a no-PK-heavy person-shaped frame at `--ns 1000000,5000000` (reuse `tests/generate_synthetic.py` / `_person_df` helpers); time `resolve_clusters` (or just the fingerprint step) with the gate ON vs OFF; report wall + peak RSS per N, plus the no-PK fraction. Print a markdown table to `$GITHUB_STEP_SUMMARY`. ASCII only.
+`bench_identity_fingerprint.py`: generate a no-PK-heavy person-shaped frame at `--ns 1000000,5000000` (reuse the synthetic-person fixture helper `_person_df` -- it lives in `tests/test_autoconfig_regressions.py`, NOT `generate_synthetic.py`; or `tests/fixtures/realistic_person.py`); time `resolve_clusters` (or just the fingerprint step) with the gate ON vs OFF; report wall + peak RSS per N, plus the no-PK fraction. Print a markdown table to `$GITHUB_STEP_SUMMARY`. ASCII only.
 
 - [ ] **Step 2: Workflow**
 

--- a/docs/superpowers/plans/2026-06-01-identity-fingerprint-arrow.md
+++ b/docs/superpowers/plans/2026-06-01-identity-fingerprint-arrow.md
@@ -1,0 +1,238 @@
+# Arrow-native fingerprints in identity resolution (#663-A) — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-row `record_fingerprint` loop in identity resolution with one vectorized `record_fingerprints_batch_arrow` call for the no-PK record subset, producing byte-identical entity ids.
+
+**Architecture:** A new `batch_fingerprints(df) -> list[str | None]` returns per-row fingerprints (None = un-fingerprintable -> legacy id), using the Arrow batch kernel for fully-batchable rows and a per-row fallback for rows/columns that can't be reproduced columnarly. It is a drop-in for `[<per-row hash> for r in df.to_dicts()]`, so parity is one assertion. `resolve_clusters` batch-computes the no-PK hashes once and threads them into `_record_id_candidates`. The whole path is gated; default-on is decided by a measure-first bench.
+
+**Tech Stack:** Python 3.11+, Polars, the `goldenmatch._native` Rust kernel (`record_fingerprints_batch_arrow`, already built + signed off as the `hashing` component). Tests via pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-identity-fingerprint-arrow-design.md` — READ its "parity crux" routing table; this plan implements it. **Branch:** `perf/identity-fingerprint-arrow`.
+
+**Run tests:** `cd packages/python/goldenmatch && ../../../.venv/Scripts/python.exe -m pytest <path> -v`. ruff: `D:/show_case/goldenmatch/.venv/Scripts/python.exe -m ruff check <files>`. Native `_native.pyd` is built in-tree locally. Do NOT run the full suite (xdist OOMs); targeted files only.
+
+---
+
+## Background the implementer needs
+
+- `identity/resolve.py::_record_id_candidates(row, source, source_pk_col)` (~line 110) is called per row from `resolve_clusters` (~line 227-238). For a row WITHOUT a usable source PK it computes `record_fingerprint(_canonical_payload(payload))[:12]` (`resolve.py:132`); with a PK it returns `f"{source}:{pk}"` and never hashes (`resolve.py:125-128`).
+- `_canonical_payload` (`resolve.py:89`) coerces a payload dict to fingerprint-able primitives: non-finite float -> `repr(v)` string; temporals/objects -> `isoformat()`/`str()`; None/bool/int/float/str/bytes -> as-is.
+- `core/_hashing.py::record_fingerprints_batch_arrow(records_df)` (line 112) takes a Polars DataFrame whose columns ARE the record fields (drops `__`-prefixed cols), returns `list[str]` (one 64-char hex per row). It falls back to the dict path off-native, BUT that fallback hashes RAW dicts and raises on raw temporals/non-finite — so the frame handed to it MUST be canonicalized first.
+- **Parity is free for clean primitives:** both the single + batch kernels delegate to the same `fingerprint_fields` (`packages/rust/extensions/fingerprint-core/src/lib.rs:54`). The work is reproducing `_canonical_payload`'s coercions columnarly (and routing the un-reproducible cases to per-row). See the spec's routing table for the EXACT rules (temporal `%.6f`+strip, narrow-int/Float32 up-cast, bare-Null->Utf8, and per-row fallback for: mixed-finite-float rows, bytes/Duration/tz-aware/non-`us`-Datetime columns, UInt64>2**63 rows, un-reproducible objects).
+
+---
+
+## File Structure
+
+- **Create** `packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py` — owns `_canonical_payload` (MOVED here from resolve.py to break the import cycle), `canonicalize_records_df`, and `batch_fingerprints`. Single responsibility: turn a records frame into per-row fingerprints with canonicalization + fallback.
+- **Modify** `packages/python/goldenmatch/goldenmatch/identity/resolve.py` — import `_canonical_payload` from the new module (back-compat); add `precomputed_h1` to `_record_id_candidates`; batch-compute no-PK hashes in `resolve_clusters`; add the gate flag.
+- **Test** `packages/python/goldenmatch/tests/identity/test_fingerprint_batch.py` (create) — the parity gate + off-native parity.
+- **Test** `packages/python/goldenmatch/tests/identity/test_resolve_batch_parity.py` (create) — end-to-end identity-id parity.
+- **Create** `packages/python/goldenmatch/scripts/bench_identity_fingerprint.py` + `.github/workflows/bench-identity-fingerprint.yml` — the measure-first bench (Task 4).
+
+---
+
+## Task 1: `batch_fingerprints` + canonicalization (the core + parity gate)
+
+**Files:**
+- Create: `packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py`
+- Modify: `packages/python/goldenmatch/goldenmatch/identity/resolve.py` (move `_canonical_payload` out, import it back)
+- Test: `packages/python/goldenmatch/tests/identity/test_fingerprint_batch.py`
+
+- [ ] **Step 1: Move `_canonical_payload` to the new module, re-import in resolve.py**
+
+Cut `_canonical_payload` (resolve.py:89-107) + its `math` import need into `identity/fingerprint_batch.py`. In `resolve.py` add `from goldenmatch.identity.fingerprint_batch import _canonical_payload`. Run the existing identity tests to confirm no breakage:
+`../../../.venv/Scripts/python.exe -m pytest tests/identity/ -q` — expect all pass (pure move).
+Commit: `refactor(identity): move _canonical_payload to fingerprint_batch module`.
+
+- [ ] **Step 2: Write the failing parity test**
+
+`tests/identity/test_fingerprint_batch.py`. The reference is the exact per-row computation (hash, or None when `record_fingerprint` raises -> legacy):
+
+```python
+import datetime as dt
+from decimal import Decimal
+import polars as pl
+import pytest
+from goldenmatch.core._hashing import record_fingerprint
+from goldenmatch.identity.fingerprint_batch import _canonical_payload, batch_fingerprints
+
+
+def _perrow(row: dict) -> str | None:
+    try:
+        return record_fingerprint(_canonical_payload(row))
+    except (TypeError, ValueError):
+        return None
+
+
+def _adversarial_df() -> pl.DataFrame:
+    # Every routing-table case from the spec. Columns are record fields.
+    return pl.DataFrame({
+        "s": ["alice", "bob", None, "x"],
+        "i64": [1, 2, 3, 4],
+        "f_finite": [1.5, 2.0, 3.25, 0.1],
+        "f_mixed": [1.5, float("nan"), float("inf"), -2.0],   # row-level fallback
+        "b": [True, False, None, True],
+        "d": [dt.date(2020, 1, 2), dt.date(1999, 12, 31), None, dt.date(2000, 2, 29)],
+        "dt_us": [dt.datetime(2020, 1, 2, 3, 4, 5, 123000),    # .123000 -> catches %.f bug
+                  dt.datetime(2020, 1, 2, 3, 4, 5, 500000),
+                  dt.datetime(2020, 1, 2, 3, 4, 5, 0),         # usec==0
+                  dt.datetime(2020, 1, 2, 3, 4, 5, 123456)],
+        "i32": pl.Series([10, 20, 30, 40], dtype=pl.Int32),
+        "f32": pl.Series([0.1, 0.2, 0.3, 0.4], dtype=pl.Float32),
+        "allnull": pl.Series([None, None, None, None]),        # bare Null dtype
+        "dec": [Decimal("2.00"), Decimal("3.5"), None, Decimal("0")],
+    })
+
+
+def test_batch_fingerprints_parity():
+    df = _adversarial_df()
+    assert batch_fingerprints(df) == [_perrow(r) for r in df.to_dicts()]
+```
+
+Add separate focused fixtures + tests for the column-level fallback dtypes that need special construction: a `Duration` column, a `Time`-with-microseconds column, a tz-aware Datetime, a non-`us` (`ms`) Datetime, a `bytes` column, a `UInt64` column with a value `> 2**63`. Each asserts `batch_fingerprints(df) == [_perrow(r) for r in df.to_dicts()]`.
+
+- [ ] **Step 3: Run it — verify FAIL**
+
+Run: `../../../.venv/Scripts/python.exe -m pytest tests/identity/test_fingerprint_batch.py -v`
+Expected: FAIL (`batch_fingerprints` not defined / not imported).
+
+- [ ] **Step 4: Implement `canonicalize_records_df` + `batch_fingerprints`**
+
+In `fingerprint_batch.py`, implement per the spec routing table. Suggested shape:
+
+```python
+def canonicalize_records_df(df):
+    """Return (batch_df, fallback_mask): a frame safe for the Arrow kernel over
+    the batchable rows, plus a bool list marking rows that must go per-row.
+    Drops __-prefixed columns (the kernel and per-row payload both exclude them).
+    Column-level un-batchable dtypes (bytes/Duration/tz-aware or non-us Datetime/
+    un-reproducible object) force the WHOLE frame to fallback (the column is part
+    of every row's hash and has no parity-preserving cast). Row-level cases
+    (non-finite float, UInt64>2**63) mask only those rows."""
+    # 1. drop __-cols. 2. classify each column. 3. if any column-level un-batchable
+    #    -> return (None, [True]*height). 4. else canonicalize batchable columns
+    #    (temporal %.6f+strip, narrow-int/Float32 upcast, bare-Null->Utf8); build
+    #    row mask over non-finite-float + UInt64-overflow; return (batch_df, mask).
+
+def batch_fingerprints(df) -> list:
+    """Per-row fingerprints aligned to df rows; None where un-fingerprintable."""
+    from goldenmatch.core._hashing import record_fingerprint, record_fingerprints_batch_arrow
+    out: list = [None] * df.height
+    batch_df, mask = canonicalize_records_df(df)
+    if batch_df is not None and batch_df.height:
+        hashes = record_fingerprints_batch_arrow(batch_df)
+        # scatter hashes back to the non-masked original row positions (order
+        # preserved: batch_df rows are the ~mask rows in original order).
+        bi = 0
+        for i in range(df.height):
+            if not mask[i]:
+                out[i] = hashes[bi]; bi += 1
+    # per-row fallback for masked rows
+    rows = df.to_dicts()
+    for i in range(df.height):
+        if mask[i]:
+            try:
+                out[i] = record_fingerprint(_canonical_payload({k: v for k, v in rows[i].items() if not k.startswith("__")}))
+            except (TypeError, ValueError):
+                out[i] = None
+    return out
+```
+
+Key correctness points to get right (cite the spec): temporal recipe
+`dt.to_string("%Y-%m-%dT%H:%M:%S%.6f").str.replace(r"\.000000$", "")` (Date via
+`%Y-%m-%d`); `Float32->Float64`, `Int8/16/32`+`UInt8/16/32 -> Int64`; bare-`Null`
+dtype `cast(Utf8)`; row mask over EVERY float col's `is_finite` + UInt64>2**63;
+column-level fallback (return `(None, all-True)`) for bytes/Duration/tz/non-`us`
+Datetime/un-reproducible object. The `batch_df` rows MUST stay in original order so
+the scatter-back is a simple sequential fill.
+
+- [ ] **Step 5: Run the parity tests — verify PASS**
+
+Run: `../../../.venv/Scripts/python.exe -m pytest tests/identity/test_fingerprint_batch.py -v`
+Expected: all pass. If any dtype mismatches, PRINT `batch_fingerprints(df)` vs the per-row list side by side and fix the canonicalization for that dtype — do NOT weaken the assertion.
+
+- [ ] **Step 6: Off-native parity test**
+
+Add to the same file, with `monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")`: the SAME `_adversarial_df` must yield `batch_fingerprints(df) == [_perrow(r) for r in df.to_dicts()]` (the wrapper's dict fallback runs on the canonicalized frame). Confirms canonicalize-before-wrapper in off-native mode.
+
+- [ ] **Step 7: ruff + commit**
+
+ruff check both files. Commit: `feat(identity): batch_fingerprints with vectorized canonicalization + per-row fallback`.
+
+---
+
+## Task 2: Wire `batch_fingerprints` into `resolve_clusters` (gated)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/identity/resolve.py` (`_record_id_candidates` ~110, `resolve_clusters` loop ~227-238)
+- Test: `packages/python/goldenmatch/tests/identity/test_resolve_batch_parity.py`
+
+- [ ] **Step 1: Add `precomputed_h1` to `_record_id_candidates`**
+
+Signature: `_record_id_candidates(row, source, source_pk_col, *, precomputed_h1=_NOT_BATCHED)` where `_NOT_BATCHED` is a module sentinel. Behavior:
+- PK path unchanged (returns `source:pk`, never uses precomputed_h1).
+- No-PK path: if `precomputed_h1 is _NOT_BATCHED` -> compute as today (per-row `record_fingerprint`). If `precomputed_h1` is a `str` -> use it as the h1 hash (build `h1_id = f"{source}:h1:{precomputed_h1[:12]}"`), skipping the per-row call. If `precomputed_h1 is None` -> the batch determined the row un-fingerprintable -> take the legacy-only path (same as today's `except` branch: `return legacy_id, [legacy_id]`).
+The candidate ordering + `_id_scheme()` logic is otherwise unchanged.
+
+- [ ] **Step 2: Write the failing end-to-end parity test**
+
+`tests/identity/test_resolve_batch_parity.py`: run `resolve_clusters` on a fixture (mix of no-PK rows incl. the adversarial dtypes AND some PK rows) twice — once with the batch path ON, once OFF (per-row) — and assert the resulting `_rowid_primary` / `_rowid_candidates` (or the stored entity ids) are IDENTICAL. Reuse an existing identity test fixture/store pattern from `tests/identity/`. Verify it FAILS first (batch path not wired).
+
+- [ ] **Step 3: Batch-compute no-PK hashes in `resolve_clusters` + thread in**
+
+Behind the gate flag (Step 4), BEFORE the `for row in rows:` loop: build the no-PK subset (rows where `source_pk_col` is unset or the pk cell is null), call `batch_fingerprints` on `df` (or the no-PK sub-frame — keep row_id alignment), producing `h1_by_rowid: dict[int, str | None]`. In the loop, pass `precomputed_h1=h1_by_rowid.get(irid, _NOT_BATCHED)` (PK rows aren't in the dict -> `_NOT_BATCHED` -> unchanged path). When the gate is off, pass nothing (per-row path, byte-identical to today).
+
+NOTE on alignment: `batch_fingerprints(df)` returns a list aligned to `df` rows in order; map it back to `__row_id__` via the same `rows` iteration so `h1_by_rowid[irid] = hashes[row_index]`. Only populate the dict for no-PK rows.
+
+- [ ] **Step 4: Add the gate flag**
+
+Default OFF until the bench (Task 4) justifies default-on. Use an env gate `GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT` (default `0`) read in `resolve_clusters` (mirrors the `GOLDENMATCH_IDENTITY_ID_SCHEME` env pattern at `resolve.py:84`). Document it next to that one.
+
+- [ ] **Step 5: Run the parity test (gate ON) — verify PASS**
+
+Run with `GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT=1`: `../../../.venv/Scripts/python.exe -m pytest tests/identity/test_resolve_batch_parity.py -v` — expect identical ids both ways. Also run the full `tests/identity/` dir to confirm no regression (gate defaults off, so the suite is unaffected unless a test opts in).
+
+- [ ] **Step 6: ruff + commit**
+
+Commit: `feat(identity): wire batch_fingerprints into resolve_clusters behind GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT`.
+
+---
+
+## Task 3: Bench harness (measure-first) — CREATE, run is an orchestrator step
+
+**Files:**
+- Create: `packages/python/goldenmatch/scripts/bench_identity_fingerprint.py`
+- Create: `.github/workflows/bench-identity-fingerprint.yml`
+
+- [ ] **Step 1: Bench script**
+
+`bench_identity_fingerprint.py`: generate a no-PK-heavy person-shaped frame at `--ns 1000000,5000000` (reuse `tests/generate_synthetic.py` / `_person_df` helpers); time `resolve_clusters` (or just the fingerprint step) with the gate ON vs OFF; report wall + peak RSS per N, plus the no-PK fraction. Print a markdown table to `$GITHUB_STEP_SUMMARY`. ASCII only.
+
+- [ ] **Step 2: Workflow**
+
+`bench-identity-fingerprint.yml`: `workflow_dispatch`, `runs-on: large-new-64GB`, build native (`scripts/build_native.py`), `uv sync --all-packages`, run the bench, upload the JSON artifact. Model it on `.github/workflows/bench-fs-stages.yml`.
+
+- [ ] **Step 3: Commit**
+
+Commit: `bench(identity): measure-first fingerprint batch vs per-row harness`.
+
+- [ ] **Step 4 (orchestrator, NOT a subagent step): dispatch the bench, decide default-on**
+
+The controller dispatches `bench-identity-fingerprint` at 1M/5M, reads wall + RSS, and decides whether to flip the gate default-on (a one-line change + a note in the spec). Per "parity is enough / measure-first": ship default-on only if it wins meaningfully; else leave gated and record the finding. Surface the numbers + the flip decision to the user.
+
+---
+
+## Final validation (orchestrator step)
+
+1. Run `tests/identity/` (gate off, default) — no regression; then `GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT=1 pytest tests/identity/` — all green.
+2. Open the PR; CI runs the goldenmatch lane (the identity tests are in it). The bench is `workflow_dispatch` only.
+3. Dispatch the bench; fold numbers into the spec; decide the gate default.
+
+## Notes for the implementer
+
+- **The durability invariant is non-negotiable:** the parity tests gate byte-identical hashes. If a dtype can't be made parity-correct columnarly, ROUTE IT TO PER-ROW FALLBACK — never ship a "close enough" hash. Entity ids must not move.
+- **DRY/YAGNI:** do NOT touch build_clusters (Sub-project B), the dedup path, the native kernels (they exist), or the canonical-fingerprint spec. Only the identity fingerprint wiring.
+- **Column-level vs row-level fallback** is the subtle bit: a bytes/Duration/tz column forces the WHOLE frame to per-row (the column is in every row's hash, no parity cast); non-finite-float / UInt64-overflow are per-row masks. Get this from the spec's routing table.
+- **Skill:** follow @superpowers:test-driven-development per task (failing parity test first).

--- a/docs/superpowers/specs/2026-06-01-identity-fingerprint-arrow-design.md
+++ b/docs/superpowers/specs/2026-06-01-identity-fingerprint-arrow-design.md
@@ -1,0 +1,145 @@
+# Arrow-native fingerprints in identity resolution (#663 Sub-project A) — design
+
+**Date:** 2026-06-01
+**Status:** design (approved, pre-plan)
+**Decision context:** Issue #663 ("route dict-I/O kernels through Arrow arrays
+like score_block_pairs_arrow"). The Arrow-native roadmap Phase 3 (#625) built two
+remaining dict-floor kernels' Arrow variants but never wired them in. #663 is
+decomposed into Sub-project A (fingerprints, THIS spec — clear leverage) and
+Sub-project B (build_clusters_arrow — deferred, marginal 1.09x dict-floor).
+
+## Problem
+
+The identity-resolution path fingerprints records ONE AT A TIME in a Python loop.
+`identity/resolve.py::_record_id_candidates` (called per row from
+`resolve_clusters`) computes
+`record_fingerprint(_canonical_payload(payload))[:12]` for each no-PK record.
+This per-row call scales with record count -- at 1M-5M identity resolution it is
+a real cost.
+
+The Arrow batch kernel that eliminates this already EXISTS but is unused:
+`core/_hashing.py::record_fingerprints_batch_arrow(records_df)` ->
+`packages/rust/extensions/native/src/hash.rs::record_fingerprints_batch_arrow`.
+It reads the DataFrame's columns as zero-copy Arrow arrays, hashes each row in
+Rust (rayon-parallel SHA-256, no per-record Python dict construction, no per-cell
+pyo3 marshalling), and returns one hex string per row. The `hashing` component is
+signed off (`_native_loader._GATED_ON`). The dict-shaped batch kernel
+(`record_fingerprints_batch`) is NOT the answer: Stage 0 benched it at 0.71x
+(slower than Python) -- the dict construction IS the cost. Only the Arrow path
+removes the boundary tax.
+
+## Goal
+
+Wire `record_fingerprints_batch_arrow` into identity resolution so no-PK record
+ids are computed in one vectorized batch instead of a per-row loop, with
+**byte-identical** fingerprints (entity ids must not move) and an end-to-end
+measured win.
+
+## The parity crux (the core design risk)
+
+`record_fingerprints_batch_arrow` hashes the frame's columns directly (supported
+dtypes: Utf8/LargeUtf8/Int64/Float64/Boolean; null -> `FpValue::Null`; `__`-cols
+dropped). But the per-row path hashes `_canonical_payload(payload)`, which
+COERCES (resolve.py:89):
+
+- non-finite floats (`nan`/`inf`/`-inf`) -> their `repr()` token STRING;
+- temporals / other non-primitives -> `isoformat()` or `str()`;
+- None/bool/int/float/str/bytes -> as-is.
+
+So feeding the RAW records frame to the Arrow kernel would NOT match the per-row
+hashes (a Date column hashes as a date, not its ISO string; a float `nan` hashes
+as a float, not `"nan"`). Entity ids would silently change -- a durability
+disaster (the identity graph keys stable `entity_id`s off these fingerprints).
+
+**Therefore the core deliverable is a vectorized `_canonicalize_records_df`** that
+reproduces `_canonical_payload`'s per-row coercion in Polars expressions BEFORE
+the batch call, so the frame fed to the kernel yields byte-identical hashes:
+
+- Temporal columns (Date/Datetime/Time/Duration) -> Utf8 via the SAME format
+  `isoformat()` produces (verify exact format: Polars `dt.to_string` /
+  `str()` of the python temporal -- the test gates this).
+- Float columns -> replace non-finite cells with their token strings
+  (`"nan"`/`"inf"`/`"-inf"`), which forces the column to Utf8 only if non-finite
+  values are present (finite floats stay Float64 and hash identically).
+- Non-primitive object columns (lists, structs, decimals, etc.) -> `str()` per
+  cell (vectorized via `map_elements` only where unavoidable; these are the rare
+  case `_canonical_payload`'s `else` branch handles).
+- bytes columns -> the kernel dtype list omits Binary; either cast to the same
+  representation the per-row path uses, OR route bytes-bearing rows to the
+  per-row fallback (decide by test).
+- Null cells -> `FpValue::Null` already matches the per-row `None`.
+
+If a column or row cannot be canonicalized to a kernel-supported dtype with
+provable parity, that row falls back to the per-row path (correctness over
+speed). The legacy-fallback for un-fingerprintable rows (`:hash:` id) is preserved.
+
+## Approach (vectorized canonicalize -> batch arrow -> per-record id logic)
+
+1. In `resolve_clusters` (or a new helper), assemble the no-PK records as a
+   Polars DataFrame (they already originate from the deduped frame; confirm the
+   data shape at plan time -- if records are dict rows, reassemble a frame once).
+2. `_canonicalize_records_df(df)` -> a frame whose `__`-stripped columns
+   reproduce `_canonical_payload` per row (the parity crux above).
+3. `record_fingerprints_batch_arrow(canonical_df)` -> `list[str]` hashes aligned
+   to rows (it already falls back to the dict path when native is absent --
+   correctness preserved off-native).
+4. Build ids vectorized: `h1_id = f"{source}:h1:{hash[:12]}"`, apply the
+   `h1`/`hash` scheme (`_id_scheme()`) and the legacy candidate ordering exactly
+   as `_record_id_candidates` does today. PK records (`source:pk`) skip
+   fingerprinting entirely.
+5. The per-row `_record_id_candidates` stays as the fallback path (rows that
+   can't be canonicalized; and the whole batch path is gated so it can be
+   disabled).
+
+### Rejected alternatives
+- **Dict batch kernel (`record_fingerprints_batch`):** safe parity (uses the same
+  `_canonical_payload`) but Stage 0 = 0.71x; the dict construction is the cost.
+  Does not solve #663.
+- **Feed the raw frame to the Arrow kernel without canonicalization:** fast but
+  breaks parity on temporals / non-finite floats -> entity ids move. Unacceptable.
+
+## Testing
+
+- **Parity gate (HARD, the safety net):** an adversarial fixture frame covering
+  every supported + coercion dtype -- Utf8, Int64, Float64 (incl. nan/inf/-inf),
+  Boolean, Null, Date, Datetime, a list/struct object column, bytes. Assert the
+  batched path (`_canonicalize_records_df` -> `record_fingerprints_batch_arrow`)
+  returns BYTE-IDENTICAL hashes to `[record_fingerprint(_canonical_payload(r))
+  for r in df.to_dicts()]`, row for row. Any mismatch fails. This is the entity-id
+  durability guarantee.
+- **Identity end-to-end parity:** run `resolve_clusters` on a fixture both ways
+  (batch path on, per-row path) and assert the resulting `entity_id`s / record
+  ids are identical.
+- **Off-native correctness:** with `GOLDENMATCH_NATIVE=0`, the path degrades to
+  the dict/per-row fallback and still produces identical ids.
+- **Measure-first (gate on shipping default-on):** bench identity resolution
+  end-to-end at 1M-5M deduped records (wall + peak RSS) batch vs per-row on
+  `large-new-64GB`. Ship default-on only if it wins meaningfully; otherwise keep
+  it gated and record the finding (per the repo perf-audit lesson -- measure
+  wall-clock on the real shape before trusting the microbench).
+- **Legacy-fallback preserved:** a row whose payload can't be fingerprinted still
+  yields the `:hash:` legacy id + candidate ordering unchanged.
+
+## Scope boundary (YAGNI)
+
+- ONLY wire fingerprints in `identity/resolve.py`. Do NOT touch build_clusters
+  (Sub-project B), the dedup path (deprioritized), the native kernels (they
+  exist), or the canonical-fingerprint spec itself.
+- Do NOT change the `h1`/`hash` scheme, the legacy-fallback semantics, or the
+  `GOLDENMATCH_IDENTITY_ID_SCHEME` kill-switch.
+- A new gate (env var or `config.identity` flag) toggles the batch path so the
+  per-row path remains available; default-on decided by the measure-first bench.
+
+## References
+
+- Issue #663; roadmap `docs/superpowers/specs/2026-05-31-arrow-native-roadmap.md`
+  (Phase 3); bulk-fingerprint kernel spec
+  `docs/superpowers/specs/2026-05-30-bulk-record-fingerprint-kernel-spec.md`.
+- Python: `core/_hashing.py` (`record_fingerprint`, `record_fingerprints_batch`,
+  `record_fingerprints_batch_arrow`); `identity/resolve.py`
+  (`_record_id_candidates`, `_canonical_payload`, `_id_scheme`, `resolve_clusters`).
+- Rust: `packages/rust/extensions/native/src/hash.rs::record_fingerprints_batch_arrow`.
+- Proven pattern: `score_block_pairs_arrow` (the wired, default Arrow kernel).
+- Durability invariant: identity-graph design
+  (`docs/superpowers/specs/2026-05-12-identity-graph-design.md`); record-hash
+  stability (`[[project_stable_record_fingerprint]]`).

--- a/docs/superpowers/specs/2026-06-01-identity-fingerprint-arrow-design.md
+++ b/docs/superpowers/specs/2026-06-01-identity-fingerprint-arrow-design.md
@@ -35,61 +35,80 @@ ids are computed in one vectorized batch instead of a per-row loop, with
 **byte-identical** fingerprints (entity ids must not move) and an end-to-end
 measured win.
 
-## The parity crux (the core design risk)
+## The parity crux
 
-`record_fingerprints_batch_arrow` hashes the frame's columns directly (supported
-dtypes: Utf8/LargeUtf8/Int64/Float64/Boolean; null -> `FpValue::Null`; `__`-cols
-dropped). But the per-row path hashes `_canonical_payload(payload)`, which
-COERCES (resolve.py:89):
+**Confirmed by spec review (de-risks the design):** the single-record kernel
+(`record_fingerprint`, hash.rs:64) and the batch-arrow kernel
+(`record_fingerprints_batch_arrow`, hash.rs:148) BOTH build `Vec<(String,
+FpValue)>` and call the SAME `goldenmatch_fingerprint_core::fingerprint_fields`
+(fingerprint-core/src/lib.rs:54) -- shared field ordering, type tags
+(`n/b/i/f/s/y`), separators, null handling, `-0.0`->`0.0` collapse. So a CLEAN
+all-primitive frame (Int64 / finite Float64 / Bool / Utf8 / Null) is byte-identical
+to the per-row path FOR FREE. There is no kernel-level canonicalization mismatch.
 
-- non-finite floats (`nan`/`inf`/`-inf`) -> their `repr()` token STRING;
-- temporals / other non-primitives -> `isoformat()` or `str()`;
-- None/bool/int/float/str/bytes -> as-is.
+The REAL risk is narrower: `record_fingerprints_batch_arrow` reads columns
+directly (Utf8/LargeUtf8/Int64/Float64/Boolean; null -> `FpValue::Null`; `__`-cols
+dropped), but the per-row path hashes `_canonical_payload(payload)`, which COERCES
+(resolve.py:89) -- and the coercions do NOT all have a clean columnar equivalent.
+A vectorized `_canonicalize_records_df` reproduces the coercible ones; rows that
+can't be reproduced columnarly ROUTE TO THE PER-ROW FALLBACK (correctness over
+speed). Three concrete cases the review pinned down:
 
-So feeding the RAW records frame to the Arrow kernel would NOT match the per-row
-hashes (a Date column hashes as a date, not its ISO string; a float `nan` hashes
-as a float, not `"nan"`). Entity ids would silently change -- a durability
-disaster (the identity graph keys stable `entity_id`s off these fingerprints).
+- **Temporals (Date/Datetime/Time):** per-row uses Python `isoformat()`. Polars
+  `dt.to_string()` / `cast(Utf8)` does NOT match: Datetime uses a SPACE separator
+  (`2020-01-02 03:04:05`) vs isoformat's `T`; Time `cast` DROPS microseconds. The
+  canonicalize step MUST reproduce `isoformat()` exactly -- Datetime via
+  `dt.to_string("%Y-%m-%dT%H:%M:%S%.f")` AND handle the microsecond==0 case
+  (Python `isoformat()` omits the fractional part entirely when usec==0; `%.f`
+  must be verified/trimmed to match). Date already matches both ways (`2020-01-02`).
+  The parity fixture gates this with both sub-second and zero-microsecond values.
+- **Mixed finite/non-finite float columns: NO columnar equivalent -> per-row
+  fallback.** A Polars column is single-dtype. If any cell is non-finite, casting
+  the column to Utf8 also turns the FINITE cells into strings -> they'd hash as
+  `FpValue::Str("1.5")` (tag `s`) instead of `FpValue::Float` (tag `f`) -> diverge.
+  The per-row path is per-cell (finite stays float, non-finite -> `repr` string)
+  and cannot be reproduced columnarly. Therefore: any row containing a non-finite
+  float in any float column routes to the per-row fallback. (A float column with
+  ONLY finite values stays Float64 and hashes identically -- no fallback needed.)
+- **bytes columns: NO columnar equivalent -> per-row fallback.** The kernel
+  rejects Binary (hash.rs ArrayKind::from_data); the per-row path hashes bytes as
+  `FpValue::Bytes` (tag `y`). Casting to Utf8 changes the tag `y`->`s` and breaks
+  parity. Bytes-bearing rows route to the per-row fallback.
+- Non-primitive object columns (lists/structs/decimals) -> `str()` per cell,
+  matching `_canonical_payload`'s `else` branch; if not provably reproducible,
+  fall back.
+- Null cells -> `FpValue::Null` already matches per-row `None`.
 
-**Therefore the core deliverable is a vectorized `_canonicalize_records_df`** that
-reproduces `_canonical_payload`'s per-row coercion in Polars expressions BEFORE
-the batch call, so the frame fed to the kernel yields byte-identical hashes:
-
-- Temporal columns (Date/Datetime/Time/Duration) -> Utf8 via the SAME format
-  `isoformat()` produces (verify exact format: Polars `dt.to_string` /
-  `str()` of the python temporal -- the test gates this).
-- Float columns -> replace non-finite cells with their token strings
-  (`"nan"`/`"inf"`/`"-inf"`), which forces the column to Utf8 only if non-finite
-  values are present (finite floats stay Float64 and hash identically).
-- Non-primitive object columns (lists, structs, decimals, etc.) -> `str()` per
-  cell (vectorized via `map_elements` only where unavoidable; these are the rare
-  case `_canonical_payload`'s `else` branch handles).
-- bytes columns -> the kernel dtype list omits Binary; either cast to the same
-  representation the per-row path uses, OR route bytes-bearing rows to the
-  per-row fallback (decide by test).
-- Null cells -> `FpValue::Null` already matches the per-row `None`.
-
-If a column or row cannot be canonicalized to a kernel-supported dtype with
-provable parity, that row falls back to the per-row path (correctness over
-speed). The legacy-fallback for un-fingerprintable rows (`:hash:` id) is preserved.
+The legacy-fallback for un-fingerprintable rows (`:hash:` id) is preserved.
 
 ## Approach (vectorized canonicalize -> batch arrow -> per-record id logic)
 
-1. In `resolve_clusters` (or a new helper), assemble the no-PK records as a
-   Polars DataFrame (they already originate from the deduped frame; confirm the
-   data shape at plan time -- if records are dict rows, reassemble a frame once).
-2. `_canonicalize_records_df(df)` -> a frame whose `__`-stripped columns
-   reproduce `_canonical_payload` per row (the parity crux above).
+`resolve_clusters` already receives `df: pl.DataFrame` and does `rows =
+df.to_dicts()` (resolve.py:218) then loops per row (`:227`), so the frame already
+exists -- "assemble a frame" is trivial.
+
+1. **Partition rows into the no-PK subset** (the only rows that fingerprint).
+   When `source_pk_col` is set and present+non-null, `_record_id_candidates`
+   returns `source:pk` WITHOUT hashing (resolve.py:125-128). The batch path
+   computes fingerprints ONLY for the no-PK subset; PK rows keep their cheap path.
+2. **`_canonicalize_records_df(df)`** -> a frame whose `__`-stripped columns
+   reproduce `_canonical_payload` per row (the parity crux above). Rows that hit
+   the no-columnar-equivalent cases (non-finite float, bytes, un-reproducible
+   object) are MARKED for the per-row fallback rather than canonicalized.
+   `_canonicalize_records_df` MUST run before the wrapper in ALL modes (native
+   on AND off): the off-native fallback inside the wrapper calls
+   `record_fingerprint` on raw dicts, which RAISES on raw temporals / non-finite
+   floats (`_hashing.py:139-141` does NOT apply `_canonical_payload`). Feeding it
+   the canonicalized frame is what keeps the off-native path correct.
 3. `record_fingerprints_batch_arrow(canonical_df)` -> `list[str]` hashes aligned
-   to rows (it already falls back to the dict path when native is absent --
-   correctness preserved off-native).
-4. Build ids vectorized: `h1_id = f"{source}:h1:{hash[:12]}"`, apply the
-   `h1`/`hash` scheme (`_id_scheme()`) and the legacy candidate ordering exactly
-   as `_record_id_candidates` does today. PK records (`source:pk`) skip
-   fingerprinting entirely.
-5. The per-row `_record_id_candidates` stays as the fallback path (rows that
-   can't be canonicalized; and the whole batch path is gated so it can be
-   disabled).
+   to the no-PK rows.
+4. Build ids: `h1_id = f"{src}:h1:{hash[:12]}"` where `src` is **per-row**
+   (`str(row.get("__source__", "dataframe"))`, resolve.py:232) -- zip the hashes
+   with the per-row source, NOT a scalar. Apply the `h1`/`hash` scheme
+   (`_id_scheme()`) and the legacy candidate ordering exactly as
+   `_record_id_candidates` does today.
+5. The per-row `_record_id_candidates` stays as the fallback path (the marked
+   rows from step 2; and the whole batch path is gated so it can be disabled).
 
 ### Rejected alternatives
 - **Dict batch kernel (`record_fingerprints_batch`):** safe parity (uses the same
@@ -100,23 +119,29 @@ speed). The legacy-fallback for un-fingerprintable rows (`:hash:` id) is preserv
 
 ## Testing
 
-- **Parity gate (HARD, the safety net):** an adversarial fixture frame covering
-  every supported + coercion dtype -- Utf8, Int64, Float64 (incl. nan/inf/-inf),
-  Boolean, Null, Date, Datetime, a list/struct object column, bytes. Assert the
-  batched path (`_canonicalize_records_df` -> `record_fingerprints_batch_arrow`)
-  returns BYTE-IDENTICAL hashes to `[record_fingerprint(_canonical_payload(r))
-  for r in df.to_dicts()]`, row for row. Any mismatch fails. This is the entity-id
-  durability guarantee.
+- **Parity gate (HARD, the safety net):** an adversarial fixture frame that MUST
+  include the cases the review pinned -- Utf8, Int64, Float64 finite, a float
+  column with mixed finite + nan/inf/-inf, Boolean, Null, Date, Datetime with
+  sub-second AND with usec==0, Time with microseconds, a list/struct object
+  column, bytes. Assert the batched path (`_canonicalize_records_df` -> batch,
+  with marked rows routed per-row) returns BYTE-IDENTICAL hashes to
+  `[record_fingerprint(_canonical_payload(r)) for r in df.to_dicts()]`, row for
+  row. Any mismatch fails -- this is the entity-id durability guarantee. The
+  datetime separator (`T` vs space), Time microseconds, mixed-float fallback, and
+  bytes fallback are the specific things this fixture catches.
+- **Off-native parity (run the SAME fixture with `GOLDENMATCH_NATIVE=0`):** the
+  canonicalized frame must produce identical ids on the dict/per-row fallback too.
+  Critically, this confirms `_canonicalize_records_df` runs before the wrapper in
+  off-native mode (else the raw-dict fallback raises on temporals/non-finite).
 - **Identity end-to-end parity:** run `resolve_clusters` on a fixture both ways
   (batch path on, per-row path) and assert the resulting `entity_id`s / record
-  ids are identical.
-- **Off-native correctness:** with `GOLDENMATCH_NATIVE=0`, the path degrades to
-  the dict/per-row fallback and still produces identical ids.
+  ids are identical, including a no-PK + PK mix.
 - **Measure-first (gate on shipping default-on):** bench identity resolution
   end-to-end at 1M-5M deduped records (wall + peak RSS) batch vs per-row on
-  `large-new-64GB`. Ship default-on only if it wins meaningfully; otherwise keep
-  it gated and record the finding (per the repo perf-audit lesson -- measure
-  wall-clock on the real shape before trusting the microbench).
+  `large-new-64GB`. The fixture must be **no-PK-heavy** -- PK rows bypass
+  fingerprinting entirely, so a PK-backed frame under-reads the kernel's value.
+  Ship default-on only if it wins meaningfully; otherwise keep it gated and record
+  the finding (repo perf-audit lesson -- measure wall-clock on the real shape).
 - **Legacy-fallback preserved:** a row whose payload can't be fingerprinted still
   yields the `:hash:` legacy id + candidate ordering unchanged.
 

--- a/docs/superpowers/specs/2026-06-01-identity-fingerprint-arrow-design.md
+++ b/docs/superpowers/specs/2026-06-01-identity-fingerprint-arrow-design.md
@@ -56,28 +56,43 @@ speed). Three concrete cases the review pinned down:
 
 - **Temporals (Date/Datetime/Time):** per-row uses Python `isoformat()`. Polars
   `dt.to_string()` / `cast(Utf8)` does NOT match: Datetime uses a SPACE separator
-  (`2020-01-02 03:04:05`) vs isoformat's `T`; Time `cast` DROPS microseconds. The
-  canonicalize step MUST reproduce `isoformat()` exactly -- Datetime via
-  `dt.to_string("%Y-%m-%dT%H:%M:%S%.f")` AND handle the microsecond==0 case
-  (Python `isoformat()` omits the fractional part entirely when usec==0; `%.f`
-  must be verified/trimmed to match). Date already matches both ways (`2020-01-02`).
-  The parity fixture gates this with both sub-second and zero-microsecond values.
+  vs isoformat's `T`; Time `cast` DROPS microseconds. AND chrono's `%.f` trims
+  trailing zeros to 3/6/9-digit groups (`.123000` -> `.123`) while `isoformat()`
+  emits exactly 0 or 6 digits. **Verified-correct recipe:**
+  `dt.to_string("%Y-%m-%dT%H:%M:%S%.6f").str.replace(r"\.000000$", "")` (same for
+  Time with `%H:%M:%S%.6f` + strip) -- byte-equal to `isoformat()` across usec
+  `{0, 1, 123000, 123456, 500000}`. Date already matches both ways (`2020-01-02`).
+  **Timezone-aware Datetimes and non-`us` time units route to the per-row
+  fallback** (isoformat emits the `+00:00` offset which the format string drops;
+  `ms`/`ns` units render differently under `%.6f`). Per-row is safe -- `to_dicts()`
+  yields a real `datetime` and `_canonical_payload` calls its `.isoformat()`.
+- **Narrow / unsigned ints and Float32: up-cast, with one fallback.** The kernel's
+  `ArrayKind::from_data` accepts ONLY Int64/Float64/Utf8/LargeUtf8/Boolean and
+  RAISES on others. `_canonicalize_records_df` must up-cast `Int8/16/32` and
+  `UInt8/16/32` -> Int64, and `Float32` -> Float64 (verified byte-identical to the
+  `to_dicts()` value). **Exception:** a `UInt64` value > `i64::MAX` raises on
+  `cast(Int64)` -> those rows route to the per-row fallback (per-row handles a
+  Python int via `str()`).
 - **Mixed finite/non-finite float columns: NO columnar equivalent -> per-row
-  fallback.** A Polars column is single-dtype. If any cell is non-finite, casting
-  the column to Utf8 also turns the FINITE cells into strings -> they'd hash as
-  `FpValue::Str("1.5")` (tag `s`) instead of `FpValue::Float` (tag `f`) -> diverge.
-  The per-row path is per-cell (finite stays float, non-finite -> `repr` string)
-  and cannot be reproduced columnarly. Therefore: any row containing a non-finite
-  float in any float column routes to the per-row fallback. (A float column with
-  ONLY finite values stays Float64 and hashes identically -- no fallback needed.)
+  fallback (via a row mask).** A Polars column is single-dtype; one non-finite
+  cell forces the whole column to Utf8, turning the FINITE cells into `FpValue::Str`
+  (tag `s`) instead of `FpValue::Float` (tag `f`) -> diverge. The per-row path is
+  per-cell. Mechanism: build an `is_finite` mask over EVERY Float column; the UNION
+  of rows with any non-finite float goes to the per-row path; the complement stays
+  in the batch frame; re-merge by row index preserving order (the same split must
+  preserve the no-PK row alignment used to zip hashes back -- see Approach step 4).
+  A float column with ONLY finite values stays Float64 and hashes identically.
 - **bytes columns: NO columnar equivalent -> per-row fallback.** The kernel
-  rejects Binary (hash.rs ArrayKind::from_data); the per-row path hashes bytes as
-  `FpValue::Bytes` (tag `y`). Casting to Utf8 changes the tag `y`->`s` and breaks
-  parity. Bytes-bearing rows route to the per-row fallback.
-- Non-primitive object columns (lists/structs/decimals) -> `str()` per cell,
-  matching `_canonical_payload`'s `else` branch; if not provably reproducible,
+  rejects Binary; the per-row path hashes bytes as `FpValue::Bytes` (tag `y`).
+  Casting to Utf8 changes the tag `y`->`s` and breaks parity. Bytes-bearing rows
+  route to the per-row fallback.
+- Non-primitive object columns (lists/structs/Decimal/Categorical/Enum) -> `str()`
+  per cell, matching `_canonical_payload`'s `else` branch. Verify each at plan time
+  against `to_dicts()` (a `Decimal` row yields a Python `decimal.Decimal` whose
+  `str()` must equal the `else: str(v)` output); if not provably reproducible,
   fall back.
-- Null cells -> `FpValue::Null` already matches per-row `None`.
+- Null cells -> `FpValue::Null` already matches per-row `None`. An all-null column
+  still appears in BOTH paths and must NOT be dropped by canonicalize.
 
 The legacy-fallback for un-fingerprintable rows (`:hash:` id) is preserved.
 
@@ -121,14 +136,17 @@ exists -- "assemble a frame" is trivial.
 
 - **Parity gate (HARD, the safety net):** an adversarial fixture frame that MUST
   include the cases the review pinned -- Utf8, Int64, Float64 finite, a float
-  column with mixed finite + nan/inf/-inf, Boolean, Null, Date, Datetime with
-  sub-second AND with usec==0, Time with microseconds, a list/struct object
-  column, bytes. Assert the batched path (`_canonicalize_records_df` -> batch,
-  with marked rows routed per-row) returns BYTE-IDENTICAL hashes to
-  `[record_fingerprint(_canonical_payload(r)) for r in df.to_dicts()]`, row for
-  row. Any mismatch fails -- this is the entity-id durability guarantee. The
-  datetime separator (`T` vs space), Time microseconds, mixed-float fallback, and
-  bytes fallback are the specific things this fixture catches.
+  column with mixed finite + nan/inf/-inf, Boolean, Null (incl. an all-null
+  column), Date, Datetime with usec in `{0, 123000, 500000, 123456}` (the
+  `.123000`/`.500000` values are what catch the chrono `%.f`-vs-isoformat bug; a
+  fixture with only sub-second + usec==0 would PASS the buggy recipe and miss it),
+  a tz-aware Datetime + a non-`us` (`ms`) Datetime, Time with microseconds,
+  Int32 / UInt32 / Float32, a `UInt64` value > 2**63, Decimal, Categorical, a
+  list/struct object column, and bytes. Assert the batched path
+  (`_canonicalize_records_df` -> batch, with marked rows routed per-row) returns
+  BYTE-IDENTICAL hashes to `[record_fingerprint(_canonical_payload(r)) for r in
+  df.to_dicts()]`, row for row. Any mismatch fails -- this is the entity-id
+  durability guarantee.
 - **Off-native parity (run the SAME fixture with `GOLDENMATCH_NATIVE=0`):** the
   canonicalized frame must produce identical ids on the dict/per-row fallback too.
   Critically, this confirms `_canonicalize_records_df` runs before the wrapper in
@@ -163,7 +181,10 @@ exists -- "assemble a frame" is trivial.
 - Python: `core/_hashing.py` (`record_fingerprint`, `record_fingerprints_batch`,
   `record_fingerprints_batch_arrow`); `identity/resolve.py`
   (`_record_id_candidates`, `_canonical_payload`, `_id_scheme`, `resolve_clusters`).
-- Rust: `packages/rust/extensions/native/src/hash.rs::record_fingerprints_batch_arrow`.
+- Rust: `packages/rust/extensions/native/src/hash.rs::record_fingerprints_batch_arrow`
+  (both the single + batch kernels delegate to
+  `packages/rust/extensions/fingerprint-core/src/lib.rs::fingerprint_fields` --
+  note the crate is at `extensions/fingerprint-core/`, NOT under `native/`).
 - Proven pattern: `score_block_pairs_arrow` (the wired, default Arrow kernel).
 - Durability invariant: identity-graph design
   (`docs/superpowers/specs/2026-05-12-identity-graph-design.md`); record-hash

--- a/docs/superpowers/specs/2026-06-01-identity-fingerprint-arrow-design.md
+++ b/docs/superpowers/specs/2026-06-01-identity-fingerprint-arrow-design.md
@@ -62,10 +62,14 @@ speed). Three concrete cases the review pinned down:
   `dt.to_string("%Y-%m-%dT%H:%M:%S%.6f").str.replace(r"\.000000$", "")` (same for
   Time with `%H:%M:%S%.6f` + strip) -- byte-equal to `isoformat()` across usec
   `{0, 1, 123000, 123456, 500000}`. Date already matches both ways (`2020-01-02`).
-  **Timezone-aware Datetimes and non-`us` time units route to the per-row
-  fallback** (isoformat emits the `+00:00` offset which the format string drops;
-  `ms`/`ns` units render differently under `%.6f`). Per-row is safe -- `to_dicts()`
-  yields a real `datetime` and `_canonical_payload` calls its `.isoformat()`.
+  **Timezone-aware Datetimes, non-`us` time units, and `Duration` columns route to
+  the per-row fallback.** tz-aware: isoformat emits the `+00:00` offset the format
+  string drops; `ms`/`ns`: render differently under `%.6f`. `Duration`: a timedelta
+  has no `isoformat` so `_canonical_payload` does `str()` (`'0:00:05'`), but Polars
+  `cast(Utf8)` on Duration RAISES `InvalidOperationError` (NOT in resolve.py:133's
+  `except (TypeError, ValueError)`, so it would crash the whole batch) -- Duration
+  must go per-row, never a columnar cast. Per-row is safe -- `to_dicts()` yields a
+  real `datetime`/`timedelta` and `_canonical_payload` calls `.isoformat()`/`str()`.
 - **Narrow / unsigned ints and Float32: up-cast, with one fallback.** The kernel's
   `ArrayKind::from_data` accepts ONLY Int64/Float64/Utf8/LargeUtf8/Boolean and
   RAISES on others. `_canonicalize_records_df` must up-cast `Int8/16/32` and
@@ -92,7 +96,14 @@ speed). Three concrete cases the review pinned down:
   `str()` must equal the `else: str(v)` output); if not provably reproducible,
   fall back.
 - Null cells -> `FpValue::Null` already matches per-row `None`. An all-null column
-  still appears in BOTH paths and must NOT be dropped by canonicalize.
+  still appears in BOTH paths and must NOT be dropped by canonicalize. BUT a bare
+  `Null`-DTYPE column (untyped all-null, e.g. `pl.Series([None, None])` -> Arrow
+  `null` type) is REJECTED by the kernel (`ArrayKind::from_data` raises "unsupported
+  dtype Null") -> `_canonicalize_records_df` must `cast(Utf8)` such columns (the
+  kernel's Utf8 `value_at` returns `FpValue::Null` for null cells, preserving
+  parity with per-row `None`). A TYPED all-null column (e.g. Float64 all-null) is
+  already accepted -> no cast needed. The parity fixture's all-null column must be
+  UNTYPED to gate this.
 
 The legacy-fallback for un-fingerprintable rows (`:hash:` id) is preserved.
 
@@ -140,7 +151,9 @@ exists -- "assemble a frame" is trivial.
   column), Date, Datetime with usec in `{0, 123000, 500000, 123456}` (the
   `.123000`/`.500000` values are what catch the chrono `%.f`-vs-isoformat bug; a
   fixture with only sub-second + usec==0 would PASS the buggy recipe and miss it),
-  a tz-aware Datetime + a non-`us` (`ms`) Datetime, Time with microseconds,
+  a tz-aware Datetime + a non-`us` (`ms`) Datetime, Time with microseconds, a
+  `Duration` column, an UNTYPED all-null column (`pl.Series([None, None])`, bare
+  `Null` dtype -- a typed all-null column would pass and miss the bug),
   Int32 / UInt32 / Float32, a `UInt64` value > 2**63, Decimal, Categorical, a
   list/struct object column, and bytes. Assert the batched path
   (`_canonicalize_records_df` -> batch, with marked rows routed per-row) returns

--- a/packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py
@@ -85,7 +85,11 @@ def canonicalize_records_df(df: pl.DataFrame):
     height = df.height
     # Drop __-prefixed columns (both kernels + per-row payload exclude them).
     keep_cols = [c for c in df.columns if not c.startswith("__")]
-    sub = df.select(keep_cols) if keep_cols else df.select([])
+    if not keep_cols:
+        # No content fields after dropping __-cols: route the whole frame to per-row
+        # (each row hashes the empty payload {} -> a fixed hash). Cheap + parity-safe.
+        return None, [True] * height
+    sub = df.select(keep_cols)
 
     # Column-level un-batchable -> whole frame per-row.
     for col in keep_cols:
@@ -129,6 +133,7 @@ def canonicalize_records_df(df: pl.DataFrame):
         elif dtype == pl.Float32:
             exprs.append(pl.col(col).cast(pl.Float64))
         elif isinstance(dtype, _INT_UPCAST) or dtype == pl.UInt64:
+            # UInt64 handled here not in _INT_UPCAST: its overflow rows are already masked out above
             exprs.append(pl.col(col).cast(pl.Int64))
         elif isinstance(dtype, (pl.Categorical, pl.Enum)):
             exprs.append(pl.col(col).cast(pl.Utf8))
@@ -159,6 +164,7 @@ def batch_fingerprints(df: pl.DataFrame) -> list[str | None]:
     batch_df, mask = canonicalize_records_df(df)
     if batch_df is not None and batch_df.height:
         hashes = record_fingerprints_batch_arrow(batch_df)  # aligned to batch rows
+        # batch_df.height == count(not m for m in mask), guaranteed by survivors = sub.filter(~mask)
         bi = 0
         for i in range(df.height):
             if not mask[i]:

--- a/packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py
@@ -1,0 +1,175 @@
+"""Batch record fingerprinting for identity id derivation.
+
+``batch_fingerprints(df)`` returns one fingerprint per row of a records
+DataFrame -- a byte-identical drop-in for the per-row list comprehension
+``[record_fingerprint(_canonical_payload(payload)) for r in df.to_dicts()]``
+(with ``None`` for un-fingerprintable rows -> caller uses the legacy id).
+
+Entity ids key off these hashes, so byte-identical parity with the per-row
+path is the durability invariant. Fully-batchable rows go through the Arrow
+batch kernel after a vectorized canonicalization; anything that can't reach
+byte-identical parity via a Polars cast routes to the per-row fallback
+(column-level -- the whole frame -- or row-level -- only the offending rows).
+"""
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import polars as pl
+
+
+def _canonical_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Coerce a row payload to the primitives ``record_fingerprint`` accepts.
+
+    Temporals -> ISO-8601; non-finite floats -> their token string; other
+    non-primitives -> ``str()``. v1 of the canonical spec is primitive-only;
+    these coercions are a documented v1.1 follow-up (pinned in the kernel +
+    mirrored across surfaces when a second write surface adopts the C ABI). For
+    now they keep ingest working on real data (date columns etc.) while clean
+    str/int/float/bool/None records get a fully cross-surface fingerprint."""
+    out: dict[str, Any] = {}
+    for k, v in payload.items():
+        if isinstance(v, float) and not math.isfinite(v):
+            out[k] = repr(v)  # "nan" / "inf" / "-inf" as a stable token
+        elif v is None or isinstance(v, (bool, int, float, str, bytes)):
+            out[k] = v
+        else:
+            iso = getattr(v, "isoformat", None)
+            out[k] = iso() if callable(iso) else str(v)
+    return out
+
+
+# Integer dtypes that up-cast to Int64 without changing the canonical value.
+_INT_UPCAST = (
+    pl.Int8, pl.Int16, pl.Int32,
+    pl.UInt8, pl.UInt16, pl.UInt32,
+)
+_I64_MAX = 2**63 - 1
+
+
+def _is_unbatchable_dtype(dtype: pl.DataType) -> bool:
+    """True for a column-level un-batchable dtype: no parity-preserving cast
+    exists, so the WHOLE frame must go per-row (the column is in every row's
+    hash). ``Date`` and ``us``-unit tz-naive ``Datetime`` are batchable via the
+    temporal recipe and are NOT flagged here."""
+    if dtype == pl.Binary:
+        return True
+    if dtype == pl.Duration or dtype == pl.Time:
+        return True
+    if dtype == pl.Decimal:
+        return True
+    if isinstance(dtype, pl.Datetime):
+        # tz-aware or non-us unit cannot be reproduced as Python isoformat()
+        # by the temporal recipe below.
+        if dtype.time_zone is not None or dtype.time_unit != "us":
+            return True
+        return False
+    if isinstance(dtype, (pl.List, pl.Array, pl.Struct, pl.Object)):
+        return True
+    return False
+
+
+def canonicalize_records_df(df: pl.DataFrame):
+    """Return ``(batch_df_or_None, fallback_mask)``.
+
+    ``batch_df`` is a canonicalized frame (clean Int64/finite-Float64/Bool/Utf8
+    /typed-Null) restricted to the fully-batchable rows, in ORIGINAL row order,
+    ready for ``record_fingerprints_batch_arrow``. ``fallback_mask[i]`` is True
+    when row ``i`` must go through the per-row path instead.
+
+    ``batch_df`` is ``None`` (and the mask all-True) when any column-level
+    un-batchable dtype is present -- that column is in every row's hash, so no
+    row can be batched.
+    """
+    height = df.height
+    # Drop __-prefixed columns (both kernels + per-row payload exclude them).
+    keep_cols = [c for c in df.columns if not c.startswith("__")]
+    sub = df.select(keep_cols) if keep_cols else df.select([])
+
+    # Column-level un-batchable -> whole frame per-row.
+    for col in keep_cols:
+        if _is_unbatchable_dtype(sub.schema[col]):
+            return None, [True] * height
+
+    # Build the union row-level fallback mask BEFORE any cast. Two row-level
+    # cases: non-finite Float64 cells, and UInt64 cells > Int64 max.
+    mask = pl.Series([False] * height, dtype=pl.Boolean)
+    for col in keep_cols:
+        dtype = sub.schema[col]
+        if dtype == pl.Float64:
+            non_finite = ~sub[col].is_finite() & sub[col].is_not_null()
+            mask = mask | non_finite.fill_null(False)
+        elif dtype == pl.Float32:
+            non_finite = ~sub[col].cast(pl.Float64).is_finite() & sub[col].is_not_null()
+            mask = mask | non_finite.fill_null(False)
+        elif dtype == pl.UInt64:
+            overflow = (sub[col] > _I64_MAX).fill_null(False)
+            mask = mask | overflow
+
+    mask_list = mask.to_list()
+
+    # Restrict to surviving rows (original order preserved by filter), THEN
+    # cast -- so an overflow UInt64 cell never reaches a column-wide Int64 cast
+    # (which would raise InvalidOperationError, not TypeError/ValueError).
+    survivors = sub.filter(~mask)
+
+    exprs: list[pl.Expr] = []
+    for col in keep_cols:
+        dtype = survivors.schema[col]
+        if dtype == pl.Date:
+            exprs.append(pl.col(col).dt.to_string("%Y-%m-%d"))
+        elif isinstance(dtype, pl.Datetime):
+            # us-unit tz-naive (others were filtered as un-batchable above).
+            exprs.append(
+                pl.col(col)
+                .dt.to_string("%Y-%m-%dT%H:%M:%S%.6f")
+                .str.replace(r"\.000000$", "")
+            )
+        elif dtype == pl.Float32:
+            exprs.append(pl.col(col).cast(pl.Float64))
+        elif isinstance(dtype, _INT_UPCAST) or dtype == pl.UInt64:
+            exprs.append(pl.col(col).cast(pl.Int64))
+        elif isinstance(dtype, (pl.Categorical, pl.Enum)):
+            exprs.append(pl.col(col).cast(pl.Utf8))
+        elif dtype == pl.Null:
+            # Untyped all-null column: kernel rejects the Arrow null type; Utf8
+            # null cells hash as FpValue::Null, matching the per-row path.
+            exprs.append(pl.col(col).cast(pl.Utf8))
+        else:
+            exprs.append(pl.col(col))
+
+    batch_df = survivors.with_columns(exprs) if exprs else survivors
+    return batch_df, mask_list
+
+
+def batch_fingerprints(df: pl.DataFrame) -> list[str | None]:
+    """One fingerprint per row of ``df``, in row order. ``None`` for a row the
+    canonical spec can't fingerprint (caller falls back to the legacy id).
+
+    Byte-identical to ``[record_fingerprint(_canonical_payload(payload))
+    for r in df.to_dicts()]`` (with ``__``-prefixed keys dropped and
+    ``TypeError``/``ValueError`` mapped to ``None``)."""
+    from goldenmatch.core._hashing import (
+        record_fingerprint,
+        record_fingerprints_batch_arrow,
+    )
+
+    out: list[str | None] = [None] * df.height
+    batch_df, mask = canonicalize_records_df(df)
+    if batch_df is not None and batch_df.height:
+        hashes = record_fingerprints_batch_arrow(batch_df)  # aligned to batch rows
+        bi = 0
+        for i in range(df.height):
+            if not mask[i]:
+                out[i] = hashes[bi]
+                bi += 1
+    rows = df.to_dicts()
+    for i in range(df.height):
+        if mask[i]:
+            payload = {k: v for k, v in rows[i].items() if not k.startswith("__")}
+            try:
+                out[i] = record_fingerprint(_canonical_payload(payload))
+            except (TypeError, ValueError):
+                out[i] = None
+    return out

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import math
 import os
 from collections import Counter
 from dataclasses import dataclass
@@ -25,6 +24,7 @@ from typing import Any
 import polars as pl
 
 from goldenmatch.core._hashing import record_fingerprint
+from goldenmatch.identity.fingerprint_batch import _canonical_payload
 from goldenmatch.identity.model import (
     EdgeKind,
     EventKind,
@@ -84,27 +84,6 @@ def _id_scheme() -> str:
     return "hash" if os.environ.get(
         "GOLDENMATCH_IDENTITY_ID_SCHEME", "h1"
     ).strip().lower() == "hash" else "h1"
-
-
-def _canonical_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    """Coerce a row payload to the primitives ``record_fingerprint`` accepts.
-
-    Temporals -> ISO-8601; non-finite floats -> their token string; other
-    non-primitives -> ``str()``. v1 of the canonical spec is primitive-only;
-    these coercions are a documented v1.1 follow-up (pinned in the kernel +
-    mirrored across surfaces when a second write surface adopts the C ABI). For
-    now they keep ingest working on real data (date columns etc.) while clean
-    str/int/float/bool/None records get a fully cross-surface fingerprint."""
-    out: dict[str, Any] = {}
-    for k, v in payload.items():
-        if isinstance(v, float) and not math.isfinite(v):
-            out[k] = repr(v)  # "nan" / "inf" / "-inf" as a stable token
-        elif v is None or isinstance(v, (bool, int, float, str, bytes)):
-            out[k] = v
-        else:
-            iso = getattr(v, "isoformat", None)
-            out[k] = iso() if callable(iso) else str(v)
-    return out
 
 
 def _record_id_candidates(

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -24,7 +24,10 @@ from typing import Any
 import polars as pl
 
 from goldenmatch.core._hashing import record_fingerprint
-from goldenmatch.identity.fingerprint_batch import _canonical_payload
+from goldenmatch.identity.fingerprint_batch import (
+    _canonical_payload,
+    batch_fingerprints,
+)
 from goldenmatch.identity.model import (
     EdgeKind,
     EventKind,
@@ -75,6 +78,25 @@ def _hash_payload(payload: dict[str, Any]) -> str:
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
 
+# Sentinel: ``_record_id_candidates`` was called WITHOUT a precomputed batch
+# hash, so it must compute the fingerprint per-row (the legacy default path).
+# Distinct from ``None``, which means the batch *determined* this row is
+# un-fingerprintable (-> legacy-only id).
+_NOT_BATCHED = object()
+
+
+def _batch_fingerprint_enabled() -> bool:
+    """Opt-in batch fingerprinting for ``resolve_clusters``: when
+    ``GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT=1``, no-PK record h1 hashes are
+    computed once via ``batch_fingerprints(df)`` instead of per-row inside the
+    cluster loop. Default OFF (``0``) -- byte-identical to the per-row path, so
+    the gate is a no-op on output. Default-on is pending a perf bench. See
+    ``_id_scheme`` for the sibling content-hash kill-switch."""
+    return os.environ.get(
+        "GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT", "0"
+    ).strip() == "1"
+
+
 def _id_scheme() -> str:
     """Primary content-hash record-id scheme: ``"h1"`` (canonical
     cross-surface fingerprint, the default) or ``"hash"`` (legacy json.dumps).
@@ -90,16 +112,27 @@ def _record_id_candidates(
     row: dict[str, Any],
     source: str,
     source_pk_col: str | None,
+    *,
+    precomputed_h1: object = _NOT_BATCHED,
 ) -> tuple[str, list[str]]:
     """Return ``(primary_id, lookup_candidates)`` for a record row.
 
-    Natural PK -> ``("{source}:{pk}", ["{source}:{pk}"])`` (unchanged).
+    Natural PK -> ``("{source}:{pk}", ["{source}:{pk}"])`` (unchanged; never
+    touches ``precomputed_h1``).
     No PK -> a content-hash id. The primary is the canonical cross-surface
     fingerprint (``"{source}:h1:{12}"``); the legacy json.dumps id
     (``"{source}:hash:{12}"``) is kept as an additional *lookup candidate* so
     records ingested before the cutover keep resolving to the same entity (no
     rewrite, no split). Candidates are ordered primary-first. A record whose
     values the canonical spec can't yet fingerprint stays on the legacy scheme.
+
+    ``precomputed_h1`` (keyword-only) lets a caller supply the FULL 64-char h1
+    hash computed in bulk via ``batch_fingerprints`` (the
+    ``GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT`` path), skipping the per-row
+    ``record_fingerprint`` call. ``_NOT_BATCHED`` (default) -> compute per-row.
+    A ``str`` -> use it as the full h1 hash. ``None`` -> the batch determined
+    the row un-fingerprintable, take the legacy-only path (byte-identical to
+    the per-row ``except`` branch).
     """
     if source_pk_col and source_pk_col in row and row[source_pk_col] is not None:
         pk = str(row[source_pk_col])
@@ -107,12 +140,20 @@ def _record_id_candidates(
         return rid, [rid]
     payload = _row_to_payload(row)
     legacy_id = f"{source}:hash:{_hash_payload(payload)[:12]}"
-    try:
-        h1_id = f"{source}:h1:{record_fingerprint(_canonical_payload(payload))[:12]}"
-    except (TypeError, ValueError):
-        # Belt-and-suspenders: anything the canonical spec can't handle stays
-        # legacy-only (still fully resolvable). Should be rare after coercion.
+    if precomputed_h1 is _NOT_BATCHED:
+        try:
+            full_h1 = record_fingerprint(_canonical_payload(payload))
+        except (TypeError, ValueError):
+            # Belt-and-suspenders: anything the canonical spec can't handle
+            # stays legacy-only (still fully resolvable). Rare after coercion.
+            return legacy_id, [legacy_id]
+    elif precomputed_h1 is None:
+        # Batch flagged this row un-fingerprintable -> legacy-only (matches the
+        # per-row except branch byte-for-byte).
         return legacy_id, [legacy_id]
+    else:
+        full_h1 = precomputed_h1  # type: ignore[assignment]
+    h1_id = f"{source}:h1:{full_h1[:12]}"
     if _id_scheme() == "hash":
         return legacy_id, [legacy_id, h1_id]
     return h1_id, [h1_id, legacy_id]
@@ -203,13 +244,41 @@ def resolve_clusters(
     _rowid_primary: dict[int, str] = {}
     _rowid_candidates: dict[int, list[str]] = {}
 
+    # Optional batch fingerprinting (GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT=1):
+    # compute every no-PK row's h1 hash once via the Arrow batch kernel instead
+    # of per-row inside the loop. ``batch_fingerprints`` returns FULL 64-char
+    # hashes positionally aligned to ``df`` rows (None = un-fingerprintable),
+    # so it MUST run on the full df (not a sub-frame) to stay aligned with
+    # ``enumerate(rows)``. Only NO-PK rows get a precomputed hash -- the
+    # PK-detection here mirrors ``_record_id_candidates`` exactly, so a PK row
+    # never receives one (it would be ignored anyway) and a no-PK row always
+    # does. Gate off -> ``h1_by_rowid`` empty -> every row falls to _NOT_BATCHED
+    # -> byte-identical to the per-row path.
+    h1_by_rowid: dict[int, str | None] = {}
+    if _batch_fingerprint_enabled():
+        h1_list = batch_fingerprints(df)
+        for i, row in enumerate(rows):
+            rid = row.get("__row_id__")
+            if rid is None:
+                continue
+            has_pk = (
+                source_pk_col is not None
+                and source_pk_col in row
+                and row[source_pk_col] is not None
+            )
+            if not has_pk:
+                h1_by_rowid[int(rid)] = h1_list[i]
+
     for row in rows:
         rid = row.get("__row_id__")
         if rid is None:
             continue
         irid = int(rid)
         source = str(row.get("__source__", "dataframe"))
-        primary_id, candidates = _record_id_candidates(row, source, source_pk_col)
+        primary_id, candidates = _record_id_candidates(
+            row, source, source_pk_col,
+            precomputed_h1=h1_by_rowid.get(irid, _NOT_BATCHED),
+        )
         _rowid_primary[irid] = primary_id
         _rowid_candidates[irid] = candidates
         rowid_to_payload[irid] = _row_to_payload(row)

--- a/packages/python/goldenmatch/scripts/bench_identity_fingerprint.py
+++ b/packages/python/goldenmatch/scripts/bench_identity_fingerprint.py
@@ -1,0 +1,310 @@
+"""Measure-first bench: batch_fingerprints vs per-row record_fingerprint loop.
+
+Gate: before flipping GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT default to "1",
+measure whether the batch path (Arrow kernel or dict-bulk fallback) actually
+wins end-to-end inside resolve_clusters at the row counts we care about.
+
+Two modes, selected automatically:
+  end-to-end  -- calls resolve_clusters with the gate on vs off and times the
+                 full fingerprint + record-id derivation + store-write loop.
+                 Preferred: isolates the same code path the gate controls.
+  fingerprint-only -- if resolve_clusters setup is unavailable, times just
+                 batch_fingerprints(df) vs the per-row list comprehension.
+                 Labelled clearly in output.
+
+Usage:
+    uv run python packages/python/goldenmatch/scripts/bench_identity_fingerprint.py \\
+        [--ns 1000000,5000000] [--output bench.json]
+
+Smoke (local, ~1s):
+    .venv/Scripts/python.exe packages/python/goldenmatch/scripts/bench_identity_fingerprint.py \\
+        --ns 1000 --output ./_bench_smoke.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import polars as pl
+
+
+# ---------------------------------------------------------------------------
+# RSS helper (Linux only; graceful on Windows)
+# ---------------------------------------------------------------------------
+
+def _peak_rss_mb() -> float:
+    """Best-effort peak RSS in MB. Returns 0.0 on Windows / unsupported."""
+    try:
+        import resource  # noqa: PLC0415 -- conditional import
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        if sys.platform == "darwin":
+            return usage.ru_maxrss / (1024 * 1024)
+        return usage.ru_maxrss / 1024  # Linux: KB
+    except Exception:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Synthetic person DataFrame (NO source PK so every row fingerprints)
+# ---------------------------------------------------------------------------
+
+_FIRST = [
+    "Alex", "Blair", "Casey", "Dana", "Eli", "Finley", "Gray", "Harper",
+    "Indigo", "Jamie", "Kendall", "Logan", "Morgan", "Noel", "Oakley",
+    "Parker", "Quinn", "Riley", "Sage", "Taylor",
+]
+_LAST = [
+    "Smith", "Jones", "Williams", "Brown", "Davis", "Miller", "Wilson",
+    "Moore", "Taylor", "Anderson", "Thomas", "Jackson", "White", "Harris",
+    "Martin", "Thompson", "Garcia", "Martinez", "Robinson", "Clark",
+]
+
+
+def _make_df(n: int) -> pl.DataFrame:
+    import random
+
+    import polars as pl
+
+    rng = random.Random(42)
+    first_names = [rng.choice(_FIRST) for _ in range(n)]
+    last_names = [rng.choice(_LAST) for _ in range(n)]
+    return pl.DataFrame({
+        "__row_id__": list(range(n)),
+        "__source__": ["bench"] * n,
+        "first_name": first_names,
+        "last_name": last_names,
+        "email": [f"{fn.lower()}.{ln.lower()}.{i}@example.com"
+                  for i, (fn, ln) in enumerate(zip(first_names, last_names))],
+        "city": [rng.choice(["Springfield", "Shelbyville", "Capital City", "Ogdenville"]) for _ in range(n)],
+        "zip": [f"{rng.randint(10000, 99999):05d}" for _ in range(n)],
+    })
+
+
+# ---------------------------------------------------------------------------
+# Cluster helpers: N singleton clusters (one per row -- trivial topology,
+# forces resolve_clusters to fingerprint every row without any store-absorb
+# shortcuts from previous runs).
+# ---------------------------------------------------------------------------
+
+def _singleton_clusters(n: int) -> dict[int, dict[str, Any]]:
+    return {
+        i: {
+            "members": [i],
+            "size": 1,
+            "oversized": False,
+            "pair_scores": {},
+            "confidence": 1.0,
+            "cluster_quality": "strong",
+        }
+        for i in range(n)
+    }
+
+
+# ---------------------------------------------------------------------------
+# End-to-end bench via resolve_clusters
+# ---------------------------------------------------------------------------
+
+def _bench_end_to_end(n: int, runs: int) -> dict[str, Any]:
+    """Time resolve_clusters with gate ON vs OFF. Returns per-run stats."""
+    from goldenmatch.identity import IdentityStore, resolve_clusters
+
+    df = _make_df(n)
+    clusters = _singleton_clusters(n)
+
+    def run_once(gate_value: str) -> float:
+        os.environ["GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT"] = gate_value
+        with tempfile.TemporaryDirectory() as td:
+            store = IdentityStore(path=str(Path(td) / "identity.db"))
+            try:
+                t0 = time.perf_counter()
+                resolve_clusters(
+                    clusters, df, [], None, store,
+                    run_name="bench", source_pk_col=None,
+                )
+                return time.perf_counter() - t0
+            finally:
+                store.close()
+
+    walls_off = [run_once("0") for _ in range(runs)]
+    walls_on = [run_once("1") for _ in range(runs)]
+
+    med_off = statistics.median(walls_off)
+    med_on = statistics.median(walls_on)
+    speedup = med_off / med_on if med_on > 0 else float("nan")
+
+    return {
+        "n": n,
+        "mode": "end-to-end",
+        "no_pk_fraction": 1.0,
+        "wall_off_s": med_off,
+        "wall_on_s": med_on,
+        "speedup": speedup,
+        "peak_rss_mb": _peak_rss_mb(),
+        "runs": runs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint-only microbench (fallback if resolve import fails)
+# ---------------------------------------------------------------------------
+
+def _bench_fingerprint_only(n: int, runs: int) -> dict[str, Any]:
+    """Time batch_fingerprints vs per-row loop directly."""
+    from goldenmatch.core._hashing import record_fingerprint
+    from goldenmatch.identity.fingerprint_batch import (
+        _canonical_payload,
+        batch_fingerprints,
+    )
+
+    df = _make_df(n)
+    rows_dicts = df.to_dicts()
+
+    def _per_row():
+        return [
+            record_fingerprint(_canonical_payload({k: v for k, v in r.items() if not k.startswith("__")}))
+            for r in rows_dicts
+        ]
+
+    def _batch():
+        return batch_fingerprints(df)
+
+    walls_per_row = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        _per_row()
+        walls_per_row.append(time.perf_counter() - t0)
+
+    walls_batch = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        _batch()
+        walls_batch.append(time.perf_counter() - t0)
+
+    med_off = statistics.median(walls_per_row)
+    med_on = statistics.median(walls_batch)
+    speedup = med_off / med_on if med_on > 0 else float("nan")
+
+    return {
+        "n": n,
+        "mode": "fingerprint-only",
+        "no_pk_fraction": 1.0,
+        "wall_off_s": med_off,
+        "wall_on_s": med_on,
+        "speedup": speedup,
+        "peak_rss_mb": _peak_rss_mb(),
+        "runs": runs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Markdown table
+# ---------------------------------------------------------------------------
+
+def _print_table(results: list[dict[str, Any]], mode: str) -> None:
+    header = (
+        f"\n### bench-identity-fingerprint  [{mode}]\n\n"
+        f"| {'N':>10} | {'per-row (s)':>12} | {'batch (s)':>10} | {'speedup':>9} | "
+        f"{'no-PK %':>8} | {'peak RSS MB':>12} |\n"
+        f"| {'-'*10} | {'-'*12} | {'-'*10} | {'-'*9} | {'-'*8} | {'-'*12} |"
+    )
+    print(header)
+    for r in results:
+        speedup_s = f"{r['speedup']:.2f}x" if r['speedup'] == r['speedup'] else "n/a"
+        print(
+            f"| {r['n']:>10,} | {r['wall_off_s']:>12.3f} | {r['wall_on_s']:>10.3f} | "
+            f"{speedup_s:>9} | {r['no_pk_fraction']*100:>7.0f}% | "
+            f"{r['peak_rss_mb']:>12.1f} |"
+        )
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="bench-identity-fingerprint: batch vs per-row speedup"
+    )
+    ap.add_argument("--ns", default="1000000,5000000",
+                    help="Comma-separated row counts (default: 1000000,5000000)")
+    ap.add_argument("--runs", type=int, default=3,
+                    help="Repetitions per measurement (median reported, default: 3)")
+    ap.add_argument("--output", default=None,
+                    help="JSON output path (optional)")
+    args = ap.parse_args()
+
+    ns = [int(x.strip()) for x in args.ns.split(",") if x.strip()]
+    runs = max(1, args.runs)
+
+    # Choose mode: prefer end-to-end, fall back to fingerprint-only.
+    try:
+        from goldenmatch.identity import IdentityStore, resolve_clusters  # noqa: F401
+        mode = "end-to-end"
+        bench_fn = _bench_end_to_end
+    except Exception as exc:
+        print(f"[bench] WARNING: resolve_clusters unavailable ({exc!r}); falling back to fingerprint-only mode", flush=True)
+        mode = "fingerprint-only"
+        bench_fn = _bench_fingerprint_only
+
+    print(f"ns={ns}  runs={runs}  mode={mode}", flush=True)
+
+    from goldenmatch.core._native_loader import native_available
+    print(f"native ext importable: {native_available()}", flush=True)
+
+    results = []
+    for n in ns:
+        print(f"  N={n:,} ...", flush=True)
+        try:
+            row = bench_fn(n, runs)
+            results.append(row)
+            speedup_s = f"{row['speedup']:.2f}x" if row['speedup'] == row['speedup'] else "n/a"
+            print(f"    per-row={row['wall_off_s']:.3f}s  batch={row['wall_on_s']:.3f}s  speedup={speedup_s}", flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  N={n:,}  ERROR {type(exc).__name__}: {exc}", flush=True)
+
+    _print_table(results, mode)
+
+    # Append to GITHUB_STEP_SUMMARY if set.
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write(f"\n## bench-identity-fingerprint [{mode}]\n\n")
+                fh.write(
+                    f"| {'N':>10} | {'per-row (s)':>12} | {'batch (s)':>10} | "
+                    f"{'speedup':>9} | {'no-PK %':>8} | {'peak RSS MB':>12} |\n"
+                )
+                fh.write(
+                    f"| {'-'*10} | {'-'*12} | {'-'*10} | {'-'*9} | {'-'*8} | {'-'*12} |\n"
+                )
+                for r in results:
+                    speedup_s = f"{r['speedup']:.2f}x" if r['speedup'] == r['speedup'] else "n/a"
+                    fh.write(
+                        f"| {r['n']:>10,} | {r['wall_off_s']:>12.3f} | {r['wall_on_s']:>10.3f} | "
+                        f"{speedup_s:>9} | {r['no_pk_fraction']*100:>7.0f}% | "
+                        f"{r['peak_rss_mb']:>12.1f} |\n"
+                    )
+        except OSError as exc:
+            print(f"[bench] WARNING: could not write GITHUB_STEP_SUMMARY: {exc}", flush=True)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump({"mode": mode, "results": results}, fh, indent=2)
+        print(f"[bench] JSON written to {out_path}", flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/tests/identity/test_fingerprint_batch.py
+++ b/packages/python/goldenmatch/tests/identity/test_fingerprint_batch.py
@@ -113,6 +113,13 @@ def test_parity_uint64_overflow_column():
     _assert_parity(df)
 
 
+def test_parity_all_internal_columns_frame():
+    # Every column is __-prefixed, so keep_cols is empty after the drop. The whole
+    # frame routes to per-row; each row hashes the empty payload {} (a fixed hash).
+    df = pl.DataFrame({"__row_id__": [0, 1, 2], "__source__": ["a", "b", "c"]})
+    assert batch_fingerprints(df) == [_perrow(r) for r in df.to_dicts()]
+
+
 def test_batch_fingerprints_parity_off_native(monkeypatch):
     # GOLDENMATCH_NATIVE=0 forces the pure-Python / dict-fallback wrapper path.
     # native_enabled reads os.environ per call so the monkeypatch takes effect.

--- a/packages/python/goldenmatch/tests/identity/test_fingerprint_batch.py
+++ b/packages/python/goldenmatch/tests/identity/test_fingerprint_batch.py
@@ -1,0 +1,121 @@
+import datetime as dt
+from decimal import Decimal
+
+import polars as pl
+from goldenmatch.core._hashing import record_fingerprint
+from goldenmatch.identity.fingerprint_batch import _canonical_payload, batch_fingerprints
+
+
+def _perrow(row: dict):
+    payload = {k: v for k, v in row.items() if not k.startswith("__")}
+    try:
+        return record_fingerprint(_canonical_payload(payload))
+    except (TypeError, ValueError):
+        return None
+
+
+def _adversarial_df() -> pl.DataFrame:
+    # Batchable + ROW-level-mask cases only (NO column-level-fallback dtypes here --
+    # a single bytes/Decimal/Duration column would force the WHOLE frame per-row).
+    return pl.DataFrame({
+        "s": ["alice", "bob", None, "x"],
+        "i64": [1, 2, 3, 4],
+        "f_finite": [1.5, 2.0, 3.25, 0.1],
+        "f_mixed": [1.5, float("nan"), float("inf"), -2.0],   # row-level mask
+        "b": [True, False, None, True],
+        "d": [dt.date(2020, 1, 2), dt.date(1999, 12, 31), None, dt.date(2000, 2, 29)],
+        "dt_us": [dt.datetime(2020, 1, 2, 3, 4, 5, 123000), dt.datetime(2020, 1, 2, 3, 4, 5, 500000),
+                  dt.datetime(2020, 1, 2, 3, 4, 5, 0), dt.datetime(2020, 1, 2, 3, 4, 5, 123456)],
+        "i32": pl.Series([10, 20, 30, 40], dtype=pl.Int32),
+        "f32": pl.Series([0.1, 0.2, 0.3, 0.4], dtype=pl.Float32),
+        "allnull": pl.Series([None, None, None, None]),       # bare Null dtype
+    })
+
+
+def test_batch_fingerprints_parity():
+    df = _adversarial_df()
+    assert batch_fingerprints(df) == [_perrow(r) for r in df.to_dicts()]
+
+
+def _assert_parity(df: pl.DataFrame):
+    got = batch_fingerprints(df)
+    want = [_perrow(r) for r in df.to_dicts()]
+    assert got == want, f"\n got={got}\nwant={want}"
+
+
+def test_parity_duration_column():
+    df = pl.DataFrame({
+        "s": ["a", "b"],
+        "dur": pl.Series(
+            [dt.timedelta(seconds=1), dt.timedelta(days=2, seconds=3)],
+            dtype=pl.Duration("us"),
+        ),
+    })
+    _assert_parity(df)
+
+
+def test_parity_time_with_micros_column():
+    df = pl.DataFrame({
+        "s": ["a", "b"],
+        "t": pl.Series([dt.time(1, 2, 3, 123456), dt.time(23, 59, 59, 1)], dtype=pl.Time),
+    })
+    _assert_parity(df)
+
+
+def test_parity_tz_aware_datetime_column():
+    df = pl.DataFrame({
+        "s": ["a", "b"],
+        "dt_tz": pl.Series(
+            [dt.datetime(2020, 1, 2, 3, 4, 5), dt.datetime(2021, 6, 7, 8, 9, 10)],
+            dtype=pl.Datetime("us", time_zone="UTC"),
+        ),
+    })
+    _assert_parity(df)
+
+
+def test_parity_ms_unit_datetime_column():
+    df = pl.DataFrame({
+        "s": ["a", "b"],
+        "dt_ms": pl.Series(
+            [dt.datetime(2020, 1, 2, 3, 4, 5, 123000), dt.datetime(2021, 6, 7, 8, 9, 10)],
+            dtype=pl.Datetime("ms"),
+        ),
+    })
+    _assert_parity(df)
+
+
+def test_parity_bytes_column_drives_full_fallback():
+    df = pl.DataFrame({
+        "s": ["a", "b"],
+        "raw": pl.Series([b"\x00\x01", b"hello"], dtype=pl.Binary),
+    })
+    # bytes column => canonicalize_records_df returns (None, [True]*height).
+    from goldenmatch.identity.fingerprint_batch import canonicalize_records_df
+    batch_df, mask = canonicalize_records_df(df)
+    assert batch_df is None
+    assert mask == [True, True]
+    _assert_parity(df)
+
+
+def test_parity_decimal_column():
+    df = pl.DataFrame({
+        "s": ["a", "b"],
+        "dec": pl.Series([Decimal("1.50"), Decimal("2.25")], dtype=pl.Decimal(scale=2)),
+    })
+    _assert_parity(df)
+
+
+def test_parity_uint64_overflow_column():
+    df = pl.DataFrame({
+        "s": ["a", "b", "c"],
+        "u": pl.Series([1, 2**63, 2**63 + 7], dtype=pl.UInt64),  # row 2,3 overflow Int64
+    })
+    _assert_parity(df)
+
+
+def test_batch_fingerprints_parity_off_native(monkeypatch):
+    # GOLDENMATCH_NATIVE=0 forces the pure-Python / dict-fallback wrapper path.
+    # native_enabled reads os.environ per call so the monkeypatch takes effect.
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    df = _adversarial_df()
+    assert batch_fingerprints(df) == [_perrow(r) for r in df.to_dicts()]

--- a/packages/python/goldenmatch/tests/identity/test_resolve_batch_parity.py
+++ b/packages/python/goldenmatch/tests/identity/test_resolve_batch_parity.py
@@ -1,0 +1,196 @@
+"""End-to-end parity: ``GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT=1`` (batch h1)
+must produce BYTE-IDENTICAL record/entity ids vs the default per-row path.
+
+The byte-identical id invariant is the durability gate for the batch wiring --
+entity ids key off the h1 hash, so any divergence splits identities across the
+flag. The spy assertion (``batch_fingerprints`` is actually called when the
+gate is on) is the TDD red: it fails before the wiring exists and passes after.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.identity import IdentityStore, resolve_clusters
+
+
+@pytest.fixture()
+def store(tmp_path):
+    p = str(tmp_path / "identity.db")
+    s = IdentityStore(path=p)
+    yield s
+    s.close()
+
+
+def _df(rows):
+    out = []
+    for i, r in enumerate(rows):
+        rec = {"__row_id__": i, "__source__": r.get("__source__", "src")}
+        for k, v in r.items():
+            if k.startswith("__"):
+                continue
+            rec[k] = v
+        out.append(rec)
+    return pl.DataFrame(out)
+
+
+def _cluster(members, score=0.95):
+    pair_scores = {}
+    for i, a in enumerate(members):
+        for b in members[i + 1:]:
+            pair_scores[(min(a, b), max(a, b))] = score
+    return {
+        "members": list(members),
+        "size": len(members),
+        "oversized": False,
+        "pair_scores": pair_scores,
+        "confidence": score,
+        "cluster_quality": "strong",
+    }
+
+
+def _mixed_df():
+    """A frame mixing fully-batchable rows with a row-level-fallback row.
+
+      - clean no-PK rows (str/int/finite-float) -> fully batchable via the
+        Arrow kernel
+      - one no-PK row carrying a non-finite float (``nan``) -> row-level
+        fallback inside ``batch_fingerprints`` (that single row routes per-row
+        while the rest go through the kernel)
+
+    Exercises BOTH branches of ``batch_fingerprints`` in one frame; the stored
+    record ids must still be byte-identical to the all-per-row path.
+    """
+    return pl.DataFrame(
+        {
+            "__row_id__": [0, 1, 2, 3],
+            "__source__": ["src", "src", "src", "src"],
+            "name": ["Alice", "Alyce", "Bob", "Bobby"],
+            "age": [30, 31, 40, 41],
+            "score": [1.0, 2.0, float("nan"), 4.0],
+        }
+    )
+
+
+def _record_ids_for_store(store: IdentityStore) -> set[str]:
+    ids: set[str] = set()
+    for node in store.list_identities():
+        for rec in store.get_records_for_entity(node.entity_id):
+            ids.add(rec.record_id)
+    return ids
+
+
+def _resolve_once(store, df, clusters, pairs):
+    return resolve_clusters(
+        clusters, df, pairs, "wd", store, run_name="r1", source_pk_col=None,
+    )
+
+
+def test_batch_path_is_exercised_when_gate_on(tmp_path, monkeypatch):
+    """TDD red: with the gate on, ``resolve_clusters`` must call
+    ``batch_fingerprints``. Fails before the wiring (gate is a no-op)."""
+    import goldenmatch.identity.resolve as resolve_mod
+
+    calls: list[int] = []
+    real = resolve_mod.batch_fingerprints
+
+    def _spy(df):
+        calls.append(df.height)
+        return real(df)
+
+    monkeypatch.setattr(resolve_mod, "batch_fingerprints", _spy)
+    monkeypatch.setenv("GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT", "1")
+
+    store = IdentityStore(path=str(tmp_path / "spy.db"))
+    try:
+        df = _df([{"name": "Alice"}, {"name": "Alyce"}])
+        _resolve_once(store, df, {0: _cluster([0, 1])}, [(0, 1, 0.95)])
+    finally:
+        store.close()
+
+    assert calls, "batch_fingerprints was not called with the gate on"
+
+
+def test_batch_not_called_when_gate_off(tmp_path, monkeypatch):
+    """Default OFF: ``batch_fingerprints`` is never invoked."""
+    import goldenmatch.identity.resolve as resolve_mod
+
+    calls: list[int] = []
+    real = resolve_mod.batch_fingerprints
+    monkeypatch.setattr(
+        resolve_mod, "batch_fingerprints",
+        lambda df: (calls.append(df.height), real(df))[1],
+    )
+    monkeypatch.delenv("GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT", raising=False)
+
+    store = IdentityStore(path=str(tmp_path / "off.db"))
+    try:
+        df = _df([{"name": "Alice"}, {"name": "Alyce"}])
+        _resolve_once(store, df, {0: _cluster([0, 1])}, [(0, 1, 0.95)])
+    finally:
+        store.close()
+
+    assert not calls, "batch_fingerprints must not run with the gate off"
+
+
+def test_record_ids_byte_identical_batch_vs_per_row_no_pk(tmp_path, monkeypatch):
+    """Mixed no-PK frame (clean + column-level-fallback dtype): the stored
+    record ids must be byte-identical batch-vs-per-row."""
+    df = _mixed_df()
+    clusters = {0: _cluster([0, 1]), 1: _cluster([2, 3])}
+    pairs = [(0, 1, 0.95), (2, 3, 0.95)]
+
+    # Per-row (gate off).
+    monkeypatch.delenv("GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT", raising=False)
+    s_off = IdentityStore(path=str(tmp_path / "per_row.db"))
+    try:
+        _resolve_once(s_off, df, clusters, pairs)
+        ids_per_row = _record_ids_for_store(s_off)
+    finally:
+        s_off.close()
+
+    # Batch (gate on).
+    monkeypatch.setenv("GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT", "1")
+    s_on = IdentityStore(path=str(tmp_path / "batch.db"))
+    try:
+        _resolve_once(s_on, df, clusters, pairs)
+        ids_batch = _record_ids_for_store(s_on)
+    finally:
+        s_on.close()
+
+    assert ids_per_row == ids_batch, (
+        f"record id divergence: only per-row={ids_per_row - ids_batch} "
+        f"only batch={ids_batch - ids_per_row}"
+    )
+    assert all(rid.startswith("src:h1:") for rid in ids_batch)
+
+
+def test_record_ids_byte_identical_clean_only_no_pk(tmp_path, monkeypatch):
+    """Fully-batchable clean frame (str/int) -> ids byte-identical and on the
+    batch (not row-level fallback) code path."""
+    df = _df([
+        {"name": "Alice", "email": "a@x.com"},
+        {"name": "Alyce", "email": "a@x.com"},
+        {"name": "Carol", "email": "c@x.com"},
+    ])
+    clusters = {0: _cluster([0, 1]), 1: {"members": [2], "size": 1,
+                "oversized": False, "pair_scores": {}, "confidence": 1.0}}
+    pairs = [(0, 1, 0.95)]
+
+    monkeypatch.delenv("GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT", raising=False)
+    s_off = IdentityStore(path=str(tmp_path / "clean_per_row.db"))
+    try:
+        _resolve_once(s_off, df, clusters, pairs)
+        ids_per_row = _record_ids_for_store(s_off)
+    finally:
+        s_off.close()
+
+    monkeypatch.setenv("GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT", "1")
+    s_on = IdentityStore(path=str(tmp_path / "clean_batch.db"))
+    try:
+        _resolve_once(s_on, df, clusters, pairs)
+        ids_batch = _record_ids_for_store(s_on)
+    finally:
+        s_on.close()
+
+    assert ids_per_row == ids_batch
+    assert all(rid.startswith("src:h1:") for rid in ids_batch)


### PR DESCRIPTION
Wires the existing `record_fingerprints_batch_arrow` kernel into identity resolution (#663 Sub-project A), replacing the per-row `record_fingerprint` loop with one vectorized batch call for the no-PK record subset. **Gated default-OFF** (`GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT=1`); a measure-first bench decides default-on.

## Durability invariant: byte-identical entity ids
Entity ids key off these fingerprints, so the whole change is built around byte-identical parity (verified 3 spec-review + 2 plan-review rounds, each catching a real hazard):
- Clean primitive frames are byte-identical free (single + batch kernels share `fingerprint_fields`).
- `canonicalize_records_df` reproduces `_canonical_payload` columnarly where it can (exact `%.6f` isoformat temporal recipe, narrow-int/Float32 up-casts, bare-Null->Utf8) and routes the rest to a **per-row fallback** (bytes/Duration/Time/tz/non-us-Datetime/Decimal/object columns; non-finite-float + UInt64-overflow rows).
- `batch_fingerprints(df) -> list[str|None]` is a drop-in for the per-row list, so parity is one assertion.

## Validation
- `test_fingerprint_batch.py`: 10 parity tests (every routing-table dtype + off-native `NATIVE=0`), all byte-identical.
- `test_resolve_batch_parity.py`: end-to-end ids identical batch-vs-per-row.
- **All 78 existing identity tests pass byte-identically with the gate ON and OFF.**

## Measure-first
`bench-identity-fingerprint` (workflow_dispatch, large-new-64GB, fresh native build) measures resolve wall+RSS batch-vs-per-row at 1M/5M. Default-on flips only if it wins; numbers fold into the spec. (Local builds can't rebuild native — pinned toolchain unavailable — so the Arrow path only runs in CI; parity is guaranteed via the shared kernel core regardless.)

Spec/plan: `docs/superpowers/specs|plans/2026-06-01-identity-fingerprint-arrow*`. #663-B (build_clusters_arrow) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)