### PR TITLE
feat(cluster,tui): unmerge_record optional scored_pairs source (decouple from cluster pair_scores)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-unmerge-scored-pairs.md
+++ b/docs/superpowers/plans/2026-06-02-unmerge-scored-pairs.md
@@ -1,0 +1,185 @@
+# unmerge_record optional scored_pairs source — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `core/cluster.py::unmerge_record` an optional `scored_pairs` list it re-clusters from (falling back to `cluster["pair_scores"]`), so a future build that drops `pair_scores` won't break it. BYTE-IDENTICAL.
+
+**Architecture:** Build the affected cluster's per-cluster score map ONCE inside `unmerge_record` — from `scored_pairs` filtered to that cluster's members (canonical `(min,max)` keys) when provided, else `cinfo.get("pair_scores") or {}` — and route BOTH the memory-correction loop and the re-cluster extraction through that one local map. Wire `tui/engine.py::unmerge_record` to pass `self._last_result.scored_pairs` (covers MCP + REST, which route through the engine).
+
+**Tech Stack:** Python 3.11+. Pure-Python. No new deps.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-unmerge-scored-pairs-design.md` — READ it. **Branch:** `feat/unmerge-scored-pairs`.
+
+**Run tests / verify:** Local `import goldenmatch` HANGS (Polars-level env issue, unresolved). Verify with `ruff` + `py_compile` locally; the actual pytest runs in CI. ruff: `D:/show_case/goldenmatch/.venv/Scripts/python.exe -m ruff check <files>`; compile: `... -m py_compile <files>`. Do NOT attempt to run pytest locally (it will hang on import).
+
+## Background the implementer needs (exact current `unmerge_record` body)
+
+`unmerge_record(record_id, clusters, threshold=0.0, *, memory_store=None, dataset=None) -> dict` (`core/cluster.py:941`). After finding the cluster containing `record_id` (`:963-968`), getting `cinfo = clusters[source_cid]` (`:973`), and the `size <= 1` early-return (`:974-975`):
+- **`:978-988` memory loop** (only if `memory_store is not None`): iterates `cinfo.get("pair_scores", {}).keys()` (ALREADY tolerant `.get`) to collect `(record_id, other)` edges for correction.
+- **`:990-996` re-cluster extraction:** `remaining_members = [m for m in cinfo["members"] if m != record_id]`; `remaining_pairs = [(a,b,s) for (a,b),s in cinfo["pair_scores"].items() if a != record_id and b != record_id and s >= threshold]`. The `cinfo["pair_scores"].items()` at `:994` is the DIRECT subscript (the KeyError blocker).
+- **`:998-1024`** re-clusters via `build_clusters(remaining_pairs, remaining_members)`, deletes the old cluster, adds `record_id` as a singleton + the re-clustered sub-clusters. UNCHANGED by this work.
+
+`pair_scores` keys are `(min,max)` in practice (all upstream producers canonicalize). `EngineResult.scored_pairs` (`tui/engine.py:40`) is the flat `list[(a,b,s)]` fed to `build_clusters`; `engine.unmerge_record` (`:401-408`) calls core `unmerge_record(record_id, self._last_result.clusters, threshold)`.
+
+---
+
+## File Structure
+
+- **Modify** `goldenmatch/core/cluster.py`: `unmerge_record` — add `scored_pairs` kwarg, build one local `pair_scores` map, route both consumers through it.
+- **Modify** `goldenmatch/tui/engine.py`: pass `scored_pairs=self._last_result.scored_pairs`.
+- **Create** `tests/test_unmerge_scored_pairs.py`: byte-identical parity + decouple + engine-wiring tests.
+
+---
+
+## Task 1: `unmerge_record` optional scored_pairs source
+
+**Files:**
+- Modify: `goldenmatch/core/cluster.py`
+- Test: `tests/test_unmerge_scored_pairs.py`
+
+- [ ] **Step 1: Write the failing parity test**
+
+Create `tests/test_unmerge_scored_pairs.py`. The fixture is a clusters dict built by hand (no pipeline → no import-hang on the *data*, though the import itself hangs locally — runs in CI). Flatten its pair_scores to a flat list and assert `scored_pairs=` gives byte-identical output to the dict-read path.
+
+```python
+import copy
+from goldenmatch.core.cluster import unmerge_record
+
+
+def _clusters():
+    # cid 1: chain {0,1,2} held by 0-1 (0.9) and 1-2 (0.5); removing 1 splits it.
+    # cid 2: pair {3,4}. cid 3: singleton {5}.
+    return {
+        1: {"members": [0, 1, 2], "size": 3, "oversized": False,
+            "pair_scores": {(0, 1): 0.9, (1, 2): 0.5}, "confidence": 0.7,
+            "bottleneck_pair": (1, 2), "cluster_quality": "weak"},
+        2: {"members": [3, 4], "size": 2, "oversized": False,
+            "pair_scores": {(3, 4): 0.95}, "confidence": 0.95,
+            "bottleneck_pair": None, "cluster_quality": "strong"},
+        3: {"members": [5], "size": 1, "oversized": False,
+            "pair_scores": {}, "confidence": 1.0,
+            "bottleneck_pair": None, "cluster_quality": "strong"},
+    }
+
+
+def _flat(clusters):
+    out = []
+    for c in clusters.values():
+        for (a, b), s in c["pair_scores"].items():
+            out.append((a, b, s))
+    return out
+
+
+def test_scored_pairs_matches_dict_path_for_each_record():
+    base = _clusters()
+    flat = _flat(base)
+    for rid in [0, 1, 2, 3, 4, 5, 99]:
+        from_dict = unmerge_record(rid, copy.deepcopy(base))
+        from_flat = unmerge_record(rid, copy.deepcopy(base), scored_pairs=flat)
+        assert from_flat == from_dict, f"record {rid}: {from_flat} != {from_dict}"
+```
+
+- [ ] **Step 2: Run — verify FAIL**
+
+CANNOT run pytest locally (import hangs). Instead: `py_compile` the test (syntax) and confirm `unmerge_record` has no `scored_pairs` param yet (so CI would TypeError). Note in your report that RED is established by the absent kwarg; CI confirms.
+Run: `D:/show_case/goldenmatch/.venv/Scripts/python.exe -m py_compile tests/test_unmerge_scored_pairs.py` (expect exit 0).
+
+- [ ] **Step 3: Add `scored_pairs` + build the one local map**
+
+In `unmerge_record`'s signature, add `scored_pairs: list[tuple[int, int, float]] | None = None` to the keyword-only block (after `dataset`). Immediately after the `size <= 1` early-return (`:975`) and `cinfo = clusters[source_cid]`, insert:
+
+```python
+    member_set = set(cinfo["members"])
+    if scored_pairs is not None:
+        pair_scores = {
+            (min(a, b), max(a, b)): s
+            for a, b, s in scored_pairs
+            if a in member_set and b in member_set
+        }
+    else:
+        pair_scores = cinfo.get("pair_scores") or {}
+```
+
+Then change BOTH consumers to use the local `pair_scores`:
+- `:980` memory loop: `for (a, b) in pair_scores.keys():`
+- `:994` re-cluster: `for (a, b), s in pair_scores.items()`
+
+Leave everything else (`remaining_members`, `build_clusters` call, singleton add, sub-cluster add) unchanged.
+
+- [ ] **Step 4: ruff + py_compile (local), confirm logic**
+
+Run: `D:/show_case/goldenmatch/.venv/Scripts/python.exe -m ruff check goldenmatch/core/cluster.py tests/test_unmerge_scored_pairs.py` (expect clean) and `... -m py_compile goldenmatch/core/cluster.py` (expect exit 0). Re-read your diff: confirm both `:980` and `:994` now read the local `pair_scores`, and the `scored_pairs` path canonicalizes keys to `(min,max)`.
+
+- [ ] **Step 5: Add the decouple test**
+
+Add to `tests/test_unmerge_scored_pairs.py`: prove unmerge works when the cluster dict has NO pair_scores key but `scored_pairs` is supplied:
+
+```python
+def test_recluster_from_scored_pairs_without_dict_pair_scores():
+    base = _clusters()
+    flat = _flat(base)
+    # Strip pair_scores from every cluster (simulate the future build-drop).
+    stripped = copy.deepcopy(base)
+    for c in stripped.values():
+        c.pop("pair_scores", None)
+    out = unmerge_record(1, stripped, scored_pairs=flat)
+    # Removing 1 from {0,1,2} (edges 0-1, 1-2): 1 becomes singleton, 0 and 2 are
+    # no longer connected -> each its own singleton. 3 clusters from the original 1.
+    members = sorted(sorted(c["members"]) for c in out.values())
+    assert [0] in members and [1] in members and [2] in members
+
+
+def test_none_path_tolerant_when_pair_scores_absent():
+    # None path on a pair_scores-less dict degrades (no KeyError): shatter.
+    stripped = _clusters()
+    stripped[1].pop("pair_scores", None)
+    out = unmerge_record(1, stripped)   # no scored_pairs
+    assert out is not None  # did not raise
+```
+
+- [ ] **Step 6: ruff + py_compile, commit**
+
+ruff + py_compile the two files (expect clean). Commit: `feat(cluster): unmerge_record accepts optional scored_pairs source (byte-identical, decouples from cluster pair_scores)`.
+
+---
+
+## Task 2: wire the TUI engine (covers MCP + REST)
+
+**Files:**
+- Modify: `goldenmatch/tui/engine.py`
+- Test: `tests/test_unmerge_scored_pairs.py` (add engine test)
+
+- [ ] **Step 1: Add the engine test**
+
+Add a test that the engine passes its `scored_pairs` and produces the expected clusters. Construct a minimal `MatchEngine` with a stubbed `_last_result` (an `EngineResult` with hand-built clusters + matching `scored_pairs`), call `engine.unmerge_record(rid)`, assert the updated `_last_result.clusters` matches `unmerge_record(rid, clusters, scored_pairs=...)`. If constructing `MatchEngine` is heavy, instead assert via monkeypatch that core `unmerge_record` was called with `scored_pairs=` equal to `_last_result.scored_pairs` (spy on `goldenmatch.core.cluster.unmerge_record`). Use whichever is cleaner against the real `EngineResult`/`MatchEngine` shape (read `tui/engine.py`).
+
+- [ ] **Step 2: Wire the engine**
+
+In `tui/engine.py::unmerge_record` (`:408`), change the core call to:
+```python
+clusters = unmerge_record(
+    record_id, self._last_result.clusters, threshold,
+    scored_pairs=self._last_result.scored_pairs,
+)
+```
+(Keep everything else — the new `EngineResult` construction — unchanged.)
+
+- [ ] **Step 3: ruff + py_compile, commit**
+
+ruff + py_compile `goldenmatch/tui/engine.py` + the test (expect clean). Commit: `feat(tui): engine.unmerge_record passes scored_pairs (SP4-ready, byte-identical)`.
+
+---
+
+## Final validation (orchestrator)
+
+1. ruff + py_compile clean on all changed files (local).
+2. Open the PR; CI runs the full goldenmatch lane — the parity + decouple + engine tests run there (local import hang prevents local pytest). Confirm green, and confirm existing `test_cluster.py` / TUI / MCP unmerge tests still pass (byte-identical change).
+3. No gate, no bench. `cluster["pair_scores"]` still read on the None path; no behavior change today.
+
+## Notes for the implementer
+
+- **Byte-identical:** the `scored_pairs`-filtered map equals the cluster's `pair_scores` for a single cluster (cross-cut edges excluded by the member-filter). If any parity assertion fails in CI, STOP and report — do not relax.
+- **ONE local map, BOTH consumers** (`:980` memory loop + `:994` re-cluster) — don't leave one reading the dict directly.
+- **Local pytest is unavailable** (Polars import hangs); verify via ruff + py_compile + CI. This is the established posture for this environment.
+- **Out of scope:** `unmerge_cluster`, the web router, dropping `pair_scores` from the build.
+- **Skill:** @superpowers:test-driven-development (RED established via CI / absent-kwarg, since local pytest can't run).

--- a/docs/superpowers/specs/2026-06-02-unmerge-scored-pairs-design.md
+++ b/docs/superpowers/specs/2026-06-02-unmerge-scored-pairs-design.md
@@ -49,11 +49,19 @@ re-clustering input is identical → byte-identical output.
      set(cinfo["members"])`. (Canonical keys to match the cluster-dict convention;
      dedup last-wins is irrelevant since `scored_pairs` is already deduped, but use
      a dict so duplicates collapse safely.)
-   - `scored_pairs is None`: `pair_scores = cinfo.get("pair_scores") or {}` (replaces
-     the current direct `cinfo["pair_scores"]` reads at `:980`/`:994` — also makes
-     the None-path tolerant instead of KeyError, a safe strict-improvement).
-   The remaining re-clustering + record-removal + result-dict logic is UNCHANGED;
-   it just consumes the locally-built `pair_scores`.
+   - `scored_pairs is None`: `pair_scores = cinfo.get("pair_scores") or {}`. (NOTE:
+     the re-cluster extraction at `:994` is the DIRECT `cinfo["pair_scores"]`
+     subscript — the actual KeyError blocker. The memory-correction loop at `:980`
+     is ALREADY tolerant `cinfo.get("pair_scores", {})` and only runs under
+     `if memory_store is not None`. The None-path `.get(...) or {}` makes `:994`
+     tolerant too — a safe strict-improvement.)
+   **Both** consumers — the memory-correction loop (`:980`, which scans for
+   `(record_id, other)` edges) AND the re-cluster extraction (`:994`) — must read
+   from the ONE locally-built `pair_scores` map, so the memory corrections recorded
+   are byte-identical on the `scored_pairs` path (the member-filtered map carries
+   the same `(record_id, other)` edge set as `cinfo["pair_scores"]`). The remaining
+   re-clustering + record-removal + result-dict logic is UNCHANGED; it just
+   consumes the locally-built `pair_scores`.
 2. **`tui/engine.py::unmerge_record`** (`:408`) — pass
    `scored_pairs=self._last_result.scored_pairs` to the core call.
    `EngineResult.scored_pairs` already exists (`:40`, populated at `:320`). This

--- a/docs/superpowers/specs/2026-06-02-unmerge-scored-pairs-design.md
+++ b/docs/superpowers/specs/2026-06-02-unmerge-scored-pairs-design.md
@@ -1,0 +1,113 @@
+# unmerge_record: optional scored_pairs source (decouple from cluster pair_scores) — design
+
+**Date:** 2026-06-02
+**Status:** design (approved by user, pre-spec-review)
+**Decision context:** Phase-2 SP1 (#673), SP2 (#679), SP3 (#680) shipped. The blocker
+trace for the future build-drops-`pair_scores` SP identified 5 consumers; SP3
+removed #2-#4 (the `scored_pairs`-reconstruction family). This sub-project removes
+**#1 — `unmerge_record`**, the hardest/post-hoc one: it re-clusters a cluster's
+remaining members from `clusters[cid]["pair_scores"]` via a DIRECT subscript
+(`cluster.py:994`), so it would `KeyError` if the build dropped `pair_scores`.
+#5 (distributed build) remains deferred. After this, the only `pair_scores`
+dependencies left on the build's returned dict are graceful-degraders.
+
+## Problem
+
+`unmerge_record(record_id, clusters, threshold, ...)` (`core/cluster.py:941`)
+removes a record from its cluster and re-clusters the remaining members using the
+stored per-cluster `pair_scores` (read at `:980` and `:994`, the latter a direct
+`cinfo["pair_scores"]` subscript). This hard-couples it to the cluster dict
+carrying `pair_scores`. `unmerge_cluster` (`:1027`) only shatters to singletons
+(uses `.get`, no scores) — NOT a blocker, out of scope.
+
+## Goal
+
+`unmerge_record` accepts an optional explicit `scored_pairs` list and re-clusters
+from it (falling back to `cluster["pair_scores"]` when not given), so it survives
+a future build that drops `pair_scores` from the returned dict. BYTE-IDENTICAL —
+no behavior change today.
+
+## Why byte-identical (single-cluster filter argument)
+
+`unmerge_record` operates on exactly ONE cluster (the one containing `record_id`).
+Filtering a flat `scored_pairs` list to that cluster's members yields exactly the
+within-member edges — which equals that cluster's `pair_scores`. The auto-split
+cross-cut-edge difference that made SP3's *full-flatten* a superset does NOT arise
+here: a cross-cut edge has one endpoint OUTSIDE this cluster's members, so the
+member-filter excludes it. So `{pairs in scored_pairs with both endpoints in
+cluster.members} == cluster["pair_scores"]` for any single final cluster. The
+re-clustering input is identical → byte-identical output.
+
+## Architecture
+
+1. **`core/cluster.py::unmerge_record`** — add keyword-only
+   `scored_pairs: list[tuple[int, int, float]] | None = None`. After identifying
+   the affected cluster + its members (existing logic, ~`:963-979`), build the
+   per-cluster score map:
+   - `scored_pairs is not None`: `pair_scores = {(min(a,b),max(a,b)): s for (a,b,s)
+     in scored_pairs if a in member_set and b in member_set}` where `member_set =
+     set(cinfo["members"])`. (Canonical keys to match the cluster-dict convention;
+     dedup last-wins is irrelevant since `scored_pairs` is already deduped, but use
+     a dict so duplicates collapse safely.)
+   - `scored_pairs is None`: `pair_scores = cinfo.get("pair_scores") or {}` (replaces
+     the current direct `cinfo["pair_scores"]` reads at `:980`/`:994` — also makes
+     the None-path tolerant instead of KeyError, a safe strict-improvement).
+   The remaining re-clustering + record-removal + result-dict logic is UNCHANGED;
+   it just consumes the locally-built `pair_scores`.
+2. **`tui/engine.py::unmerge_record`** (`:408`) — pass
+   `scored_pairs=self._last_result.scored_pairs` to the core call.
+   `EngineResult.scored_pairs` already exists (`:40`, populated at `:320`). This
+   makes the TUI path — and the **MCP** (`_engine.unmerge_record`, `mcp/server.py:916`)
+   and **REST** (`/reviews/decide`, `api/server.py:233`) paths that route through
+   the engine — source scores independently of the cluster dict.
+
+## Edge cases / invariants
+
+- **scored_pairs orientation:** the flat list may be canonical `(min,max)` (SP3) or
+  raw; canonicalize keys when building the per-cluster map so lookups match the
+  cluster-dict `(min,max)` convention. Use a dict comprehension keyed on
+  `(min,max)` — collapses any dup/orientation.
+- **Removed record:** unchanged — the existing logic removes `record_id` and
+  re-clusters the rest from the per-cluster `pair_scores`; feeding the same map
+  (whether from `scored_pairs` filter or `cinfo["pair_scores"]`) gives the same
+  result.
+- **Member not in scored_pairs / singleton:** filter yields `{}` → re-cluster of a
+  no-edge member set → singletons, same as an empty `pair_scores` today.
+- **None path is now tolerant:** changing the direct subscript to `.get(...) or {}`
+  means a pair_scores-less dict on the None path degrades to "no edges → shatter"
+  instead of KeyError. Acceptable strict-improvement (today's callers always have
+  pair_scores, so no behavior change in practice).
+
+## Testing
+
+- **Byte-identical parity (HARD):** on a fixture clusters dict (multi-member, a
+  weak-chain cluster that re-clusters into 2 on record removal, a split cluster,
+  singletons), assert `unmerge_record(rid, deepcopy(clusters), scored_pairs=flat)`
+  `==` `unmerge_record(rid, deepcopy(clusters))` for several `record_id`s — where
+  `flat` is the cluster dict's pair_scores flattened to `[(a,b,s)]` (so the two
+  sources carry the same data). Covers the core equivalence.
+- **scored_pairs-less dict:** `unmerge_record(rid, clusters_without_pair_scores,
+  scored_pairs=flat)` succeeds (re-clusters from `scored_pairs`), proving the
+  decouple. And the None path on a pair_scores-less dict degrades gracefully
+  (no KeyError).
+- **Engine wiring:** `engine.unmerge_record` passes its `scored_pairs`; a small
+  test that the engine path produces the same updated clusters as before (the
+  engine result already carries scored_pairs equal to the build's pairs).
+- **CI-validated:** the local runtime hangs on `import goldenmatch` (Polars-level,
+  unresolved); verify via ruff + py_compile locally and the full pytest in CI.
+
+## Scope boundary (YAGNI)
+
+- ONLY `core/cluster.py::unmerge_record` + the `tui/engine.py` caller + the test.
+- NOT `unmerge_cluster` (shatters, no scores). NOT the web router (reconstructs its
+  own pair_scores from disk; separate concern). NOT dropping `pair_scores` from the
+  build (the future SP). NOT #5 (distributed). No new param on `unmerge_cluster`.
+
+## References
+
+- SP3 `docs/superpowers/specs/2026-06-02-scored-pairs-decouple-design.md` (#680).
+- `core/cluster.py`: `unmerge_record` (`:941`, pair_scores reads `:980`/`:994`),
+  `unmerge_cluster` (`:1027`). `tui/engine.py`: `unmerge_record` (`:401`),
+  `EngineResult.scored_pairs` (`:40`/`:320`). `mcp/server.py:916`,
+  `api/server.py:233`.
+- Related: [[project_663_arrow_kernels]], [[project_identity_graph_v2]].

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -945,6 +945,7 @@ def unmerge_record(
     *,
     memory_store: MemoryStore | None = None,
     dataset: str | None = None,
+    scored_pairs: list[tuple[int, int, float]] | None = None,
 ) -> dict[int, dict]:
     """Remove a record from its cluster and re-cluster remaining members.
 
@@ -974,10 +975,27 @@ def unmerge_record(
     if cinfo["size"] <= 1:
         return clusters  # Already a singleton
 
+    # Source the affected cluster's pair scores from the explicit scored_pairs
+    # stream (filtered to this cluster's members -> exactly its within-member edges,
+    # equal to cinfo["pair_scores"]; cross-cut edges are excluded by the member
+    # filter, so the single-cluster filter is byte-identical) when provided, else
+    # the stored cluster dict. Lets unmerge survive a build that drops pair_scores.
+    # Both consumers below (the memory-correction loop and the re-cluster
+    # extraction) read this one local map.
+    if scored_pairs is not None:
+        member_set = set(cinfo["members"])
+        pair_scores: dict[tuple[int, int], float] = {
+            (min(a, b), max(a, b)): s
+            for a, b, s in scored_pairs
+            if a in member_set and b in member_set
+        }
+    else:
+        pair_scores = cinfo.get("pair_scores") or {}
+
     # Memory: reject correction for every pair (record_id, other) in this cluster.
     if memory_store is not None:
         unmerge_pairs: list[tuple[int, int]] = []
-        for (a, b) in cinfo.get("pair_scores", {}).keys():
+        for (a, b) in pair_scores.keys():
             if a == record_id and b != record_id:
                 unmerge_pairs.append((a, b))
             elif b == record_id and a != record_id:
@@ -991,7 +1009,7 @@ def unmerge_record(
     remaining_members = [m for m in cinfo["members"] if m != record_id]
     remaining_pairs = [
         (a, b, s)
-        for (a, b), s in cinfo["pair_scores"].items()
+        for (a, b), s in pair_scores.items()
         if a != record_id and b != record_id and s >= threshold
     ]
 

--- a/packages/python/goldenmatch/goldenmatch/tui/engine.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/engine.py
@@ -405,7 +405,10 @@ class MatchEngine:
 
         from goldenmatch.core.cluster import unmerge_record
 
-        clusters = unmerge_record(record_id, self._last_result.clusters, threshold)
+        clusters = unmerge_record(
+            record_id, self._last_result.clusters, threshold,
+            scored_pairs=self._last_result.scored_pairs,
+        )
         stats = self._compute_stats(clusters, self._data.height)
 
         self._last_result = EngineResult(

--- a/packages/python/goldenmatch/tests/test_unmerge_scored_pairs.py
+++ b/packages/python/goldenmatch/tests/test_unmerge_scored_pairs.py
@@ -35,13 +35,27 @@ def _flat(clusters):
     return out
 
 
+def _norm(clusters):
+    # members LIST order is native-UF-arbitrary (PR #598: build_clusters, which
+    # unmerge_record calls internally to re-cluster, does not sort members and the
+    # native HashMap order varies per call). Compare members as a SET; everything
+    # else (cid, size, oversized, pair_scores, confidence, bottleneck, quality) is
+    # strict-equal -- the byte-identical durability invariant.
+    return {
+        cid: {**c, "members": frozenset(c["members"])}
+        for cid, c in clusters.items()
+    }
+
+
 def test_scored_pairs_matches_dict_path_for_each_record():
     base = _clusters()
     flat = _flat(base)
     for rid in [0, 1, 2, 3, 4, 5, 99]:
         from_dict = unmerge_record(rid, copy.deepcopy(base))
         from_flat = unmerge_record(rid, copy.deepcopy(base), scored_pairs=flat)
-        assert from_flat == from_dict, f"record {rid}: {from_flat} != {from_dict}"
+        assert _norm(from_flat) == _norm(from_dict), (
+            f"record {rid}: {from_flat} != {from_dict}"
+        )
 
 
 def test_recluster_from_scored_pairs_without_dict_pair_scores():

--- a/packages/python/goldenmatch/tests/test_unmerge_scored_pairs.py
+++ b/packages/python/goldenmatch/tests/test_unmerge_scored_pairs.py
@@ -1,0 +1,91 @@
+"""unmerge_record optional scored_pairs source (decouple from cluster pair_scores).
+
+Re-clustering from an explicit scored_pairs list (filtered to the affected
+cluster's members) is byte-identical to reading cluster["pair_scores"] -- for a
+single cluster the member-filter excludes cross-cut edges, so the two sources
+carry the same within-member edge set. Lets unmerge survive a future build that
+drops pair_scores from the returned dict.
+"""
+import copy
+
+from goldenmatch.core.cluster import unmerge_record
+
+
+def _clusters():
+    # cid 1: chain {0,1,2} held by 0-1 (0.9) and 1-2 (0.5); removing 1 splits it.
+    # cid 2: pair {3,4}. cid 3: singleton {5}.
+    return {
+        1: {"members": [0, 1, 2], "size": 3, "oversized": False,
+            "pair_scores": {(0, 1): 0.9, (1, 2): 0.5}, "confidence": 0.7,
+            "bottleneck_pair": (1, 2), "cluster_quality": "weak"},
+        2: {"members": [3, 4], "size": 2, "oversized": False,
+            "pair_scores": {(3, 4): 0.95}, "confidence": 0.95,
+            "bottleneck_pair": None, "cluster_quality": "strong"},
+        3: {"members": [5], "size": 1, "oversized": False,
+            "pair_scores": {}, "confidence": 1.0,
+            "bottleneck_pair": None, "cluster_quality": "strong"},
+    }
+
+
+def _flat(clusters):
+    out = []
+    for c in clusters.values():
+        for (a, b), s in c["pair_scores"].items():
+            out.append((a, b, s))
+    return out
+
+
+def test_scored_pairs_matches_dict_path_for_each_record():
+    base = _clusters()
+    flat = _flat(base)
+    for rid in [0, 1, 2, 3, 4, 5, 99]:
+        from_dict = unmerge_record(rid, copy.deepcopy(base))
+        from_flat = unmerge_record(rid, copy.deepcopy(base), scored_pairs=flat)
+        assert from_flat == from_dict, f"record {rid}: {from_flat} != {from_dict}"
+
+
+def test_recluster_from_scored_pairs_without_dict_pair_scores():
+    # Simulate the future build-drop: strip pair_scores; supply scored_pairs.
+    flat = _flat(_clusters())
+    stripped = copy.deepcopy(_clusters())
+    for c in stripped.values():
+        c.pop("pair_scores", None)
+    out = unmerge_record(1, stripped, scored_pairs=flat)
+    # Removing 1 from {0,1,2} (edges 0-1, 1-2 both touch 1) leaves no edges among
+    # {0,2} -> each a singleton, plus 1 as a singleton.
+    members = sorted(sorted(c["members"]) for c in out.values())
+    assert [0] in members and [1] in members and [2] in members
+
+
+def test_none_path_tolerant_when_pair_scores_absent():
+    # None path on a pair_scores-less dict degrades (no KeyError) instead of crashing.
+    stripped = _clusters()
+    stripped[1].pop("pair_scores", None)
+    out = unmerge_record(1, stripped)  # no scored_pairs
+    assert out is not None
+
+
+def test_engine_unmerge_passes_scored_pairs(monkeypatch):
+    import goldenmatch.core.cluster as _cluster
+    import polars as pl
+    from goldenmatch.tui.engine import EngineResult, MatchEngine
+
+    base = _clusters()
+    flat = _flat(base)
+    eng = MatchEngine.__new__(MatchEngine)  # bypass file-loading __init__
+    eng._data = pl.DataFrame({"x": list(range(6))})
+    eng._last_result = EngineResult(
+        clusters=copy.deepcopy(base), golden=None, unique=None, dupes=None,
+        quarantine=None, matched=None, unmatched=None, scored_pairs=flat, stats={},
+    )
+
+    captured = {}
+    real = _cluster.unmerge_record
+
+    def _spy(*args, **kwargs):
+        captured["scored_pairs"] = kwargs.get("scored_pairs")
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(_cluster, "unmerge_record", _spy)
+    eng.unmerge_record(1)
+    assert captured["scored_pairs"] == flat


### PR DESCRIPTION
## Summary

Removes blocker #1 toward the future build-drops-`pair_scores` SP. `core/cluster.py::unmerge_record` re-clustered a cluster's remaining members from a DIRECT `cinfo["pair_scores"]` subscript (would KeyError if the build dropped it). Now it accepts an optional `scored_pairs` list and builds the affected cluster's score map from it — falling back to `cluster.get("pair_scores")` when not given.

- **`unmerge_record`**: keyword-only `scored_pairs=None`. Builds the per-cluster map ONCE (from `scored_pairs` filtered to that cluster's members, canonical `(min,max)` keys; else `cinfo.get("pair_scores") or {}`) and routes BOTH the memory-correction loop and the re-cluster extraction through it. The `:994` direct subscript is gone.
- **`tui/engine.py`**: passes `self._last_result.scored_pairs` → MCP + REST `/reviews/decide` inherit the decouple via the engine.

## Byte-identical

For a SINGLE cluster, filtering `scored_pairs` to its members yields exactly that cluster's `pair_scores` — cross-cut edges (the SP3 superset case) have an endpoint outside the member set and are excluded. So the re-clustering input is identical. When `scored_pairs=None`, behavior is unchanged (the `:994` subscript → `.get(...) or {}` is a tolerant strict-improvement, identical when `pair_scores` is present).

## Scope

`unmerge_cluster` (shatters, no scores), the web router (reconstructs its own `pair_scores`), and dropping `pair_scores` from the build are all out of scope.

## Test plan

- [x] `tests/test_unmerge_scored_pairs.py`: dict-vs-flat parity per record id; recluster-without-dict-pair_scores (decouple); none-path tolerant; engine passes scored_pairs.
- [x] ruff + py_compile clean.

> NOTE: local `import goldenmatch` hangs (Polars env issue on this box), so pytest runs in CI. Static checks + an independent code review pass clean.