### PR TITLE
feat(cluster): columnar cluster-build core + dict adapter (Phase 2 SP1, gated)

### DIFF
--- a/.github/workflows/bench-columnar-cluster-build.yml
+++ b/.github/workflows/bench-columnar-cluster-build.yml
@@ -1,0 +1,46 @@
+name: bench-columnar-cluster-build
+
+# Measure-first SP2 bench (workflow_dispatch only). Builds the native ext fresh
+# so the columnar gate-ON path hits the real Arrow UF kernel (not the off-native
+# fallback), then benches build_clusters gate-OFF (dict path) vs gate-ON
+# (columnar) at scale. Feeds the default-on decision for
+# GOLDENMATCH_COLUMNAR_CLUSTER_BUILD. Parity is asserted before any perf number.
+on:
+  workflow_dispatch:
+    inputs:
+      np:
+        description: "Comma-separated target pair counts"
+        default: "1000000,5000000"
+      runs:
+        description: "Repetitions per measurement (median)"
+        default: "3"
+
+jobs:
+  bench:
+    runs-on: large-new-64GB
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Build native extension (exposes build_clusters_arrow)
+        run: uv run python scripts/build_native.py
+      - name: Bench columnar cluster-build (gate ON vs OFF)
+        run: |
+          set -o pipefail
+          uv run python packages/python/goldenmatch/scripts/bench_columnar_cluster_build.py \
+            --np "${{ inputs.np }}" --runs "${{ inputs.runs }}" \
+            --output .profile_tmp/columnar_cluster_build.json | tee /tmp/columnar.txt
+          { echo '## bench-columnar-cluster-build'; echo '```'; cat /tmp/columnar.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: always()
+        with:
+          name: columnar-cluster-build
+          path: .profile_tmp/columnar_cluster_build.json
+          retention-days: 30

--- a/docs/superpowers/plans/2026-06-02-columnar-cluster-build-core.md
+++ b/docs/superpowers/plans/2026-06-02-columnar-cluster-build-core.md
@@ -1,0 +1,176 @@
+# Columnar cluster-build core + dict adapter (Phase 2 SP1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `core/cluster.py::build_clusters` compute clusters columnar (Arrow UF + the existing kernel's batched confidence + columnar pair_scores; auto-split unchanged) and emit a BYTE-IDENTICAL `dict[int,dict]` via an adapter, behind a gate — so the ~25 cluster consumers are untouched.
+
+**Architecture:** A new internal `_build_clusters_via_frames(...)` that `build_clusters` dispatches to behind `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` (default OFF), AFTER the Ray short-circuit. It reuses `build_clusters_arrow_native` (Arrow UF → `ClusterFrames` whose metadata already carries bit-identical confidence/bottleneck), materializes `pair_scores` order-preservingly, runs the unchanged auto-split, computes cluster_quality, and a dict adapter reproduces the exact `dict[int,dict]`. NO new Rust kernel.
+
+**Tech Stack:** Python 3.11+, Polars, the existing `goldenmatch._native` Arrow cluster kernel (already built). Pure-Python SP1.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-columnar-cluster-build-core-design.md` — READ it; this plan implements its routing. **Branch:** `feat/columnar-cluster-build`.
+
+**Run tests:** `cd packages/python/goldenmatch && ../../../.venv/Scripts/python.exe -m pytest <path> -v`. ruff: `D:/show_case/goldenmatch/.venv/Scripts/python.exe -m ruff check <files>`. Native `_native.pyd` is built in-tree locally (so the native path is exercised). Do NOT run the full suite (xdist OOMs); targeted files only.
+
+## Background the implementer needs (read these lines first)
+
+- `build_clusters(pairs, all_ids, max_cluster_size, weak_cluster_threshold, auto_split) -> dict[int,dict]` (`cluster.py:361`). Flow: Ray short-circuit (:376-394) → derive all_ids → UF `connected_components` (:419-434) → sort clusters by `min(members)` + enumerate start=1 (:436-446) → `member_to_cid` → result dict `{members(list, UNSORTED per PR#598), size, oversized, pair_scores:{}}` (:448-466) → pair_scores fill (:468-471) → `compute_cluster_confidence` per cluster (:477-481) → auto-split oversized (:494-528) → cluster_quality (:531-546) → `_emit_cluster_profile(result)` (:548) → return.
+- The output dict per cluster has EXACTLY: `members, size, oversized, pair_scores (dict[(a,b)]->score), confidence, bottleneck_pair, cluster_quality` (+ transient `_was_split` popped at :546). NOT `min_edge/avg_edge/connectivity`.
+- `build_clusters_arrow_native(pairs_df, all_ids, max_cluster_size) -> ClusterFrames` (`cluster.py:1216`): Arrow UF; metadata columns `cluster_id, size, confidence, quality, oversized, bottleneck_pair_a/b`. The kernel computes confidence/bottleneck per cluster in pair-INPUT order via the same `cluster_confidence` logic (cluster.rs:478-486) → **bit-identical to the dict path's confidence** (the parity test proves this). `quality` is always "strong" (no auto-split/weak in the kernel) — do NOT use it; compute quality yourself.
+- `compute_cluster_confidence(pair_scores, size)` (`cluster.py:552`): the off-native confidence path (bit-identical; Python sequential sum).
+- `split_oversized_cluster(members, pair_scores)` (`cluster.py:157`): the auto-split, reused unchanged.
+- `cluster_frames_to_dict` (`cluster.py:1121`) is LOSSY (sets `pair_scores={}`, :1157) — do NOT reuse it for the adapter; build a full-pair_scores adapter.
+- `ClusterFrames` (`cluster.py:1009`); `PAIR_STREAM_SCHEMA` (id_a,id_b,score) from `core/scorer.py`.
+
+---
+
+## File Structure
+
+- **Modify** `packages/python/goldenmatch/goldenmatch/core/cluster.py`: add `_columnar_cluster_build_enabled()` gate, `_build_clusters_via_frames(...)`, and dispatch in `build_clusters` (after the Ray short-circuit). The dict adapter is internal to `_build_clusters_via_frames`.
+- **Test** `packages/python/goldenmatch/tests/test_columnar_cluster_build_parity.py` (create): the byte-identical gate.
+- **Modify** `packages/python/goldenmatch/scripts/bench_build_clusters_arrow_spike.py` OR create `bench_columnar_cluster_build.py` + a workflow: the measure-first bench (Task 2).
+
+---
+
+## Task 1: `_build_clusters_via_frames` + gate + byte-identical parity gate
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/cluster.py`
+- Test: `packages/python/goldenmatch/tests/test_columnar_cluster_build_parity.py`
+
+- [ ] **Step 1: Write the failing byte-identical parity test**
+
+The test runs `build_clusters` on an adversarial fixture with the gate OFF (current path) and ON (new columnar path) and asserts the dicts are IDENTICAL, key for key, under BOTH `GOLDENMATCH_NATIVE` states.
+
+```python
+import os
+import polars as pl
+import pytest
+from goldenmatch.core.cluster import build_clusters
+
+
+def _adversarial_pairs():
+    # Cluster A: singleton id 0 (no pairs). Cluster B: 2-member {1,2}.
+    # Cluster C: fully-connected {3,4,5}. Cluster D: weak chain {6,7,8}
+    # (one weak edge -> triggers weak). Cluster E: oversized that SPLITS
+    # (a barbell: two dense triangles joined by one weak bridge, > max_cluster_size=5).
+    # Cluster F: score-tied edges (bottleneck tie-break). Plus duplicate canonical pair.
+    pairs = [
+        (1, 2, 0.95),
+        (3, 4, 0.9), (4, 5, 0.92), (3, 5, 0.88),
+        (6, 7, 0.99), (7, 8, 0.40),                 # weak: avg-min large
+        # barbell F-side oversized (ids 10..16, 7 members > max 5):
+        (10, 11, 0.99), (11, 12, 0.99), (10, 12, 0.99),
+        (14, 15, 0.99), (15, 16, 0.99), (14, 16, 0.99),
+        (12, 14, 0.31),                              # weak bridge -> splits
+        (20, 21, 0.5), (20, 22, 0.5),                # score ties -> bottleneck first-occurrence
+        (1, 2, 0.95),                                # duplicate canonical pair
+    ]
+    all_ids = list(range(0, 23))
+    return pairs, all_ids
+
+
+def _run(pairs, all_ids, gate, native):
+    import goldenmatch.core.cluster as _c
+    # Build twice with identical args; only the env differs.
+    return build_clusters(pairs, all_ids=all_ids, max_cluster_size=5,
+                          weak_cluster_threshold=0.3, auto_split=True)
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_columnar_build_byte_identical(monkeypatch, native):
+    pairs, all_ids = _adversarial_pairs()
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+
+    monkeypatch.setenv("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "0")
+    off = build_clusters(pairs, all_ids=all_ids, max_cluster_size=5,
+                         weak_cluster_threshold=0.3, auto_split=True)
+
+    monkeypatch.setenv("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "1")
+    on = build_clusters(pairs, all_ids=all_ids, max_cluster_size=5,
+                        weak_cluster_threshold=0.3, auto_split=True)
+
+    assert on.keys() == off.keys()
+    for cid in off:
+        assert on[cid] == off[cid], f"cluster {cid} differs: {on[cid]} vs {off[cid]}"
+    # Belt-and-suspenders on the float-sensitive field:
+    for cid in off:
+        assert on[cid].get("confidence") == off[cid].get("confidence")
+```
+
+(Cluster ids may renumber after split; the test compares the full dicts key-for-key, so the columnar path MUST produce the same id numbering. If the fixture's split makes id comparison fragile, compare a canonicalized view: a set of `(frozenset(members), size, oversized, cluster_quality, round(confidence,12), bottleneck_pair, frozenset(pair_scores.items()))` per cluster — but prefer exact dict equality and only fall back if the dict path's own id numbering is non-deterministic, which it is NOT.)
+
+- [ ] **Step 2: Run it — verify FAIL**
+
+Run: `cd packages/python/goldenmatch && ../../../.venv/Scripts/python.exe -m pytest tests/test_columnar_cluster_build_parity.py -v`
+Expected: FAIL — the gate ON currently does nothing (or `_build_clusters_via_frames` not defined). It should fall through to the same path and PASS trivially until you wire the gate to the new path; to get a real RED, ALSO assert (via a monkeypatch spy on `_build_clusters_via_frames`) that the columnar path actually ran with the gate on. Add that spy assertion so Step 2 is genuinely red.
+
+- [ ] **Step 3: Add the gate + dispatch (gate ON still calls the OLD path)**
+
+Add `_columnar_cluster_build_enabled()` (env `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD`, default `"0"`, enabled when `!= "0"` — mirror the identity `_batch_fingerprint_enabled` pattern). In `build_clusters`, AFTER the Ray short-circuit (:394) and the all_ids derivation, add: `if _columnar_cluster_build_enabled(): return _build_clusters_via_frames(...)`. Initially make `_build_clusters_via_frames` just call the existing body (extract the existing :419-548 body into a `_build_clusters_dict_path(...)` helper that BOTH the gate-off path and the temporary `_build_clusters_via_frames` call). Run the test — the spy now sees the columnar fn called, and parity passes trivially (both run the same body). Commit: `refactor(cluster): extract dict-path body + add columnar gate (no-op)`.
+
+- [ ] **Step 4: Implement the real `_build_clusters_via_frames`**
+
+Per the spec routing. Build the `pairs_df` (PAIR_STREAM_SCHEMA) from `pairs`. Then:
+1. **UF:** `frames = build_clusters_arrow_native(pairs_df, all_ids=all_ids, max_cluster_size=max_cluster_size)` -> `ClusterFrames`. Derive `member_to_cid` from `frames.assignments` AND the cluster ids from the SAME sort-by-min-member + enumerate(start=1) the dict path uses, so ids match. `members` per cluster in the assignments' member order (which equals the dict path's UF order — verified in spec).
+2. **pair_scores (ORDER-PRESERVING):** add a `cluster_id` column to `pairs_df` via `pl.col("id_a").replace_strict(member_to_cid)` (NOT a join). Iterate the resulting frame IN ORDER to build per-cluster `pair_scores` dicts (same as the dict path's :468-471, in pairs order). Duplicate canonical pairs overwrite (last wins) exactly as the dict path's `result[cid]["pair_scores"][(a,b)] = score`.
+3. **confidence + bottleneck:** native -> read `confidence` + `(bottleneck_pair_a, bottleneck_pair_b)` from `frames.metadata` per cluster_id (map `(0,0) -> None`). off-native -> call `compute_cluster_confidence(pair_scores, size)` per cluster (bit-identical). Compute these on the ORIGINAL (pre-split) clusters, matching the dict path's ordering (confidence at :477-481 is BEFORE auto-split at :494).
+4. **auto-split:** identical to the dict path's :494-528 loop, reusing `split_oversized_cluster(members, pair_scores)` + the edge-work-budget / no-progress guards. (The simplest correct approach: build the SAME `result` dict shape the dict path has just before :494, then run the dict path's auto-split + quality code verbatim. This guarantees parity for the split/quality logic — the columnar win is in steps 1-3.)
+5. **cluster_quality:** identical to :531-546 (split if `_was_split`; else weak if `avg_edge - min_edge > weak_cluster_threshold` with `confidence *= 0.7`; else strong). Reuse the dict path's code.
+6. **adapter / emit:** the `result` dict IS the byte-identical output. Call `_emit_cluster_profile(result)` (:548) and return.
+
+KEY: steps 4-5-6 should literally REUSE the dict path's code (extract :494-548 into a shared `_finalize_clusters(result, max_cluster_size, weak_cluster_threshold, auto_split)` helper that both paths call). The columnar path only changes HOW `result` is built up to :493 (UF + pair_scores + confidence). This minimizes the parity surface to steps 1-3.
+
+- [ ] **Step 5: Run the parity test — verify PASS (both native states)**
+
+Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_columnar_cluster_build_parity.py -v`
+Expected: PASS for `native=1` AND `native=0`. If a cluster differs, PRINT `on[cid]` vs `off[cid]` and fix the columnar build for that field — do NOT relax the assertion (byte-identical is the durability invariant feeding golden/identity). Likely culprits: pair_scores order (must be pairs order), member order, confidence (native metadata vs dict), id numbering, the `(0,0)` sentinel.
+
+- [ ] **Step 6: Run the existing cluster tests with the gate ON (regression)**
+
+Run: `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1 ../../../.venv/Scripts/python.exe -m pytest tests/test_cluster.py tests/test_golden.py tests/test_native_parity.py -q` — confirm no regressions with the columnar path forced on. NOTE: `test_native_parity.py::test_split_oversized_cluster_parity` may FAIL LOCALLY on a stale `_native.pyd` (AttributeError `mst_split_components`) — that is a PRE-EXISTING local artifact, ignore it; flag only NEW failures.
+
+- [ ] **Step 7: ruff + commit**
+
+ruff check the changed files. Commit: `feat(cluster): columnar cluster-build via _build_clusters_via_frames (byte-identical, gated)`.
+
+---
+
+## Task 2: measure-first bench
+
+**Files:**
+- Create: `packages/python/goldenmatch/scripts/bench_columnar_cluster_build.py`
+- Create: `.github/workflows/bench-columnar-cluster-build.yml`
+
+- [ ] **Step 1: Bench script**
+
+Model on the spike `scripts/bench_build_clusters_arrow_spike.py` (it has the deterministic pair generator `_make_pairs_df`). Bench `build_clusters(pairs, ...)` gate-OFF vs gate-ON (via `os.environ["GOLDENMATCH_COLUMNAR_CLUSTER_BUILD"]`) at `--np 1000000,5000000`, median of 3, wall + peak RSS, with a dict-equality parity assertion on a small N first. Print a markdown table to `$GITHUB_STEP_SUMMARY`. ASCII only. Smoke locally at `--np 50000`.
+
+- [ ] **Step 2: Workflow**
+
+`bench-columnar-cluster-build.yml`: workflow_dispatch, `runs-on: large-new-64GB`, build native (`uv run python scripts/build_native.py`), run the bench. Model on `bench-build-clusters-arrow-spike.yml`.
+
+- [ ] **Step 3: Commit**
+
+Commit: `bench(cluster): columnar build vs dict measure-first harness`.
+
+- [ ] **Step 4 (orchestrator, NOT a subagent step): dispatch + decide default-on**
+
+Merge (the workflow must be on main to dispatch), dispatch at 1M/5M, read wall + RSS. Ship default-on only if the columnar build beats the dict build net of the adapter; else keep gated as the SP2-enabling foundation. Record the numbers in the spec.
+
+---
+
+## Final validation (orchestrator)
+
+1. `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1 pytest tests/test_cluster.py tests/test_golden.py` + the parity test — green both native states.
+2. Open the PR; CI runs the goldenmatch lane (cluster tests). Bench is workflow_dispatch.
+3. Dispatch the bench; fold numbers into the spec; decide the gate default.
+
+## Notes for the implementer
+
+- **Byte-identical is the durability invariant** (cluster output feeds golden/identity). The parity test gates it native-on AND off. If a field can't be made identical, STOP and report the diff — do not relax.
+- **Minimize the parity surface:** reuse the dict path's auto-split + quality + emit code verbatim (extract `_finalize_clusters`); the columnar path only changes the UF + pair_scores + confidence build (steps 1-3). DRY.
+- **Order matters:** pair_scores in pairs order (`replace_strict` + in-order iterate, NOT a Polars join); members in UF order; confidence computed pre-split.
+- **No new Rust kernel** — reuse the confidence/bottleneck on `ClusterFrames.metadata` (native) and `compute_cluster_confidence` (off-native).
+- **Gate after the Ray short-circuit** (never intercept Ray datasets).
+- **Skill:** @superpowers:test-driven-development per task.

--- a/docs/superpowers/plans/2026-06-02-columnar-cluster-build-core.md
+++ b/docs/superpowers/plans/2026-06-02-columnar-cluster-build-core.md
@@ -70,15 +70,18 @@ def _adversarial_pairs():
     return pairs, all_ids
 
 
-def _run(pairs, all_ids, gate, native):
-    import goldenmatch.core.cluster as _c
-    # Build twice with identical args; only the env differs.
-    return build_clusters(pairs, all_ids=all_ids, max_cluster_size=5,
-                          weak_cluster_threshold=0.3, auto_split=True)
+def _norm(cinfo: dict) -> dict:
+    # members compared as a SET (order is hash-arbitrary + the columnar path runs a
+    # separate UF -> list order legitimately differs; see spec). Everything else
+    # byte-identical, incl. confidence float.
+    out = {k: v for k, v in cinfo.items() if k not in ("members", "_was_split")}
+    out["members"] = frozenset(cinfo["members"])
+    return out
 
 
 @pytest.mark.parametrize("native", ["1", "0"])
 def test_columnar_build_byte_identical(monkeypatch, native):
+    import goldenmatch.core.cluster as _cmod
     pairs, all_ids = _adversarial_pairs()
     monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
 
@@ -86,19 +89,25 @@ def test_columnar_build_byte_identical(monkeypatch, native):
     off = build_clusters(pairs, all_ids=all_ids, max_cluster_size=5,
                          weak_cluster_threshold=0.3, auto_split=True)
 
+    # Spy to prove the columnar path actually runs with the gate ON (the RED in
+    # Step 2/3: pre-impl the spy is never called).
+    calls = []
+    real = _cmod._build_clusters_via_frames
+    monkeypatch.setattr(_cmod, "_build_clusters_via_frames",
+                        lambda *a, **k: (calls.append(1), real(*a, **k))[1])
     monkeypatch.setenv("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "1")
     on = build_clusters(pairs, all_ids=all_ids, max_cluster_size=5,
                         weak_cluster_threshold=0.3, auto_split=True)
+    assert calls, "columnar path (_build_clusters_via_frames) did not run with gate ON"
 
     assert on.keys() == off.keys()
     for cid in off:
-        assert on[cid] == off[cid], f"cluster {cid} differs: {on[cid]} vs {off[cid]}"
-    # Belt-and-suspenders on the float-sensitive field:
-    for cid in off:
-        assert on[cid].get("confidence") == off[cid].get("confidence")
+        assert _norm(on[cid]) == _norm(off[cid]), f"cluster {cid} differs:\n on={on[cid]}\n off={off[cid]}"
 ```
 
-(Cluster ids may renumber after split; the test compares the full dicts key-for-key, so the columnar path MUST produce the same id numbering. If the fixture's split makes id comparison fragile, compare a canonicalized view: a set of `(frozenset(members), size, oversized, cluster_quality, round(confidence,12), bottleneck_pair, frozenset(pair_scores.items()))` per cluster — but prefer exact dict equality and only fall back if the dict path's own id numbering is non-deterministic, which it is NOT.)
+(Cluster ids are deterministic and identical gate-on/off: both sort by `min(members)` + enumerate(start=1) pre-split, and splits assign `max(result.keys())+1` -- so `on.keys() == off.keys()`. The only legitimately-differing field is `members` LIST order, which `_norm` collapses to a set. `pair_scores`, `confidence`, `bottleneck_pair`, `cluster_quality`, `oversized` are compared exactly.)
+
+ALSO add a **can't-split oversized cluster** to `_adversarial_pairs` (spec requires it): a DENSE oversized clique (e.g. 7 members 30..36 with ALL pairs at 0.99, no weak bridge) -> `split_oversized_cluster` returns it unchanged -> left `oversized`, quality stays (not "split"). This exercises the no-progress guard (:508-512).
 
 - [ ] **Step 2: Run it — verify FAIL**
 
@@ -111,20 +120,50 @@ Add `_columnar_cluster_build_enabled()` (env `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD
 
 - [ ] **Step 4: Implement the real `_build_clusters_via_frames`**
 
-Per the spec routing. Build the `pairs_df` (PAIR_STREAM_SCHEMA) from `pairs`. Then:
-1. **UF:** `frames = build_clusters_arrow_native(pairs_df, all_ids=all_ids, max_cluster_size=max_cluster_size)` -> `ClusterFrames`. Derive `member_to_cid` from `frames.assignments` AND the cluster ids from the SAME sort-by-min-member + enumerate(start=1) the dict path uses, so ids match. `members` per cluster in the assignments' member order (which equals the dict path's UF order — verified in spec).
+Per the spec routing. Build `pairs_df` from `pairs` using the canonical schema:
+`import` `PAIR_STREAM_SCHEMA` from `goldenmatch.core.scorer` (columns `id_a:i64,
+id_b:i64, score:f64`) -- the kernel validates these dtypes (cluster.rs) and raises
+on mismatch. Then:
+1. **UF (source differs native vs off-native -- ISSUE 3):**
+   - **Native** (`native_enabled("clustering")` and the arrow kernel is exposed):
+     `frames = build_clusters_arrow_native(pairs_df, all_ids=all_ids,
+     max_cluster_size=max_cluster_size)` -> `ClusterFrames`. The kernel does UF ONLY
+     (no auto-split, verified) -> assignments + metadata are PRE-split. Get raw
+     member sets per UF-component from `frames.assignments`.
+   - **Off-native:** do NOT call `build_clusters_arrow_native` -- its
+     `build_clusters_v2_columnar` fallback runs the FULL `build_clusters` incl.
+     auto-split (POST-split frames). Instead source UF membership DIRECTLY from
+     `connected_components(list(pairs), all_ids)` (or the Python `UnionFind`), the
+     same pre-split UF the dict path uses (:419-434).
+   Then, for BOTH: build the SAME pre-split `result` dict the dict path has at :466
+   -- sort the UF member sets by `min(members)`, enumerate(start=1) for cluster ids,
+   `members = list(members)` (set/UF order; the parity gate compares members as a
+   SET so order need not match the dict path), `size`, `oversized = size >
+   max_cluster_size`, `pair_scores = {}`. `member_to_cid` from this.
 2. **pair_scores (ORDER-PRESERVING):** add a `cluster_id` column to `pairs_df` via `pl.col("id_a").replace_strict(member_to_cid)` (NOT a join). Iterate the resulting frame IN ORDER to build per-cluster `pair_scores` dicts (same as the dict path's :468-471, in pairs order). Duplicate canonical pairs overwrite (last wins) exactly as the dict path's `result[cid]["pair_scores"][(a,b)] = score`.
 3. **confidence + bottleneck:** native -> read `confidence` + `(bottleneck_pair_a, bottleneck_pair_b)` from `frames.metadata` per cluster_id (map `(0,0) -> None`). off-native -> call `compute_cluster_confidence(pair_scores, size)` per cluster (bit-identical). Compute these on the ORIGINAL (pre-split) clusters, matching the dict path's ordering (confidence at :477-481 is BEFORE auto-split at :494).
 4. **auto-split:** identical to the dict path's :494-528 loop, reusing `split_oversized_cluster(members, pair_scores)` + the edge-work-budget / no-progress guards. (The simplest correct approach: build the SAME `result` dict shape the dict path has just before :494, then run the dict path's auto-split + quality code verbatim. This guarantees parity for the split/quality logic — the columnar win is in steps 1-3.)
 5. **cluster_quality:** identical to :531-546 (split if `_was_split`; else weak if `avg_edge - min_edge > weak_cluster_threshold` with `confidence *= 0.7`; else strong). Reuse the dict path's code.
-6. **adapter / emit:** the `result` dict IS the byte-identical output. Call `_emit_cluster_profile(result)` (:548) and return.
+6. **adapter / emit:** `result` IS the byte-identical output. `_finalize_clusters`
+   (below) already calls `_emit_cluster_profile(result)` (it's at :548, inside the
+   extracted range) -- do NOT call it again here (would double-emit). Just return
+   what `_finalize_clusters` returns.
 
-KEY: steps 4-5-6 should literally REUSE the dict path's code (extract :494-548 into a shared `_finalize_clusters(result, max_cluster_size, weak_cluster_threshold, auto_split)` helper that both paths call). The columnar path only changes HOW `result` is built up to :493 (UF + pair_scores + confidence). This minimizes the parity surface to steps 1-3.
+KEY: steps 4-5-6 should literally REUSE the dict path's code (extract :494-548 --
+the auto-split loop + cluster_quality + the `_emit_cluster_profile(result)` call --
+into a shared `_finalize_clusters(result, max_cluster_size, weak_cluster_threshold,
+auto_split) -> result` helper that BOTH the dict path and the columnar path call).
+The extraction is clean: :494-548 reads only `result` + the 3 params + module-level
+helpers (`member_to_cid`/`sorted_clusters`/`pairs` are already `del`'d at :474-475).
+The columnar path only changes HOW `result` is built up to :493 (UF + pair_scores +
+confidence). This minimizes the parity surface to steps 1-3.
 
 - [ ] **Step 5: Run the parity test — verify PASS (both native states)**
 
 Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_columnar_cluster_build_parity.py -v`
-Expected: PASS for `native=1` AND `native=0`. If a cluster differs, PRINT `on[cid]` vs `off[cid]` and fix the columnar build for that field — do NOT relax the assertion (byte-identical is the durability invariant feeding golden/identity). Likely culprits: pair_scores order (must be pairs order), member order, confidence (native metadata vs dict), id numbering, the `(0,0)` sentinel.
+Expected: PASS for `native=1` AND `native=0`. If a cluster differs (other than members-set), PRINT `on[cid]` vs `off[cid]` and fix the columnar build for that field — do NOT relax the assertion beyond the members-set already in `_norm` (byte-identical on the rest is the durability invariant feeding golden/identity). Likely culprits: pair_scores order (must be pairs order), confidence (native metadata vs dict), id numbering, the `(0,0)` sentinel.
+
+**LOCAL NATIVE CAVEAT (ISSUE 2):** the in-tree `_native.pyd` is STALE -- it lacks `build_clusters_arrow` (and `mst_split_components`), and it CANNOT be rebuilt locally (the pinned Rust toolchain is unavailable, `build_native.py` fails). So LOCALLY, `build_clusters_arrow_native` falls back to the columnar path even with `native=1`, meaning the `native=1` parity run exercises the OFF-NATIVE source, NOT the real Arrow kernel. The real native kernel path is validated ONLY in CI (fresh native build). Confirm `getattr(native_module(), "build_clusters_arrow", None)` locally; if None, note in your report that the native-kernel path is CI-only-validated. Do NOT block on it locally.
 
 - [ ] **Step 6: Run the existing cluster tests with the gate ON (regression)**
 

--- a/docs/superpowers/specs/2026-06-02-columnar-cluster-build-core-design.md
+++ b/docs/superpowers/specs/2026-06-02-columnar-cluster-build-core-design.md
@@ -1,0 +1,145 @@
+# Columnar cluster-build core + dict adapter (Phase 2 SP1) — design
+
+**Date:** 2026-06-02
+**Status:** design (approved, pre-plan)
+**Decision context:** #663-B measure-first spike (run 26794944441) found the Arrow
+cluster UF kernel `build_clusters_arrow_native` is 2.4-3.1x faster than the
+dict-shaped `build_clusters` with byte-identical membership -- but that was
+UF-only vs UF+post-processing. The dict path's ~1.4s/1M is the Python
+`pair_scores` fill + per-cluster `compute_cluster_confidence`. Realizing the win
+needs the post-processing columnar too (Phase 2 / #624 "cluster representation
+columnar"). Phase 2 decomposes into SP1 (THIS spec: columnar build core + a
+`dict[int,dict]` adapter so the ~25 cluster consumers stay untouched) and SP2..N
+(incremental consumer migration off the adapter). Clustering is ~32% of wall at
+25M, so the full win is high-leverage.
+
+## Problem
+
+`core/cluster.py::build_clusters(pairs) -> dict[int, dict]` (the production path,
+12 call sites, ~25 consumers) does, after the Union-Find:
+- `pair_scores` fill: a Python loop assigning every pair's score to its cluster's
+  `pair_scores` dict (cluster.py:468-471);
+- per-cluster `compute_cluster_confidence` (:477-481);
+- auto-split of oversized clusters via MST (:494-528);
+- `cluster_quality` weak/split assignment (:531-541).
+
+The Arrow UF (`build_clusters_arrow_native -> ClusterFrames`) only does the
+Union-Find; the post-processing is the dict-floor cost. SP1 makes the WHOLE build
+columnar while preserving the exact `dict[int,dict]` output via an adapter.
+
+## Goal
+
+`build_clusters` produces a byte-identical `dict[int,dict]` via a columnar core
+(Arrow UF + columnar `pair_scores`/confidence/quality, auto-split unchanged) +
+a `ClusterFrames -> dict` adapter, behind a gate, with the columnar path measured
+against the current one. No consumer changes (SP2+).
+
+## Architecture: columnar core, dict adapter, gated
+
+New internal path `_build_clusters_columnar_core(pairs_df, all_ids, max_cluster_size,
+weak_cluster_threshold, auto_split) -> dict[int, dict]`. `build_clusters` keeps its
+signature and dispatches to it behind the gate; OFF -> the current path verbatim.
+
+1. **Arrow Union-Find** -> `ClusterFrames` (assignments `cluster_id <-> member_id`;
+   metadata `size`, `oversized`). The 2.4-3.1x kernel (`build_clusters_arrow_native`,
+   already built; falls back to `build_clusters_v2_columnar` off-native).
+2. **Columnar `pair_scores`** -- join `pairs_df` to the member->cluster assignment
+   (from ClusterFrames.assignments) to get a per-cluster edge frame
+   `(cluster_id, id_a, id_b, score)`. Canonical `(min,max)` orientation already
+   holds upstream. Replaces the Python loop at :468-471.
+3. **Columnar confidence + bottleneck** -- group-by `cluster_id` aggregations over
+   the edge frame, reproducing `compute_cluster_confidence` EXACTLY:
+   - size <= 1: `connectivity=1.0, confidence=1.0`, `min_edge/avg_edge/bottleneck_pair=None`.
+   - else: `min_edge=min(score)`, `avg_edge=mean(score)`,
+     `connectivity = n_edges / (size*(size-1)/2)`,
+     `bottleneck_pair = (id_a,id_b)` of the argmin-score edge,
+     `confidence = 0.4*min_edge + 0.3*avg_edge + 0.3*connectivity`.
+   **Bottleneck tie-break is the parity crux:** the dict path scans `pair_scores.items()`
+   and the FIRST minimum wins (insertion order = the order pairs were filled =
+   `pairs` iteration order). The columnar argmin MUST reproduce that exact
+   first-occurrence-by-pair-order tie-break (e.g. stable sort by `(score, original
+   pair index)` then take first per cluster). A different tie-break moves
+   `bottleneck_pair` on score-tied clusters -> parity fail.
+4. **Auto-split (UNCHANGED, oversized-only)** -- for clusters with
+   `size > max_cluster_size` (when `auto_split`), materialize that cluster's
+   `members` + `pair_scores` DICT and call the existing
+   `split_oversized_cluster(members, pair_scores)` under the SAME edge-work-budget
+   + no-progress guards (:494-528, the #661 dense-cluster pathology guard).
+   Oversized clusters are rare, so the per-oversized dict materialization is cheap.
+   Split sub-clusters get new ids, `_was_split=True`, recompute `oversized` per
+   sub-cluster size; re-enqueue still-oversized subs (same loop as today).
+5. **Columnar `cluster_quality`** -- `split` if `_was_split`; else `weak` (with
+   `confidence *= 0.7`) when `size > 1 and pair_scores and avg_edge - min_edge >
+   weak_cluster_threshold`; else `strong`. Vectorizable for the non-split clusters;
+   split flag comes from step 4.
+6. **dict adapter** -- materialize `dict[int, dict]` byte-identical to the current
+   output: per cluster `{members: list[int], size, oversized, pair_scores:
+   dict[(a,b)]->score, confidence, bottleneck_pair, cluster_quality}` (and the
+   transient `_was_split` where the current code sets it). Cluster id numbering +
+   ordering must match the current path (clusters sorted by `min(members)`,
+   id-anchored, start=1 -- see :436-450; the Arrow UF membership is identical, so
+   apply the same sort+enumerate to assign ids).
+
+### Gate
+`GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` (default OFF until the measure-first bench),
+read in `build_clusters`, mirroring the `GOLDENMATCH_NATIVE`/identity env pattern.
+
+### Rejected
+- **Per-cluster confidence in a loop on the columnar path:** keeps the Python
+  per-cluster cost we're removing -- no post-processing win.
+- **Migrate consumers now:** that's SP2+; SP1 keeps the dict adapter so the ~25
+  consumers (golden/identity/lineage/unmerge/dashboard/compare/...; CLI/web/TUI/
+  MCP/API/db) are untouched and the change is independently shippable.
+
+## Edge cases / invariants
+
+- **Cluster id parity:** ids must match the current sort-by-min-member + enumerate
+  (start=1). The Arrow UF returns identical membership; re-apply the same sort.
+- **Singletons / empty:** size<=1 -> confidence 1.0 path; empty pairs -> empty/all-
+  singleton result, same as today.
+- **Score-tie edges + bottleneck tie:** covered by step 3's first-occurrence rule.
+- **Oversized + budget-tripped:** the auto-split budget/no-progress guards (#661)
+  must behave identically -- leave oversized, warn, exclude from golden downstream.
+- **Off-native:** Arrow UF degrades to `build_clusters_v2_columnar`; the columnar
+  post-processing is pure Polars (no native dependency) so it still runs; the dict
+  adapter output is identical. (Confidence has a native `cluster_confidence` kernel
+  used by the dict path; the columnar path computes the SAME formula in Polars --
+  the parity gate covers both-native-states.)
+
+## Testing
+
+- **Byte-identical dict gate (HARD):** an adversarial cluster fixture --
+  singletons, multi-member, a fully-connected cluster, a weak chain (triggers
+  `weak`), an oversized cluster that splits (triggers `split` + new ids), an
+  oversized cluster that CAN'T split (budget/no-progress -> left oversized),
+  score-tied edges (bottleneck tie-break), and a cluster with duplicate canonical
+  pairs. Assert `build_clusters(pairs, ...)` with the gate ON `==` the gate-OFF
+  output, key for key, including `pair_scores` dicts, `confidence` (exact float),
+  `bottleneck_pair`, `cluster_quality`, `oversized`, and the cluster id numbering.
+  Run with `GOLDENMATCH_NATIVE` on AND off.
+- **Confidence parity unit test:** the columnar confidence aggregation matches
+  `compute_cluster_confidence` for each fixture cluster, incl. the size<=1 case and
+  a score-tie bottleneck.
+- **Measure-first bench:** columnar-core+adapter vs current dict `build_clusters` at
+  1M/5M pairs on `large-new-64GB` (fresh native), wall + peak RSS, with the
+  membership/dict parity asserted. Reuse the spike's pair generator
+  (`scripts/bench_build_clusters_arrow_spike.py`). Records whether SP1's columnar
+  post-processing beats the Python loops net of the dict adapter; ship default-on
+  only if it wins, else keep gated as the SP2-enabling foundation.
+
+## Scope boundary (YAGNI)
+
+- ONLY `core/cluster.py` (`build_clusters` internals + the columnar core + adapter
+  + gate). NO consumer changes (SP2+). NO new auto-split algorithm (reuse
+  `split_oversized_cluster`). NO new native kernel (Arrow UF + cluster_confidence
+  exist). Don't change the `ClusterFrames` schema.
+
+## References
+
+- #663-B / #624 (Phase 2). Roadmap `docs/superpowers/specs/2026-05-31-arrow-native-roadmap.md`.
+- `core/cluster.py`: `build_clusters` (:361-541), `compute_cluster_confidence`
+  (:552), `build_clusters_arrow_native` (:1216), `build_clusters_v2_columnar`
+  (:1162), `ClusterFrames` (:1009), `split_oversized_cluster`. Spike:
+  `scripts/bench_build_clusters_arrow_spike.py` + `bench-build-clusters-arrow-spike.yml`.
+- Related: [[project_663_arrow_kernels]], [[project_build_clusters_dense_split_pathology]] (#661),
+  [[project_arrow_native_finish_line]].

--- a/docs/superpowers/specs/2026-06-02-columnar-cluster-build-core-design.md
+++ b/docs/superpowers/specs/2026-06-02-columnar-cluster-build-core-design.md
@@ -146,7 +146,26 @@ read in `build_clusters`, mirroring the `GOLDENMATCH_NATIVE`/identity env patter
 
 ## Testing
 
-- **Byte-identical dict gate (HARD, STRICT -- no float tolerance):** an adversarial
+- **`members` parity = SET-equality (decision 2026-06-02, plan-review).** The
+  columnar path runs a SEPARATE Union-Find (`build_clusters_arrow_native`) from the
+  dict path's `connected_components`; two independent UF groupings iterate set/HashMap
+  in DIFFERENT member order, and the dict path itself does NOT sort members (PR #598
+  removed it for perf). So byte-identical `members` LIST order is unachievable
+  without re-sorting both paths (re-incurring the #598 cost). The gate compares
+  `members` as a SET (`frozenset`); EVERYTHING ELSE (`pair_scores`, `confidence`,
+  `bottleneck_pair`, `cluster_quality`, `oversized`, cluster ids) stays STRICT
+  byte-identical. Safe: every consumer treats members as a set / re-sorts, and the
+  dict path's order is already hash-arbitrary.
+- **Off-native UF sourcing (plan-review ISSUE 3):** off-native,
+  `build_clusters_arrow_native` falls back to `build_clusters_v2_columnar` which runs
+  the FULL `build_clusters` INCLUDING auto-split -> its frames are POST-split. The
+  columnar path needs PRE-split UF membership. So off-native, source UF membership
+  from `connected_components(pairs, all_ids)` (or the Python `UnionFind`) DIRECTLY --
+  NOT `build_clusters_arrow_native` -- then columnar pair_scores + per-cluster
+  `compute_cluster_confidence` + `_finalize_clusters` (which does the single
+  auto-split). Native: `build_clusters_arrow_native` is UF-only (the kernel does NOT
+  split, verified), so its assignments/metadata are pre-split -- use them.
+- **Byte-identical dict gate (HARD, STRICT -- no float tolerance, members as SET):** an adversarial
   cluster fixture -- singletons (incl. id `0`), multi-member, a fully-connected
   cluster, a weak chain (triggers `weak`), an oversized cluster that splits
   (triggers `split` + new ids), an oversized cluster that CAN'T split

--- a/docs/superpowers/specs/2026-06-02-columnar-cluster-build-core-design.md
+++ b/docs/superpowers/specs/2026-06-02-columnar-cluster-build-core-design.md
@@ -48,40 +48,41 @@ branch -- AFTER the Ray-Dataset short-circuit at the top of `build_clusters`
 1. **Arrow Union-Find** -> `ClusterFrames` (assignments `cluster_id <-> member_id`;
    metadata `size`, `oversized`). The 2.4-3.1x kernel (`build_clusters_arrow_native`,
    already built; falls back to `build_clusters_v2_columnar` off-native).
-2. **Columnar `pair_scores`** -- join `pairs_df` to the member->cluster assignment
-   (from ClusterFrames.assignments) to get a per-cluster edge frame
-   `(cluster_id, id_a, id_b, score)`. Canonical `(min,max)` orientation already
-   holds upstream. Replaces the Python loop at :468-471.
-3. **Confidence + bottleneck via a BATCH-NATIVE kernel (decision 2026-06-02).**
-   `compute_cluster_confidence` computes `avg_edge = sum(scores)/len` as a
-   SEQUENTIAL left-fold in pair order; the existing native `cluster_confidence`
-   kernel deliberately replicates that exact float order. A vectorized Polars
-   `group_by().mean()` uses SIMD/pairwise summation -> a different float (~1e-13)
-   -> NOT byte-identical on `confidence` (and a measure-zero weak/strong flip).
-   To keep STRICT byte-identical AND remove the per-cluster Python overhead, add a
-   NEW native batch kernel **`cluster_confidence_batch`** that does per-cluster
-   sequential sums in Rust (bit-identical to the existing per-cluster
-   `cluster_confidence`) for ALL clusters in ONE call:
-   - Input: the edge frame as Arrow arrays (`cluster_id`, `id_a`, `id_b`, `score`,
-     IN pair-fill order) + per-cluster `size`. Output: per-cluster `(min_edge,
-     avg_edge, connectivity, bottleneck_pair=(a,b), confidence)`.
-   - Per cluster, Rust reproduces EXACTLY: size<=1 -> `connectivity=1.0,
-     confidence=1.0`, others `None`; else `min_edge`, `avg_edge` (sequential sum in
-     the input edge order), `connectivity = n_edges/(size*(size-1)/2)`,
-     `bottleneck_pair` = the argmin-score edge with STRICT `<` (first-occurrence in
-     input order, matching Python `min()` and the existing kernel cluster.rs:206-214),
-     `confidence = 0.4*min + 0.3*avg + 0.3*connectivity`.
-   - **Edge order into the kernel MUST be the pair-fill order** (same order
-     `pair_scores` was populated = `pairs` iteration order), so both the sequential
-     sum and the bottleneck tie-break match the dict path. The columnar edge frame
-     must preserve that order (do NOT reorder by group).
-   - Python wrapper `cluster_confidence_batch(...)` with dispatch: native ->
-     the kernel; **off-native -> the existing per-cluster `compute_cluster_confidence`
-     loop** (bit-identical, the slow path -- off-native is the non-perf path anyway).
-     STRICT byte-identical in BOTH states; no float tolerance.
-   - `bottleneck_pair` sentinel: the kernel/ClusterFrames carry `(0,0)` for
+2. **`pair_scores` (ORDER-PRESERVING, no join)** -- map `cluster_id` onto
+   `pairs_df` via `pl.col("id_a").replace_strict(member_to_cid)` in a
+   `with_columns` (NOT a Polars `join` -- a join does not preserve left-frame row
+   order, which would silently break the sequential-sum + bottleneck tie-break
+   parity). Both endpoints share a cluster post-UF, so keying on `id_a` matches the
+   dict path (:470) and the Rust kernel (cluster.rs:482). The result is a flat
+   `(cluster_id, id_a, id_b, score)` frame IN PAIR-FILL ORDER. The adapter
+   materializes per-cluster `pair_scores` dicts from it (order preserved).
+3. **Confidence + bottleneck -- REUSE the batched confidence the Arrow kernel
+   ALREADY emits (no new kernel; decision 2026-06-02 refined by spec-review).**
+   `compute_cluster_confidence`'s `avg_edge = sum/len` is a SEQUENTIAL left-fold;
+   a vectorized Polars `group_by().mean()` (SIMD/pairwise) differs by ~1e-13 and
+   breaks byte-identical. The fix does NOT need a new kernel: the EXISTING
+   `build_clusters_arrow` Rust kernel (cluster.rs:392-548) ALREADY computes
+   per-cluster confidence + bottleneck in Rust, in pair-INPUT order, via the same
+   `cluster_confidence` logic (cluster.rs:478-486 buckets edges per cluster by a
+   single-pass push -- NOT a group_by/sort -- then folds), and returns them on
+   `ClusterFrames.metadata` (`confidence`, `bottleneck_pair_a/b`). That IS the
+   batched-native, bit-identical confidence we want.
+   - **Native path:** take `confidence` + `bottleneck_pair` straight off the
+     `ClusterFrames.metadata` that step 1's `build_clusters_arrow_native` already
+     produced. No second computation, no new kernel.
+   - **Off-native path:** `build_clusters_arrow_native` falls back to
+     `build_clusters_v2_columnar`; compute confidence via the existing per-cluster
+     `compute_cluster_confidence` loop (Python, bit-identical; off-native is the
+     non-perf path). STRICT byte-identical in BOTH states; no float tolerance.
+   - `bottleneck_pair` sentinel: `ClusterFrames.metadata` carries `(0,0)` for
      "no bottleneck"; the adapter maps `(0,0) <-> None`. No real edge is `(0,0)`
-     (a pair has two distinct ids), so the sentinel is collision-free.
+     (a pair has two distinct ids), so it is collision-free.
+   - **Verify at plan time:** that the metadata `confidence`/`bottleneck` from
+     `build_clusters_arrow` are bit-identical to the dict path on the parity
+     fixture (the kernel uses the same `cluster_confidence` in input order, so they
+     should be -- the parity gate proves it). If a gap is found, the fallback is a
+     `cluster_confidence_batch` kernel, but reusing the existing metadata is the
+     first choice (no new native surface).
 4. **Auto-split (UNCHANGED, oversized-only)** -- for clusters with
    `size > max_cluster_size` (when `auto_split`), materialize that cluster's
    `members` + `pair_scores` DICT and call the existing
@@ -169,15 +170,15 @@ read in `build_clusters`, mirroring the `GOLDENMATCH_NATIVE`/identity env patter
 
 ## Scope boundary (YAGNI)
 
-- `core/cluster.py` (`build_clusters` internals + the `_build_clusters_via_frames`
-  columnar core + dict adapter + gate) AND the new `cluster_confidence_batch` Rust
-  kernel (`packages/rust/extensions/native/src/cluster.rs` + Python wrapper in
-  `core/cluster.py`, mirroring the existing `cluster_confidence` kernel pattern).
-  NO consumer changes (SP2+). NO new auto-split algorithm (reuse
-  `split_oversized_cluster`). Reuse the existing Arrow UF (`build_clusters_arrow_native`).
-  Don't change the `ClusterFrames` schema. (The batch kernel is the one new native
-  surface, added deliberately to keep STRICT byte-identical confidence floats while
-  removing the per-cluster Python overhead -- decision 2026-06-02.)
+- ONLY `core/cluster.py` (`build_clusters` internals + the `_build_clusters_via_frames`
+  columnar core + dict adapter + gate). **NO new native kernel** -- the existing
+  `build_clusters_arrow` already emits batched bit-identical confidence/bottleneck
+  on `ClusterFrames.metadata`; reuse it. NO consumer changes (SP2+). NO new
+  auto-split algorithm (reuse `split_oversized_cluster`). Reuse the existing Arrow
+  UF (`build_clusters_arrow_native`). Don't change the `ClusterFrames` schema. (If
+  plan-time parity testing finds the metadata confidence is NOT bit-identical, the
+  fallback is a `cluster_confidence_batch` kernel -- but reusing existing infra is
+  the design.)
 
 ## References
 

--- a/docs/superpowers/specs/2026-06-02-columnar-cluster-build-core-design.md
+++ b/docs/superpowers/specs/2026-06-02-columnar-cluster-build-core-design.md
@@ -36,9 +36,14 @@ against the current one. No consumer changes (SP2+).
 
 ## Architecture: columnar core, dict adapter, gated
 
-New internal path `_build_clusters_columnar_core(pairs_df, all_ids, max_cluster_size,
-weak_cluster_threshold, auto_split) -> dict[int, dict]`. `build_clusters` keeps its
-signature and dispatches to it behind the gate; OFF -> the current path verbatim.
+New internal path `_build_clusters_via_frames(pairs_df, all_ids, max_cluster_size,
+weak_cluster_threshold, auto_split) -> dict[int, dict]` (name chosen to NOT collide
+with the existing `build_clusters_columnar` :891 [df->list->build_clusters] and
+`build_clusters_v2_columnar` :1162 -- both different; wire the gate into NEITHER).
+`build_clusters` keeps its signature and dispatches to it behind the gate; OFF ->
+the current path verbatim. **The gate is read only on the in-memory list/DataFrame
+branch -- AFTER the Ray-Dataset short-circuit at the top of `build_clusters`
+(:376-394), so it never intercepts the distributed path.**
 
 1. **Arrow Union-Find** -> `ClusterFrames` (assignments `cluster_id <-> member_id`;
    metadata `size`, `oversized`). The 2.4-3.1x kernel (`build_clusters_arrow_native`,
@@ -47,19 +52,36 @@ signature and dispatches to it behind the gate; OFF -> the current path verbatim
    (from ClusterFrames.assignments) to get a per-cluster edge frame
    `(cluster_id, id_a, id_b, score)`. Canonical `(min,max)` orientation already
    holds upstream. Replaces the Python loop at :468-471.
-3. **Columnar confidence + bottleneck** -- group-by `cluster_id` aggregations over
-   the edge frame, reproducing `compute_cluster_confidence` EXACTLY:
-   - size <= 1: `connectivity=1.0, confidence=1.0`, `min_edge/avg_edge/bottleneck_pair=None`.
-   - else: `min_edge=min(score)`, `avg_edge=mean(score)`,
-     `connectivity = n_edges / (size*(size-1)/2)`,
-     `bottleneck_pair = (id_a,id_b)` of the argmin-score edge,
-     `confidence = 0.4*min_edge + 0.3*avg_edge + 0.3*connectivity`.
-   **Bottleneck tie-break is the parity crux:** the dict path scans `pair_scores.items()`
-   and the FIRST minimum wins (insertion order = the order pairs were filled =
-   `pairs` iteration order). The columnar argmin MUST reproduce that exact
-   first-occurrence-by-pair-order tie-break (e.g. stable sort by `(score, original
-   pair index)` then take first per cluster). A different tie-break moves
-   `bottleneck_pair` on score-tied clusters -> parity fail.
+3. **Confidence + bottleneck via a BATCH-NATIVE kernel (decision 2026-06-02).**
+   `compute_cluster_confidence` computes `avg_edge = sum(scores)/len` as a
+   SEQUENTIAL left-fold in pair order; the existing native `cluster_confidence`
+   kernel deliberately replicates that exact float order. A vectorized Polars
+   `group_by().mean()` uses SIMD/pairwise summation -> a different float (~1e-13)
+   -> NOT byte-identical on `confidence` (and a measure-zero weak/strong flip).
+   To keep STRICT byte-identical AND remove the per-cluster Python overhead, add a
+   NEW native batch kernel **`cluster_confidence_batch`** that does per-cluster
+   sequential sums in Rust (bit-identical to the existing per-cluster
+   `cluster_confidence`) for ALL clusters in ONE call:
+   - Input: the edge frame as Arrow arrays (`cluster_id`, `id_a`, `id_b`, `score`,
+     IN pair-fill order) + per-cluster `size`. Output: per-cluster `(min_edge,
+     avg_edge, connectivity, bottleneck_pair=(a,b), confidence)`.
+   - Per cluster, Rust reproduces EXACTLY: size<=1 -> `connectivity=1.0,
+     confidence=1.0`, others `None`; else `min_edge`, `avg_edge` (sequential sum in
+     the input edge order), `connectivity = n_edges/(size*(size-1)/2)`,
+     `bottleneck_pair` = the argmin-score edge with STRICT `<` (first-occurrence in
+     input order, matching Python `min()` and the existing kernel cluster.rs:206-214),
+     `confidence = 0.4*min + 0.3*avg + 0.3*connectivity`.
+   - **Edge order into the kernel MUST be the pair-fill order** (same order
+     `pair_scores` was populated = `pairs` iteration order), so both the sequential
+     sum and the bottleneck tie-break match the dict path. The columnar edge frame
+     must preserve that order (do NOT reorder by group).
+   - Python wrapper `cluster_confidence_batch(...)` with dispatch: native ->
+     the kernel; **off-native -> the existing per-cluster `compute_cluster_confidence`
+     loop** (bit-identical, the slow path -- off-native is the non-perf path anyway).
+     STRICT byte-identical in BOTH states; no float tolerance.
+   - `bottleneck_pair` sentinel: the kernel/ClusterFrames carry `(0,0)` for
+     "no bottleneck"; the adapter maps `(0,0) <-> None`. No real edge is `(0,0)`
+     (a pair has two distinct ids), so the sentinel is collision-free.
 4. **Auto-split (UNCHANGED, oversized-only)** -- for clusters with
    `size > max_cluster_size` (when `auto_split`), materialize that cluster's
    `members` + `pair_scores` DICT and call the existing
@@ -68,17 +90,30 @@ signature and dispatches to it behind the gate; OFF -> the current path verbatim
    Oversized clusters are rare, so the per-oversized dict materialization is cheap.
    Split sub-clusters get new ids, `_was_split=True`, recompute `oversized` per
    sub-cluster size; re-enqueue still-oversized subs (same loop as today).
-5. **Columnar `cluster_quality`** -- `split` if `_was_split`; else `weak` (with
+5. **`cluster_quality`** -- `split` if `_was_split` (from step 4); else `weak` (with
    `confidence *= 0.7`) when `size > 1 and pair_scores and avg_edge - min_edge >
-   weak_cluster_threshold`; else `strong`. Vectorizable for the non-split clusters;
-   split flag comes from step 4.
+   weak_cluster_threshold`; else `strong`. The current code RECOMPUTES `min_edge`/
+   `avg_edge` here (:535-538) from `pair_scores.values()` -- same edge order, same
+   sequential sum as step 3. REUSE the batch kernel's per-cluster `min_edge`/
+   `avg_edge` for the weak test (bit-identical, avoids a second pass). Split
+   clusters skip the weak branch (quality set to `split` first), matching today.
 6. **dict adapter** -- materialize `dict[int, dict]` byte-identical to the current
    output: per cluster `{members: list[int], size, oversized, pair_scores:
    dict[(a,b)]->score, confidence, bottleneck_pair, cluster_quality}` (and the
-   transient `_was_split` where the current code sets it). Cluster id numbering +
+   transient `_was_split` where the current code sets it). It persists ONLY
+   `confidence` + `bottleneck_pair` from the confidence step -- do NOT add
+   `min_edge`/`avg_edge`/`connectivity` keys (the current dict drops them; extra
+   keys fail the key-for-key gate). `pair_scores` MUST be fully materialized (the
+   existing `cluster_frames_to_dict` :1157 sets `pair_scores={}` -- do NOT reuse it;
+   `_emit_cluster_profile` :548 reads `pair_scores`). Cluster id numbering +
    ordering must match the current path (clusters sorted by `min(members)`,
-   id-anchored, start=1 -- see :436-450; the Arrow UF membership is identical, so
-   apply the same sort+enumerate to assign ids).
+   id-anchored, start=1 -- see :436-450). **`members` is `list(members)` in the UF
+   iteration order (deliberately UNSORTED, PR #598) -- derive it from the SAME UF
+   output the dict path uses; do NOT re-group independently** (off-native the UF
+   member order must come from the same source). The Arrow UF membership is
+   identical, so apply the same sort-by-min-member + enumerate to assign ids.
+7. **`_emit_cluster_profile`** (:548) is still called on the final adapter dict
+   (reads size/confidence/members/pair_scores) -- unchanged.
 
 ### Gate
 `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` (default OFF until the measure-first bench),
@@ -100,26 +135,31 @@ read in `build_clusters`, mirroring the `GOLDENMATCH_NATIVE`/identity env patter
 - **Score-tie edges + bottleneck tie:** covered by step 3's first-occurrence rule.
 - **Oversized + budget-tripped:** the auto-split budget/no-progress guards (#661)
   must behave identically -- leave oversized, warn, exclude from golden downstream.
-- **Off-native:** Arrow UF degrades to `build_clusters_v2_columnar`; the columnar
-  post-processing is pure Polars (no native dependency) so it still runs; the dict
-  adapter output is identical. (Confidence has a native `cluster_confidence` kernel
-  used by the dict path; the columnar path computes the SAME formula in Polars --
-  the parity gate covers both-native-states.)
+- **Off-native:** Arrow UF degrades to `build_clusters_v2_columnar`; confidence
+  falls back to the existing per-cluster `compute_cluster_confidence` sequential
+  loop (bit-identical, no perf claim off-native -- the non-perf path). pair_scores
+  grouping is pure Polars. The dict adapter output is byte-identical in BOTH native
+  states; the parity gate runs both.
+- **`id=0` record:** a singleton id `0` -> `bottleneck_pair=None` -> `(0,0)` in the
+  frame -> back to `None` in the adapter. Collision-free; the fixture includes it.
 
 ## Testing
 
-- **Byte-identical dict gate (HARD):** an adversarial cluster fixture --
-  singletons, multi-member, a fully-connected cluster, a weak chain (triggers
-  `weak`), an oversized cluster that splits (triggers `split` + new ids), an
-  oversized cluster that CAN'T split (budget/no-progress -> left oversized),
-  score-tied edges (bottleneck tie-break), and a cluster with duplicate canonical
+- **Byte-identical dict gate (HARD, STRICT -- no float tolerance):** an adversarial
+  cluster fixture -- singletons (incl. id `0`), multi-member, a fully-connected
+  cluster, a weak chain (triggers `weak`), an oversized cluster that splits
+  (triggers `split` + new ids), an oversized cluster that CAN'T split
+  (budget/no-progress -> left oversized), score-tied edges (bottleneck tie-break),
+  a cluster with 3+ edges (the sequential-sum float case), and duplicate canonical
   pairs. Assert `build_clusters(pairs, ...)` with the gate ON `==` the gate-OFF
-  output, key for key, including `pair_scores` dicts, `confidence` (exact float),
-  `bottleneck_pair`, `cluster_quality`, `oversized`, and the cluster id numbering.
-  Run with `GOLDENMATCH_NATIVE` on AND off.
-- **Confidence parity unit test:** the columnar confidence aggregation matches
-  `compute_cluster_confidence` for each fixture cluster, incl. the size<=1 case and
-  a score-tie bottleneck.
+  output, key for key, including `pair_scores` dicts, `confidence` (EXACT float --
+  the batch kernel's sequential sum makes this bit-identical), `bottleneck_pair`,
+  `cluster_quality`, `oversized`, and cluster id numbering + `members` order. Run
+  with `GOLDENMATCH_NATIVE` on AND off (off exercises the per-cluster fallback).
+- **Confidence-batch parity unit test:** `cluster_confidence_batch` (native) matches
+  the existing per-cluster `compute_cluster_confidence` bit-for-bit across the
+  fixture clusters, incl. size<=1, a score-tie bottleneck, and a 3+-edge cluster
+  (sequential-sum order). Also a native-parity test mirroring `test_native_parity.py`.
 - **Measure-first bench:** columnar-core+adapter vs current dict `build_clusters` at
   1M/5M pairs on `large-new-64GB` (fresh native), wall + peak RSS, with the
   membership/dict parity asserted. Reuse the spike's pair generator
@@ -129,10 +169,15 @@ read in `build_clusters`, mirroring the `GOLDENMATCH_NATIVE`/identity env patter
 
 ## Scope boundary (YAGNI)
 
-- ONLY `core/cluster.py` (`build_clusters` internals + the columnar core + adapter
-  + gate). NO consumer changes (SP2+). NO new auto-split algorithm (reuse
-  `split_oversized_cluster`). NO new native kernel (Arrow UF + cluster_confidence
-  exist). Don't change the `ClusterFrames` schema.
+- `core/cluster.py` (`build_clusters` internals + the `_build_clusters_via_frames`
+  columnar core + dict adapter + gate) AND the new `cluster_confidence_batch` Rust
+  kernel (`packages/rust/extensions/native/src/cluster.rs` + Python wrapper in
+  `core/cluster.py`, mirroring the existing `cluster_confidence` kernel pattern).
+  NO consumer changes (SP2+). NO new auto-split algorithm (reuse
+  `split_oversized_cluster`). Reuse the existing Arrow UF (`build_clusters_arrow_native`).
+  Don't change the `ClusterFrames` schema. (The batch kernel is the one new native
+  surface, added deliberately to keep STRICT byte-identical confidence floats while
+  removing the per-cluster Python overhead -- decision 2026-06-02.)
 
 ## References
 

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -617,11 +617,133 @@ def _build_clusters_via_frames(
     weak_cluster_threshold: float,
     auto_split: bool,
 ) -> dict[int, dict]:
-    """Columnar cluster-build core (SP1). Step 3 stub: delegates to the dict
-    path so the gate is a verified no-op refactor. Step 4 replaces this body
-    with the real columnar build."""
-    return _build_clusters_dict_path(
-        pairs, all_ids, max_cluster_size, weak_cluster_threshold, auto_split,
+    """Columnar cluster-build core (SP1). Builds the same pre-split ``result``
+    dict the dict path produces (members/size/oversized/pair_scores/confidence/
+    bottleneck_pair), then shares the auto-split/quality/emit tail via
+    ``_finalize_clusters`` so split/quality/emit are byte-identical.
+
+    Union-Find source differs native vs off-native:
+      * Native + the Arrow kernel present: ``build_clusters_arrow_native`` runs
+        UF in Rust (UF-ONLY, pre-split) and the raw member sets come from
+        ``frames.assignments``.
+      * Off-native (or the Arrow kernel absent): UF membership comes DIRECTLY
+        from ``connected_components`` (when exposed) or the pure-Python
+        ``UnionFind`` -- the SAME pre-split UF the dict path uses. We do NOT call
+        ``build_clusters_arrow_native`` in that case: its
+        ``build_clusters_v2_columnar`` fallback re-runs the FULL ``build_clusters``
+        (including auto-split), which would hand us POST-split frames.
+
+    Confidence + bottleneck are computed on the PRE-split clusters via
+    ``compute_cluster_confidence`` on the materialized ``pair_scores`` in BOTH
+    branches. Per spec this is bit-identical to the native metadata by
+    construction and sidesteps re-aligning the kernel's raw cluster_id labels to
+    our sorted-by-min-member ids; the native-metadata path is CI-only anyway.
+    """
+    import polars as _pl
+
+    from goldenmatch.core.scorer import PAIR_STREAM_SCHEMA
+
+    pairs_list = list(pairs)
+    pairs_df = _pl.DataFrame(
+        {
+            "id_a": [p[0] for p in pairs_list],
+            "id_b": [p[1] for p in pairs_list],
+            "score": [p[2] for p in pairs_list],
+        },
+        schema=PAIR_STREAM_SCHEMA,
+    )
+
+    # --- Step 1: Union-Find member sets (PRE-split). -----------------------
+    native = native_module() if native_enabled("clustering") else None
+    arrow_fn = getattr(native, "build_clusters_arrow", None) if native else None
+
+    member_sets: list[set[int]]
+    if native is not None and arrow_fn is not None:
+        # Native Arrow kernel: UF-ONLY assignments (pre-split). Derive raw
+        # member sets per UF component from the assignments frame.
+        with stage("cluster_connected_components"):
+            frames = build_clusters_arrow_native(
+                pairs_df, all_ids=all_ids, max_cluster_size=max_cluster_size,
+            )
+            by_kernel_cid: dict[int, set[int]] = {}
+            for kcid, mid in zip(
+                frames.assignments["cluster_id"].to_list(),
+                frames.assignments["member_id"].to_list(),
+                strict=True,
+            ):
+                by_kernel_cid.setdefault(int(kcid), set()).add(int(mid))
+            member_sets = list(by_kernel_cid.values())
+    else:
+        # Off-native: source UF DIRECTLY (same pre-split UF as the dict path).
+        with stage("cluster_connected_components"):
+            if native is not None:
+                # connected_components is exposed even when the Arrow kernel
+                # isn't (returns list[list[int]]).
+                member_sets = [
+                    set(c)
+                    for c in native.connected_components(pairs_list, all_ids)
+                ]
+            else:
+                uf = UnionFind()
+                uf.add_many(all_ids)
+                for id_a, id_b, _score in pairs_list:
+                    uf.union(id_a, id_b)
+                member_sets = uf.get_clusters()
+                del uf
+
+    # --- Step 2: build the SAME pre-split result dict as the dict path. ----
+    with stage("cluster_sort_clusters"):
+        sorted_clusters = sorted(member_sets, key=lambda s: min(s))
+        del member_sets
+
+    with stage("cluster_member_to_cid"):
+        member_to_cid: dict[int, int] = {}
+        for cluster_id, members in enumerate(sorted_clusters, start=1):
+            for m in members:
+                member_to_cid[m] = cluster_id
+
+    with stage("cluster_result_dict_init"):
+        result: dict[int, dict] = {}
+        for cluster_id, members in enumerate(sorted_clusters, start=1):
+            size = len(members)
+            result[cluster_id] = {
+                "members": list(members),
+                "size": size,
+                "oversized": size > max_cluster_size,
+                "pair_scores": {},
+            }
+
+    # --- Step 3: pair_scores (ORDER-PRESERVING -- NOT a join). -------------
+    # A Polars join would reorder rows and break the sequential-sum +
+    # first-occurrence bottleneck tie-break parity. replace_strict maps id_a ->
+    # cluster_id in place; iterate the frame IN ROW ORDER (= pairs order).
+    # Duplicate canonical pairs overwrite (last wins), matching the dict path.
+    with stage("cluster_pair_scores_fill"):
+        if not pairs_df.is_empty():
+            tagged = pairs_df.with_columns(
+                _pl.col("id_a").replace_strict(member_to_cid).alias("__cid__"),
+            )
+            for id_a, id_b, score, cid in zip(
+                tagged["id_a"].to_list(),
+                tagged["id_b"].to_list(),
+                tagged["score"].to_list(),
+                tagged["__cid__"].to_list(),
+                strict=True,
+            ):
+                result[int(cid)]["pair_scores"][(id_a, id_b)] = score
+        del member_to_cid
+        del sorted_clusters
+
+    # --- Step 4: confidence + bottleneck on PRE-split clusters. ------------
+    with stage("cluster_compute_confidence"):
+        for cid, cinfo in result.items():
+            conf = compute_cluster_confidence(cinfo["pair_scores"], cinfo["size"])
+            cinfo["confidence"] = conf["confidence"]
+            cinfo["bottleneck_pair"] = conf["bottleneck_pair"]
+
+    # --- Steps 5-7: auto-split + cluster_quality + emit (shared tail). -----
+    return _finalize_clusters(
+        result, max_cluster_size, weak_cluster_threshold, auto_split,
     )
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -571,6 +571,14 @@ def _finalize_clusters(
             cinfo["oversized"] = cinfo["size"] > max_cluster_size
             result[cid] = cinfo
             continue
+        # Deterministic cluster-id assignment. The native mst_split_components
+        # kernel returns sub-clusters in Rust HashMap iteration order
+        # (nondeterministic per call), which made split-cluster ids vary
+        # run-to-run -- and diverge between the dict and columnar build paths,
+        # which call this independently. Sort by min member so next_cid below is
+        # assigned stably. The partition content is already deterministic; this
+        # only pins the labels, the durability invariant identity ids depend on.
+        sub_clusters.sort(key=lambda sc: min(sc["members"]))
         next_cid = max(result.keys(), default=0) + 1
         for sc in sub_clusters:
             sc["oversized"] = sc["size"] > max_cluster_size

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -416,6 +416,48 @@ def build_clusters(
             seen.add(id_b)
         all_ids = list(seen)
 
+    # SP1 (columnar cluster-build core): when enabled, build the same
+    # ``dict[int, dict]`` via the columnar Arrow path. Default OFF; the output
+    # is byte-identical to the dict path (parity gate
+    # tests/test_columnar_cluster_build_parity.py), differing only in member
+    # LIST ORDER (a separate Union-Find -> compared as a set). Gate goes AFTER
+    # the Ray short-circuit, the DataFrame branch, and the all_ids derivation so
+    # it never intercepts Ray and always has a concrete pairs list + all_ids.
+    if _columnar_cluster_build_enabled():
+        return _build_clusters_via_frames(
+            pairs, all_ids, max_cluster_size, weak_cluster_threshold, auto_split,
+        )
+
+    return _build_clusters_dict_path(
+        pairs, all_ids, max_cluster_size, weak_cluster_threshold, auto_split,
+    )
+
+
+def _columnar_cluster_build_enabled() -> bool:
+    """Columnar cluster-build core for ``build_clusters`` (SP1): build the
+    ``dict[int, dict]`` via the two-frame columnar path
+    (``_build_clusters_via_frames``) instead of the list/dict Union-Find path.
+    Default OFF -- byte-identical to the dict path on OUTPUT (member list order
+    aside; a separate UF runs so order legitimately differs but membership is
+    identical). Kill-switch ``GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=0`` (the
+    default) restores the dict path. Mirrors the identity
+    ``_batch_fingerprint_enabled`` gate."""
+    return os.environ.get(
+        "GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "0"
+    ).strip() != "0"
+
+
+def _build_clusters_dict_path(
+    pairs: Any,
+    all_ids: list[int],
+    max_cluster_size: int,
+    weak_cluster_threshold: float,
+    auto_split: bool,
+) -> dict[int, dict]:
+    """Legacy list/dict Union-Find cluster build. Verbatim extraction of the
+    original ``build_clusters`` body (UF stage -> emit); behavior is unchanged.
+    The columnar path (``_build_clusters_via_frames``) shares the tail via
+    ``_finalize_clusters``."""
     with stage("cluster_connected_components"):
         if native_enabled("clustering"):
             # Native Union-Find (component membership is identical to the Python
@@ -480,6 +522,25 @@ def build_clusters(
             cinfo["confidence"] = conf["confidence"]
             cinfo["bottleneck_pair"] = conf["bottleneck_pair"]
 
+    return _finalize_clusters(
+        result, max_cluster_size, weak_cluster_threshold, auto_split,
+    )
+
+
+def _finalize_clusters(
+    result: dict[int, dict],
+    max_cluster_size: int,
+    weak_cluster_threshold: float,
+    auto_split: bool,
+) -> dict[int, dict]:
+    """Shared cluster-build tail: auto-split oversized clusters, assign
+    ``cluster_quality`` (+ weak confidence downgrade), then emit the profile.
+
+    Reads only ``result`` (the pre-split per-cluster dict with members/size/
+    oversized/pair_scores/confidence/bottleneck_pair) plus the three params. Both
+    the dict path and the columnar path call this so split/quality/emit are
+    byte-identical. OWNS the ``_emit_cluster_profile`` call -- callers must NOT
+    emit again."""
     # Auto-split oversized clusters (when enabled). See _split_edge_work_budget:
     # the per-pass single-weakest-edge split degrades to O(nodes * edges) on a
     # large dense cluster, so two guards keep the loop terminating without
@@ -547,6 +608,21 @@ def build_clusters(
 
     _emit_cluster_profile(result)
     return result
+
+
+def _build_clusters_via_frames(
+    pairs: Any,
+    all_ids: list[int],
+    max_cluster_size: int,
+    weak_cluster_threshold: float,
+    auto_split: bool,
+) -> dict[int, dict]:
+    """Columnar cluster-build core (SP1). Step 3 stub: delegates to the dict
+    path so the gate is a verified no-op refactor. Step 4 replaces this body
+    with the real columnar build."""
+    return _build_clusters_dict_path(
+        pairs, all_ids, max_cluster_size, weak_cluster_threshold, auto_split,
+    )
 
 
 def compute_cluster_confidence(

--- a/packages/python/goldenmatch/scripts/bench_columnar_cluster_build.py
+++ b/packages/python/goldenmatch/scripts/bench_columnar_cluster_build.py
@@ -1,0 +1,270 @@
+"""Measure-first harness: columnar cluster-build (gate ON) vs dict path (gate OFF).
+
+SP2 decision bench for the Arrow-native columnar-cluster roadmap. Task 1 landed
+the columnar core behind ``GOLDENMATCH_COLUMNAR_CLUSTER_BUILD`` (default OFF);
+this bench measures wall + peak RSS of ``build_clusters(pairs, ...)`` with the
+gate OFF (verbatim dict path) vs ON (columnar two-frame path), at scale, with a
+fresh native build in CI (so gate-ON exercises the real Arrow UF kernel, not the
+off-native fallback).
+
+Each variant runs in its OWN subprocess (``--child {off|on}``) so wall AND peak
+RSS are clean -- the off variant's allocations and the gate's in-process state
+never leak into the on variant's numbers. The parent spawns both children per N,
+parses their JSON, and assembles the markdown table.
+
+Parity is asserted FIRST, in-process, on a small N: gate-OFF and gate-ON must
+produce byte-identical dicts (members compared as a frozenset; everything else
+strict). A perf number on a non-byte-identical path is meaningless, so parity
+failure short-circuits before the perf loop.
+
+Run via the bench-columnar-cluster-build workflow (large runner, fresh native).
+Local smoke: python ... --np 50000 --runs 1  (gate-ON uses the off-native
+columnar fallback; resource is unavailable on Windows so RSS is 0.0 -- fine).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _make_pairs_df(n_pairs_target: int):
+    """Build a frame of ~n_pairs_target intra-cluster pairs.
+
+    M clusters of size k=5 -> 10 pairs each. Deterministic, no RNG (we want
+    reproducibility across runs and harnesses)."""
+    import polars as pl
+
+    k = 5
+    per = k * (k - 1) // 2  # 10
+    m = max(1, n_pairs_target // per)
+    a_col: list[int] = []
+    b_col: list[int] = []
+    for c in range(m):
+        base = c * k
+        for i in range(k):
+            for j in range(i + 1, k):
+                a_col.append(base + i)
+                b_col.append(base + j)
+    s_col = [0.95] * len(a_col)
+    return pl.DataFrame(
+        {"id_a": a_col, "id_b": b_col, "score": s_col},
+        schema={"id_a": pl.Int64, "id_b": pl.Int64, "score": pl.Float64},
+    )
+
+
+def _pairs_list_from_df(pairs_df) -> list[tuple[int, int, float]]:
+    """Convert the pair frame to the list[(int, int, float)] form
+    ``build_clusters`` consumes (mirrors the spike's pairs_list zip)."""
+    return list(
+        zip(
+            pairs_df["id_a"].to_list(),
+            pairs_df["id_b"].to_list(),
+            pairs_df["score"].to_list(),
+        )
+    )
+
+
+def _peak_rss_mb() -> float:
+    try:
+        import resource
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+    except Exception:
+        return 0.0
+
+
+def _norm(cinfo: dict) -> dict:
+    """Normalise one cluster info dict for parity comparison: members as a
+    frozenset (separate UF -> list order legitimately differs), drop _was_split.
+    Mirrors tests/test_columnar_cluster_build_parity.py::_norm."""
+    out = {k: v for k, v in cinfo.items() if k not in ("members", "_was_split")}
+    out["members"] = frozenset(cinfo["members"])
+    return out
+
+
+def _run_child(variant: str, n_pairs: int, runs: int) -> int:
+    """Child mode: set the gate, build pairs once, run build_clusters R times,
+    print ONE JSON line with walls + peak RSS for this variant only."""
+    os.environ["GOLDENMATCH_COLUMNAR_CLUSTER_BUILD"] = "1" if variant == "on" else "0"
+
+    import polars as pl  # noqa: F401
+    from goldenmatch.core.cluster import build_clusters
+
+    pairs_df = _make_pairs_df(n_pairs)
+    pairs_list = _pairs_list_from_df(pairs_df)
+    actual_pairs = pairs_df.height
+
+    # Warm once (kept out of the timed walls).
+    build_clusters(pairs_list, auto_split=True)
+
+    walls: list[float] = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        build_clusters(pairs_list, auto_split=True)
+        walls.append(time.perf_counter() - t0)
+
+    print(json.dumps({
+        "variant": variant,
+        "n_pairs": actual_pairs,
+        "walls": walls,
+        "peak_rss_mb": _peak_rss_mb(),
+    }), flush=True)
+    return 0
+
+
+def _assert_parity(n_pairs: int) -> bool:
+    """In-process parity on a small N: gate OFF vs ON must be byte-identical
+    (members as a set, everything else strict). Returns True on parity."""
+    from goldenmatch.core.cluster import build_clusters
+
+    pairs_df = _make_pairs_df(n_pairs)
+    pairs_list = _pairs_list_from_df(pairs_df)
+
+    os.environ["GOLDENMATCH_COLUMNAR_CLUSTER_BUILD"] = "0"
+    off = build_clusters(pairs_list, auto_split=True)
+
+    os.environ["GOLDENMATCH_COLUMNAR_CLUSTER_BUILD"] = "1"
+    on = build_clusters(pairs_list, auto_split=True)
+
+    if on.keys() != off.keys():
+        print(f"PARITY FAIL: cluster id sets differ "
+              f"(off={len(off)} ids, on={len(on)} ids)", flush=True)
+        return False
+    for cid in off:
+        if _norm(on[cid]) != _norm(off[cid]):
+            print(f"PARITY FAIL: cluster {cid} differs:\n"
+                  f"  off={off[cid]}\n  on={on[cid]}", flush=True)
+            return False
+    return True
+
+
+def _bench_variant(variant: str, n: int, runs: int) -> dict[str, Any]:
+    """Spawn a child subprocess for one variant + N. Raises on non-zero exit."""
+    cmd = [
+        sys.executable, os.path.abspath(__file__),
+        "--child", variant, "--np", str(n), "--runs", str(runs),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"child {variant} np={n} exited {proc.returncode}\n"
+            f"--- stderr ---\n{proc.stderr.strip()}"
+        )
+    # The child prints native-availability lines too; take the last JSON line.
+    last_json = None
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            last_json = line
+    if last_json is None:
+        raise RuntimeError(
+            f"child {variant} np={n} produced no JSON line\n"
+            f"--- stdout ---\n{proc.stdout.strip()}"
+        )
+    return json.loads(last_json)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--np", default="1000000,5000000",
+                    help="Comma-separated target pair counts")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--output", default=None)
+    ap.add_argument("--child", choices=["off", "on"], default=None,
+                    help="Internal: run a single variant in this process")
+    args = ap.parse_args()
+
+    runs = max(1, args.runs)
+
+    # Child mode: one variant, one N, one JSON line.
+    if args.child is not None:
+        nps = [int(x.strip()) for x in args.np.split(",") if x.strip()]
+        n = nps[0] if nps else 1000000
+        return _run_child(args.child, n, runs)
+
+    nps = [int(x.strip()) for x in args.np.split(",") if x.strip()]
+
+    # Native availability (records whether gate-ON hit the real Arrow kernel).
+    from goldenmatch.core._native_loader import native_available, native_module
+    print(f"native importable: {native_available()}", flush=True)
+    m = native_module()
+    print(f"build_clusters_arrow exposed: "
+          f"{bool(m) and hasattr(m, 'build_clusters_arrow')}", flush=True)
+
+    # PARITY FIRST -- byte-identical or bust, before any perf measurement.
+    parity_n = 2000
+    print(f"parity check (np={parity_n:,}) ...", flush=True)
+    if not _assert_parity(parity_n):
+        print("ERROR: gate ON is NOT byte-identical to gate OFF; "
+              "refusing to report perf on a non-parity path.", flush=True)
+        return 1
+    print("parity OK", flush=True)
+
+    results = []
+    for n in nps:
+        print(f"  target_pairs={n:,} ...", flush=True)
+        try:
+            off = _bench_variant("off", n, runs)
+            on = _bench_variant("on", n, runs)
+            off_s = statistics.median(off["walls"])
+            on_s = statistics.median(on["walls"])
+            row = {
+                "n_pairs": off["n_pairs"],
+                "off_s": off_s,
+                "on_s": on_s,
+                "speedup": (off_s / on_s) if on_s else float("nan"),
+                "off_rss_mb": off["peak_rss_mb"],
+                "on_rss_mb": on["peak_rss_mb"],
+            }
+            results.append(row)
+            sp = f"{row['speedup']:.2f}x" if row["speedup"] == row["speedup"] else "n/a"
+            print(f"    pairs={row['n_pairs']:,}  off={off_s:.3f}s  "
+                  f"on={on_s:.3f}s  speedup={sp}", flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  target_pairs={n:,}  ERROR {type(exc).__name__}: {exc}",
+                  flush=True)
+            results.append({"n_pairs": n, "error": str(exc)})
+
+    lines = [
+        "\n## bench-columnar-cluster-build\n",
+        f"| {'pairs':>12} | {'off (s)':>10} | {'on (s)':>10} | "
+        f"{'speedup':>9} | {'off RSS MB':>11} | {'on RSS MB':>11} |",
+        f"| {'-'*12} | {'-'*10} | {'-'*10} | {'-'*9} | {'-'*11} | {'-'*11} |",
+    ]
+    for r in results:
+        if "error" in r:
+            lines.append(
+                f"| {r['n_pairs']:>12,} | {'ERROR':>10} | {'ERROR':>10} | "
+                f"{'n/a':>9} | {'n/a':>11} | {'n/a':>11} |"
+            )
+            continue
+        sp = f"{r['speedup']:.2f}x" if r["speedup"] == r["speedup"] else "n/a"
+        lines.append(
+            f"| {r['n_pairs']:>12,} | {r['off_s']:>10.3f} | {r['on_s']:>10.3f} | "
+            f"{sp:>9} | {r['off_rss_mb']:>11.1f} | {r['on_rss_mb']:>11.1f} |"
+        )
+    table = "\n".join(lines)
+    print(table, flush=True)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        try:
+            with open(summary, "a", encoding="utf-8") as fh:
+                fh.write(table + "\n")
+        except OSError:
+            pass
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump({"results": results}, fh, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/tests/test_columnar_cluster_build_parity.py
+++ b/packages/python/goldenmatch/tests/test_columnar_cluster_build_parity.py
@@ -1,0 +1,79 @@
+"""Byte-identical parity: ``GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1`` (columnar
+cluster-build core via ``_build_clusters_via_frames``) must produce a
+``dict[int, dict]`` that is IDENTICAL to the default dict path -- key for key,
+under BOTH ``GOLDENMATCH_NATIVE`` states.
+
+This is the durability gate for SP1 of the Arrow-native columnar-cluster
+roadmap. The columnar path feeds golden-record + identity-graph durability, so
+parity is the hard invariant. ``members`` is compared as a SET (the columnar
+path runs a SEPARATE Union-Find, so list order legitimately differs -- PR #598
+removed sorting); EVERYTHING ELSE (pair_scores, confidence EXACT float,
+bottleneck_pair, cluster_quality, oversized, cluster ids) is STRICT
+byte-identical.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.core.cluster import build_clusters
+
+
+def _adversarial_pairs():
+    # Cluster A: singleton id 0 (no pairs). Cluster B: 2-member {1,2}.
+    # Cluster C: fully-connected {3,4,5}. Cluster D: weak chain {6,7,8}
+    # (one weak edge -> triggers weak). Cluster E: oversized that SPLITS
+    # (a barbell: two dense triangles joined by one weak bridge, > max_cluster_size=5).
+    # Cluster F: score-tied edges (bottleneck tie-break). Plus duplicate canonical pair.
+    # Cluster G: DENSE oversized clique {30..36} all at 0.99 (no weak bridge) ->
+    # split_oversized_cluster returns it unchanged -> stays oversized, exercises
+    # the no-progress guard.
+    pairs = [
+        (1, 2, 0.95),
+        (3, 4, 0.9), (4, 5, 0.92), (3, 5, 0.88),
+        (6, 7, 0.99), (7, 8, 0.40),                 # weak: avg-min large
+        # barbell oversized (ids 10..16, 7 members > max 5):
+        (10, 11, 0.99), (11, 12, 0.99), (10, 12, 0.99),
+        (14, 15, 0.99), (15, 16, 0.99), (14, 16, 0.99),
+        (12, 14, 0.31),                              # weak bridge -> splits
+        (20, 21, 0.5), (20, 22, 0.5),                # score ties -> bottleneck first-occurrence
+        (1, 2, 0.95),                                # duplicate canonical pair
+        # dense oversized clique 30..36 (7 members > max 5), all 0.99, no weak
+        # bridge -> can't split -> stays oversized (no-progress guard):
+        (30, 31, 0.99), (30, 32, 0.99), (30, 33, 0.99), (30, 34, 0.99),
+        (30, 35, 0.99), (30, 36, 0.99), (31, 32, 0.99), (31, 33, 0.99),
+        (31, 34, 0.99), (31, 35, 0.99), (31, 36, 0.99), (32, 33, 0.99),
+        (32, 34, 0.99), (32, 35, 0.99), (32, 36, 0.99), (33, 34, 0.99),
+        (33, 35, 0.99), (33, 36, 0.99), (34, 35, 0.99), (34, 36, 0.99),
+        (35, 36, 0.99),
+    ]
+    all_ids = list(range(0, 23)) + list(range(30, 37))
+    return pairs, all_ids
+
+
+def _norm(cinfo: dict) -> dict:
+    out = {k: v for k, v in cinfo.items() if k not in ("members", "_was_split")}
+    out["members"] = frozenset(cinfo["members"])
+    return out
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_columnar_build_byte_identical(monkeypatch, native):
+    import goldenmatch.core.cluster as _cmod
+    pairs, all_ids = _adversarial_pairs()
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+
+    monkeypatch.setenv("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "0")
+    off = build_clusters(pairs, all_ids=all_ids, max_cluster_size=5,
+                         weak_cluster_threshold=0.3, auto_split=True)
+
+    calls = []
+    real = _cmod._build_clusters_via_frames
+    monkeypatch.setattr(_cmod, "_build_clusters_via_frames",
+                        lambda *a, **k: (calls.append(1), real(*a, **k))[1])
+    monkeypatch.setenv("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "1")
+    on = build_clusters(pairs, all_ids=all_ids, max_cluster_size=5,
+                        weak_cluster_threshold=0.3, auto_split=True)
+    assert calls, "columnar path (_build_clusters_via_frames) did not run with gate ON"
+
+    assert on.keys() == off.keys()
+    for cid in off:
+        assert _norm(on[cid]) == _norm(off[cid]), f"cluster {cid} differs:\n on={on[cid]}\n off={off[cid]}"

--- a/packages/python/goldenmatch/tests/test_columnar_cluster_build_parity.py
+++ b/packages/python/goldenmatch/tests/test_columnar_cluster_build_parity.py
@@ -84,6 +84,25 @@ def test_columnar_build_byte_identical(monkeypatch, native):
                         weak_cluster_threshold=0.3, auto_split=True)
     assert calls, "columnar path (_build_clusters_via_frames) did not run with gate ON"
 
-    assert on.keys() == off.keys()
+    if on.keys() != off.keys():
+        def _digest(d: dict) -> dict:
+            return {
+                cid: {
+                    "members": sorted(c["members"]),
+                    "size": c["size"],
+                    "oversized": c["oversized"],
+                    "quality": c.get("cluster_quality"),
+                }
+                for cid, c in d.items()
+            }
+        only_on = sorted(set(on) - set(off))
+        only_off = sorted(set(off) - set(on))
+        raise AssertionError(
+            f"cluster-id sets differ (native={native}):\n"
+            f"  n_on={len(on)} n_off={len(off)}\n"
+            f"  only_on={only_on}\n  only_off={only_off}\n"
+            f"  ON  digest={_digest(on)}\n"
+            f"  OFF digest={_digest(off)}"
+        )
     for cid in off:
         assert _norm(on[cid]) == _norm(off[cid]), f"cluster {cid} differs:\n on={on[cid]}\n off={off[cid]}"

--- a/packages/python/goldenmatch/tests/test_columnar_cluster_build_parity.py
+++ b/packages/python/goldenmatch/tests/test_columnar_cluster_build_parity.py
@@ -61,6 +61,16 @@ def test_columnar_build_byte_identical(monkeypatch, native):
     pairs, all_ids = _adversarial_pairs()
     monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
 
+    if native == "1":
+        from goldenmatch.core._native_loader import native_module
+        nm = native_module()
+        if nm is None or getattr(nm, "build_clusters_arrow", None) is None:
+            pytest.skip(
+                "native cluster kernel (build_clusters_arrow/mst_split_components) "
+                "absent in this environment; native=1 parity is validated in CI's "
+                "fresh native build"
+            )
+
     monkeypatch.setenv("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "0")
     off = build_clusters(pairs, all_ids=all_ids, max_cluster_size=5,
                          weak_cluster_threshold=0.3, auto_split=True)


### PR DESCRIPTION
## Summary

Phase-2 SP1 of the Arrow-native roadmap (#663-B / #624). Makes `core/cluster.py::build_clusters` able to compute clusters via a **columnar core** behind a default-OFF gate (`GOLDENMATCH_COLUMNAR_CLUSTER_BUILD`), emitting a **byte-identical** `dict[int,dict]` via an adapter so the ~25 cluster consumers are untouched. This is the SP2..N-enabling foundation; default-on is deferred to the measure-first bench.

- **`_build_clusters_via_frames`**: Arrow UF (`build_clusters_arrow_native` when the native kernel is present; off-native sources UF directly from `connected_components`/Python `UnionFind`, NOT the v2 fallback which would double-split) + order-preserving `pair_scores` via `replace_strict` (not a join) + confidence via `compute_cluster_confidence`.
- **`_finalize_clusters`**: shared auto-split + cluster_quality + emit tail, called by both the dict path and the columnar path so the parity surface is just UF + pair_scores + confidence.
- **`_build_clusters_dict_path`**: the existing body extracted verbatim (no-op refactor commit).
- Gate is read AFTER the Ray short-circuit, so it never intercepts the distributed path.

## Parity invariant

The cluster dict feeds golden-record + identity-graph durability, so output is **strict byte-identical** gate-on vs gate-off on `pair_scores`, `confidence` (exact float), `bottleneck_pair`, `cluster_quality`, `oversized`, and cluster ids. Only `members` LIST order may differ (the columnar path runs a separate UF; the dict path itself does not sort members, PR #598), so the parity gate compares `members` as a set.

## Measure-first bench (Task 2)

`scripts/bench_columnar_cluster_build.py` + `bench-columnar-cluster-build.yml` (workflow_dispatch, large runner, fresh native) compare gate-OFF vs gate-ON wall + peak RSS at 1M/5M, with a parity assertion first. Dispatched after merge; ship default-on only if the columnar build beats the dict build net of the adapter, else keep gated.

## Test plan

- [x] `tests/test_columnar_cluster_build_parity.py` byte-identical gate (adversarial fixture: singleton id 0, weak chain, oversized-that-splits, dense oversized that can't split, score-tied bottleneck, duplicate pairs). `native=0` passes locally; `native=1` validated in CI's fresh native build (local `_native.pyd` is stale, lacks `build_clusters_arrow`/`mst_split_components`, can't rebuild locally).
- [x] `test_golden.py` green with the gate forced ON.
- [x] `test_cluster.py`: no new failures with the gate ON (the 9 `mst_split_components` failures are the pre-existing stale-local-kernel artifact, identical on both gate states).
- [x] ruff clean.

> Note: the real Arrow-kernel native path (`build_clusters_arrow_native`) is **CI-only validated** here, since the in-tree `_native.pyd` is stale and the pinned Rust toolchain is unavailable locally. The CI lane builds native fresh and runs the `native=1` parity case.