### PR TITLE
feat(identity): batch fingerprinting default-ON (2.6x) + bench per-N fallback

### DIFF
--- a/docs/superpowers/specs/2026-06-01-identity-fingerprint-arrow-design.md
+++ b/docs/superpowers/specs/2026-06-01-identity-fingerprint-arrow-design.md
@@ -173,6 +173,27 @@ exists -- "assemble a frame" is trivial.
   fingerprinting entirely, so a PK-backed frame under-reads the kernel's value.
   Ship default-on only if it wins meaningfully; otherwise keep it gated and record
   the finding (repo perf-audit lesson -- measure wall-clock on the real shape).
+
+  **RESULT (2026-06-02, run 26793348836, fresh native build, no-PK 1M/5M):
+  DEFAULT-ON.** End-to-end `resolve_clusters` could NOT complete -- the SQLite
+  `IdentityStore` raised `OperationalError: too many SQL variables` bulk-upserting
+  1M+ records (a SQLite-store-scaling artifact, NOT the feature; production scale
+  uses the Postgres store w/ bulk COPY). So the bench fell back to the
+  fingerprint-only microbench, which isolates the gate's actual delta (store I/O is
+  identical on/off and cancels):
+
+  | N  | per-row | batch (Arrow) | speedup | peak RSS |
+  | -- | ------- | ------------- | ------- | -------- |
+  | 1M | 5.54s   | 2.13s         | 2.60x   | 2.2 GB   |
+  | 5M | 27.52s  | 10.55s        | 2.61x   | 10.2 GB  |
+
+  2.6x consistent on the real Arrow kernel, byte-identical ids (79 identity tests
+  pass with the gate default-on AND with the `=0` kill-switch). Flipped default-on
+  (`_batch_fingerprint_enabled` default `1`, kill-switch `GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT=0`).
+  Caveat: the end-to-end PERCENTAGE win is unmeasured (resolve is store-bound at
+  scale); the change is never a regression and saves real absolute time
+  (3.4s@1M / 17s@5M on the fingerprinting step). FOLLOW-UP: the SQLite store's
+  bulk-upsert variable-limit at 1M+ is a separate scaling bug worth filing.
 - **Legacy-fallback preserved:** a row whose payload can't be fingerprinted still
   yields the `:hash:` legacy id + candidate ordering unchanged.
 

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -86,15 +86,17 @@ _NOT_BATCHED = object()
 
 
 def _batch_fingerprint_enabled() -> bool:
-    """Opt-in batch fingerprinting for ``resolve_clusters``: when
-    ``GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT=1``, no-PK record h1 hashes are
-    computed once via ``batch_fingerprints(df)`` instead of per-row inside the
-    cluster loop. Default OFF (``0``) -- byte-identical to the per-row path, so
-    the gate is a no-op on output. Default-on is pending a perf bench. See
-    ``_id_scheme`` for the sibling content-hash kill-switch."""
+    """Batch fingerprinting for ``resolve_clusters``: no-PK record h1 hashes are
+    computed once via ``batch_fingerprints(df)`` (Arrow kernel) instead of per-row
+    inside the cluster loop. Default ON -- byte-identical to the per-row path
+    (verified across the full identity suite + the real Arrow path in CI), so it
+    is a no-op on OUTPUT, only faster. Bench (run 26793348836, fresh native, 1M/5M
+    no-PK): 2.6x on the fingerprinting step (5.54s->2.13s @1M, 27.5s->10.5s @5M).
+    Kill-switch ``GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT=0`` restores the per-row
+    path. See ``_id_scheme`` for the sibling content-hash kill-switch."""
     return os.environ.get(
-        "GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT", "0"
-    ).strip() == "1"
+        "GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT", "1"
+    ).strip() != "0"
 
 
 def _id_scheme() -> str:

--- a/packages/python/goldenmatch/scripts/bench_identity_fingerprint.py
+++ b/packages/python/goldenmatch/scripts/bench_identity_fingerprint.py
@@ -240,22 +240,25 @@ def main() -> int:
                     help="Repetitions per measurement (median reported, default: 3)")
     ap.add_argument("--output", default=None,
                     help="JSON output path (optional)")
+    ap.add_argument("--mode", choices=["auto", "end-to-end", "fingerprint-only"],
+                    default="auto",
+                    help="auto (default): try end-to-end per N, fall back to "
+                         "fingerprint-only on error (e.g. SQLite var limit at scale). "
+                         "fingerprint-only isolates the actual gate delta (store I/O "
+                         "is identical on/off, so it cancels).")
     args = ap.parse_args()
 
     ns = [int(x.strip()) for x in args.ns.split(",") if x.strip()]
     runs = max(1, args.runs)
 
-    # Choose mode: prefer end-to-end, fall back to fingerprint-only.
     try:
         from goldenmatch.identity import IdentityStore, resolve_clusters  # noqa: F401
-        mode = "end-to-end"
-        bench_fn = _bench_end_to_end
+        _e2e_available = True
     except Exception as exc:
-        print(f"[bench] WARNING: resolve_clusters unavailable ({exc!r}); falling back to fingerprint-only mode", flush=True)
-        mode = "fingerprint-only"
-        bench_fn = _bench_fingerprint_only
+        print(f"[bench] WARNING: resolve_clusters unavailable ({exc!r}); fingerprint-only only", flush=True)
+        _e2e_available = False
 
-    print(f"ns={ns}  runs={runs}  mode={mode}", flush=True)
+    print(f"ns={ns}  runs={runs}  mode={args.mode}", flush=True)
 
     from goldenmatch.core._native_loader import native_available
     print(f"native ext importable: {native_available()}", flush=True)
@@ -263,22 +266,35 @@ def main() -> int:
     results = []
     for n in ns:
         print(f"  N={n:,} ...", flush=True)
-        try:
-            row = bench_fn(n, runs)
-            results.append(row)
-            speedup_s = f"{row['speedup']:.2f}x" if row['speedup'] == row['speedup'] else "n/a"
-            print(f"    per-row={row['wall_off_s']:.3f}s  batch={row['wall_on_s']:.3f}s  speedup={speedup_s}", flush=True)
-        except Exception as exc:  # noqa: BLE001
-            print(f"  N={n:,}  ERROR {type(exc).__name__}: {exc}", flush=True)
+        row = None
+        # End-to-end first (unless mode forces fingerprint-only); fall back to the
+        # fingerprint-only microbench on any error so we always get the gate delta.
+        if args.mode in ("auto", "end-to-end") and _e2e_available:
+            try:
+                row = _bench_end_to_end(n, runs)
+            except Exception as exc:  # noqa: BLE001
+                print(f"  N={n:,}  end-to-end ERROR {type(exc).__name__}: {exc}", flush=True)
+                if args.mode == "end-to-end":
+                    continue  # caller demanded end-to-end; don't silently switch
+        if row is None:
+            try:
+                row = _bench_fingerprint_only(n, runs)
+            except Exception as exc:  # noqa: BLE001
+                print(f"  N={n:,}  fingerprint-only ERROR {type(exc).__name__}: {exc}", flush=True)
+                continue
+        results.append(row)
+        speedup_s = f"{row['speedup']:.2f}x" if row['speedup'] == row['speedup'] else "n/a"
+        print(f"    [{row['mode']}] per-row={row['wall_off_s']:.3f}s  batch={row['wall_on_s']:.3f}s  speedup={speedup_s}", flush=True)
 
-    _print_table(results, mode)
+    table_mode = results[0]["mode"] if results else args.mode
+    _print_table(results, table_mode)
 
     # Append to GITHUB_STEP_SUMMARY if set.
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_path:
         try:
             with open(summary_path, "a", encoding="utf-8") as fh:
-                fh.write(f"\n## bench-identity-fingerprint [{mode}]\n\n")
+                fh.write(f"\n## bench-identity-fingerprint [{table_mode}]\n\n")
                 fh.write(
                     f"| {'N':>10} | {'per-row (s)':>12} | {'batch (s)':>10} | "
                     f"{'speedup':>9} | {'no-PK %':>8} | {'peak RSS MB':>12} |\n"
@@ -300,7 +316,7 @@ def main() -> int:
         out_path = Path(args.output)
         out_path.parent.mkdir(parents=True, exist_ok=True)
         with open(out_path, "w", encoding="utf-8") as fh:
-            json.dump({"mode": mode, "results": results}, fh, indent=2)
+            json.dump({"mode": table_mode, "results": results}, fh, indent=2)
         print(f"[bench] JSON written to {out_path}", flush=True)
 
     return 0

--- a/packages/python/goldenmatch/tests/identity/test_resolve_batch_parity.py
+++ b/packages/python/goldenmatch/tests/identity/test_resolve_batch_parity.py
@@ -110,8 +110,31 @@ def test_batch_path_is_exercised_when_gate_on(tmp_path, monkeypatch):
     assert calls, "batch_fingerprints was not called with the gate on"
 
 
-def test_batch_not_called_when_gate_off(tmp_path, monkeypatch):
-    """Default OFF: ``batch_fingerprints`` is never invoked."""
+def test_batch_not_called_with_kill_switch(tmp_path, monkeypatch):
+    """Kill-switch ``=0`` restores the per-row path: ``batch_fingerprints`` is
+    never invoked. (Default is now ON, so this needs the explicit ``=0``.)"""
+    import goldenmatch.identity.resolve as resolve_mod
+
+    calls: list[int] = []
+    real = resolve_mod.batch_fingerprints
+    monkeypatch.setattr(
+        resolve_mod, "batch_fingerprints",
+        lambda df: (calls.append(df.height), real(df))[1],
+    )
+    monkeypatch.setenv("GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT", "0")
+
+    store = IdentityStore(path=str(tmp_path / "off.db"))
+    try:
+        df = _df([{"name": "Alice"}, {"name": "Alyce"}])
+        _resolve_once(store, df, {0: _cluster([0, 1])}, [(0, 1, 0.95)])
+    finally:
+        store.close()
+
+    assert not calls, "batch_fingerprints must not run with the kill-switch =0"
+
+
+def test_batch_called_by_default(tmp_path, monkeypatch):
+    """Default (no env var) is ON: ``batch_fingerprints`` runs."""
     import goldenmatch.identity.resolve as resolve_mod
 
     calls: list[int] = []
@@ -122,14 +145,14 @@ def test_batch_not_called_when_gate_off(tmp_path, monkeypatch):
     )
     monkeypatch.delenv("GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT", raising=False)
 
-    store = IdentityStore(path=str(tmp_path / "off.db"))
+    store = IdentityStore(path=str(tmp_path / "default.db"))
     try:
         df = _df([{"name": "Alice"}, {"name": "Alyce"}])
         _resolve_once(store, df, {0: _cluster([0, 1])}, [(0, 1, 0.95)])
     finally:
         store.close()
 
-    assert not calls, "batch_fingerprints must not run with the gate off"
+    assert calls, "batch_fingerprints must run by default (gate default-on)"
 
 
 def test_record_ids_byte_identical_batch_vs_per_row_no_pk(tmp_path, monkeypatch):


### PR DESCRIPTION
Follow-up to #668 (#663-A). Flips `GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT` **default-ON** after the measure-first bench, + fixes the bench to fall back to the fingerprint-only microbench when end-to-end hits the SQLite store limit (#670).

Bench (run 26793348836, fresh native, no-PK): **2.60x @1M, 2.61x @5M** on the real Arrow kernel. Byte-identical entity ids: **79 identity tests pass default-on AND with the `=0` kill-switch**.

(Recreated off main; the prior #669 conflicted as a stacked-on-squash branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)