### PR TITLE
feat(cluster): frames-native finalize tail + gated build_cluster_frames (Phase-2 SP-A)

### DIFF
--- a/.github/workflows/bench-cluster-frames-out.yml
+++ b/.github/workflows/bench-cluster-frames-out.yml
@@ -1,0 +1,48 @@
+name: bench-cluster-frames-out
+
+# SP-A build-stage bench (workflow_dispatch only), RECORDED DATA not a kill gate.
+# Builds the native ext fresh so the columnar build hits the real Arrow kernel,
+# then benches build_cluster_frames (frames-out, GOLDENMATCH_CLUSTER_FRAMES_OUT=1)
+# vs the score-free dict (build_clusters, GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1) at
+# scale on the bulk-RSS axis (k=5, no oversized clusters). Parity
+# (cluster_frames_to_dict == score-free dict, except members/pair_scores) is
+# asserted before any perf.
+on:
+  workflow_dispatch:
+    inputs:
+      np:
+        description: "Comma-separated target pair counts"
+        default: "1000000,5000000"
+      runs:
+        description: "Repetitions per measurement (median)"
+        default: "3"
+
+jobs:
+  bench:
+    runs-on: large-new-64GB
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Build native extension (exposes build_clusters_arrow)
+        run: uv run python scripts/build_native.py
+      - name: Bench cluster frames-out (frames vs score-free dict)
+        run: |
+          set -o pipefail
+          uv run python packages/python/goldenmatch/scripts/bench_cluster_frames_out.py \
+            --np "${{ inputs.np }}" --runs "${{ inputs.runs }}" \
+            --output .profile_tmp/cluster_frames_out.json | tee /tmp/cluster_frames_out.txt
+          { echo '## bench-cluster-frames-out'; echo '```'; cat /tmp/cluster_frames_out.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: always()
+        with:
+          name: cluster-frames-out
+          path: .profile_tmp/cluster_frames_out.json
+          retention-days: 30

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -550,10 +550,71 @@ def build_cluster_frames(
         "avg_edge": m_avg,
     })
 
-    if auto_split and metadata.filter(_pl.col("oversized")).height > 0:
-        # TASK 2 inserts the frames-native split here (mutates assignments +
-        # metadata: oversized rows -> MST sub-clusters, quality="split").
-        pass
+    if auto_split:
+        # Frames-native auto-split: the per-cluster dict (the SP1 bench loss) is
+        # confined to the rare oversized MINORITY. Mirrors _finalize_clusters's
+        # split loop EXACTLY (next_cid from max-existing +1 before use, edge-work
+        # budget + no-progress guards, deterministic sub.sort, re-enqueue still-
+        # oversized). split rows carry quality="split" so the Step-3 vectorized
+        # weak/quality block's when(quality=="split") short-circuit preserves them.
+        oversized = metadata.filter(_pl.col("oversized"))["cluster_id"].to_list()
+        if oversized:
+            members_by_cid = {
+                int(cid): assignments.filter(_pl.col("cluster_id") == cid)["member_id"].to_list()
+                for cid in oversized
+            }
+            next_cid = int(metadata["cluster_id"].max())   # +1 inside loop
+            split_assign_rows = []
+            split_meta_rows = []
+            drop_cids = set()
+            to_split = list(oversized)
+            edge_work, edge_budget, budget_tripped = 0, _split_edge_work_budget(), False
+            while to_split:
+                cid = to_split.pop()
+                members = members_by_cid.pop(cid)
+                ms = set(members)
+                ps = {(a, b): s for a, b, s in pairs_list if a in ms and b in ms}
+                edge_work += len(ps)
+                if edge_work > edge_budget:
+                    budget_tripped = True
+                    break  # leave cid (and queued) oversized: do NOT drop them
+                subs = split_oversized_cluster(members, ps)
+                if len(subs) <= 1:
+                    continue  # unsplittable: keep original row as-is
+                subs.sort(key=lambda sc: min(sc["members"]))
+                drop_cids.add(cid)
+                for sc in subs:
+                    next_cid += 1
+                    sc_over = sc["size"] > max_cluster_size
+                    for m in sc["members"]:
+                        split_assign_rows.append((next_cid, m))
+                    _sv = list(sc["pair_scores"].values())
+                    _bot = sc["bottleneck_pair"] or (0, 0)
+                    split_meta_rows.append({
+                        "cluster_id": next_cid, "size": sc["size"],
+                        "confidence": sc["confidence"], "quality": "split",
+                        "oversized": sc_over,
+                        "bottleneck_pair_a": int(_bot[0]),
+                        "bottleneck_pair_b": int(_bot[1]),
+                        "min_edge": min(_sv) if _sv else 0.0,            # schema-fill, unused
+                        "avg_edge": (sum(_sv) / len(_sv)) if _sv else 0.0,
+                    })
+                    if sc_over:
+                        members_by_cid[next_cid] = sc["members"]
+                        to_split.append(next_cid)
+            if budget_tripped:
+                _clog.warning("build_clusters: auto-split edge-work budget (%d) "
+                              "exhausted; clusters left oversized.", edge_budget)
+            if drop_cids:
+                assignments = assignments.filter(~_pl.col("cluster_id").is_in(drop_cids))
+                metadata = metadata.filter(~_pl.col("cluster_id").is_in(drop_cids))
+            if split_assign_rows:
+                assignments = _pl.concat([assignments, _pl.DataFrame(
+                    split_assign_rows, schema=["cluster_id", "member_id"], orient="row")])
+                metadata = _pl.concat(
+                    [metadata, _pl.DataFrame(split_meta_rows, schema=metadata.schema)],
+                    how="vertical",
+                )
 
     # Step 3: vectorized weak/quality (excludes "split" rows -- none in Task 1).
     # Reproduces the dict path's _finalize_clusters weak/quality logic.

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -475,9 +475,11 @@ def build_cluster_frames(
     ``dict[int, dict]`` for non-oversized clusters. ``build_clusters`` and all
     its consumers stay UNTOUCHED.
 
-    Task 1 = the BULK path (non-oversized clusters): shared pre-split Union-Find
-    (via ``_columnar_presplit``) + vectorized weak/quality + emit. Auto-split of
-    oversized clusters is Task 2 (the stub below).
+    The BULK path (non-oversized clusters) is the shared pre-split Union-Find
+    (via ``_columnar_presplit``) + vectorized weak/quality + emit. Oversized
+    clusters are auto-split frames-natively (the dict is materialized ONLY for
+    that rare minority), reusing ``split_oversized_cluster`` and mirroring
+    ``_finalize_clusters``.
 
     ``cluster_frames_to_dict(build_cluster_frames(...))`` round-trips to
     ``build_clusters(...)`` gate-ON (the score-free dict): members-as-set,
@@ -546,7 +548,7 @@ def build_cluster_frames(
         "cluster_id": m_cid,
         "size": m_size,
         "confidence": m_conf,
-        "quality": ["strong"] * n_clusters,
+        "quality": _pl.Series("quality", ["strong"] * n_clusters, dtype=_pl.Utf8),
         "oversized": m_over,
         "bottleneck_pair_a": m_bot_a,
         "bottleneck_pair_b": m_bot_b,

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -447,6 +447,199 @@ def _columnar_cluster_build_enabled() -> bool:
     ).strip() != "0"
 
 
+def _cluster_frames_out_enabled() -> bool:
+    """SP-A frames-out path gate. When ``GOLDENMATCH_CLUSTER_FRAMES_OUT`` is set
+    (non-``0``), ``build_cluster_frames`` returns the two-frame ``ClusterFrames``
+    columnar representation directly, WITHOUT materializing the per-cluster
+    ``dict[int, dict]`` for non-oversized clusters. Default OFF. Independent of
+    ``build_clusters`` and all its consumers, which are untouched."""
+    return os.environ.get("GOLDENMATCH_CLUSTER_FRAMES_OUT", "0").strip() != "0"
+
+
+def build_cluster_frames(
+    pairs: Any,
+    all_ids: list[int] | None = None,
+    *,
+    max_cluster_size: int,
+    weak_cluster_threshold: float,
+    auto_split: bool,
+) -> ClusterFrames:
+    """SP-A frames-out entry point (gated ``GOLDENMATCH_CLUSTER_FRAMES_OUT``).
+
+    Returns the two-frame ``ClusterFrames`` columnar representation
+    (``assignments`` + 9-col ``metadata``) WITHOUT building the per-cluster
+    ``dict[int, dict]`` for non-oversized clusters. ``build_clusters`` and all
+    its consumers stay UNTOUCHED.
+
+    Task 1 = the BULK path (non-oversized clusters): shared pre-split Union-Find
+    (via ``_columnar_presplit``) + vectorized weak/quality + emit. Auto-split of
+    oversized clusters is Task 2 (the stub below).
+
+    ``cluster_frames_to_dict(build_cluster_frames(...))`` round-trips to
+    ``build_clusters(...)`` gate-ON (the score-free dict): members-as-set,
+    ``pair_scores`` stripped, everything else byte-identical.
+    """
+    import numpy as _np
+    import polars as _pl
+
+    from goldenmatch.core.scorer import PAIR_STREAM_SCHEMA
+
+    pairs_list = list(pairs)
+    if all_ids is None:                       # mirror build_clusters (:411-417)
+        seen: set[int] = set()
+        for a, b, _s in pairs_list:
+            seen.add(a)
+            seen.add(b)
+        all_ids = list(seen)
+
+    pairs_df = _pl.DataFrame(
+        {
+            "id_a": [p[0] for p in pairs_list],
+            "id_b": [p[1] for p in pairs_list],
+            "score": [p[2] for p in pairs_list],
+        },
+        schema=PAIR_STREAM_SCHEMA,
+    )
+    sorted_clusters, metadata_by_cid, _weak = _columnar_presplit(
+        pairs_list, pairs_df, all_ids, max_cluster_size,
+    )
+
+    # Pre-split frames -- build the SAME 9-col metadata + 2-col assignments
+    # schema cluster_dict_to_frames emits, DIRECTLY (numpy fills). Carry min/avg
+    # from metadata_by_cid (NOT cluster_dict_to_frames, which zeros them from the
+    # empty pair_scores). quality="strong" placeholder; Step-3 overwrites.
+    n_clusters = len(sorted_clusters)
+    total_members = sum(len(s) for s in sorted_clusters)
+    a_cid = _np.empty(total_members, dtype=_np.int64)
+    a_mid = _np.empty(total_members, dtype=_np.int64)
+    m_cid = _np.empty(n_clusters, dtype=_np.int64)
+    m_size = _np.empty(n_clusters, dtype=_np.int64)
+    m_conf = _np.empty(n_clusters, dtype=_np.float64)
+    m_over = _np.empty(n_clusters, dtype=_np.bool_)
+    m_bot_a = _np.empty(n_clusters, dtype=_np.int64)
+    m_bot_b = _np.empty(n_clusters, dtype=_np.int64)
+    m_min = _np.empty(n_clusters, dtype=_np.float64)
+    m_avg = _np.empty(n_clusters, dtype=_np.float64)
+    a_idx = 0
+    for i, members in enumerate(sorted_clusters):
+        cid = i + 1
+        n = len(members)
+        a_cid[a_idx:a_idx + n] = cid
+        a_mid[a_idx:a_idx + n] = list(members)
+        a_idx += n
+        md = metadata_by_cid[cid]
+        bot = md["bottleneck_pair"] or (0, 0)
+        m_cid[i] = cid
+        m_size[i] = n
+        m_conf[i] = md["confidence"]
+        m_over[i] = n > max_cluster_size
+        m_bot_a[i] = bot[0]
+        m_bot_b[i] = bot[1]
+        m_min[i] = md["min_edge"]   # coalesced 0.0, never None
+        m_avg[i] = md["avg_edge"]
+    assignments = _pl.DataFrame({"cluster_id": a_cid, "member_id": a_mid})
+    metadata = _pl.DataFrame({
+        "cluster_id": m_cid,
+        "size": m_size,
+        "confidence": m_conf,
+        "quality": ["strong"] * n_clusters,
+        "oversized": m_over,
+        "bottleneck_pair_a": m_bot_a,
+        "bottleneck_pair_b": m_bot_b,
+        "min_edge": m_min,
+        "avg_edge": m_avg,
+    })
+
+    if auto_split and metadata.filter(_pl.col("oversized")).height > 0:
+        # TASK 2 inserts the frames-native split here (mutates assignments +
+        # metadata: oversized rows -> MST sub-clusters, quality="split").
+        pass
+
+    # Step 3: vectorized weak/quality (excludes "split" rows -- none in Task 1).
+    # Reproduces the dict path's _finalize_clusters weak/quality logic.
+    metadata = metadata.with_columns(
+        _pl.when(_pl.col("quality") == "split").then(_pl.col("quality"))
+        .when(
+            (_pl.col("size") > 1)
+            & ((_pl.col("avg_edge") - _pl.col("min_edge")) > weak_cluster_threshold)
+        )
+        .then(_pl.lit("weak")).otherwise(_pl.lit("strong")).alias("quality"),
+    ).with_columns(
+        _pl.when(_pl.col("quality") == "weak")
+        .then(_pl.col("confidence") * 0.7).otherwise(_pl.col("confidence"))
+        .alias("confidence"),
+    )
+
+    _emit_cluster_profile_frames(metadata, assignments)
+    return ClusterFrames(assignments=assignments, metadata=metadata)
+
+
+def _emit_cluster_profile_frames(metadata: Any, assignments: Any) -> None:
+    """Frames-path twin of ``_emit_cluster_profile``. Telemetry only -- no-op
+    when no capture is active. Builds the ``ClusterProfile`` from the metadata +
+    assignments frames as closely as the columnar shape allows (no per-cluster
+    pair_scores on this path, so the transitivity threshold falls back to 0.5,
+    same as ``_emit_cluster_profile`` when ``aggregated_scores`` is empty)."""
+    import math
+
+    if not _emitter_stack.get():
+        return  # fast path: no capture active
+
+    import polars as _pl
+
+    if metadata.is_empty():
+        current_emitter().set_cluster(ClusterProfile())
+        return
+
+    sizes = sorted(metadata["size"].to_list())
+
+    def percentile(xs: list, q: float) -> int:
+        if not xs:
+            return 0
+        idx = max(0, min(len(xs) - 1, int(math.ceil(q * len(xs))) - 1))
+        return xs[idx]
+
+    confidences = sorted(
+        v for v in metadata["confidence"].to_list() if v is not None
+    )
+
+    members_by_cluster: dict[int, list[int]] = {}
+    if not assignments.is_empty():
+        for cid, mid in zip(
+            assignments["cluster_id"].to_list(),
+            assignments["member_id"].to_list(),
+            strict=True,
+        ):
+            members_by_cluster.setdefault(int(cid), []).append(int(mid))
+
+    # No per-cluster pair_scores on the frames path -> empty aggregate ->
+    # transitivity threshold falls back to 0.5 (same as _emit_cluster_profile).
+    aggregated_scores: dict[tuple[int, int], float] = {}
+    threshold = 0.5
+
+    oversized_count = int(
+        metadata.filter(_pl.col("oversized")).height
+    )
+
+    profile = ClusterProfile(
+        n_clusters=metadata.height,
+        cluster_size_p50=percentile(sizes, 0.50),
+        cluster_size_p99=percentile(sizes, 0.99),
+        cluster_size_max=sizes[-1] if sizes else 0,
+        transitivity_rate=transitivity_rate(
+            members_by_cluster, aggregated_scores, threshold,
+        ),
+        edge_confidence_p50=(
+            confidences[len(confidences) // 2] if confidences else 0.0
+        ),
+        edge_confidence_min=confidences[0] if confidences else 0.0,
+        oversized_cluster_count=oversized_count,
+        bridge_edge_count=0,
+        measured_bridge_risk=0.0,
+    )
+    current_emitter().set_cluster(profile)
+
+
 def _build_clusters_dict_path(
     pairs: Any,
     all_ids: list[int],
@@ -709,6 +902,65 @@ def _build_clusters_via_frames(
         schema=PAIR_STREAM_SCHEMA,
     )
 
+    sorted_clusters, metadata_by_cid, weak_stats = _columnar_presplit(
+        pairs_list, pairs_df, all_ids, max_cluster_size,
+    )
+
+    # --- Build the SAME pre-split result dict as the dict path. ------------
+    # confidence/bottleneck come from metadata_by_cid (native: kernel metadata;
+    # off-native: the discarded transient fill, bit-identical to
+    # compute_cluster_confidence). pair_scores stays {} (SP4: served by the view).
+    with stage("cluster_result_dict_init"):
+        result: dict[int, dict] = {}
+        for cluster_id, members in enumerate(sorted_clusters, start=1):
+            size = len(members)
+            md_c = metadata_by_cid[cluster_id]
+            result[cluster_id] = {
+                "members": list(members),
+                "size": size,
+                "oversized": size > max_cluster_size,
+                "pair_scores": {},
+                "confidence": md_c["confidence"],
+                "bottleneck_pair": md_c["bottleneck_pair"],
+            }
+
+    # --- Steps 5-7: auto-split + cluster_quality + emit (shared tail). -----
+    # raw_pairs lets _finalize materialize per-OVERSIZED pair_scores (input order,
+    # last-wins) for the MST split; weak_stats feeds the weak test. The returned
+    # dict's pair_scores is {} on every cluster.
+    return _finalize_clusters(
+        result, max_cluster_size, weak_cluster_threshold, auto_split,
+        raw_pairs=pairs_list, weak_stats=weak_stats,
+    )
+
+
+def _columnar_presplit(
+    pairs_list: list[tuple[int, int, float]],
+    pairs_df: Any,
+    all_ids: list[int],
+    max_cluster_size: int,
+) -> tuple[list[set[int]], dict[int, dict], dict[int, tuple[float, float]]]:
+    """Shared pre-split Union-Find + per-cluster confidence source.
+
+    Returns ``(sorted_clusters, metadata_by_cid, weak_stats)``.
+
+    - ``sorted_clusters``: member sets sorted by min member (cid = index+1,
+      start=1).
+    - ``metadata_by_cid``: ``{cid: {confidence, bottleneck_pair, min_edge,
+      avg_edge}}`` for EVERY cid. min/avg are COALESCED to ``0.0`` (never None)
+      so the frames-out path can write them directly into the metadata frame.
+      Native path: from the Arrow kernel metadata (pairs-input order ->
+      bit-identical to ``compute_cluster_confidence``). Off-native: from the
+      transient pairs-input-order fill (also bit-identical), discarded after.
+    - ``weak_stats``: ``{cid: (min_edge, avg_edge)}`` ONLY for multi-member cids
+      that HAVE in-cluster edges. Off-native guard ``size>1 and ps``; native
+      ``size>1``. Edgeless multi-member cids ABSENT. Carries the RAW (non-
+      coalesced) min/avg the dict path uses for the weak test; membership must
+      EXACTLY match the current ``_build_clusters_via_frames`` so SP4 parity
+      (tests/test_columnar_drop_pairscores_parity.py) doesn't regress.
+    """
+    import polars as _pl
+
     # --- Step 1: Union-Find member sets (PRE-split). -----------------------
     native = native_module() if native_enabled("clustering") else None
     arrow_fn = getattr(native, "build_clusters_arrow", None) if native else None
@@ -716,7 +968,7 @@ def _build_clusters_via_frames(
     member_sets: list[set[int]]
     # Native path: per-cluster confidence/bottleneck/min/avg from frames.metadata
     # (keyed by kernel cluster_id == our canonical cid). None off-native.
-    metadata_by_cid: dict[int, dict] | None = None
+    kernel_md_by_cid: dict[int, dict] | None = None
     if native is not None and arrow_fn is not None:
         # Native Arrow kernel: UF-ONLY assignments (pre-split). Derive raw
         # member sets per UF component from the assignments frame.
@@ -735,7 +987,7 @@ def _build_clusters_via_frames(
             # Retain the kernel's per-cluster metadata (pairs-input order ->
             # bit-identical to compute_cluster_confidence). (0,0) bottleneck -> None.
             md = frames.metadata
-            metadata_by_cid = {}
+            kernel_md_by_cid = {}
             for cid_v, conf_v, ba_v, bb_v, mn_v, av_v in zip(
                 md["cluster_id"].to_list(),
                 md["confidence"].to_list(),
@@ -745,7 +997,7 @@ def _build_clusters_via_frames(
                 md["avg_edge"].to_list(),
                 strict=True,
             ):
-                metadata_by_cid[int(cid_v)] = {
+                kernel_md_by_cid[int(cid_v)] = {
                     "confidence": conf_v,
                     "bottleneck_pair": (
                         None if (int(ba_v), int(bb_v)) == (0, 0)
@@ -772,7 +1024,7 @@ def _build_clusters_via_frames(
                 member_sets = uf.get_clusters()
                 del uf
 
-    # --- Step 2: build the SAME pre-split result dict as the dict path. ----
+    # --- Step 2: sort + member->cid map. ----------------------------------
     with stage("cluster_sort_clusters"):
         sorted_clusters = sorted(member_sets, key=lambda s: min(s))
         del member_sets
@@ -783,34 +1035,30 @@ def _build_clusters_via_frames(
             for m in members:
                 member_to_cid[m] = cluster_id
 
-    with stage("cluster_result_dict_init"):
-        result: dict[int, dict] = {}
-        for cluster_id, members in enumerate(sorted_clusters, start=1):
-            size = len(members)
-            result[cluster_id] = {
-                "members": list(members),
-                "size": size,
-                "oversized": size > max_cluster_size,
-                "pair_scores": {},
-            }
+    sizes_by_cid: dict[int, int] = {
+        cluster_id: len(members)
+        for cluster_id, members in enumerate(sorted_clusters, start=1)
+    }
 
-    # --- Steps 3-4: confidence/bottleneck/min/avg -- NO eager pair_scores fill on
-    # `result` (SP4: pair_scores stays {}; scores are served by the pipeline view).
-    # Native reads them off frames.metadata (deduped, pairs-input order).
-    # Off-native uses a TRANSIENT pairs-input-order fill (replace_strict in row
-    # order, dict last-wins -- matching the dict path) that feeds confidence + min/
-    # avg, then is DISCARDED. `weak_stats[cid] = (min_edge, avg_edge)` per
-    # multi-member cluster feeds the weak test in _finalize_clusters.
+    # --- Steps 3-4: confidence/bottleneck/min/avg for EVERY cid. ----------
+    # Native reads off frames.metadata (deduped, pairs-input order). Off-native
+    # uses a TRANSIENT pairs-input-order fill (replace_strict in row order, dict
+    # last-wins -- matching the dict path) that feeds confidence + min/avg, then
+    # is DISCARDED. weak_stats[cid] = (min_edge, avg_edge) per multi-member
+    # cluster WITH edges (raw, non-coalesced) feeds the weak test downstream.
+    metadata_by_cid: dict[int, dict] = {}
     weak_stats: dict[int, tuple[float, float]] = {}
-    if metadata_by_cid is not None:
-        del member_to_cid
-        del sorted_clusters
+    if kernel_md_by_cid is not None:
         with stage("cluster_compute_confidence"):
-            for cid, cinfo in result.items():
-                md_c = metadata_by_cid[cid]
-                cinfo["confidence"] = md_c["confidence"]
-                cinfo["bottleneck_pair"] = md_c["bottleneck_pair"]
-                if cinfo["size"] > 1:
+            for cid in sizes_by_cid:
+                md_c = kernel_md_by_cid[cid]
+                metadata_by_cid[cid] = {
+                    "confidence": md_c["confidence"],
+                    "bottleneck_pair": md_c["bottleneck_pair"],
+                    "min_edge": (md_c["min_edge"] or 0.0),
+                    "avg_edge": (md_c["avg_edge"] or 0.0),
+                }
+                if sizes_by_cid[cid] > 1:
                     weak_stats[cid] = (md_c["min_edge"], md_c["avg_edge"])
     else:
         transient: dict[int, dict[tuple[int, int], float]] = {}
@@ -828,25 +1076,23 @@ def _build_clusters_via_frames(
                 ):
                     transient.setdefault(int(cid), {})[(id_a, id_b)] = score
             del member_to_cid
-            del sorted_clusters
         with stage("cluster_compute_confidence"):
-            for cid, cinfo in result.items():
+            for cid, size in sizes_by_cid.items():
                 ps = transient.get(cid, {})
-                conf = compute_cluster_confidence(ps, cinfo["size"])
-                cinfo["confidence"] = conf["confidence"]
-                cinfo["bottleneck_pair"] = conf["bottleneck_pair"]
-                if cinfo["size"] > 1 and ps:
+                conf = compute_cluster_confidence(ps, size)
+                metadata_by_cid[cid] = {
+                    "confidence": conf["confidence"],
+                    "bottleneck_pair": conf["bottleneck_pair"],
+                    # compute_cluster_confidence returns None for size<=1 / no
+                    # edges -> coalesce to 0.0 for the frames metadata.
+                    "min_edge": (conf["min_edge"] or 0.0),
+                    "avg_edge": (conf["avg_edge"] or 0.0),
+                }
+                if size > 1 and ps:
                     _vals = list(ps.values())
                     weak_stats[cid] = (min(_vals), sum(_vals) / len(_vals))
 
-    # --- Steps 5-7: auto-split + cluster_quality + emit (shared tail). -----
-    # raw_pairs lets _finalize materialize per-OVERSIZED pair_scores (input order,
-    # last-wins) for the MST split; weak_stats feeds the weak test. The returned
-    # dict's pair_scores is {} on every cluster.
-    return _finalize_clusters(
-        result, max_cluster_size, weak_cluster_threshold, auto_split,
-        raw_pairs=pairs_list, weak_stats=weak_stats,
-    )
+    return sorted_clusters, metadata_by_cid, weak_stats
 
 
 def compute_cluster_confidence(

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -569,7 +569,13 @@ def build_cluster_frames(
                 int(cid): assignments.filter(_pl.col("cluster_id") == cid)["member_id"].to_list()
                 for cid in oversized
             }
-            next_cid = metadata.height   # contiguous 1..n_clusters pre-split => height == max cid
+            # live_cids mirrors _finalize_clusters's `result.keys()`: cids 1..n
+            # pre-split. next_cid is recomputed as max(live)+1 AFTER discarding the
+            # split cid -- so when the cid being split is the current max, its slot
+            # is REUSED, exactly as _finalize's `result.pop(cid); max(result.keys())+1`.
+            # A running counter from metadata.height does NOT reclaim that slot and
+            # shifts every split cid, breaking the partition labels.
+            live_cids = set(range(1, metadata.height + 1))
             split_assign_rows = []
             split_meta_rows = []
             drop_cids = set()
@@ -589,8 +595,9 @@ def build_cluster_frames(
                     continue  # unsplittable: keep original row as-is
                 subs.sort(key=lambda sc: min(sc["members"]))
                 drop_cids.add(cid)
+                live_cids.discard(cid)
+                next_cid = max(live_cids, default=0) + 1   # mirror _finalize (post-pop)
                 for sc in subs:
-                    next_cid += 1
                     sc_over = sc["size"] > max_cluster_size
                     for m in sc["members"]:
                         split_assign_rows.append((next_cid, m))
@@ -605,9 +612,11 @@ def build_cluster_frames(
                         "min_edge": min(_sv) if _sv else 0.0,            # schema-fill, unused
                         "avg_edge": (sum(_sv) / len(_sv)) if _sv else 0.0,
                     })
+                    live_cids.add(next_cid)
                     if sc_over:
                         members_by_cid[next_cid] = sc["members"]
                         to_split.append(next_cid)
+                    next_cid += 1
             if budget_tripped:
                 _clog.warning("build_clusters: auto-split edge-work budget (%d) "
                               "exhausted; clusters left oversized.", edge_budget)

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -447,12 +447,16 @@ def _columnar_cluster_build_enabled() -> bool:
     ).strip() != "0"
 
 
-def _cluster_frames_out_enabled() -> bool:
+def _cluster_frames_out_enabled() -> bool:  # pyright: ignore[reportUnusedFunction]
     """SP-A frames-out path gate. When ``GOLDENMATCH_CLUSTER_FRAMES_OUT`` is set
     (non-``0``), ``build_cluster_frames`` returns the two-frame ``ClusterFrames``
     columnar representation directly, WITHOUT materializing the per-cluster
     ``dict[int, dict]`` for non-oversized clusters. Default OFF. Independent of
-    ``build_clusters`` and all its consumers, which are untouched."""
+    ``build_clusters`` and all its consumers, which are untouched.
+
+    Not consumed in SP-A; the pipeline wires this gate in SP-B to choose
+    build_cluster_frames vs build_clusters. The pyright-ignore drops the
+    reportUnusedFunction false-positive until then."""
     return os.environ.get("GOLDENMATCH_CLUSTER_FRAMES_OUT", "0").strip() != "0"
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -563,7 +563,7 @@ def build_cluster_frames(
                 int(cid): assignments.filter(_pl.col("cluster_id") == cid)["member_id"].to_list()
                 for cid in oversized
             }
-            next_cid = int(metadata["cluster_id"].max())   # +1 inside loop
+            next_cid = metadata.height   # contiguous 1..n_clusters pre-split => height == max cid
             split_assign_rows = []
             split_meta_rows = []
             drop_cids = set()

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -569,16 +569,19 @@ def build_cluster_frames(
                 int(cid): assignments.filter(_pl.col("cluster_id") == cid)["member_id"].to_list()
                 for cid in oversized
             }
-            # live_cids mirrors _finalize_clusters's `result.keys()`: cids 1..n
-            # pre-split. next_cid is recomputed as max(live)+1 AFTER discarding the
-            # split cid -- so when the cid being split is the current max, its slot
-            # is REUSED, exactly as _finalize's `result.pop(cid); max(result.keys())+1`.
-            # A running counter from metadata.height does NOT reclaim that slot and
-            # shifts every split cid, breaking the partition labels.
+            # Mirror _finalize_clusters's SINGLE `result` dict for split clusters.
+            # split_result holds sub-clusters by cid; an intermediate sub that
+            # re-splits is POPPED (del split_result[cid]) so it can't be emitted
+            # twice. Rows are materialized ONLY at the end, from the FINAL entries.
+            # (Eagerly appending rows + relying on drop_cids -- which only filters
+            # the ORIGINAL bulk frame -- duplicated re-split intermediates: an
+            # invalid overlapping partition.)
+            # live_cids mirrors result.keys() (cids 1..n pre-split + split cids);
+            # next_cid = max(live)+1 AFTER discarding the split cid REUSES a freed
+            # max slot, exactly as _finalize's `result.pop(cid); max(result.keys())+1`.
             live_cids = set(range(1, metadata.height + 1))
-            split_assign_rows = []
-            split_meta_rows = []
-            drop_cids = set()
+            split_result: dict[int, dict] = {}
+            drop_cids = set()                      # ORIGINAL cids that split
             to_split = list(oversized)
             edge_work, edge_budget, budget_tripped = 0, _split_edge_work_budget(), False
             while to_split:
@@ -589,37 +592,49 @@ def build_cluster_frames(
                 edge_work += len(ps)
                 if edge_work > edge_budget:
                     budget_tripped = True
-                    break  # leave cid (and queued) oversized: do NOT drop them
+                    break  # leave cid (+ queued) oversized: don't drop / don't pop
                 subs = split_oversized_cluster(members, ps)
                 if len(subs) <= 1:
-                    continue  # unsplittable: keep original row as-is
+                    continue  # unsplittable: original row / split_result entry stays
                 subs.sort(key=lambda sc: min(sc["members"]))
-                drop_cids.add(cid)
+                # Remove the cid being split (post-pop, like _finalize's result.pop):
+                # an intermediate split sub leaves split_result; an original cid is
+                # filtered from the bulk frame via drop_cids.
+                if cid in split_result:
+                    del split_result[cid]
+                else:
+                    drop_cids.add(cid)
                 live_cids.discard(cid)
                 next_cid = max(live_cids, default=0) + 1   # mirror _finalize (post-pop)
                 for sc in subs:
-                    sc_over = sc["size"] > max_cluster_size
-                    for m in sc["members"]:
-                        split_assign_rows.append((next_cid, m))
-                    _sv = list(sc["pair_scores"].values())
-                    _bot = sc["bottleneck_pair"] or (0, 0)
-                    split_meta_rows.append({
-                        "cluster_id": next_cid, "size": sc["size"],
-                        "confidence": sc["confidence"], "quality": "split",
-                        "oversized": sc_over,
-                        "bottleneck_pair_a": int(_bot[0]),
-                        "bottleneck_pair_b": int(_bot[1]),
-                        "min_edge": min(_sv) if _sv else 0.0,            # schema-fill, unused
-                        "avg_edge": (sum(_sv) / len(_sv)) if _sv else 0.0,
-                    })
+                    split_result[next_cid] = sc
                     live_cids.add(next_cid)
-                    if sc_over:
+                    if sc["size"] > max_cluster_size:
                         members_by_cid[next_cid] = sc["members"]
                         to_split.append(next_cid)
                     next_cid += 1
             if budget_tripped:
-                _clog.warning("build_clusters: auto-split edge-work budget (%d) "
+                _clog.warning("build_cluster_frames: auto-split edge-work budget (%d) "
                               "exhausted; clusters left oversized.", edge_budget)
+            # Materialize the FINAL split sub-clusters into frame rows. split rows
+            # carry quality="split" so the Step-3 when(quality=="split") short-circuit
+            # preserves them. min/avg are schema-fill (unused: split skips the weak test).
+            split_assign_rows = []
+            split_meta_rows = []
+            for ncid, sc in split_result.items():
+                for m in sc["members"]:
+                    split_assign_rows.append((ncid, m))
+                _sv = list(sc["pair_scores"].values())
+                _bot = sc["bottleneck_pair"] or (0, 0)
+                split_meta_rows.append({
+                    "cluster_id": ncid, "size": sc["size"],
+                    "confidence": sc["confidence"], "quality": "split",
+                    "oversized": sc["size"] > max_cluster_size,
+                    "bottleneck_pair_a": int(_bot[0]),
+                    "bottleneck_pair_b": int(_bot[1]),
+                    "min_edge": min(_sv) if _sv else 0.0,
+                    "avg_edge": (sum(_sv) / len(_sv)) if _sv else 0.0,
+                })
             if drop_cids:
                 assignments = assignments.filter(~_pl.col("cluster_id").is_in(drop_cids))
                 metadata = metadata.filter(~_pl.col("cluster_id").is_in(drop_cids))

--- a/packages/python/goldenmatch/scripts/bench_cluster_frames_out.py
+++ b/packages/python/goldenmatch/scripts/bench_cluster_frames_out.py
@@ -1,0 +1,294 @@
+"""SP-A build-stage bench: build_cluster_frames (frames-out) vs score-free dict.
+
+RECORDED DATA, not a kill gate. This bench measures the build-stage wall + peak
+RSS of the SP-A frames-out entry point ``build_cluster_frames`` (gate
+``GOLDENMATCH_CLUSTER_FRAMES_OUT=1``, returns the two-frame ``ClusterFrames``
+columnar representation) against the SCORE-FREE reference dict
+(``build_clusters`` with ``GOLDENMATCH_COLUMNAR_CLUSTER_BUILD=1`` -- the gated
+columnar dict path that already drops eager per-cluster pair_scores). The
+baseline here is the score-free dict (gate-ON ``build_clusters``), NOT the
+gate-OFF verbatim dict path -- we're isolating the frames-out delta on top of
+the columnar build, not re-measuring the SP4 drop-pairscores win.
+
+The k=5 fixture (M clusters of size 5 -> 10 pairs each) has NO oversized
+clusters, so this exercises the bulk-RSS axis (many small clusters) rather than
+the auto-split/MST path. A fresh native build in CI means the columnar build
+hits the real Arrow kernel.
+
+Each variant runs in its OWN subprocess (``--child {off|on}``) so wall AND peak
+RSS are clean. Parity is asserted FIRST: ``cluster_frames_to_dict(frames_on)``
+must match the score-free dict byte-for-byte EXCEPT members (compared as a
+frozenset) and pair_scores (stripped -- both paths carry {} for non-oversized).
+A perf number on a non-parity path is meaningless, so parity failure
+short-circuits before the perf loop.
+
+Local smoke: python ... --np 50000 --runs 1  (resource is unavailable on Windows
+so RSS is 0.0 -- fine).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _make_pairs_df(n_pairs_target: int):
+    """M clusters of size k=5 -> 10 pairs each. Deterministic, no RNG."""
+    import polars as pl
+
+    k = 5
+    per = k * (k - 1) // 2  # 10
+    m = max(1, n_pairs_target // per)
+    a_col: list[int] = []
+    b_col: list[int] = []
+    for c in range(m):
+        base = c * k
+        for i in range(k):
+            for j in range(i + 1, k):
+                a_col.append(base + i)
+                b_col.append(base + j)
+    s_col = [0.95] * len(a_col)
+    return pl.DataFrame(
+        {"id_a": a_col, "id_b": b_col, "score": s_col},
+        schema={"id_a": pl.Int64, "id_b": pl.Int64, "score": pl.Float64},
+    )
+
+
+def _pairs_list_from_df(pairs_df) -> list[tuple[int, int, float]]:
+    return list(
+        zip(
+            pairs_df["id_a"].to_list(),
+            pairs_df["id_b"].to_list(),
+            pairs_df["score"].to_list(),
+        )
+    )
+
+
+def _peak_rss_mb() -> float:
+    try:
+        import resource
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+    except Exception:
+        return 0.0
+
+
+def _norm(cinfo: dict) -> dict:
+    """members as a frozenset; pair_scores STRIPPED (both score-free paths carry
+    {} for non-oversized clusters -- not compared here). Everything else strict."""
+    out = {k: v for k, v in cinfo.items() if k not in ("members", "pair_scores", "_was_split")}
+    out["members"] = frozenset(cinfo["members"])
+    return out
+
+
+def _run_child(variant: str, n_pairs: int, runs: int) -> int:
+    import polars as pl  # noqa: F401
+    from goldenmatch.core.cluster import build_cluster_frames, build_clusters
+
+    pairs_df = _make_pairs_df(n_pairs)
+    pairs_list = _pairs_list_from_df(pairs_df)
+    actual_pairs = pairs_df.height
+
+    if variant == "on":
+        os.environ["GOLDENMATCH_CLUSTER_FRAMES_OUT"] = "1"
+
+        def _build():
+            return build_cluster_frames(
+                pairs_list,
+                all_ids=None,
+                max_cluster_size=100,
+                weak_cluster_threshold=0.3,
+                auto_split=True,
+            )
+    else:
+        os.environ["GOLDENMATCH_COLUMNAR_CLUSTER_BUILD"] = "1"
+
+        def _build():
+            return build_clusters(
+                pairs_list,
+                max_cluster_size=100,
+                weak_cluster_threshold=0.3,
+                auto_split=True,
+            )
+
+    _build()  # warm
+
+    walls: list[float] = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        _build()
+        walls.append(time.perf_counter() - t0)
+
+    print(json.dumps({
+        "variant": variant,
+        "n_pairs": actual_pairs,
+        "walls": walls,
+        "peak_rss_mb": _peak_rss_mb(),
+    }), flush=True)
+    return 0
+
+
+def _assert_parity(n_pairs: int) -> bool:
+    from goldenmatch.core.cluster import (
+        build_cluster_frames,
+        build_clusters,
+        cluster_frames_to_dict,
+    )
+
+    pairs_df = _make_pairs_df(n_pairs)
+    pairs_list = _pairs_list_from_df(pairs_df)
+
+    os.environ["GOLDENMATCH_COLUMNAR_CLUSTER_BUILD"] = "1"
+    clusters_off = build_clusters(
+        pairs_list,
+        max_cluster_size=100,
+        weak_cluster_threshold=0.3,
+        auto_split=True,
+    )
+    os.environ["GOLDENMATCH_CLUSTER_FRAMES_OUT"] = "1"
+    frames_on = build_cluster_frames(
+        pairs_list,
+        all_ids=None,
+        max_cluster_size=100,
+        weak_cluster_threshold=0.3,
+        auto_split=True,
+    )
+    got = cluster_frames_to_dict(frames_on)
+
+    if got.keys() != clusters_off.keys():
+        print(f"PARITY FAIL: cluster id sets differ "
+              f"(off={len(clusters_off)} ids, on={len(got)} ids)", flush=True)
+        return False
+    for cid in clusters_off:
+        if _norm(got[cid]) != _norm(clusters_off[cid]):
+            print(f"PARITY FAIL: cluster {cid} differs:\n"
+                  f"  off={clusters_off[cid]}\n  on={got[cid]}", flush=True)
+            return False
+    return True
+
+
+def _bench_variant(variant: str, n: int, runs: int) -> dict[str, Any]:
+    cmd = [
+        sys.executable, os.path.abspath(__file__),
+        "--child", variant, "--np", str(n), "--runs", str(runs),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"child {variant} np={n} exited {proc.returncode}\n"
+            f"--- stderr ---\n{proc.stderr.strip()}"
+        )
+    last_json = None
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            last_json = line
+    if last_json is None:
+        raise RuntimeError(
+            f"child {variant} np={n} produced no JSON line\n"
+            f"--- stdout ---\n{proc.stdout.strip()}"
+        )
+    return json.loads(last_json)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--np", default="1000000,5000000",
+                    help="Comma-separated target pair counts")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--output", default=None)
+    ap.add_argument("--child", choices=["off", "on"], default=None,
+                    help="Internal: run a single variant in this process")
+    args = ap.parse_args()
+
+    runs = max(1, args.runs)
+
+    if args.child is not None:
+        nps = [int(x.strip()) for x in args.np.split(",") if x.strip()]
+        n = nps[0] if nps else 1000000
+        return _run_child(args.child, n, runs)
+
+    nps = [int(x.strip()) for x in args.np.split(",") if x.strip()]
+
+    from goldenmatch.core._native_loader import native_available, native_module
+    print(f"native importable: {native_available()}", flush=True)
+    m = native_module()
+    print(f"build_clusters_arrow exposed: "
+          f"{bool(m) and hasattr(m, 'build_clusters_arrow')}", flush=True)
+
+    parity_n = 2000
+    print(f"parity check (np={parity_n:,}) ...", flush=True)
+    if not _assert_parity(parity_n):
+        print("ERROR: frames-out is NOT byte-identical (except members/pair_scores) "
+              "to the score-free dict; refusing to report perf on a non-parity path.",
+              flush=True)
+        return 1
+    print("parity OK", flush=True)
+
+    results = []
+    for n in nps:
+        print(f"  target_pairs={n:,} ...", flush=True)
+        try:
+            off = _bench_variant("off", n, runs)
+            on = _bench_variant("on", n, runs)
+            off_s = statistics.median(off["walls"])
+            on_s = statistics.median(on["walls"])
+            row = {
+                "n_pairs": off["n_pairs"],
+                "off_s": off_s,
+                "on_s": on_s,
+                "speedup": (off_s / on_s) if on_s else float("nan"),
+                "off_rss_mb": off["peak_rss_mb"],
+                "on_rss_mb": on["peak_rss_mb"],
+            }
+            results.append(row)
+            sp = f"{row['speedup']:.2f}x" if row["speedup"] == row["speedup"] else "n/a"
+            print(f"    pairs={row['n_pairs']:,}  off={off_s:.3f}s  "
+                  f"on={on_s:.3f}s  speedup={sp}", flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  target_pairs={n:,}  ERROR {type(exc).__name__}: {exc}",
+                  flush=True)
+            results.append({"n_pairs": n, "error": str(exc)})
+
+    lines = [
+        "\n## bench-cluster-frames-out\n",
+        f"| {'pairs':>12} | {'dict (s)':>10} | {'frames (s)':>10} | "
+        f"{'speedup':>9} | {'dict RSS MB':>12} | {'frames RSS MB':>13} |",
+        f"| {'-'*12} | {'-'*10} | {'-'*10} | {'-'*9} | {'-'*12} | {'-'*13} |",
+    ]
+    for r in results:
+        if "error" in r:
+            lines.append(
+                f"| {r['n_pairs']:>12,} | {'ERROR':>10} | {'ERROR':>10} | "
+                f"{'n/a':>9} | {'n/a':>12} | {'n/a':>13} |"
+            )
+            continue
+        sp = f"{r['speedup']:.2f}x" if r["speedup"] == r["speedup"] else "n/a"
+        lines.append(
+            f"| {r['n_pairs']:>12,} | {r['off_s']:>10.3f} | {r['on_s']:>10.3f} | "
+            f"{sp:>9} | {r['off_rss_mb']:>12.1f} | {r['on_rss_mb']:>13.1f} |"
+        )
+    table = "\n".join(lines)
+    print(table, flush=True)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        try:
+            with open(summary, "a", encoding="utf-8") as fh:
+                fh.write(table + "\n")
+        except OSError:
+            pass
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump({"results": results}, fh, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py
@@ -104,6 +104,17 @@ def test_frames_out_roundtrips_to_dict_full(monkeypatch, native):
     ref = build_clusters(pairs, **kw)
     monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
     got = cluster_frames_to_dict(build_cluster_frames(pairs, **kw))
+    # DIAGNOSTIC (temporary): surface exactly how the cid sets / partitions differ.
+    if got.keys() != ref.keys():
+        ref_part = {frozenset(c["members"]) for c in ref.values()}
+        got_part = {frozenset(c["members"]) for c in got.values()}
+        print("ONLY-IN-GOT cids:", sorted(set(got) - set(ref)))
+        print("ONLY-IN-REF cids:", sorted(set(ref) - set(got)))
+        print("PARTITIONS EQUAL (label-only divergence)?", ref_part == got_part)
+        print("ONLY-IN-GOT partition:", sorted(map(sorted, got_part - ref_part)))
+        print("ONLY-IN-REF partition:", sorted(map(sorted, ref_part - got_part)))
+        print("REF  cid->members:", {k: sorted(v["members"]) for k, v in sorted(ref.items())})
+        print("GOT  cid->members:", {k: sorted(v["members"]) for k, v in sorted(got.items())})
     assert got.keys() == ref.keys()
     for cid in ref:
         assert _norm(got[cid]) == _norm(ref[cid]), f"cid {cid}: {got[cid]} vs {ref[cid]}"

--- a/packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py
@@ -104,17 +104,6 @@ def test_frames_out_roundtrips_to_dict_full(monkeypatch, native):
     ref = build_clusters(pairs, **kw)
     monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
     got = cluster_frames_to_dict(build_cluster_frames(pairs, **kw))
-    # DIAGNOSTIC (temporary): surface exactly how the cid sets / partitions differ.
-    if got.keys() != ref.keys():
-        ref_part = {frozenset(c["members"]) for c in ref.values()}
-        got_part = {frozenset(c["members"]) for c in got.values()}
-        print("ONLY-IN-GOT cids:", sorted(set(got) - set(ref)))
-        print("ONLY-IN-REF cids:", sorted(set(ref) - set(got)))
-        print("PARTITIONS EQUAL (label-only divergence)?", ref_part == got_part)
-        print("ONLY-IN-GOT partition:", sorted(map(sorted, got_part - ref_part)))
-        print("ONLY-IN-REF partition:", sorted(map(sorted, ref_part - got_part)))
-        print("REF  cid->members:", {k: sorted(v["members"]) for k, v in sorted(ref.items())})
-        print("GOT  cid->members:", {k: sorted(v["members"]) for k, v in sorted(got.items())})
     assert got.keys() == ref.keys()
     for cid in ref:
         assert _norm(got[cid]) == _norm(ref[cid]), f"cid {cid}: {got[cid]} vs {ref[cid]}"

--- a/packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py
@@ -41,6 +41,33 @@ def _skip_if_no_native(native):
             pytest.skip("native cluster kernel absent; native=1 validated in CI")
 
 
+def _adversarial_pairs():
+    # Mirror tests/test_columnar_drop_pairscores_parity.py::_adversarial_pairs:
+    # singleton id 0, {1,2}, fully-connected {3,4,5}, weak chain {6,7,8}, barbell
+    # oversized that splits (10..16 minus 13), score-tied (20,21,22), dup pair,
+    # dense clique that can't cleanly split (30..36). PLUS a different-score
+    # duplicate canonical pair (3,4) to exercise the kernel last-wins dedup.
+    pairs = [
+        (1, 2, 0.95),
+        (3, 4, 0.9), (4, 5, 0.92), (3, 5, 0.88),
+        (3, 4, 0.91),                               # different-score dup (last-wins)
+        (6, 7, 0.99), (7, 8, 0.40),
+        (10, 11, 0.99), (11, 12, 0.99), (10, 12, 0.99),
+        (14, 15, 0.99), (15, 16, 0.99), (14, 16, 0.99),
+        (12, 14, 0.31),
+        (20, 21, 0.5), (20, 22, 0.5),
+        (1, 2, 0.95),                               # same-score dup
+        (30, 31, 0.99), (30, 32, 0.99), (30, 33, 0.99), (30, 34, 0.99),
+        (30, 35, 0.99), (30, 36, 0.99), (31, 32, 0.99), (31, 33, 0.99),
+        (31, 34, 0.99), (31, 35, 0.99), (31, 36, 0.99), (32, 33, 0.99),
+        (32, 34, 0.99), (32, 35, 0.99), (32, 36, 0.99), (33, 34, 0.99),
+        (33, 35, 0.99), (33, 36, 0.99), (34, 35, 0.99), (34, 36, 0.99),
+        (35, 36, 0.99),
+    ]
+    all_ids = list(range(0, 23)) + list(range(30, 37))
+    return pairs, all_ids
+
+
 @pytest.mark.parametrize("native", ["1", "0"])
 def test_frames_out_roundtrips_to_dict_no_split(monkeypatch, native):
     pairs, all_ids = _no_split_pairs()
@@ -63,3 +90,35 @@ def test_frames_out_roundtrips_to_dict_no_split(monkeypatch, native):
         assert _norm(got[cid]) == _norm(ref[cid]), (
             f"cluster {cid}:\n got={got[cid]}\n ref={ref[cid]}"
         )
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_frames_out_roundtrips_to_dict_full(monkeypatch, native):
+    pairs, all_ids = _adversarial_pairs()
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+    _skip_if_no_native(native)
+    kw = dict(all_ids=all_ids, max_cluster_size=5,
+              weak_cluster_threshold=0.3, auto_split=True)
+    monkeypatch.setenv("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "1")
+    monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    ref = build_clusters(pairs, **kw)
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
+    got = cluster_frames_to_dict(build_cluster_frames(pairs, **kw))
+    assert got.keys() == ref.keys()
+    for cid in ref:
+        assert _norm(got[cid]) == _norm(ref[cid]), f"cid {cid}: {got[cid]} vs {ref[cid]}"
+
+
+def test_step3_quality_matches_dict_loop(monkeypatch):
+    # Seam test: vectorized weak/quality == dict loop per-row, native=0.
+    pairs, all_ids = _adversarial_pairs()
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    kw = dict(all_ids=all_ids, max_cluster_size=5,
+              weak_cluster_threshold=0.3, auto_split=True)
+    monkeypatch.setenv("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "1")
+    ref = build_clusters(pairs, **kw)
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
+    got = cluster_frames_to_dict(build_cluster_frames(pairs, **kw))
+    for cid in ref:
+        assert got[cid]["cluster_quality"] == ref[cid]["cluster_quality"]
+        assert got[cid]["confidence"] == ref[cid]["confidence"]  # EXACT

--- a/packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py
@@ -1,0 +1,65 @@
+"""SP-A: build_cluster_frames(...) -> ClusterFrames, gated
+GOLDENMATCH_CLUSTER_FRAMES_OUT. cluster_frames_to_dict(frames) must round-trip to
+build_clusters gate-ON (the score-free dict): members-as-set, pair_scores stripped
+(both carry {}), EVERYTHING ELSE strict byte-identical. Native reads the Arrow kernel
+metadata; off-native the transient fill. Native leg SKIPS locally, runs in CI.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.core.cluster import (
+    build_cluster_frames,
+    build_clusters,
+    cluster_frames_to_dict,
+)
+
+
+def _norm(cinfo: dict) -> dict:
+    out = {k: v for k, v in cinfo.items()
+           if k not in ("members", "pair_scores", "_was_split")}
+    out["members"] = frozenset(cinfo["members"])
+    return out
+
+
+def _no_split_pairs():
+    # singleton id 0, {1,2}, fully-connected {3,4,5}, weak chain {6,7,8}.
+    # max_cluster_size=5 => nothing oversized => Step-2 split path NOT exercised.
+    pairs = [
+        (1, 2, 0.95),
+        (3, 4, 0.9), (4, 5, 0.92), (3, 5, 0.88),
+        (6, 7, 0.99), (7, 8, 0.40),
+    ]
+    all_ids = list(range(0, 9))
+    return pairs, all_ids
+
+
+def _skip_if_no_native(native):
+    if native == "1":
+        from goldenmatch.core._native_loader import native_module
+        nm = native_module()
+        if nm is None or getattr(nm, "build_clusters_arrow", None) is None:
+            pytest.skip("native cluster kernel absent; native=1 validated in CI")
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_frames_out_roundtrips_to_dict_no_split(monkeypatch, native):
+    pairs, all_ids = _no_split_pairs()
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+    _skip_if_no_native(native)
+
+    kw = dict(all_ids=all_ids, max_cluster_size=5,
+              weak_cluster_threshold=0.3, auto_split=True)
+
+    monkeypatch.setenv("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "1")  # score-free dict
+    monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    ref = build_clusters(pairs, **kw)
+
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
+    frames = build_cluster_frames(pairs, **kw)
+    got = cluster_frames_to_dict(frames)
+
+    assert got.keys() == ref.keys()
+    for cid in ref:
+        assert _norm(got[cid]) == _norm(ref[cid]), (
+            f"cluster {cid}:\n got={got[cid]}\n ref={ref[cid]}"
+        )


### PR DESCRIPTION
Phase-2 columnar cutover, SP-A. Adds a gated internal `build_cluster_frames(...) -> ClusterFrames` that produces the same partition + metadata as `build_clusters`, with the per-cluster Python dict confined to the rare oversized-split minority. `build_clusters` and all ~20 dict consumers are UNTOUCHED.

**Gate:** `GOLDENMATCH_CLUSTER_FRAMES_OUT` (default OFF). SP-A gate = parity + feasibility, NOT an RSS verdict (intermediate small-N RSS is a guaranteed false-negative; the binding RSS/wall verdict lives on the complete A+B+C path at 25M+).

**Tasks**
1. `build_cluster_frames` bulk path + the shared `_columnar_presplit` helper (extracted from `_build_clusters_via_frames`, behavior-preserving — SP1/SP4 parity tests guard it).
2. Frames-native auto-split (reuses `split_oversized_cluster`; mirrors `_finalize_clusters` exactly) + full round-trip parity + the Step-3 vectorized-quality seam test.
3. Build-stage RSS bench (`scripts/bench_cluster_frames_out.py` + workflow) — frames vs the score-free dict, **recorded data, not a kill gate**.

**Parity gate (CI):** `cluster_frames_to_dict(build_cluster_frames(...)) == build_clusters` gate-ON (members-as-set, pair_scores stripped), native=1 AND native=0. The native leg runs in the `python (goldenmatch)` lane (fresh uv-built kernel).

Validated locally via ruff + py_compile + pyright (cluster.py is 0-errors); the box can't run pytest, so the parity + native legs run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)