### PR TITLE
feat(identity): ClusterPairScores lazy view + identity evidence-edge migration (Phase 2 SP2, gated)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-cluster-pairscore-view.md
+++ b/docs/superpowers/plans/2026-06-02-cluster-pairscore-view.md
@@ -197,6 +197,8 @@ Use the loop's `cluster_id` (NOT `cid`). Behavior is byte-identical because `for
 
 In `core/pipeline.py`, after the cluster-build `if/else` block closes (after ~`:1460`, where `clusters` is the dict), and before `_resolve_identities` (`:1714`): when `_columnar_cluster_build_enabled()` (import from `core.cluster`), build `view = ClusterPairScores.from_cluster_dict(clusters)`; else `view = None`. Thread `view` through `_resolve_identities` (`:245`) into its `resolve_clusters(...)` call (~`:308`) as `pair_score_view=view`. Build the view ONCE; reuse if other call sites need it later (SP3+).
 
+**Gate trap (IMPORTANT):** `pipeline.py` has TWO live columnar gates. Use `_columnar_cluster_build_enabled()` (from `core.cluster`, reads `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD`) for the view — the SAME gate that drives the columnar `build_clusters`. Do NOT reuse the in-scope local `_use_columnar` flag (pipeline.py:1445, reads the DIFFERENT `GOLDENMATCH_COLUMNAR_PIPELINE` via `_columnar_pipeline_enabled()`); that's an unrelated gate and wiring the view to it would mis-gate the migration.
+
 - [ ] **Step 5: Run — verify PASS (both native states)**
 
 Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscore_view_parity.py -v`

--- a/docs/superpowers/plans/2026-06-02-cluster-pairscore-view.md
+++ b/docs/superpowers/plans/2026-06-02-cluster-pairscore-view.md
@@ -1,0 +1,297 @@
+# Lazy cluster pair-score view + identity/golden migration (Phase 2 SP2) — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `ClusterPairScores` lazy view sourced from the FINAL (post-split) cluster partition, and migrate the two durability/output-critical `pair_scores` consumers — `identity/resolve.py` (evidence edges + bottleneck) and golden `confidence_majority` — onto it, behind the existing `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` gate, BYTE-IDENTICAL.
+
+**Architecture:** A new `core/cluster_pairscores.py::ClusterPairScores` flattens the final `build_clusters` result's per-cluster `pair_scores` into a `(cluster_id, id_a, id_b, score)` frame and exposes `iter_clusters()` (one columnar pass for identity) + `for_cluster(cid)` (per-cluster dict for golden + bottleneck). The pipeline constructs the view from the returned cluster dict when the gate is ON and threads it (optional param) into the resolver and the golden build; both fall back to `cluster["pair_scores"]` when no view is passed. Because `view.for_cluster(cid)` returns the SAME data as the dict, parity is byte-identical by construction; the parity gates prove no drift, native AND off-native.
+
+**Tech Stack:** Python 3.11+, Polars. Pure-Python SP2. No new Rust kernel; no `ClusterFrames` schema change.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-cluster-pairscore-view-design.md` — READ it. **Branch:** `feat/cluster-pairscore-view`.
+
+**Run tests:** `cd packages/python/goldenmatch && ../../../.venv/Scripts/python.exe -m pytest <path> -v`. ruff: `D:/show_case/goldenmatch/.venv/Scripts/python.exe -m ruff check <files>`. Do NOT run the full suite (xdist OOMs); targeted files only. The native cluster kernel is CI-only-validatable locally (stale `_native.pyd`); SP2 is pure-Python so this only affects the native parity lane (CI).
+
+## Background the implementer needs
+
+- `build_clusters(...) -> dict[int,dict]` (`core/cluster.py:361`). When `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD != "0"` it runs the columnar path; either way the returned dict is byte-identical (SP1, PR #673). Each cluster dict: `members, size, oversized, pair_scores (dict[(a,b)->score]), confidence, bottleneck_pair, cluster_quality`. `pair_scores` is in pairs-input order, last-wins on duplicate canonical pairs, and reflects the FINAL post-split partition (cross-cut edges dropped by `split_oversized_cluster`).
+- `identity/resolve.py`: evidence edges emitted by `for pair_key, score in info["pair_scores"].items()` at `:560`; bottleneck-score lookup `info.get("pair_scores", {}).get((min,max))` at `:601-602`. The enclosing loop has the cluster id and `info` (the cluster dict).
+- `golden.py::_confidence_majority` (`:235+`) reads a per-cluster `pair_scores` dict (param). Only the `confidence_majority` strategy (and `custom:` plugin strategies) read it; the columnar `build_golden_records_df` fast path does NOT. The pipeline golden build is at `pipeline.py:1591-1615`; it passes each multi-member cluster's `pair_scores` into `build_golden_records_batch`.
+- The gate helper `_columnar_cluster_build_enabled()` already exists in `core/cluster.py` (reads `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD`, default `"0"`).
+
+---
+
+## File Structure
+
+- **Create** `packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py`: `ClusterPairScores` (the view). One responsibility: serve per-cluster pair scores from a flat frame.
+- **Create** `packages/python/goldenmatch/tests/test_cluster_pairscores.py`: view unit tests.
+- **Modify** `packages/python/goldenmatch/goldenmatch/identity/resolve.py`: optional `pair_score_view` param; read evidence-edge + bottleneck scores from it when provided.
+- **Modify** `packages/python/goldenmatch/goldenmatch/core/pipeline.py`: when the gate is ON, build the view from the returned cluster dict and thread it into the resolver and golden build.
+- **Create** `packages/python/goldenmatch/tests/test_cluster_pairscore_view_parity.py`: byte-identical evidence-edge + golden parity gates (gate ON vs OFF, native + off-native).
+- **Create** `packages/python/goldenmatch/scripts/bench_cluster_pairscore_view.py` + `.github/workflows/bench-cluster-pairscore-view.yml`: measure-first bench.
+
+---
+
+## Task 1: `ClusterPairScores` view + unit tests
+
+**Files:**
+- Create: `packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py`
+- Test: `packages/python/goldenmatch/tests/test_cluster_pairscores.py`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+```python
+import polars as pl
+import pytest
+from goldenmatch.core.cluster_pairscores import ClusterPairScores
+
+
+def _clusters():
+    # cid 1: singleton (no pairs). cid 2: {1,2} one pair. cid 3: {3,4,5} three pairs
+    # incl a duplicate canonical pair (last-wins).
+    return {
+        1: {"members": [0], "size": 1, "pair_scores": {}},
+        2: {"members": [1, 2], "size": 2, "pair_scores": {(1, 2): 0.9}},
+        3: {"members": [3, 4, 5], "size": 3,
+            "pair_scores": {(3, 4): 0.8, (4, 5): 0.7, (3, 5): 0.6}},
+    }
+
+
+def test_for_cluster_matches_dict_exactly():
+    clusters = _clusters()
+    view = ClusterPairScores.from_cluster_dict(clusters)
+    for cid, info in clusters.items():
+        assert view.for_cluster(cid) == info["pair_scores"]
+
+
+def test_for_cluster_missing_or_singleton_is_empty():
+    view = ClusterPairScores.from_cluster_dict(_clusters())
+    assert view.for_cluster(1) == {}      # singleton, no pairs
+    assert view.for_cluster(999) == {}    # absent cluster
+
+
+def test_iter_clusters_yields_pairs_in_row_order():
+    view = ClusterPairScores.from_cluster_dict(_clusters())
+    got = {cid: list(pairs) for cid, pairs in view.iter_clusters()}
+    # only clusters WITH pairs appear; pairs in insertion/row order.
+    assert got[2] == [(1, 2, 0.9)]
+    assert got[3] == [(3, 4, 0.8), (4, 5, 0.7), (3, 5, 0.6)]
+    assert 1 not in got  # singleton contributes no rows
+
+
+def test_last_wins_on_duplicate_canonical_pair():
+    clusters = {7: {"members": [1, 2], "size": 2, "pair_scores": {(1, 2): 0.5}}}
+    # simulate the dict path's last-wins: the dict already collapsed dups, so
+    # from_cluster_dict must preserve whatever the dict holds.
+    view = ClusterPairScores.from_cluster_dict(clusters)
+    assert view.for_cluster(7) == {(1, 2): 0.5}
+
+
+def test_score_for_bottleneck_lookup():
+    view = ClusterPairScores.from_cluster_dict(_clusters())
+    assert view.score_for(3, 3, 5) == 0.6
+    assert view.score_for(3, 9, 9) is None
+```
+
+- [ ] **Step 2: Run — verify FAIL**
+
+Run: `cd packages/python/goldenmatch && ../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscores.py -v`
+Expected: FAIL (`ModuleNotFoundError` / `cluster_pairscores` not defined).
+
+- [ ] **Step 3: Implement `ClusterPairScores`**
+
+```python
+"""Lazy per-cluster pair-score view (Phase 2 SP2). Decouples pair_scores
+consumers (identity evidence edges, golden confidence_majority) from the
+legacy per-cluster ``pair_scores`` dict. Sourced from the FINAL (post-split)
+cluster partition so it is byte-identical to the dict path."""
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+
+class ClusterPairScores:
+    """Serves per-cluster pair scores from a flat ``(cluster_id, id_a, id_b,
+    score)`` table. Construct via :meth:`from_cluster_dict`."""
+
+    __slots__ = ("_by_cid",)
+
+    def __init__(self, by_cid: dict[int, dict[tuple[int, int], float]]):
+        # cid -> {(a, b): score} in insertion (pairs-input) order. Internal;
+        # callers use from_cluster_dict.
+        self._by_cid = by_cid
+
+    @classmethod
+    def from_cluster_dict(cls, clusters: dict[int, dict]) -> "ClusterPairScores":
+        """Build the view from a finalized ``build_clusters`` result dict. Copies
+        each cluster's ``pair_scores`` (already final-partition, pairs-order,
+        last-wins). Clusters with no pairs contribute nothing."""
+        by_cid: dict[int, dict[tuple[int, int], float]] = {}
+        for cid, info in clusters.items():
+            ps = info.get("pair_scores") or {}
+            if ps:
+                by_cid[cid] = dict(ps)
+        return cls(by_cid)
+
+    def for_cluster(self, cid: int) -> dict[tuple[int, int], float]:
+        """That cluster's ``{(a, b): score}`` (empty for singleton/absent)."""
+        return self._by_cid.get(cid, {})
+
+    def iter_clusters(self) -> Iterator[tuple[int, Iterable[tuple[int, int, float]]]]:
+        """Yield ``(cluster_id, pairs)`` for clusters WITH pairs; pairs as
+        ``(a, b, score)`` in row order. One pass for identity's evidence edges."""
+        for cid, ps in self._by_cid.items():
+            yield cid, [(a, b, s) for (a, b), s in ps.items()]
+
+    def score_for(self, cid: int, a: int, b: int) -> float | None:
+        """Score for the canonical pair ``(min, max)`` in ``cid`` (or None)."""
+        return self._by_cid.get(cid, {}).get((min(a, b), max(a, b)))
+```
+
+(NOTE: SP2 sources from the final result dict, so the internal repr is a
+dict-of-dicts, NOT a Polars frame. The spec's "flat frame" is the conceptual
+model; a dict-of-dicts is the simplest byte-identical-safe backing and avoids a
+premature flatten/partition_by that would only pay off once the BUILD produces
+the frame natively — explicitly deferred to a later SP. The `iter_clusters`
+interface is frame-ready: a future SP can swap the backing to a Polars
+`partition_by` without touching consumers.)
+
+- [ ] **Step 4: Run — verify PASS**
+
+Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscores.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: ruff + commit**
+
+ruff check the two files. Commit: `feat(cluster): ClusterPairScores lazy view (SP2 foundation)`.
+
+---
+
+## Task 2: identity migration + byte-identical evidence-edge parity gate
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/identity/resolve.py`
+- Modify: `packages/python/goldenmatch/goldenmatch/core/pipeline.py`
+- Test: `packages/python/goldenmatch/tests/test_cluster_pairscore_view_parity.py`
+
+- [ ] **Step 1: Write the failing byte-identical evidence-edge parity test**
+
+The test runs identity resolution against a SQLite store with the gate OFF (dict path) and ON (view path) on an adversarial cluster fixture, and asserts the emitted `evidence_edges` are byte-identical. Use the existing identity test harness pattern (`tests/identity/`) for store setup (`IdentityStore(backend="sqlite", path=str(tmp_path/"x.db"))`) and a small dedupe result. Assert the sorted edge tuples `(record_a_id, record_b_id, kind, score)` per entity are identical ON vs OFF, parametrized over `GOLDENMATCH_NATIVE` in `["1","0"]` (skip native=1 when the native cluster kernel is absent, mirroring `tests/test_columnar_cluster_build_parity.py`'s guard). Include an oversized-split cluster in the fixture so the post-split partition is exercised.
+
+The implementer should model the harness on an existing `tests/identity/` resolve test (find one that calls `resolve_clusters`/`_resolve_identities` with a clusters dict). The assertion compares the full edge set read back from the store after resolve, gate ON vs OFF.
+
+- [ ] **Step 2: Run — verify FAIL**
+
+Run: `cd packages/python/goldenmatch && ../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscore_view_parity.py -v -k evidence`
+Expected: FAIL (the resolver doesn't accept/use a view yet, OR — if you write the spy first — the view path isn't wired). Get a genuine RED by asserting (spy) that the view path actually ran with the gate ON.
+
+- [ ] **Step 3: Add the optional `pair_score_view` param to the resolver**
+
+In `identity/resolve.py`, thread an optional `pair_score_view: ClusterPairScores | None = None` into the resolve function that owns the per-cluster loop (the one with `info` at `:559`). Where it currently reads `pair_scores = info.get("pair_scores") or {}` (`:559`) and `info.get("pair_scores", {}).get(...)` (`:601-602`), change to:
+
+```python
+if pair_score_view is not None:
+    pair_scores = pair_score_view.for_cluster(cid)
+else:
+    pair_scores = info.get("pair_scores") or {}
+```
+
+and for the bottleneck lookup:
+
+```python
+bottleneck_score = (
+    pair_score_view.score_for(cid, int(ba), int(bb))
+    if pair_score_view is not None
+    else info.get("pair_scores", {}).get((min(int(ba), int(bb)), max(int(ba), int(bb))))
+)
+```
+
+`cid` is the cluster id from the enclosing loop. Behavior is byte-identical because `for_cluster(cid) == info["pair_scores"]` and `score_for` returns the same canonical-pair score. Do NOT change the edge-emit loop body otherwise.
+
+- [ ] **Step 4: Wire the pipeline to build + pass the view when the gate is ON**
+
+In `core/pipeline.py`, after `clusters = build_clusters(...)` (`:1455`) and before `_resolve_identities` (`:1714`), when `_columnar_cluster_build_enabled()` (import from `core.cluster`), build `view = ClusterPairScores.from_cluster_dict(clusters)` and pass it through `_resolve_identities` into the resolver as `pair_score_view`. When the gate is OFF, pass `None` (today's path). Thread the param through `_resolve_identities`'s signature.
+
+- [ ] **Step 5: Run — verify PASS (both native states)**
+
+Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscore_view_parity.py -v -k evidence`
+Expected: PASS for native=0 (and native=1 if the kernel is present; else SKIP). If edges differ, STOP and report — do not relax. The durability invariant (entity-id evidence edges) is the whole point.
+
+- [ ] **Step 6: ruff + commit**
+
+Commit: `feat(identity): resolve evidence edges via ClusterPairScores view (gated, byte-identical)`.
+
+---
+
+## Task 3: golden migration + byte-identical golden parity gate
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/pipeline.py` (golden build `:1591-1615`)
+- Test: `packages/python/goldenmatch/tests/test_cluster_pairscore_view_parity.py` (add golden case)
+
+- [ ] **Step 1: Write the failing byte-identical golden parity test**
+
+Add a test that builds golden records with the `confidence_majority` strategy on a multi-member-cluster fixture (configure `golden_rules` survivorship `confidence_majority`), gate OFF vs ON, and asserts the golden records are byte-identical. Reuse `tests/test_golden.py` fixtures/patterns for the `confidence_majority` setup. Parametrize `GOLDENMATCH_NATIVE` `["1","0"]` with the same native-skip guard.
+
+- [ ] **Step 2: Run — verify FAIL**
+
+Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscore_view_parity.py -v -k golden`
+Expected: FAIL (golden build not yet sourcing from the view; add a spy to assert the view path ran with the gate ON for a genuine RED).
+
+- [ ] **Step 3: Source the golden build's per-cluster pair_scores from the view when gate ON**
+
+In `pipeline.py:1591-1615`, where the golden build pulls each multi-member cluster's `pair_scores` to pass into `build_golden_records_batch`, source it from `view.for_cluster(cid)` when the view is present (gate ON), else `cluster["pair_scores"]` (today). The view is the SAME one built in Task 2 Step 4 — build it ONCE per pipeline run and reuse for both identity and golden. `confidence_majority` (and `custom:` strategies) then receive the identical per-cluster dict.
+
+- [ ] **Step 4: Run — verify PASS (both native states)**
+
+Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscore_view_parity.py -v`
+Expected: PASS (evidence + golden, native=0; native=1 if kernel present else SKIP). If golden differs, STOP and report.
+
+- [ ] **Step 5: Regression — existing identity + golden suites with the gate ON**
+
+Run: `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1 ../../../.venv/Scripts/python.exe -m pytest tests/identity/ tests/test_golden.py -q`
+Confirm no NEW failures vs gate OFF (flag only new ones; pre-existing native artifacts excepted).
+
+- [ ] **Step 6: ruff + commit**
+
+Commit: `feat(golden): source confidence_majority pair_scores via ClusterPairScores view (gated, byte-identical)`.
+
+---
+
+## Task 4: measure-first bench
+
+**Files:**
+- Create: `packages/python/goldenmatch/scripts/bench_cluster_pairscore_view.py`
+- Create: `.github/workflows/bench-cluster-pairscore-view.yml`
+
+- [ ] **Step 1: Bench script**
+
+Model on `scripts/bench_columnar_cluster_build.py` (SP1's harness — same per-variant subprocess isolation, ASCII table, `$GITHUB_STEP_SUMMARY`). Bench the identity-resolve + golden(`confidence_majority`) stages end-to-end (or the closest measurable slice that exercises the pair_scores consumers) gate OFF vs ON at `--np 1000000,5000000`, median of 3, wall + peak RSS, with a byte-identical assertion (evidence edges + golden) on a small N first. Reuse the SP1 deterministic pair generator. Smoke locally at `--np 50000`.
+
+- [ ] **Step 2: Workflow**
+
+`bench-cluster-pairscore-view.yml`: workflow_dispatch, `runs-on: large-new-64GB`, build native, run the bench. Model on `bench-columnar-cluster-build.yml`.
+
+- [ ] **Step 3: Commit**
+
+Commit: `bench(cluster): SP2 identity+golden view vs dict measure-first harness`.
+
+- [ ] **Step 4 (orchestrator, NOT a subagent step): dispatch + decide gate default**
+
+Merge (workflow must be on main to dispatch), dispatch at 1M/5M, read wall + RSS. Per spec, SP2 MAY flip `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` default-ON if the columnar identity+golden path wins net. If it's a wash/loss (likely, since the view is sourced from the still-materialized dict), keep gated; the abstraction + de-risked identity/golden migration is the deliverable, and a later SP makes the build produce the frame natively. Record the numbers in the spec.
+
+---
+
+## Final validation (orchestrator)
+
+1. `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1 pytest tests/test_cluster_pairscores.py tests/test_cluster_pairscore_view_parity.py tests/identity/ tests/test_golden.py` — green (native=0; native=1 via CI).
+2. Open the PR; CI's native lane validates the native=1 byte-identical evidence-edge + golden gates with the fresh kernel (CI-only — the durability proof, as in SP1).
+3. Dispatch the bench; fold numbers into the spec; decide the gate default.
+
+## Notes for the implementer
+
+- **Byte-identical is the durability invariant** — identity evidence edges feed entity-ids. The view returns the SAME data as the dict (`for_cluster(cid) == info["pair_scores"]`), so parity should be trivial; if it isn't, you wired something wrong — STOP and report, do not relax the gate.
+- **Build the view ONCE per pipeline run** (gate ON), reuse for identity AND golden. DRY.
+- **Gate after the columnar build returns**, at the pipeline level — never reach into `_build_clusters_via_frames` internals (the spec's "construction point" pin).
+- **Native cluster path is CI-only-validatable locally** (stale `_native.pyd`); the parity tests skip native=1 locally and run it in CI's fresh-native lane.
+- **Skill:** @superpowers:test-driven-development per task.

--- a/docs/superpowers/plans/2026-06-02-cluster-pairscore-view.md
+++ b/docs/superpowers/plans/2026-06-02-cluster-pairscore-view.md
@@ -1,34 +1,37 @@
-# Lazy cluster pair-score view + identity/golden migration (Phase 2 SP2) — Implementation Plan
+# Lazy cluster pair-score view + identity migration (Phase 2 SP2) — Implementation Plan
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a `ClusterPairScores` lazy view sourced from the FINAL (post-split) cluster partition, and migrate the two durability/output-critical `pair_scores` consumers — `identity/resolve.py` (evidence edges + bottleneck) and golden `confidence_majority` — onto it, behind the existing `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` gate, BYTE-IDENTICAL.
+**Goal:** Add a `ClusterPairScores` lazy view sourced from the FINAL (post-split) cluster partition, and migrate the `identity/resolve.py` evidence-edge consumer (all three pair_scores read sites) onto it, behind the existing `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` gate, BYTE-IDENTICAL.
 
-**Architecture:** A new `core/cluster_pairscores.py::ClusterPairScores` flattens the final `build_clusters` result's per-cluster `pair_scores` into a `(cluster_id, id_a, id_b, score)` frame and exposes `iter_clusters()` (one columnar pass for identity) + `for_cluster(cid)` (per-cluster dict for golden + bottleneck). The pipeline constructs the view from the returned cluster dict when the gate is ON and threads it (optional param) into the resolver and the golden build; both fall back to `cluster["pair_scores"]` when no view is passed. Because `view.for_cluster(cid)` returns the SAME data as the dict, parity is byte-identical by construction; the parity gates prove no drift, native AND off-native.
+**Architecture:** `core/cluster_pairscores.py::ClusterPairScores` copies the final `build_clusters` result's per-cluster `pair_scores` (dict-of-dicts backing) and exposes `for_cluster(cid)` / `iter_clusters()` / `score_for(cid,a,b)`. The pipeline constructs the view from the returned cluster dict when the gate is ON and threads it (optional param) into `_resolve_identities` -> `resolve_clusters`; the resolver reads pair_scores from the view when provided, else `info["pair_scores"]`. Because `view.for_cluster(cid)` returns the SAME data as the dict, parity is byte-identical by construction; the parity gate proves no drift, native AND off-native.
 
-**Tech Stack:** Python 3.11+, Polars. Pure-Python SP2. No new Rust kernel; no `ClusterFrames` schema change.
+**Tech Stack:** Python 3.11+. Pure-Python SP2. No new Rust kernel; no `ClusterFrames` schema change; no perf bench / gate-default flip (this is an abstraction + de-risking step, not a perf win — see spec "Measure-first / gate").
 
-**Spec:** `docs/superpowers/specs/2026-06-02-cluster-pairscore-view-design.md` — READ it. **Branch:** `feat/cluster-pairscore-view`.
+**Spec:** `docs/superpowers/specs/2026-06-02-cluster-pairscore-view-design.md` — READ it (note the IDENTITY-ONLY re-scope; golden is deferred to issue #678). **Branch:** `feat/cluster-pairscore-view`.
 
 **Run tests:** `cd packages/python/goldenmatch && ../../../.venv/Scripts/python.exe -m pytest <path> -v`. ruff: `D:/show_case/goldenmatch/.venv/Scripts/python.exe -m ruff check <files>`. Do NOT run the full suite (xdist OOMs); targeted files only. The native cluster kernel is CI-only-validatable locally (stale `_native.pyd`); SP2 is pure-Python so this only affects the native parity lane (CI).
 
 ## Background the implementer needs
 
-- `build_clusters(...) -> dict[int,dict]` (`core/cluster.py:361`). When `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD != "0"` it runs the columnar path; either way the returned dict is byte-identical (SP1, PR #673). Each cluster dict: `members, size, oversized, pair_scores (dict[(a,b)->score]), confidence, bottleneck_pair, cluster_quality`. `pair_scores` is in pairs-input order, last-wins on duplicate canonical pairs, and reflects the FINAL post-split partition (cross-cut edges dropped by `split_oversized_cluster`).
-- `identity/resolve.py`: evidence edges emitted by `for pair_key, score in info["pair_scores"].items()` at `:560`; bottleneck-score lookup `info.get("pair_scores", {}).get((min,max))` at `:601-602`. The enclosing loop has the cluster id and `info` (the cluster dict).
-- `golden.py::_confidence_majority` (`:235+`) reads a per-cluster `pair_scores` dict (param). Only the `confidence_majority` strategy (and `custom:` plugin strategies) read it; the columnar `build_golden_records_df` fast path does NOT. The pipeline golden build is at `pipeline.py:1591-1615`; it passes each multi-member cluster's `pair_scores` into `build_golden_records_batch`.
-- The gate helper `_columnar_cluster_build_enabled()` already exists in `core/cluster.py` (reads `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD`, default `"0"`).
+- `build_clusters(...) -> dict[int,dict]` (`core/cluster.py:361`). Returned dict is byte-identical gate ON/OFF (SP1, PR #673). Each cluster: `members, size, oversized, pair_scores (dict[(a,b)->score]), confidence, bottleneck_pair, cluster_quality`. `pair_scores` is pairs-input order, last-wins on dup canonical pairs, FINAL post-split partition.
+- `_columnar_cluster_build_enabled()` (`core/cluster.py:436`, reads `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD`, default `"0"`).
+- `identity/resolve.py`: per-cluster loop header `for cluster_id, info in clusters.items():` (~`:333`). THREE pair_scores read sites in that loop:
+  - bulk fast path (postgres) evidence edges: `pair_scores = info.get("pair_scores") or {}` (~`:396-398`),
+  - slow path evidence edges: `pair_scores = info.get("pair_scores") or {}` (~`:559-560`),
+  - weak bottleneck score: `info.get("pair_scores", {}).get((min(int(ba),int(bb)), max(int(ba),int(bb))))` (~`:601-602`).
+  The loop variable is `cluster_id` (NOT `cid`). `resolve_clusters(...)` signature is at ~`:209` (keyword-friendly for a new optional kwarg).
+- `core/pipeline.py`: cluster build inside an `if _use_columnar / else` block ending ~`:1460` (`build_clusters(...)` at `:1455` is the `else` branch); `_resolve_identities(clusters, ...)` defined at `:245`, called at `:1714`; `_resolve_identities` calls `resolve_clusters(...)` (~`:308`) on the in-memory path.
 
 ---
 
 ## File Structure
 
-- **Create** `packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py`: `ClusterPairScores` (the view). One responsibility: serve per-cluster pair scores from a flat frame.
-- **Create** `packages/python/goldenmatch/tests/test_cluster_pairscores.py`: view unit tests.
-- **Modify** `packages/python/goldenmatch/goldenmatch/identity/resolve.py`: optional `pair_score_view` param; read evidence-edge + bottleneck scores from it when provided.
-- **Modify** `packages/python/goldenmatch/goldenmatch/core/pipeline.py`: when the gate is ON, build the view from the returned cluster dict and thread it into the resolver and golden build.
-- **Create** `packages/python/goldenmatch/tests/test_cluster_pairscore_view_parity.py`: byte-identical evidence-edge + golden parity gates (gate ON vs OFF, native + off-native).
-- **Create** `packages/python/goldenmatch/scripts/bench_cluster_pairscore_view.py` + `.github/workflows/bench-cluster-pairscore-view.yml`: measure-first bench.
+- **Create** `goldenmatch/core/cluster_pairscores.py`: `ClusterPairScores` (the view).
+- **Create** `tests/test_cluster_pairscores.py`: view unit tests.
+- **Modify** `goldenmatch/identity/resolve.py`: optional `pair_score_view` param on `resolve_clusters`; read all three sites from it when provided.
+- **Modify** `goldenmatch/core/pipeline.py`: when the gate is ON, build the view from the returned cluster dict and thread it through `_resolve_identities` into `resolve_clusters`.
+- **Create** `tests/test_cluster_pairscore_view_parity.py`: byte-identical evidence-edge parity gate (gate ON vs OFF, native + off-native).
 
 ---
 
@@ -41,14 +44,11 @@
 - [ ] **Step 1: Write the failing unit tests**
 
 ```python
-import polars as pl
 import pytest
 from goldenmatch.core.cluster_pairscores import ClusterPairScores
 
 
 def _clusters():
-    # cid 1: singleton (no pairs). cid 2: {1,2} one pair. cid 3: {3,4,5} three pairs
-    # incl a duplicate canonical pair (last-wins).
     return {
         1: {"members": [0], "size": 1, "pair_scores": {}},
         2: {"members": [1, 2], "size": 2, "pair_scores": {(1, 2): 0.9}},
@@ -66,66 +66,50 @@ def test_for_cluster_matches_dict_exactly():
 
 def test_for_cluster_missing_or_singleton_is_empty():
     view = ClusterPairScores.from_cluster_dict(_clusters())
-    assert view.for_cluster(1) == {}      # singleton, no pairs
-    assert view.for_cluster(999) == {}    # absent cluster
+    assert view.for_cluster(1) == {}
+    assert view.for_cluster(999) == {}
 
 
 def test_iter_clusters_yields_pairs_in_row_order():
     view = ClusterPairScores.from_cluster_dict(_clusters())
     got = {cid: list(pairs) for cid, pairs in view.iter_clusters()}
-    # only clusters WITH pairs appear; pairs in insertion/row order.
     assert got[2] == [(1, 2, 0.9)]
     assert got[3] == [(3, 4, 0.8), (4, 5, 0.7), (3, 5, 0.6)]
     assert 1 not in got  # singleton contributes no rows
 
 
-def test_last_wins_on_duplicate_canonical_pair():
-    clusters = {7: {"members": [1, 2], "size": 2, "pair_scores": {(1, 2): 0.5}}}
-    # simulate the dict path's last-wins: the dict already collapsed dups, so
-    # from_cluster_dict must preserve whatever the dict holds.
-    view = ClusterPairScores.from_cluster_dict(clusters)
-    assert view.for_cluster(7) == {(1, 2): 0.5}
-
-
 def test_score_for_bottleneck_lookup():
     view = ClusterPairScores.from_cluster_dict(_clusters())
-    assert view.score_for(3, 3, 5) == 0.6
+    assert view.score_for(3, 5, 3) == 0.6   # canonical (min,max) regardless of arg order
     assert view.score_for(3, 9, 9) is None
 ```
 
 - [ ] **Step 2: Run — verify FAIL**
 
 Run: `cd packages/python/goldenmatch && ../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscores.py -v`
-Expected: FAIL (`ModuleNotFoundError` / `cluster_pairscores` not defined).
+Expected: FAIL (`ModuleNotFoundError`).
 
 - [ ] **Step 3: Implement `ClusterPairScores`**
 
 ```python
-"""Lazy per-cluster pair-score view (Phase 2 SP2). Decouples pair_scores
-consumers (identity evidence edges, golden confidence_majority) from the
-legacy per-cluster ``pair_scores`` dict. Sourced from the FINAL (post-split)
-cluster partition so it is byte-identical to the dict path."""
+"""Lazy per-cluster pair-score view (Phase 2 SP2). Decouples the identity
+evidence-edge consumer from the legacy per-cluster ``pair_scores`` dict. Sourced
+from the FINAL (post-split) cluster partition so it is byte-identical to the dict
+path. dict-of-dicts backing; the ``iter_clusters`` interface is frame-ready for a
+future SP that makes the build produce a columnar pair frame natively."""
 from __future__ import annotations
 
 from typing import Iterable, Iterator
 
 
 class ClusterPairScores:
-    """Serves per-cluster pair scores from a flat ``(cluster_id, id_a, id_b,
-    score)`` table. Construct via :meth:`from_cluster_dict`."""
-
     __slots__ = ("_by_cid",)
 
     def __init__(self, by_cid: dict[int, dict[tuple[int, int], float]]):
-        # cid -> {(a, b): score} in insertion (pairs-input) order. Internal;
-        # callers use from_cluster_dict.
         self._by_cid = by_cid
 
     @classmethod
     def from_cluster_dict(cls, clusters: dict[int, dict]) -> "ClusterPairScores":
-        """Build the view from a finalized ``build_clusters`` result dict. Copies
-        each cluster's ``pair_scores`` (already final-partition, pairs-order,
-        last-wins). Clusters with no pairs contribute nothing."""
         by_cid: dict[int, dict[tuple[int, int], float]] = {}
         for cid, info in clusters.items():
             ps = info.get("pair_scores") or {}
@@ -134,36 +118,24 @@ class ClusterPairScores:
         return cls(by_cid)
 
     def for_cluster(self, cid: int) -> dict[tuple[int, int], float]:
-        """That cluster's ``{(a, b): score}`` (empty for singleton/absent)."""
         return self._by_cid.get(cid, {})
 
     def iter_clusters(self) -> Iterator[tuple[int, Iterable[tuple[int, int, float]]]]:
-        """Yield ``(cluster_id, pairs)`` for clusters WITH pairs; pairs as
-        ``(a, b, score)`` in row order. One pass for identity's evidence edges."""
         for cid, ps in self._by_cid.items():
             yield cid, [(a, b, s) for (a, b), s in ps.items()]
 
     def score_for(self, cid: int, a: int, b: int) -> float | None:
-        """Score for the canonical pair ``(min, max)`` in ``cid`` (or None)."""
         return self._by_cid.get(cid, {}).get((min(a, b), max(a, b)))
 ```
-
-(NOTE: SP2 sources from the final result dict, so the internal repr is a
-dict-of-dicts, NOT a Polars frame. The spec's "flat frame" is the conceptual
-model; a dict-of-dicts is the simplest byte-identical-safe backing and avoids a
-premature flatten/partition_by that would only pay off once the BUILD produces
-the frame natively — explicitly deferred to a later SP. The `iter_clusters`
-interface is frame-ready: a future SP can swap the backing to a Polars
-`partition_by` without touching consumers.)
 
 - [ ] **Step 4: Run — verify PASS**
 
 Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscores.py -v`
-Expected: PASS (5 tests).
+Expected: PASS (4 tests).
 
 - [ ] **Step 5: ruff + commit**
 
-ruff check the two files. Commit: `feat(cluster): ClusterPairScores lazy view (SP2 foundation)`.
+ruff check both files. Commit: `feat(cluster): ClusterPairScores lazy view (SP2 foundation)`.
 
 ---
 
@@ -176,122 +148,84 @@ ruff check the two files. Commit: `feat(cluster): ClusterPairScores lazy view (S
 
 - [ ] **Step 1: Write the failing byte-identical evidence-edge parity test**
 
-The test runs identity resolution against a SQLite store with the gate OFF (dict path) and ON (view path) on an adversarial cluster fixture, and asserts the emitted `evidence_edges` are byte-identical. Use the existing identity test harness pattern (`tests/identity/`) for store setup (`IdentityStore(backend="sqlite", path=str(tmp_path/"x.db"))`) and a small dedupe result. Assert the sorted edge tuples `(record_a_id, record_b_id, kind, score)` per entity are identical ON vs OFF, parametrized over `GOLDENMATCH_NATIVE` in `["1","0"]` (skip native=1 when the native cluster kernel is absent, mirroring `tests/test_columnar_cluster_build_parity.py`'s guard). Include an oversized-split cluster in the fixture so the post-split partition is exercised.
-
-The implementer should model the harness on an existing `tests/identity/` resolve test (find one that calls `resolve_clusters`/`_resolve_identities` with a clusters dict). The assertion compares the full edge set read back from the store after resolve, gate ON vs OFF.
+The test resolves identities against a SQLite store with the gate OFF (dict path) then ON (view path) on an adversarial cluster fixture, and asserts the emitted `evidence_edges` are byte-identical. Model the harness on an existing `tests/identity/` test that calls `resolve_clusters(...)` with a clusters dict + an `IdentityStore(backend="sqlite", path=str(tmp_path/"x.db"))` (find one and copy its setup). Steps:
+- Build a clusters dict via `build_clusters(pairs, all_ids, max_cluster_size=5, auto_split=True)` on an adversarial fixture (multi-member, an oversized-split cluster, singletons, dup canonical pair) — reuse the fixture shape from `tests/test_columnar_cluster_build_parity.py`.
+- Resolve gate OFF (no view), read back all edges from the store, sort to a canonical tuple list `[(entity_id, record_a_id, record_b_id, kind, score), ...]`.
+- Resolve gate ON: build `view = ClusterPairScores.from_cluster_dict(clusters)`, pass `pair_score_view=view` to `resolve_clusters`; read back + sort the same way. Add a spy asserting the view path actually ran (e.g. wrap `view.for_cluster`).
+- `assert on_edges == off_edges`. Parametrize `GOLDENMATCH_NATIVE` `["1","0"]`; skip native=1 when the native cluster kernel is absent (copy the guard from `test_columnar_cluster_build_parity.py`).
 
 - [ ] **Step 2: Run — verify FAIL**
 
-Run: `cd packages/python/goldenmatch && ../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscore_view_parity.py -v -k evidence`
-Expected: FAIL (the resolver doesn't accept/use a view yet, OR — if you write the spy first — the view path isn't wired). Get a genuine RED by asserting (spy) that the view path actually ran with the gate ON.
+Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscore_view_parity.py -v`
+Expected: FAIL (`resolve_clusters` doesn't accept `pair_score_view` yet / spy never fires).
 
-- [ ] **Step 3: Add the optional `pair_score_view` param to the resolver**
+- [ ] **Step 3: Add the optional `pair_score_view` param to `resolve_clusters` and use it at all three sites**
 
-In `identity/resolve.py`, thread an optional `pair_score_view: ClusterPairScores | None = None` into the resolve function that owns the per-cluster loop (the one with `info` at `:559`). Where it currently reads `pair_scores = info.get("pair_scores") or {}` (`:559`) and `info.get("pair_scores", {}).get(...)` (`:601-602`), change to:
+In `identity/resolve.py`, add `pair_score_view: "ClusterPairScores | None" = None` to `resolve_clusters` (~`:209`; use a string annotation or a TYPE_CHECKING import to avoid a runtime import cycle). Inside the `for cluster_id, info in clusters.items():` loop, replace the THREE reads:
 
+At `:396-398` (bulk path) and `:559-560` (slow path), both currently:
 ```python
-if pair_score_view is not None:
-    pair_scores = pair_score_view.for_cluster(cid)
-else:
-    pair_scores = info.get("pair_scores") or {}
+pair_scores = info.get("pair_scores") or {}
+```
+become:
+```python
+pair_scores = (
+    pair_score_view.for_cluster(cluster_id)
+    if pair_score_view is not None
+    else (info.get("pair_scores") or {})
+)
 ```
 
-and for the bottleneck lookup:
-
+At `:601-602` (bottleneck), currently:
 ```python
 bottleneck_score = (
-    pair_score_view.score_for(cid, int(ba), int(bb))
+    info.get("pair_scores", {}).get((min(int(ba), int(bb)), max(int(ba), int(bb))))
+)
+```
+becomes:
+```python
+bottleneck_score = (
+    pair_score_view.score_for(cluster_id, int(ba), int(bb))
     if pair_score_view is not None
     else info.get("pair_scores", {}).get((min(int(ba), int(bb)), max(int(ba), int(bb))))
 )
 ```
 
-`cid` is the cluster id from the enclosing loop. Behavior is byte-identical because `for_cluster(cid) == info["pair_scores"]` and `score_for` returns the same canonical-pair score. Do NOT change the edge-emit loop body otherwise.
+Use the loop's `cluster_id` (NOT `cid`). Behavior is byte-identical because `for_cluster(cluster_id) == info["pair_scores"]` and `score_for` returns the same canonical-pair score. Do NOT otherwise change the edge-emit loops. (Both the bulk `:396` and slow `:559` sites get the identical substitution; the SQLite parity test covers the slow path, the bulk path is the same one-line change in the same loop reading the same `info` — covered by code parity, no postgres CI lane required for SP2.)
 
 - [ ] **Step 4: Wire the pipeline to build + pass the view when the gate is ON**
 
-In `core/pipeline.py`, after `clusters = build_clusters(...)` (`:1455`) and before `_resolve_identities` (`:1714`), when `_columnar_cluster_build_enabled()` (import from `core.cluster`), build `view = ClusterPairScores.from_cluster_dict(clusters)` and pass it through `_resolve_identities` into the resolver as `pair_score_view`. When the gate is OFF, pass `None` (today's path). Thread the param through `_resolve_identities`'s signature.
+In `core/pipeline.py`, after the cluster-build `if/else` block closes (after ~`:1460`, where `clusters` is the dict), and before `_resolve_identities` (`:1714`): when `_columnar_cluster_build_enabled()` (import from `core.cluster`), build `view = ClusterPairScores.from_cluster_dict(clusters)`; else `view = None`. Thread `view` through `_resolve_identities` (`:245`) into its `resolve_clusters(...)` call (~`:308`) as `pair_score_view=view`. Build the view ONCE; reuse if other call sites need it later (SP3+).
 
 - [ ] **Step 5: Run — verify PASS (both native states)**
 
-Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscore_view_parity.py -v -k evidence`
-Expected: PASS for native=0 (and native=1 if the kernel is present; else SKIP). If edges differ, STOP and report — do not relax. The durability invariant (entity-id evidence edges) is the whole point.
-
-- [ ] **Step 6: ruff + commit**
-
-Commit: `feat(identity): resolve evidence edges via ClusterPairScores view (gated, byte-identical)`.
-
----
-
-## Task 3: golden migration + byte-identical golden parity gate
-
-**Files:**
-- Modify: `packages/python/goldenmatch/goldenmatch/core/pipeline.py` (golden build `:1591-1615`)
-- Test: `packages/python/goldenmatch/tests/test_cluster_pairscore_view_parity.py` (add golden case)
-
-- [ ] **Step 1: Write the failing byte-identical golden parity test**
-
-Add a test that builds golden records with the `confidence_majority` strategy on a multi-member-cluster fixture (configure `golden_rules` survivorship `confidence_majority`), gate OFF vs ON, and asserts the golden records are byte-identical. Reuse `tests/test_golden.py` fixtures/patterns for the `confidence_majority` setup. Parametrize `GOLDENMATCH_NATIVE` `["1","0"]` with the same native-skip guard.
-
-- [ ] **Step 2: Run — verify FAIL**
-
-Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscore_view_parity.py -v -k golden`
-Expected: FAIL (golden build not yet sourcing from the view; add a spy to assert the view path ran with the gate ON for a genuine RED).
-
-- [ ] **Step 3: Source the golden build's per-cluster pair_scores from the view when gate ON**
-
-In `pipeline.py:1591-1615`, where the golden build pulls each multi-member cluster's `pair_scores` to pass into `build_golden_records_batch`, source it from `view.for_cluster(cid)` when the view is present (gate ON), else `cluster["pair_scores"]` (today). The view is the SAME one built in Task 2 Step 4 — build it ONCE per pipeline run and reuse for both identity and golden. `confidence_majority` (and `custom:` strategies) then receive the identical per-cluster dict.
-
-- [ ] **Step 4: Run — verify PASS (both native states)**
-
 Run: `../../../.venv/Scripts/python.exe -m pytest tests/test_cluster_pairscore_view_parity.py -v`
-Expected: PASS (evidence + golden, native=0; native=1 if kernel present else SKIP). If golden differs, STOP and report.
+Expected: PASS for native=0 (native=1 if the kernel is present; else SKIP). If edges differ, STOP and report — do NOT relax. This is the entity-id durability proof.
 
-- [ ] **Step 5: Regression — existing identity + golden suites with the gate ON**
+- [ ] **Step 6: Regression — existing identity suite with the gate ON**
 
-Run: `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1 ../../../.venv/Scripts/python.exe -m pytest tests/identity/ tests/test_golden.py -q`
+Run: `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1 ../../../.venv/Scripts/python.exe -m pytest tests/identity/ -q`
 Confirm no NEW failures vs gate OFF (flag only new ones; pre-existing native artifacts excepted).
 
-- [ ] **Step 6: ruff + commit**
+- [ ] **Step 7: ruff + commit**
 
-Commit: `feat(golden): source confidence_majority pair_scores via ClusterPairScores view (gated, byte-identical)`.
-
----
-
-## Task 4: measure-first bench
-
-**Files:**
-- Create: `packages/python/goldenmatch/scripts/bench_cluster_pairscore_view.py`
-- Create: `.github/workflows/bench-cluster-pairscore-view.yml`
-
-- [ ] **Step 1: Bench script**
-
-Model on `scripts/bench_columnar_cluster_build.py` (SP1's harness — same per-variant subprocess isolation, ASCII table, `$GITHUB_STEP_SUMMARY`). Bench the identity-resolve + golden(`confidence_majority`) stages end-to-end (or the closest measurable slice that exercises the pair_scores consumers) gate OFF vs ON at `--np 1000000,5000000`, median of 3, wall + peak RSS, with a byte-identical assertion (evidence edges + golden) on a small N first. Reuse the SP1 deterministic pair generator. Smoke locally at `--np 50000`.
-
-- [ ] **Step 2: Workflow**
-
-`bench-cluster-pairscore-view.yml`: workflow_dispatch, `runs-on: large-new-64GB`, build native, run the bench. Model on `bench-columnar-cluster-build.yml`.
-
-- [ ] **Step 3: Commit**
-
-Commit: `bench(cluster): SP2 identity+golden view vs dict measure-first harness`.
-
-- [ ] **Step 4 (orchestrator, NOT a subagent step): dispatch + decide gate default**
-
-Merge (workflow must be on main to dispatch), dispatch at 1M/5M, read wall + RSS. Per spec, SP2 MAY flip `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` default-ON if the columnar identity+golden path wins net. If it's a wash/loss (likely, since the view is sourced from the still-materialized dict), keep gated; the abstraction + de-risked identity/golden migration is the deliverable, and a later SP makes the build produce the frame natively. Record the numbers in the spec.
+ruff check the changed files. Commit: `feat(identity): resolve evidence edges via ClusterPairScores view (gated, byte-identical)`.
 
 ---
 
 ## Final validation (orchestrator)
 
-1. `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1 pytest tests/test_cluster_pairscores.py tests/test_cluster_pairscore_view_parity.py tests/identity/ tests/test_golden.py` — green (native=0; native=1 via CI).
-2. Open the PR; CI's native lane validates the native=1 byte-identical evidence-edge + golden gates with the fresh kernel (CI-only — the durability proof, as in SP1).
-3. Dispatch the bench; fold numbers into the spec; decide the gate default.
+1. `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1 pytest tests/test_cluster_pairscores.py tests/test_cluster_pairscore_view_parity.py tests/identity/` — green (native=0; native=1 via CI).
+2. Open the PR; CI's native lane validates the native=1 byte-identical evidence-edge gate with the fresh kernel (CI-only — the durability proof, as in SP1).
+3. No bench / gate-flip (per spec: identity-only is an abstraction step, gate stays default-OFF; the perf win + default-on decision belong to a future columnar-frame SP).
 
 ## Notes for the implementer
 
-- **Byte-identical is the durability invariant** — identity evidence edges feed entity-ids. The view returns the SAME data as the dict (`for_cluster(cid) == info["pair_scores"]`), so parity should be trivial; if it isn't, you wired something wrong — STOP and report, do not relax the gate.
-- **Build the view ONCE per pipeline run** (gate ON), reuse for identity AND golden. DRY.
-- **Gate after the columnar build returns**, at the pipeline level — never reach into `_build_clusters_via_frames` internals (the spec's "construction point" pin).
-- **Native cluster path is CI-only-validatable locally** (stale `_native.pyd`); the parity tests skip native=1 locally and run it in CI's fresh-native lane.
+- **Byte-identical is the durability invariant** — identity evidence edges feed entity-ids. The view returns the SAME data as the dict (`for_cluster(cid) == info["pair_scores"]`), so parity should be trivial; if it isn't, you wired something wrong — STOP and report, do not relax.
+- **Build the view ONCE per pipeline run** (gate ON). DRY.
+- **Gate at the pipeline level** after the cluster build returns — never reach into `_build_clusters_via_frames` internals.
+- **Loop variable is `cluster_id`**, not `cid`.
+- **All three resolve sites** migrate (bulk `:396`, slow `:559`, bottleneck `:601`) — the bulk path matters for the postgres lane even though the SQLite parity test exercises the slow path.
+- **Native cluster path is CI-only-validatable locally**; the parity test skips native=1 locally, runs it in CI's fresh-native lane.
+- **Golden is NOT in scope** (issue #678). Do not touch golden.
 - **Skill:** @superpowers:test-driven-development per task.

--- a/docs/superpowers/specs/2026-06-02-cluster-pairscore-view-design.md
+++ b/docs/superpowers/specs/2026-06-02-cluster-pairscore-view-design.md
@@ -1,0 +1,176 @@
+# Lazy cluster pair-score view + identity/golden migration (Phase 2 SP2) — design
+
+**Date:** 2026-06-02
+**Status:** design (approved by user, pre-spec-review)
+**Decision context:** Phase-2 SP1 (PR #673, columnar cluster-build core + dict
+adapter, gated `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD`) SHIPPED but the measure-first
+bench found the columnar path LOSES net of the adapter (0.77-0.82x, ~2x RSS) — the
+eager per-cluster `dict[int,dict]` (esp. the per-cluster `pair_scores` dicts)
+materialization swamps the fast Arrow UF. So the gate stays default-OFF. The win
+(spike: 2.4-3.1x UF-only) lands only when consumers migrate OFF the dict adapter.
+SP2 takes the first, highest-value slice: a **lazy pair-score view** (kills the
+eager per-cluster `pair_scores` dict) + migrate the two durability/output-critical
+`pair_scores` consumers — `identity/resolve.py` (evidence edges) and `golden.py`
+`confidence_majority` survivorship — onto it. unmerge/explain/compare/display
+consumers stay on the dict adapter (SP3+).
+
+## Problem
+
+`build_clusters() -> dict[int, dict]` materializes, per cluster, a
+`pair_scores: dict[(a,b)->score]`. That eager materialization is the SP1
+adapter cost. The two `pair_scores` consumers SP2 targets:
+
+- **`identity/resolve.py`** — emits ONE evidence edge per within-cluster scored
+  pair by iterating `info["pair_scores"].items()` (`resolve.py:396-398` and
+  `:558-560`), plus a bottleneck-pair score lookup
+  (`info.get("pair_scores", {}).get((min,max))`, `:601-602`). This feeds the
+  identity graph (entity-ids + evidence edges) — the **durability invariant**.
+- **`golden.py` `_confidence_majority`** (`golden.py:235+`) — sums `pair_scores`
+  of agreeing edges per candidate value for survivorship. Only reached when the
+  golden strategy is `confidence_majority` (a slow-path strategy via
+  `build_golden_records_batch`; the columnar `build_golden_records_df` fast path
+  never uses pair_scores). So golden's pair_scores dependence is NARROW.
+
+`ClusterFrames` (assignments + metadata) deliberately carries NO `pair_scores`.
+SP2 provides the scores via a lazy view over a cluster-tagged pair frame instead
+of N per-cluster dicts.
+
+## Goal
+
+A `ClusterPairScores` lazy view, sourced from a cluster-tagged pair frame the
+columnar build already nearly produces, that `identity/resolve.py` and
+`golden.py::_confidence_majority` consume — with **byte-identical evidence edges
+and golden records** vs the dict path, behind the existing
+`GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` gate, measured against the dict path.
+
+## Architecture: lazy view, gated columnar consumers
+
+**Gate reuse.** Extend the existing `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` gate
+(no new env var). When ON, the pipeline produces `(ClusterFrames,
+ClusterPairScores)` from the columnar build and routes identity + golden through
+columnar consumers; when OFF, today's dict path verbatim. `build_clusters() ->
+dict` is UNCHANGED for all other consumers (SP3+).
+
+### Component 1: `ClusterPairScores` (the lazy view)
+
+Backed by a **cluster-tagged pair frame** `(cluster_id, id_a, id_b, score)`.
+SP1's `_build_clusters_via_frames` ALREADY computes exactly this frame at
+`cluster.py` step 3: `tagged = pairs_df.with_columns(pl.col("id_a").
+replace_strict(member_to_cid).alias("__cid__"))`, then iterates it to fill
+per-cluster dicts. SP2 RETAINS that `tagged` frame (in pairs-input row order)
+and STOPS materializing the per-cluster dicts on the columnar path. New module
+`core/cluster_pairscores.py` (keep `cluster.py` from growing):
+
+- `ClusterPairScores(tagged_frame)` — wraps the frame; cheap to construct.
+- `iter_clusters() -> Iterator[tuple[int, Iterable[tuple[int,int,float]]]]` —
+  ONE `partition_by("cluster_id", maintain_order=True)` pass yielding each
+  cluster's pairs IN ROW ORDER. For identity's "every within-cluster pair -> one
+  evidence edge" — one columnar pass, no per-cluster dict.
+- `for_cluster(cid) -> dict[(int,int), float]` — that cluster's pairs as a dict
+  on demand (filter + build), for golden's per-cluster `confidence_majority` and
+  the bottleneck-score lookup. Last-wins on duplicate canonical pairs (matches
+  the dict path's `result[cid]["pair_scores"][(a,b)] = score` overwrite).
+
+**Order + dedup invariants (load-bearing for byte-identical):** pairs in
+ROW/pairs-input order; duplicate canonical pairs overwrite last-wins; cluster id
+numbering = SP1's sort-by-min-member. The pre-split mapping is correct because
+identity/golden operate on the FINAL (post-split) clusters — see "Post-split
+keying" below.
+
+### Component 2: identity migration (durability-critical)
+
+`resolve.py` currently reads each cluster's `pair_scores` dict from the cluster
+dict. Migrate the columnar path to consume `ClusterPairScores`:
+- Evidence edges (`:396-398`, `:558-560`): pull the cluster's pairs from the
+  view IN THE SAME ORDER and emit the SAME edges. The resolver's edge-emit loop
+  must produce a byte-identical edge set + order (the `evidence_edges` UNIQUE
+  constraint + replay idempotency mean order isn't semantically load-bearing,
+  but we gate it byte-identical anyway to prove no drift).
+- Bottleneck score lookup (`:601-602`): `view.for_cluster(cid).get((min,max))`
+  or a dedicated `score_for(cid,a,b)` — identical value.
+- **Hard gate:** byte-identical evidence-edge set (+ bottleneck score), native
+  AND off-native, gate ON vs OFF. This is the entity-id durability proof.
+
+### Component 3: golden migration
+
+`pipeline.py` golden build (`:1591-1615`) passes each multi-member cluster's
+`pair_scores` to `build_golden_records_batch` (slow path) which forwards to
+`_confidence_majority`. Migrate the columnar path to source each cluster's
+`pair_scores` from `view.for_cluster(cid)` instead of `cluster["pair_scores"]`.
+The narrow surface: ONLY the `confidence_majority` strategy reads pair_scores;
+the columnar `build_golden_records_df` fast path is untouched. **Hard gate:**
+byte-identical golden records on a `confidence_majority` fixture, gate ON vs OFF.
+
+### Post-split keying (correctness invariant)
+
+Auto-split renumbers oversized clusters (new cids, partitioned pair_scores).
+identity/golden consume FINAL clusters, so the view must key by FINAL cluster_id,
+not the pre-split tag. Resolution: build the view's tagged frame AFTER
+`_finalize_clusters`, by re-tagging from the final `member_to_cid` (post-split).
+The split sub-clusters' pair_scores partition is exactly what `split_oversized_
+cluster` already computes (`sub_pairs`); the view must reflect that partition.
+**Simplest correct approach:** derive the view's tagged frame from the FINAL
+`result` dict's per-cluster `pair_scores` (one pass flattening to
+`(cid, a, b, score)`), so the view is provably consistent with the dict path's
+final partition — the columnar win is removing the eager dict from the
+CONSUMERS, while the build still computes the canonical partition. (If profiling
+shows the final-dict flatten is itself the cost, a later SP pushes the split
+partition fully columnar; out of scope for SP2.)
+
+## Measure-first
+
+This is where the adapter-free win should appear. Bench identity-resolve +
+golden (confidence_majority) end-to-end, columnar (gate ON) vs dict (gate OFF),
+1M/5M, wall + peak RSS, with the byte-identical evidence-edge + golden parity
+asserted. Flip `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` default-ON only if the
+columnar identity+golden path wins net (per user: SP2 IS allowed to flip the gate
+default-on if the bench wins). Else stay gated; SP3 migrates the remaining HARD
+consumers before re-measuring.
+
+## Edge cases / invariants
+
+- **Singletons / empty:** no pairs -> empty per-cluster slice -> identical to
+  today's empty `pair_scores`.
+- **Duplicate canonical pairs:** last-wins in `for_cluster`; iter order in
+  pairs-input order for `iter_clusters`.
+- **Off-native:** the view sources from the same final `result` partition; no
+  perf claim off-native (non-perf path), byte-identical gate runs both.
+- **Bottleneck `(0,0)`/None sentinel:** unchanged from SP1 (handled in the build).
+- **Identity replay idempotency:** unchanged (`has_run_event`, UNIQUE edges).
+
+## Testing
+
+- **Byte-identical evidence edges (HARD, durability):** run the pipeline's
+  identity resolve gate ON vs OFF on an adversarial fixture (multi-member,
+  oversized-split, singletons, dup pairs); assert the emitted `evidence_edges`
+  (entity_id, record_a, record_b, kind, score) are byte-identical, native AND
+  off-native. Mirror the existing identity test harness.
+- **Byte-identical golden (HARD):** a `confidence_majority`-strategy fixture;
+  assert golden records identical gate ON vs OFF, native AND off-native.
+- **View unit tests:** `iter_clusters` order, `for_cluster` last-wins dedup,
+  empty/singleton, post-split keying (view's per-cluster pairs == the dict path's
+  final `pair_scores`).
+- **Measure-first bench:** identity+golden columnar vs dict at 1M/5M, parity
+  asserted; decides the gate default.
+
+## Scope boundary (YAGNI)
+
+- ONLY `core/cluster_pairscores.py` (the view), the columnar branches in
+  `identity/resolve.py` + the pipeline golden build, and the gate plumbing.
+- NO new Rust kernel. NO `ClusterFrames` schema change. NO migration of
+  unmerge/explain/compare/display consumers (SP3+). NO change to the dict path
+  or to `build_clusters`'s default return.
+- The view sources from the FINAL `result` partition (provably consistent);
+  pushing the split partition fully columnar is a later SP.
+
+## References
+
+- SP1: `docs/superpowers/specs/2026-06-02-columnar-cluster-build-core-design.md`
+  (PR #673). `core/cluster.py`: `_build_clusters_via_frames` (tagged frame at
+  step 3), `_finalize_clusters`, `split_oversized_cluster` (`sub_pairs`).
+- Consumers: `identity/resolve.py:396-398,558-560,601-602`;
+  `golden.py:_confidence_majority` (`:235+`), `build_golden_records_batch`
+  (`:662`), `build_golden_records_from_frames` (`:1049`); `pipeline.py` clustering
+  `:1455`, golden `:1591-1615`, identity `:1714`.
+- Related: [[project_663_arrow_kernels]], [[project_identity_graph_v2]],
+  [[project_stable_record_fingerprint]].

--- a/docs/superpowers/specs/2026-06-02-cluster-pairscore-view-design.md
+++ b/docs/superpowers/specs/2026-06-02-cluster-pairscore-view-design.md
@@ -54,11 +54,15 @@ dict` is UNCHANGED for all other consumers (SP3+).
 ### Component 1: `ClusterPairScores` (the lazy view)
 
 Backed by a **cluster-tagged pair frame** `(cluster_id, id_a, id_b, score)`.
-SP1's `_build_clusters_via_frames` ALREADY computes exactly this frame at
-`cluster.py` step 3: `tagged = pairs_df.with_columns(pl.col("id_a").
-replace_strict(member_to_cid).alias("__cid__"))`, then iterates it to fill
-per-cluster dicts. SP2 RETAINS that `tagged` frame (in pairs-input row order)
-and STOPS materializing the per-cluster dicts on the columnar path. New module
+SP1's `_build_clusters_via_frames` already builds a structurally-identical frame
+at `cluster.py` step 3 (`tagged = pairs_df.with_columns(pl.col("id_a").
+replace_strict(member_to_cid).alias("__cid__"))`) — that is the **shape
+precedent** ONLY. SP2 does NOT plumb that transient pre-split frame out (it is
+keyed by PRE-split cluster_id and is `del`'d inside the columnar core); SP2
+SOURCES the view from the FINAL post-split `result` partition instead (see
+"Post-split keying" below — this is byte-identical-load-bearing, not cosmetic).
+The win is that the CONSUMERS stop holding N per-cluster `pair_scores` dicts, not
+that the build stops computing the partition. New module
 `core/cluster_pairscores.py` (keep `cluster.py` from growing):
 
 - `ClusterPairScores(tagged_frame)` — wraps the frame; cheap to construct.
@@ -97,9 +101,13 @@ dict. Migrate the columnar path to consume `ClusterPairScores`:
 `pair_scores` to `build_golden_records_batch` (slow path) which forwards to
 `_confidence_majority`. Migrate the columnar path to source each cluster's
 `pair_scores` from `view.for_cluster(cid)` instead of `cluster["pair_scores"]`.
-The narrow surface: ONLY the `confidence_majority` strategy reads pair_scores;
-the columnar `build_golden_records_df` fast path is untouched. **Hard gate:**
-byte-identical golden records on a `confidence_majority` fixture, gate ON vs OFF.
+The narrow surface: among built-in strategies ONLY `confidence_majority` reads
+pair_scores; the columnar `build_golden_records_df` fast path is untouched.
+(`custom:` plugin strategies are ALSO forwarded `pair_scores` at `golden.py:82,
+:345` — they are covered transparently: the view feeds the SAME per-cluster dict
+via `for_cluster(cid)`, so any pair_scores-reading strategy is byte-identical
+without per-strategy work.) **Hard gate:** byte-identical golden records on a
+`confidence_majority` fixture, gate ON vs OFF.
 
 ### Post-split keying (correctness invariant)
 
@@ -116,6 +124,12 @@ final partition — the columnar win is removing the eager dict from the
 CONSUMERS, while the build still computes the canonical partition. (If profiling
 shows the final-dict flatten is itself the cost, a later SP pushes the split
 partition fully columnar; out of scope for SP2.)
+
+**Construction point (pin for the planner):** the view is built at the
+`build_clusters` call site / pipeline level FROM the `_finalize_clusters` output
+(the returned `result` dict's per-cluster `pair_scores`), NOT by reaching into
+`_build_clusters_via_frames` internals (which `del`s its tagged frame and is
+pre-split). This keeps view-construction post-split and out of the columnar core.
 
 ## Measure-first
 

--- a/docs/superpowers/specs/2026-06-02-cluster-pairscore-view-design.md
+++ b/docs/superpowers/specs/2026-06-02-cluster-pairscore-view-design.md
@@ -1,190 +1,174 @@
-# Lazy cluster pair-score view + identity/golden migration (Phase 2 SP2) — design
+# Lazy cluster pair-score view + identity migration (Phase 2 SP2) — design
 
 **Date:** 2026-06-02
-**Status:** design (approved by user, pre-spec-review)
+**Status:** design (approved by user; re-scoped to IDENTITY-ONLY after plan review
+found golden's pair_scores is a phantom — see "Re-scope" below)
 **Decision context:** Phase-2 SP1 (PR #673, columnar cluster-build core + dict
-adapter, gated `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD`) SHIPPED but the measure-first
-bench found the columnar path LOSES net of the adapter (0.77-0.82x, ~2x RSS) — the
-eager per-cluster `dict[int,dict]` (esp. the per-cluster `pair_scores` dicts)
-materialization swamps the fast Arrow UF. So the gate stays default-OFF. The win
-(spike: 2.4-3.1x UF-only) lands only when consumers migrate OFF the dict adapter.
-SP2 takes the first, highest-value slice: a **lazy pair-score view** (kills the
-eager per-cluster `pair_scores` dict) + migrate the two durability/output-critical
-`pair_scores` consumers — `identity/resolve.py` (evidence edges) and `golden.py`
-`confidence_majority` survivorship — onto it. unmerge/explain/compare/display
-consumers stay on the dict adapter (SP3+).
+adapter, gated `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD`) SHIPPED but its measure-first
+bench found the columnar path LOSES net of the eager per-cluster `dict[int,dict]`
+materialization (0.77-0.82x, ~2x RSS), so the gate stays default-OFF. The win
+(spike: 2.4-3.1x UF-only) lands only when consumers migrate OFF the dict adapter
+AND the build produces a columnar pair frame natively. SP2 is the first,
+durability-critical slice: a **lazy `ClusterPairScores` view** + migrate the
+`identity/resolve.py` evidence-edge consumer onto it, byte-identical. It is an
+ABSTRACTION + de-risking step, not (yet) a perf win — see "Measure-first / gate".
+
+## Re-scope (plan review, 2026-06-02)
+
+The original spec also migrated golden `confidence_majority`. Plan review found
+that **the pipeline never feeds `pair_scores` to golden**:
+`build_golden_records_batch` (`golden.py:662`) takes no `pair_scores` arg, the
+per-cluster `merge_field` call (~`:810`) passes none, and `_confidence_majority`
+(`:242`) silently falls back to count-majority when `pair_scores is None`. So a
+"byte-identical golden migration onto the view" is vacuous (nothing to migrate;
+the parity test would be a false-green no-op). That latent golden-survivorship bug
+(confidence_majority never actually runs end-to-end) is filed as **issue #678**
+and deferred to its own workstream (it's a behavior change, not byte-identical).
+**SP2 is therefore identity-only.**
 
 ## Problem
 
 `build_clusters() -> dict[int, dict]` materializes, per cluster, a
-`pair_scores: dict[(a,b)->score]`. That eager materialization is the SP1
-adapter cost. The two `pair_scores` consumers SP2 targets:
+`pair_scores: dict[(a,b)->score]`. That eager materialization is the SP1 adapter
+cost. The `pair_scores` consumer SP2 targets:
 
 - **`identity/resolve.py`** — emits ONE evidence edge per within-cluster scored
-  pair by iterating `info["pair_scores"].items()` (`resolve.py:396-398` and
-  `:558-560`), plus a bottleneck-pair score lookup
-  (`info.get("pair_scores", {}).get((min,max))`, `:601-602`). This feeds the
+  pair. TWO emit sites in the same `for cluster_id, info in clusters.items()`
+  loop: the in-memory slow path (`:559-560`) and the postgres bulk fast path
+  (`:396-398`); plus a weak-cluster bottleneck-pair score lookup
+  (`info.get("pair_scores", {}).get((min,max))`, `:601-602`). These feed the
   identity graph (entity-ids + evidence edges) — the **durability invariant**.
-- **`golden.py` `_confidence_majority`** (`golden.py:235+`) — sums `pair_scores`
-  of agreeing edges per candidate value for survivorship. Only reached when the
-  golden strategy is `confidence_majority` (a slow-path strategy via
-  `build_golden_records_batch`; the columnar `build_golden_records_df` fast path
-  never uses pair_scores). So golden's pair_scores dependence is NARROW.
 
 `ClusterFrames` (assignments + metadata) deliberately carries NO `pair_scores`.
-SP2 provides the scores via a lazy view over a cluster-tagged pair frame instead
-of N per-cluster dicts.
+SP2 provides the scores via a lazy view instead of the per-cluster dict.
 
 ## Goal
 
-A `ClusterPairScores` lazy view, sourced from a cluster-tagged pair frame the
-columnar build already nearly produces, that `identity/resolve.py` and
-`golden.py::_confidence_majority` consume — with **byte-identical evidence edges
-and golden records** vs the dict path, behind the existing
-`GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` gate, measured against the dict path.
+A `ClusterPairScores` lazy view, sourced from the FINAL (post-split) cluster
+partition, that `identity/resolve.py` consumes at all three sites — with
+**byte-identical evidence edges + bottleneck score** vs the dict path, behind the
+existing `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` gate, native AND off-native.
 
-## Architecture: lazy view, gated columnar consumers
+## Architecture: lazy view, gated identity consumer
 
-**Gate reuse.** Extend the existing `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` gate
-(no new env var). When ON, the pipeline produces `(ClusterFrames,
-ClusterPairScores)` from the columnar build and routes identity + golden through
-columnar consumers; when OFF, today's dict path verbatim. `build_clusters() ->
-dict` is UNCHANGED for all other consumers (SP3+).
+**Gate reuse.** Reuse the existing `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` gate (no
+new env var). When ON, the pipeline builds the view from the returned cluster
+dict and threads it into the resolver; when OFF, today's dict path verbatim.
+`build_clusters() -> dict` is UNCHANGED for all other consumers (SP3+).
 
 ### Component 1: `ClusterPairScores` (the lazy view)
 
-Backed by a **cluster-tagged pair frame** `(cluster_id, id_a, id_b, score)`.
-SP1's `_build_clusters_via_frames` already builds a structurally-identical frame
-at `cluster.py` step 3 (`tagged = pairs_df.with_columns(pl.col("id_a").
-replace_strict(member_to_cid).alias("__cid__"))`) — that is the **shape
-precedent** ONLY. SP2 does NOT plumb that transient pre-split frame out (it is
-keyed by PRE-split cluster_id and is `del`'d inside the columnar core); SP2
-SOURCES the view from the FINAL post-split `result` partition instead (see
-"Post-split keying" below — this is byte-identical-load-bearing, not cosmetic).
-The win is that the CONSUMERS stop holding N per-cluster `pair_scores` dicts, not
-that the build stops computing the partition. New module
-`core/cluster_pairscores.py` (keep `cluster.py` from growing):
+New module `core/cluster_pairscores.py` (keep `cluster.py` from growing). Sourced
+from the FINAL post-split `result` dict's per-cluster `pair_scores` (see
+"Post-split keying"). SP1's `_build_clusters_via_frames` step-3 `tagged` frame
+(`pl.col("id_a").replace_strict(member_to_cid)`) is the **shape precedent ONLY**;
+SP2 does NOT plumb that pre-split, `del`'d-internally frame out. API:
 
-- `ClusterPairScores(tagged_frame)` — wraps the frame; cheap to construct.
-- `iter_clusters() -> Iterator[tuple[int, Iterable[tuple[int,int,float]]]]` —
-  ONE `partition_by("cluster_id", maintain_order=True)` pass yielding each
-  cluster's pairs IN ROW ORDER. For identity's "every within-cluster pair -> one
-  evidence edge" — one columnar pass, no per-cluster dict.
-- `for_cluster(cid) -> dict[(int,int), float]` — that cluster's pairs as a dict
-  on demand (filter + build), for golden's per-cluster `confidence_majority` and
-  the bottleneck-score lookup. Last-wins on duplicate canonical pairs (matches
-  the dict path's `result[cid]["pair_scores"][(a,b)] = score` overwrite).
+- `from_cluster_dict(clusters) -> ClusterPairScores` — copy each cluster's
+  `pair_scores` (already final-partition, pairs-input order, last-wins on dup
+  canonical pairs).
+- `for_cluster(cid) -> dict[(int,int),float]` — that cluster's scores (empty for
+  singleton/absent). Used for the bottleneck lookup and the per-cluster edge set.
+- `iter_clusters() -> Iterator[(cid, Iterable[(a,b,score)])]` — clusters WITH
+  pairs, pairs in row order. For the evidence-edge emit loop (one pass).
+- `score_for(cid, a, b) -> float | None` — canonical-pair `(min,max)` lookup.
 
-**Order + dedup invariants (load-bearing for byte-identical):** pairs in
-ROW/pairs-input order; duplicate canonical pairs overwrite last-wins; cluster id
-numbering = SP1's sort-by-min-member. The pre-split mapping is correct because
-identity/golden operate on the FINAL (post-split) clusters — see "Post-split
-keying" below.
+**Internal repr is a dict-of-dicts** (the simplest byte-identical-safe backing
+given the build still produces the dict). The spec's "flat frame" is the
+conceptual model; the `iter_clusters` interface is frame-ready so a FUTURE SP can
+swap the backing to a Polars `partition_by` once the BUILD produces the frame
+natively (and drops the dict) — that future SP is where the perf win + the
+columnar pair frame land. SP2 deliberately does not add a premature flatten.
 
 ### Component 2: identity migration (durability-critical)
 
-`resolve.py` currently reads each cluster's `pair_scores` dict from the cluster
-dict. Migrate the columnar path to consume `ClusterPairScores`:
-- Evidence edges (`:396-398`, `:558-560`): pull the cluster's pairs from the
-  view IN THE SAME ORDER and emit the SAME edges. The resolver's edge-emit loop
-  must produce a byte-identical edge set + order (the `evidence_edges` UNIQUE
-  constraint + replay idempotency mean order isn't semantically load-bearing,
-  but we gate it byte-identical anyway to prove no drift).
-- Bottleneck score lookup (`:601-602`): `view.for_cluster(cid).get((min,max))`
-  or a dedicated `score_for(cid,a,b)` — identical value.
-- **Hard gate:** byte-identical evidence-edge set (+ bottleneck score), native
-  AND off-native, gate ON vs OFF. This is the entity-id durability proof.
+`identity/resolve.py` reads each cluster's `pair_scores` from the cluster dict at
+THREE sites in the `for cluster_id, info` loop. Thread an optional
+`pair_score_view: ClusterPairScores | None` into the resolver; when provided, all
+three sites read from it (`for_cluster(cluster_id)` for the edge sets,
+`score_for(cluster_id, a, b)` for the bottleneck), else `info["pair_scores"]`:
 
-### Component 3: golden migration
+- in-memory slow path evidence edges (`:559-560`),
+- postgres bulk fast path evidence edges (`:396-398`),
+- weak-cluster bottleneck score (`:601-602`).
 
-`pipeline.py` golden build (`:1591-1615`) passes each multi-member cluster's
-`pair_scores` to `build_golden_records_batch` (slow path) which forwards to
-`_confidence_majority`. Migrate the columnar path to source each cluster's
-`pair_scores` from `view.for_cluster(cid)` instead of `cluster["pair_scores"]`.
-The narrow surface: among built-in strategies ONLY `confidence_majority` reads
-pair_scores; the columnar `build_golden_records_df` fast path is untouched.
-(`custom:` plugin strategies are ALSO forwarded `pair_scores` at `golden.py:82,
-:345` — they are covered transparently: the view feeds the SAME per-cluster dict
-via `for_cluster(cid)`, so any pair_scores-reading strategy is byte-identical
-without per-strategy work.) **Hard gate:** byte-identical golden records on a
-`confidence_majority` fixture, gate ON vs OFF.
+Because `for_cluster(cid) == info["pair_scores"]` by construction, behavior is
+byte-identical; the parity gate proves no drift.
+
+**Hard gate:** byte-identical evidence-edge set (+ bottleneck score), native AND
+off-native, gate ON vs OFF — the entity-id durability proof. The SQLite parity
+test exercises the slow path (`:559`); the postgres bulk path (`:396`) takes the
+IDENTICAL one-line `info["pair_scores"] -> view.for_cluster(cluster_id)`
+substitution in the same loop reading the same `info`, so it is covered by code
+parity (a postgres CI lane is not required for SP2; note it explicitly).
 
 ### Post-split keying (correctness invariant)
 
-Auto-split renumbers oversized clusters (new cids, partitioned pair_scores).
-identity/golden consume FINAL clusters, so the view must key by FINAL cluster_id,
-not the pre-split tag. Resolution: build the view's tagged frame AFTER
-`_finalize_clusters`, by re-tagging from the final `member_to_cid` (post-split).
-The split sub-clusters' pair_scores partition is exactly what `split_oversized_
-cluster` already computes (`sub_pairs`); the view must reflect that partition.
-**Simplest correct approach:** derive the view's tagged frame from the FINAL
-`result` dict's per-cluster `pair_scores` (one pass flattening to
-`(cid, a, b, score)`), so the view is provably consistent with the dict path's
-final partition — the columnar win is removing the eager dict from the
-CONSUMERS, while the build still computes the canonical partition. (If profiling
-shows the final-dict flatten is itself the cost, a later SP pushes the split
-partition fully columnar; out of scope for SP2.)
+Auto-split renumbers oversized clusters and re-partitions `pair_scores` (cross-cut
+edges dropped). identity consumes FINAL clusters, so the view MUST key by FINAL
+cluster_id. Resolution: build the view from the FINAL `result` dict (post-split)
+— provably consistent, since `for_cluster(cid)` returns exactly `result[cid]
+["pair_scores"]`. **Construction point (pin for the planner):** built at the
+pipeline level FROM the returned cluster dict, NOT by reaching into
+`_build_clusters_via_frames` internals.
 
-**Construction point (pin for the planner):** the view is built at the
-`build_clusters` call site / pipeline level FROM the `_finalize_clusters` output
-(the returned `result` dict's per-cluster `pair_scores`), NOT by reaching into
-`_build_clusters_via_frames` internals (which `del`s its tagged frame and is
-pre-split). This keeps view-construction post-split and out of the columnar core.
+## Measure-first / gate
 
-## Measure-first
-
-This is where the adapter-free win should appear. Bench identity-resolve +
-golden (confidence_majority) end-to-end, columnar (gate ON) vs dict (gate OFF),
-1M/5M, wall + peak RSS, with the byte-identical evidence-edge + golden parity
-asserted. Flip `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` default-ON only if the
-columnar identity+golden path wins net (per user: SP2 IS allowed to flip the gate
-default-on if the bench wins). Else stay gated; SP3 migrates the remaining HARD
-consumers before re-measuring.
+SP2 is identity-only and the view is sourced from the still-materialized dict
+(adds a copy), so it is NOT expected to win perf — it is an abstraction +
+de-risking of the durability-critical identity path. Therefore SP2 does NOT flip
+the gate default (stays OFF) and ships no dedicated perf bench: a dict-copy
+abstraction has no win to chase, and a regression guard rides on SP1's existing
+`bench-columnar-cluster-build` workflow (which already exercises `build_clusters`
+gate on/off). The perf win + default-on decision belong to a FUTURE SP that makes
+the build produce the columnar pair frame natively and drops the per-cluster dict
+— at which point identity already consumes the view, so that SP needs no further
+identity-durability re-validation.
 
 ## Edge cases / invariants
 
 - **Singletons / empty:** no pairs -> empty per-cluster slice -> identical to
   today's empty `pair_scores`.
-- **Duplicate canonical pairs:** last-wins in `for_cluster`; iter order in
-  pairs-input order for `iter_clusters`.
-- **Off-native:** the view sources from the same final `result` partition; no
-  perf claim off-native (non-perf path), byte-identical gate runs both.
-- **Bottleneck `(0,0)`/None sentinel:** unchanged from SP1 (handled in the build).
+- **Duplicate canonical pairs:** the source dict already collapsed them
+  (last-wins); the view copies as-is.
+- **Off-native:** the view sources from the same final `result`; byte-identical
+  gate runs native AND off-native.
+- **Bottleneck `(0,0)`/None:** unchanged (handled in the build / `bottleneck_pair`).
 - **Identity replay idempotency:** unchanged (`has_run_event`, UNIQUE edges).
 
 ## Testing
 
-- **Byte-identical evidence edges (HARD, durability):** run the pipeline's
-  identity resolve gate ON vs OFF on an adversarial fixture (multi-member,
-  oversized-split, singletons, dup pairs); assert the emitted `evidence_edges`
-  (entity_id, record_a, record_b, kind, score) are byte-identical, native AND
-  off-native. Mirror the existing identity test harness.
-- **Byte-identical golden (HARD):** a `confidence_majority`-strategy fixture;
-  assert golden records identical gate ON vs OFF, native AND off-native.
-- **View unit tests:** `iter_clusters` order, `for_cluster` last-wins dedup,
-  empty/singleton, post-split keying (view's per-cluster pairs == the dict path's
-  final `pair_scores`).
-- **Measure-first bench:** identity+golden columnar vs dict at 1M/5M, parity
-  asserted; decides the gate default.
+- **Byte-identical evidence edges (HARD, durability):** run identity resolve on
+  an adversarial cluster fixture (multi-member, oversized-split, singletons, dup
+  pairs) against a SQLite store, gate ON vs OFF; assert the read-back
+  `evidence_edges` (entity_id, record_a, record_b, kind, score) are byte-identical,
+  parametrized `GOLDENMATCH_NATIVE` `["1","0"]` (skip native=1 when the native
+  cluster kernel is absent, mirroring `test_columnar_cluster_build_parity.py`).
+  Include an oversized-split cluster so the post-split partition is exercised.
+- **View unit tests:** `for_cluster` == dict, `iter_clusters` order, `score_for`
+  canonical lookup, empty/singleton/absent.
+- **Regression:** existing `tests/identity/` green with the gate ON (no new
+  failures vs OFF).
 
 ## Scope boundary (YAGNI)
 
-- ONLY `core/cluster_pairscores.py` (the view), the columnar branches in
-  `identity/resolve.py` + the pipeline golden build, and the gate plumbing.
-- NO new Rust kernel. NO `ClusterFrames` schema change. NO migration of
-  unmerge/explain/compare/display consumers (SP3+). NO change to the dict path
-  or to `build_clusters`'s default return.
-- The view sources from the FINAL `result` partition (provably consistent);
-  pushing the split partition fully columnar is a later SP.
+- ONLY `core/cluster_pairscores.py` (the view), the three gated read sites in
+  `identity/resolve.py`, and the pipeline gate plumbing.
+- NO golden migration (golden's pair_scores is a phantom — issue #678, separate
+  workstream). NO new Rust kernel. NO `ClusterFrames` schema change. NO migration
+  of unmerge/explain/compare/display (SP3+). NO change to `build_clusters`'s
+  default return or the dict path. NO dedicated perf bench / gate-default flip
+  (deferred to the future columnar-frame SP).
 
 ## References
 
 - SP1: `docs/superpowers/specs/2026-06-02-columnar-cluster-build-core-design.md`
-  (PR #673). `core/cluster.py`: `_build_clusters_via_frames` (tagged frame at
-  step 3), `_finalize_clusters`, `split_oversized_cluster` (`sub_pairs`).
-- Consumers: `identity/resolve.py:396-398,558-560,601-602`;
-  `golden.py:_confidence_majority` (`:235+`), `build_golden_records_batch`
-  (`:662`), `build_golden_records_from_frames` (`:1049`); `pipeline.py` clustering
-  `:1455`, golden `:1591-1615`, identity `:1714`.
+  (PR #673). `core/cluster.py`: `_columnar_cluster_build_enabled()` (`:436`),
+  `_build_clusters_via_frames` (`:621`), `_finalize_clusters` (`:530`).
+- Consumers: `identity/resolve.py` evidence edges `:396-398` (bulk) + `:559-560`
+  (slow), bottleneck `:601-602`, loop `for cluster_id, info` (`:333`),
+  `resolve_clusters` (`:209`); `pipeline.py` clustering `:1455`, `_resolve_identities`
+  (`:245`), identity call `:1714`.
+- Golden phantom (deferred): issue #678; `golden.py:662,242`, `pipeline.py:1600-1612`.
 - Related: [[project_663_arrow_kernels]], [[project_identity_graph_v2]],
   [[project_stable_record_fingerprint]].

--- a/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
@@ -1,0 +1,34 @@
+"""Lazy per-cluster pair-score view (Phase 2 SP2). Decouples the identity
+evidence-edge consumer from the legacy per-cluster ``pair_scores`` dict. Sourced
+from the FINAL (post-split) cluster partition so it is byte-identical to the dict
+path. dict-of-dicts backing; the ``iter_clusters`` interface is frame-ready for a
+future SP that makes the build produce a columnar pair frame natively."""
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+
+
+class ClusterPairScores:
+    __slots__ = ("_by_cid",)
+
+    def __init__(self, by_cid: dict[int, dict[tuple[int, int], float]]):
+        self._by_cid = by_cid
+
+    @classmethod
+    def from_cluster_dict(cls, clusters: dict[int, dict]) -> ClusterPairScores:
+        by_cid: dict[int, dict[tuple[int, int], float]] = {}
+        for cid, info in clusters.items():
+            ps = info.get("pair_scores") or {}
+            if ps:
+                by_cid[cid] = dict(ps)
+        return cls(by_cid)
+
+    def for_cluster(self, cid: int) -> dict[tuple[int, int], float]:
+        return self._by_cid.get(cid, {})
+
+    def iter_clusters(self) -> Iterator[tuple[int, Iterable[tuple[int, int, float]]]]:
+        for cid, ps in self._by_cid.items():
+            yield cid, [(a, b, s) for (a, b), s in ps.items()]
+
+    def score_for(self, cid: int, a: int, b: int) -> float | None:
+        return self._by_cid.get(cid, {}).get((min(a, b), max(a, b)))

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -249,6 +249,7 @@ def _resolve_identities(
     matchkeys: list,
     config: GoldenMatchConfig,
     run_name: str,
+    pair_score_view: Any = None,
 ) -> dict | None:
     """Run identity resolution as a post-cluster step. Best-effort: failures
     log a warning and return None without affecting dedupe output.
@@ -312,6 +313,7 @@ def _resolve_identities(
             source_pk_col=config.identity.source_pk_column,
             emit_singletons=config.identity.emit_singletons,
             weak_confidence_threshold=config.identity.weak_confidence_threshold,
+            pair_score_view=pair_score_view,
         )
         return summary.as_dict()
     except Exception as e:
@@ -1710,9 +1712,21 @@ def _run_dedupe_pipeline(
             logger.warning("Lineage generation failed: %s", e)
 
     # ── Step 7.6: IDENTITY GRAPH (optional) ──
+    # When the columnar-cluster-build gate is ON, feed the identity evidence-edge
+    # consumer from a ClusterPairScores view (byte-identical to the dict path,
+    # built once here). Gate via _columnar_cluster_build_enabled
+    # (GOLDENMATCH_COLUMNAR_CLUSTER_BUILD) -- NOT the _use_columnar pipeline flag,
+    # which is a different env var.
+    pair_score_view = None
+    if isinstance(clusters, dict):
+        from goldenmatch.core.cluster import _columnar_cluster_build_enabled
+        if _columnar_cluster_build_enabled():
+            from goldenmatch.core.cluster_pairscores import ClusterPairScores
+            pair_score_view = ClusterPairScores.from_cluster_dict(clusters)
     with stage("identity_resolve"):
         identity_summary = _resolve_identities(
-            clusters, collected_df, all_pairs, matchkeys, config, run_name
+            clusters, collected_df, all_pairs, matchkeys, config, run_name,
+            pair_score_view=pair_score_view,
         )
 
     results = {

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -19,9 +19,12 @@ import os
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
+
+if TYPE_CHECKING:
+    from goldenmatch.core.cluster_pairscores import ClusterPairScores
 
 from goldenmatch.core._hashing import record_fingerprint
 from goldenmatch.identity.fingerprint_batch import (
@@ -219,6 +222,7 @@ def resolve_clusters(
     controller_snapshot: dict[str, Any] | None = None,
     emit_singletons: bool = True,
     weak_confidence_threshold: float = 0.6,
+    pair_score_view: ClusterPairScores | None = None,
 ) -> ResolveSummary:
     """Resolve run-local clusters to durable identities.
 
@@ -393,7 +397,11 @@ def resolve_clusters(
                     "last_seen_at": now,
                 })
                 summary.records_upserted += 1
-            pair_scores = info.get("pair_scores") or {}
+            pair_scores = (
+                pair_score_view.for_cluster(cluster_id)
+                if pair_score_view is not None
+                else (info.get("pair_scores") or {})
+            )
             for pair_key, score in pair_scores.items():
                 if isinstance(pair_key, tuple) and len(pair_key) == 2:
                     a, b = pair_key
@@ -556,7 +564,11 @@ def resolve_clusters(
             summary.records_upserted += 1
 
         # 3d. Record evidence edges for every scored within-cluster pair.
-        pair_scores = info.get("pair_scores") or {}
+        pair_scores = (
+            pair_score_view.for_cluster(cluster_id)
+            if pair_score_view is not None
+            else (info.get("pair_scores") or {})
+        )
         for pair_key, score in pair_scores.items():
             if isinstance(pair_key, tuple) and len(pair_key) == 2:
                 a, b = pair_key
@@ -599,7 +611,9 @@ def resolve_clusters(
             ra = rowid_to_recid.get(int(ba))
             rb = rowid_to_recid.get(int(bb))
             bottleneck_score = (
-                info.get("pair_scores", {}).get((min(int(ba), int(bb)), max(int(ba), int(bb))))
+                pair_score_view.score_for(cluster_id, int(ba), int(bb))
+                if pair_score_view is not None
+                else info.get("pair_scores", {}).get((min(int(ba), int(bb)), max(int(ba), int(bb))))
             )
             if ra and rb:
                 store.add_edge(EvidenceEdge(

--- a/packages/python/goldenmatch/tests/test_cluster_pairscore_view_parity.py
+++ b/packages/python/goldenmatch/tests/test_cluster_pairscore_view_parity.py
@@ -16,6 +16,14 @@ stable across the two resolves.
 
 Parametrized over ``GOLDENMATCH_NATIVE`` in {"1","0"}; native=1 skips when the
 native cluster kernel is absent (validated in CI's fresh native build).
+
+Scope: this test exercises the CONSUMER swap (``resolve_clusters`` reading from
+the view vs the dict) by passing ``pair_score_view=`` directly. The pipeline
+WIRING that builds the view and threads it in (``_run_dedupe_pipeline`` ->
+``_resolve_identities``, gated on ``_columnar_cluster_build_enabled()`` +
+``isinstance(clusters, dict)``) is exercised end-to-end by the existing
+``tests/identity/`` suite run with ``GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1``
+(no new failures vs gate OFF).
 """
 from __future__ import annotations
 
@@ -62,7 +70,9 @@ def _normalized_edges(store: IdentityStore) -> list[tuple]:
     canonical list EXCLUDING entity_id (per-run UUID). Compares the durable
     edge structure: record_a, record_b, kind, score."""
     edges = []
-    for node in store.list_identities():
+    # Explicit high limit: list_identities() defaults to 100; a silent truncation
+    # would make the parity assertion a false pass (both sides truncate alike).
+    for node in store.list_identities(limit=10_000):
         for e in store.edges_for_entity(node.entity_id):
             edges.append((e.record_a_id, e.record_b_id, e.kind, e.score))
     return sorted(edges, key=lambda t: (t[0], t[1], t[2], -1.0 if t[3] is None else t[3]))

--- a/packages/python/goldenmatch/tests/test_cluster_pairscore_view_parity.py
+++ b/packages/python/goldenmatch/tests/test_cluster_pairscore_view_parity.py
@@ -1,0 +1,128 @@
+"""Byte-identical parity: resolving identity evidence edges via the
+``ClusterPairScores`` view (gate ON, ``pair_score_view=`` passed) must emit the
+SAME evidence-edge set as the legacy cluster-dict path (gate OFF).
+
+This is the durability gate for Phase 2 SP2: the identity graph (entity-ids +
+evidence edges) is the durable layer above run-local clusters, so the edge set
+must be byte-identical to the dict path. ``view.for_cluster(cid) ==
+clusters[cid]["pair_scores"]`` by construction (the view copies), so any diff is
+a wiring bug (wrong gate, wrong loop var, missed a read site), not an algorithm
+change.
+
+Entity ids are per-run UUIDs, so the comparison EXCLUDES entity_id and compares
+the edge STRUCTURE: (record_a_id, record_b_id, kind, score). Record ids are
+deterministic (``src:<id>`` via ``source_pk_col="id"``), so the edge set is
+stable across the two resolves.
+
+Parametrized over ``GOLDENMATCH_NATIVE`` in {"1","0"}; native=1 skips when the
+native cluster kernel is absent (validated in CI's fresh native build).
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.core.cluster import build_clusters
+from goldenmatch.core.cluster_pairscores import ClusterPairScores
+from goldenmatch.identity import IdentityStore, resolve_clusters
+
+
+def _adversarial_pairs():
+    # Mirror tests/test_columnar_cluster_build_parity.py::_adversarial_pairs:
+    # singleton (id 0), 2-member, fully-connected triple, weak chain, an
+    # oversized barbell that SPLITS at max_cluster_size=5, score-tied edges,
+    # a duplicate canonical pair, and a dense oversized clique (can't-split).
+    pairs = [
+        (1, 2, 0.95),
+        (3, 4, 0.9), (4, 5, 0.92), (3, 5, 0.88),
+        (6, 7, 0.99), (7, 8, 0.40),
+        (10, 11, 0.99), (11, 12, 0.99), (10, 12, 0.99),
+        (14, 15, 0.99), (15, 16, 0.99), (14, 16, 0.99),
+        (12, 14, 0.31),
+        (20, 21, 0.5), (20, 22, 0.5),
+        (1, 2, 0.95),
+        (30, 31, 0.99), (30, 32, 0.99), (30, 33, 0.99), (30, 34, 0.99),
+        (30, 35, 0.99), (30, 36, 0.99), (31, 32, 0.99), (31, 33, 0.99),
+        (31, 34, 0.99), (31, 35, 0.99), (31, 36, 0.99), (32, 33, 0.99),
+        (32, 34, 0.99), (32, 35, 0.99), (32, 36, 0.99), (33, 34, 0.99),
+        (33, 35, 0.99), (33, 36, 0.99), (34, 35, 0.99), (34, 36, 0.99),
+        (35, 36, 0.99),
+    ]
+    all_ids = list(range(0, 23)) + list(range(30, 37))
+    return pairs, all_ids
+
+
+def _df(all_ids):
+    rows = [{"__row_id__": i, "__source__": "src", "id": str(i), "name": f"n{i}"}
+            for i in all_ids]
+    return pl.DataFrame(rows)
+
+
+def _normalized_edges(store: IdentityStore) -> list[tuple]:
+    """Read back ALL edges across all identities, normalize to a sorted
+    canonical list EXCLUDING entity_id (per-run UUID). Compares the durable
+    edge structure: record_a, record_b, kind, score."""
+    edges = []
+    for node in store.list_identities():
+        for e in store.edges_for_entity(node.entity_id):
+            edges.append((e.record_a_id, e.record_b_id, e.kind, e.score))
+    return sorted(edges, key=lambda t: (t[0], t[1], t[2], -1.0 if t[3] is None else t[3]))
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_evidence_edges_byte_identical_via_pairscore_view(monkeypatch, tmp_path, native):
+    pairs, all_ids = _adversarial_pairs()
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+
+    if native == "1":
+        from goldenmatch.core._native_loader import native_module
+        nm = native_module()
+        if nm is None or getattr(nm, "build_clusters_arrow", None) is None:
+            pytest.skip(
+                "native cluster kernel (build_clusters_arrow) absent in this "
+                "environment; native=1 parity is validated in CI's fresh "
+                "native build"
+            )
+
+    clusters = build_clusters(
+        pairs, all_ids=all_ids, max_cluster_size=5,
+        weak_cluster_threshold=0.3, auto_split=True,
+    )
+    df = _df(all_ids)
+
+    # Gate OFF: dict path, fresh store.
+    store_off = IdentityStore(path=str(tmp_path / "off.db"))
+    try:
+        resolve_clusters(
+            clusters, df, pairs, "wd", store_off,
+            run_name="run-off", source_pk_col="id",
+        )
+        off_edges = _normalized_edges(store_off)
+    finally:
+        store_off.close()
+
+    # Gate ON: view path, fresh store. Spy on for_cluster to prove it ran.
+    # ClusterPairScores uses __slots__ (no per-instance attrs), so spy via a
+    # thin subclass that records each lookup.
+    calls: list[int] = []
+
+    class _SpyView(ClusterPairScores):
+        def for_cluster(self, cid):
+            calls.append(cid)
+            return super().for_cluster(cid)
+
+    base = ClusterPairScores.from_cluster_dict(clusters)
+    view = _SpyView(base._by_cid)
+
+    store_on = IdentityStore(path=str(tmp_path / "on.db"))
+    try:
+        resolve_clusters(
+            clusters, df, pairs, "wd", store_on,
+            run_name="run-on", source_pk_col="id",
+            pair_score_view=view,
+        )
+        on_edges = _normalized_edges(store_on)
+    finally:
+        store_on.close()
+
+    assert calls, "view.for_cluster never ran with the gate ON (view not wired)"
+    assert on_edges == off_edges

--- a/packages/python/goldenmatch/tests/test_cluster_pairscores.py
+++ b/packages/python/goldenmatch/tests/test_cluster_pairscores.py
@@ -1,0 +1,37 @@
+from goldenmatch.core.cluster_pairscores import ClusterPairScores
+
+
+def _clusters():
+    return {
+        1: {"members": [0], "size": 1, "pair_scores": {}},
+        2: {"members": [1, 2], "size": 2, "pair_scores": {(1, 2): 0.9}},
+        3: {"members": [3, 4, 5], "size": 3,
+            "pair_scores": {(3, 4): 0.8, (4, 5): 0.7, (3, 5): 0.6}},
+    }
+
+
+def test_for_cluster_matches_dict_exactly():
+    clusters = _clusters()
+    view = ClusterPairScores.from_cluster_dict(clusters)
+    for cid, info in clusters.items():
+        assert view.for_cluster(cid) == info["pair_scores"]
+
+
+def test_for_cluster_missing_or_singleton_is_empty():
+    view = ClusterPairScores.from_cluster_dict(_clusters())
+    assert view.for_cluster(1) == {}
+    assert view.for_cluster(999) == {}
+
+
+def test_iter_clusters_yields_pairs_in_row_order():
+    view = ClusterPairScores.from_cluster_dict(_clusters())
+    got = {cid: list(pairs) for cid, pairs in view.iter_clusters()}
+    assert got[2] == [(1, 2, 0.9)]
+    assert got[3] == [(3, 4, 0.8), (4, 5, 0.7), (3, 5, 0.6)]
+    assert 1 not in got  # singleton contributes no rows
+
+
+def test_score_for_bottleneck_lookup():
+    view = ClusterPairScores.from_cluster_dict(_clusters())
+    assert view.score_for(3, 5, 3) == 0.6   # canonical (min,max) regardless of arg order
+    assert view.score_for(3, 9, 9) is None


### PR DESCRIPTION
## Summary

Phase-2 SP2 (follow-on to SP1 #673). Adds a lazy `ClusterPairScores` view and migrates the durability-critical `identity/resolve.py` evidence-edge consumer onto it, BYTE-IDENTICAL, behind the existing `GOLDENMATCH_COLUMNAR_CLUSTER_BUILD` gate (default OFF).

- **`core/cluster_pairscores.py::ClusterPairScores`** (new): `for_cluster(cid)` / `iter_clusters()` / `score_for(cid,a,b)`, sourced from the FINAL post-split cluster dict so it is byte-identical to the dict path (`for_cluster(cid) == clusters[cid]["pair_scores"]` by construction). dict-of-dicts backing; the `iter_clusters` interface is frame-ready for a future SP that makes the build produce a columnar pair frame natively.
- **`identity/resolve.py`**: optional `pair_score_view` on `resolve_clusters`; all three `pair_scores` read sites (bulk postgres path, slow path, weak-cluster bottleneck) read from the view when provided, else the dict.
- **`core/pipeline.py`**: when the gate is ON, build the view once from the cluster dict and thread it into `_resolve_identities` (guarded `isinstance(clusters, dict)` so the Ray path is untouched).

## Re-scope: identity-only

Plan review found golden's `pair_scores` is a phantom: the pipeline never feeds `pair_scores` to `confidence_majority` (it silently falls back to count-majority), so a byte-identical golden migration would be a vacuous no-op. That latent golden-survivorship bug is filed as **#678** and deferred. SP2 is identity-only.

## Not a perf win (by design)

The view is sourced from the still-materialized dict (adds a copy), so SP2 is an abstraction + de-risking step, NOT a perf win — the gate stays default-OFF and there's no bench. It decouples identity from the dict shape so a future SP can make the build produce the columnar frame natively (and drop the per-cluster dict) WITHOUT re-touching the durability-critical identity path.

## Test plan

- [x] `tests/test_cluster_pairscores.py` view unit tests (4).
- [x] `tests/test_cluster_pairscore_view_parity.py` byte-identical evidence-edge gate (gate ON vs OFF; fixture has multi-member + oversized-split + singletons + dup pair; 15 clusters / 26 edges). native=0 passes locally; native=1 validated in CI's fresh native build (local `_native.pyd` is stale).
- [x] `tests/identity/` green with the gate forced ON (no new failures vs OFF).
- [x] ruff clean.

> The byte-identical evidence-edge invariant feeds identity entity-ids (durability). The native cluster path is CI-only validated here (stale local kernel); CI's native lane runs the native=1 parity case.