### PR TITLE
feat(pipeline): consume cluster frames end-to-end behind GOLDENMATCH_CLUSTER_FRAMES_OUT (Phase-2 SP-B)

### DIFF
--- a/.github/workflows/bench-pipeline-frames-out.yml
+++ b/.github/workflows/bench-pipeline-frames-out.yml
@@ -1,0 +1,47 @@
+name: bench-pipeline-frames-out
+
+# SP-B residual bench (workflow_dispatch only), RECORDED DATA not a kill gate.
+# Builds the native ext fresh so the columnar build hits the real Arrow kernel,
+# then benches the identity dict-rebuild residual: cluster_frames_to_dict(
+# build_cluster_frames(..., GOLDENMATCH_CLUSTER_FRAMES_OUT=1)). Isolates the
+# frames build wall from the dict-rebuild wall (the cost SP-C removes) plus peak
+# RSS, at scale on the bulk-RSS axis (k=5, no oversized clusters).
+on:
+  workflow_dispatch:
+    inputs:
+      np:
+        description: "Comma-separated target pair counts"
+        default: "1000000,5000000"
+      runs:
+        description: "Repetitions per measurement (median)"
+        default: "3"
+
+jobs:
+  bench:
+    runs-on: large-new-64GB
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Build native extension (exposes build_clusters_arrow)
+        run: uv run python scripts/build_native.py
+      - name: Bench pipeline frames-out (identity dict-rebuild residual)
+        run: |
+          set -o pipefail
+          uv run python packages/python/goldenmatch/scripts/bench_pipeline_frames_out.py \
+            --np "${{ inputs.np }}" --runs "${{ inputs.runs }}" \
+            --output .profile_tmp/pipeline_frames_out.json | tee /tmp/pipeline_frames_out.txt
+          { echo '## bench-pipeline-frames-out'; echo '```'; cat /tmp/pipeline_frames_out.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: always()
+        with:
+          name: pipeline-frames-out
+          path: .profile_tmp/pipeline_frames_out.json
+          retention-days: 30

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -1046,13 +1046,53 @@ def build_golden_record_with_provenance(
 # (gitignored).
 
 
+def _multi_df_from_frames(
+    source_df: pl.DataFrame,
+    frames,  # cluster.ClusterFrames
+) -> pl.DataFrame:
+    """Join the assignments frame onto the source df, keeping only
+    rows that belong to a multi-member, NON-oversized cluster.
+
+    Returns a ``multi_df`` with a ``__cluster_id__`` column, the same
+    shape the per-column golden aggregation runs on. Returns an empty
+    frame (height 0) when there are no eligible clusters/rows.
+
+    The cluster selection mirrors the dict pipeline's golden filter in
+    ``pipeline.py`` (``info["size"] > 1 and not info["oversized"]``):
+    oversized clusters are EXCLUDED, exactly like the legacy path.
+    """
+    # Singleton + oversized drop via the metadata frame. NOTE the
+    # parentheses: Polars ``&`` binds tighter than ``>``, so the
+    # unparenthesized ``pl.col("size") > 1 & ~pl.col("oversized")``
+    # is a different (wrong) predicate.
+    multi_cluster_ids = (
+        frames.metadata
+        .filter((pl.col("size") > 1) & ~pl.col("oversized"))
+        .select("cluster_id")
+    )
+
+    # Vectorized join: attach __cluster_id__ to each source row whose
+    # __row_id__ appears in the assignments frame. ``inner`` join
+    # drops rows that aren't members of any eligible cluster.
+    assignments_multi = frames.assignments.join(
+        multi_cluster_ids, on="cluster_id", how="inner",
+    ).rename({"cluster_id": "__cluster_id__"})
+
+    return source_df.join(
+        assignments_multi,
+        left_on="__row_id__",
+        right_on="member_id",
+        how="inner",
+    )
+
+
 def build_golden_records_from_frames(
     source_df: pl.DataFrame,
     frames,  # cluster.ClusterFrames; imported lazily to keep golden.py independent
     rules: GoldenRulesConfig,
     quality_scores: dict[tuple[int, str], float] | None = None,
     provenance: bool = False,
-) -> list[dict]:
+) -> tuple[pl.DataFrame | None, list[dict]]:
     """Phase 4 entry point: build golden records from a Phase-2
     ``ClusterFrames`` plus the source DataFrame.
 
@@ -1065,25 +1105,37 @@ def build_golden_records_from_frames(
             ``cluster.build_clusters_v2_columnar`` (or equivalent). The
             ``assignments`` frame must have ``cluster_id`` (i64) and
             ``member_id`` (i64) columns. The ``metadata`` frame is read
-            to filter singletons via the ``size`` column.
-        rules: forwarded to ``build_golden_records_batch`` unchanged.
+            to filter singletons (``size``) AND oversized clusters
+            (``oversized``) -- matching the dict pipeline's golden
+            selection ``size > 1 and not oversized``.
+        rules: forwarded to the golden builder unchanged.
         quality_scores, provenance: forwarded unchanged.
 
     Returns:
-        Same shape as ``build_golden_records_batch`` -- list of golden
-        record dicts, one per multi-member cluster, sorted by
-        ``__cluster_id__``.
+        A ``(golden_df, golden_records)`` tuple. Exactly one slot is
+        populated, mirroring the dict pipeline's fast/slow decision:
 
-    Empty cases:
-        - empty ``source_df`` -> ``[]``.
-        - empty ``assignments`` -> ``[]``.
-        - assignments contains member_ids absent from ``source_df`` ->
-          those clusters are silently dropped (consistent with how the
-          existing pipeline drops rows whose __row_id__ isn't in the
-          source).
+        - FAST path (``not provenance`` AND
+          ``_polars_native_eligible(rules, quality_scores=None)``):
+          returns ``(golden_df, [])`` where ``golden_df`` is the
+          columnar ``pl.DataFrame`` from ``build_golden_records_df``.
+        - SLOW path (provenance requested OR quality_scores present OR
+          custom field rules): returns ``(None, golden_records)`` where
+          ``golden_records`` is the ``list[dict]`` from
+          ``build_golden_records_batch``.
+
+        The fast path DROPS quality_scores/provenance, so it fires ONLY
+        when both are absent (same gate as ``pipeline.py``).
+
+    Empty cases (both slots empty):
+        - empty ``source_df`` -> ``(None, [])``.
+        - empty ``assignments`` -> ``(None, [])``.
+        - assignments contains only member_ids absent from
+          ``source_df`` -> ``(None, [])`` (those clusters are silently
+          dropped, consistent with the existing pipeline).
     """
     if source_df.height == 0 or frames.assignments.is_empty():
-        return []
+        return None, []
 
     if "__row_id__" not in source_df.columns:
         raise ValueError(
@@ -1093,39 +1145,27 @@ def build_golden_records_from_frames(
             "frame doesn't have one.",
         )
 
-    # Drop singleton clusters via the metadata.size filter -- golden
-    # only processes multi-member clusters per the existing
-    # ``build_golden_records_batch`` contract. This filter is cheap
-    # (Polars filter on a small metadata frame) and avoids feeding
-    # singleton clusters through the per-column group_by pipeline.
-    multi_cluster_ids = (
-        frames.metadata
-        .filter(pl.col("size") > 1)
-        .select("cluster_id")
-    )
-
-    # Vectorized join: attach __cluster_id__ to each source row whose
-    # __row_id__ appears in the assignments frame. ``inner`` join
-    # drops rows that aren't members of any multi-member cluster (the
-    # "rows NOT referenced ... are silently dropped" contract above).
-    assignments_multi = frames.assignments.join(
-        multi_cluster_ids, on="cluster_id", how="inner",
-    ).rename({"cluster_id": "__cluster_id__"})
-
-    multi_df = source_df.join(
-        assignments_multi,
-        left_on="__row_id__",
-        right_on="member_id",
-        how="inner",
-    )
+    multi_df = _multi_df_from_frames(source_df, frames)
 
     if multi_df.height == 0:
-        return []
+        return None, []
 
-    return build_golden_records_batch(
+    # Preserve the dict pipeline's fast/slow decision (pipeline.py
+    # ~:1598). The fast columnar path drops quality_scores + provenance,
+    # so it's only valid when BOTH are absent.
+    fast_eligible = (
+        not provenance
+        and _polars_native_eligible(rules, quality_scores=None)
+    )
+    if fast_eligible:
+        golden_df = build_golden_records_df(multi_df, rules)
+        return golden_df, []
+
+    golden_records = build_golden_records_batch(
         multi_df,
         rules,
         quality_scores=quality_scores,
         provenance=provenance,
     )
+    return None, golden_records
 

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -1116,8 +1116,9 @@ def build_golden_records_from_frames(
         populated, mirroring the dict pipeline's fast/slow decision:
 
         - FAST path (``not provenance`` AND
-          ``_polars_native_eligible(rules, quality_scores=None)``):
-          returns ``(golden_df, [])`` where ``golden_df`` is the
+          ``_polars_native_eligible(rules, quality_scores=quality_scores)``,
+          i.e. no quality_scores -- they'd be dropped by the columnar
+          builder): returns ``(golden_df, [])`` where ``golden_df`` is the
           columnar ``pl.DataFrame`` from ``build_golden_records_df``.
         - SLOW path (provenance requested OR quality_scores present OR
           custom field rules): returns ``(None, golden_records)`` where

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -1155,7 +1155,7 @@ def build_golden_records_from_frames(
     # so it's only valid when BOTH are absent.
     fast_eligible = (
         not provenance
-        and _polars_native_eligible(rules, quality_scores=None)
+        and _polars_native_eligible(rules, quality_scores=quality_scores)
     )
     if fast_eligible:
         golden_df = build_golden_records_df(multi_df, rules)

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -116,7 +116,14 @@ def _get_block_scorer(config: GoldenMatchConfig):
         )
         return score_blocks_datafusion
     return score_blocks_parallel
-from goldenmatch.core.cluster import build_clusters, build_clusters_columnar
+from goldenmatch.core.cluster import (
+    ClusterFrames,
+    _cluster_frames_out_enabled,
+    build_cluster_frames,
+    build_clusters,
+    build_clusters_columnar,
+    cluster_frames_to_dict,
+)
 
 # ── Columnar pipeline fast-path (Arrow roadmap Phase A) ──────────────
 # Routes the eligible single-fuzzy-matchkey dedupe shape through the
@@ -1443,6 +1450,16 @@ def _run_dedupe_pipeline(
         if (_use_columnar and _columnar_pairs_df is not None)
         else len(all_pairs),
     )
+    # SP-B: frames-out path (gate GOLDENMATCH_CLUSTER_FRAMES_OUT, default OFF).
+    # When ON, build the two-frame ClusterFrames representation and consume it
+    # for GOLDEN + STATS + DUPES below. `clusters` is rebuilt from the frames via
+    # cluster_frames_to_dict so every remaining dict consumer (report,
+    # output_clusters, lineage, identity, results["clusters"]) stays byte-
+    # identical. Identity stays on the dict here; Task 3 wires its boundary
+    # rebuild. The frames-out path is additive -- the dict path (gate OFF) below
+    # is untouched. Mutually exclusive with the columnar pair-stream branch
+    # (frames-out only fires on the non-columnar list build site).
+    cluster_frames: ClusterFrames | None = None
     with stage("cluster"):
         if _use_columnar and _columnar_pairs_df is not None:
             # Phase A columnar path: same clusters as build_clusters on the
@@ -1453,6 +1470,16 @@ def _run_dedupe_pipeline(
                 weak_cluster_threshold=weak_threshold,
                 auto_split=auto_split,
             )
+        elif _cluster_frames_out_enabled():
+            cluster_frames = build_cluster_frames(
+                all_pairs, all_ids,
+                max_cluster_size=max_cluster_size,
+                weak_cluster_threshold=weak_threshold,
+                auto_split=auto_split,
+            )
+            # Rebuild the dict so stats / dupes / report / output_clusters /
+            # lineage / identity / results all see the unchanged shape.
+            clusters = cluster_frames_to_dict(cluster_frames)
         else:
             clusters = build_clusters(
                 all_pairs, all_ids,
@@ -1521,7 +1548,27 @@ def _run_dedupe_pipeline(
     #   4. partition by cluster_id → dict of small DataFrames,
     #   5. call build_golden_record on each pre-filtered partition.
     # Total: O(N + sum-of-cluster-sizes) which is O(N), independent of K.
-    with stage("golden"):
+    #
+    # SP-B frames-out: when build_cluster_frames ran (gate ON), build golden
+    # directly from the ClusterFrames via the Task-1 helper, which DEMUXes into
+    # the same golden_df / golden_records slots the dict path uses (fast ->
+    # golden_df set + golden_records=[]; slow -> golden_records set, golden_df
+    # rebuilt by the shared block below). quality_scores is always None in this
+    # pipeline (matching the dict path's _polars_native_eligible(..., None)
+    # gate); provenance mirrors config.output.lineage_provenance.
+    if cluster_frames is not None:
+        with stage("golden"):
+            from goldenmatch.core.golden import build_golden_records_from_frames
+            _provenance_on = config.output.lineage_provenance
+            golden_df, golden_records = build_golden_records_from_frames(
+                collected_df,
+                cluster_frames,
+                golden_rules,
+                quality_scores=None,
+                provenance=_provenance_on,
+            )
+    else:
+      with stage("golden"):
         with stage("golden_eligible_filter"):
             eligible: list[tuple[int, dict[str, Any]]] = [
                 (cid, info) for cid, info in clusters.items()

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1606,8 +1606,22 @@ def _run_dedupe_pipeline(
         with stage("golden"):
             from goldenmatch.core.golden import build_golden_records_from_frames
             _provenance_on = config.output.lineage_provenance
+            # Mirror the dict path's slim projection (below): drop internal
+            # __xform_*__ / __mk_*__ / __block_key__ / __bucket__ columns that
+            # survivorship never reads, BEFORE the join, so golden records carry
+            # the same columns as the dict path (byte-identical golden). Keep
+            # __row_id__ (the from-frames join needs it). Same env opt-out.
+            _golden_source = collected_df
+            if os.environ.get("GOLDENMATCH_GOLDEN_SLIM_MULTIDF", "1") != "0":
+                _internal_prefixes = (
+                    "__xform_", "__mk_", "__block_key__", "__bucket__",
+                )
+                _golden_source = collected_df.select([
+                    c for c in collected_df.columns
+                    if not any(c.startswith(p) for p in _internal_prefixes)
+                ])
             golden_df, golden_records = build_golden_records_from_frames(
-                collected_df,
+                _golden_source,
                 cluster_frames,
                 golden_rules,
                 quality_scores=None,

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1452,14 +1452,25 @@ def _run_dedupe_pipeline(
     )
     # SP-B: frames-out path (gate GOLDENMATCH_CLUSTER_FRAMES_OUT, default OFF).
     # When ON, build the two-frame ClusterFrames representation and consume it
-    # for GOLDEN + STATS + DUPES below. `clusters` is rebuilt from the frames via
-    # cluster_frames_to_dict so every remaining dict consumer (report,
-    # output_clusters, lineage, identity, results["clusters"]) stays byte-
-    # identical. Identity stays on the dict here; Task 3 wires its boundary
-    # rebuild. The frames-out path is additive -- the dict path (gate OFF) below
-    # is untouched. Mutually exclusive with the columnar pair-stream branch
-    # (frames-out only fires on the non-columnar list build site).
+    # DIRECTLY for GOLDEN + STATS + DUPES + REPORT below (no dict). The legacy
+    # `clusters` dict is rebuilt LAZILY via `_clusters_dict()` -- at most once,
+    # as late as the OUTPUT block -- only for the remaining dict consumers
+    # (adaptive refiner if enabled, output_clusters rows, lineage, identity,
+    # results["clusters"]). Keeping golden + stats + dupes dict-free is the SP-B
+    # prerequisite for the SP-C RSS win: once identity + results stop needing the
+    # dict, the lazy rebuild simply never fires on the hot path. Identity still
+    # RECEIVES a (rebuilt) dict here; Task 3 wires its ClusterPairScores view.
+    # The frames-out path is additive -- the dict path (gate OFF) below is
+    # untouched and byte-identical. Mutually exclusive with the columnar
+    # pair-stream branch (frames-out only fires on the non-columnar list build
+    # site).
     cluster_frames: ClusterFrames | None = None
+    # `clusters` is bound to the real dict on the gate-OFF and columnar branches;
+    # on the frames-out branch it stays {} until the lazy rebuild at OUTPUT time
+    # (the {} is never read -- every earlier dict consumer is guarded by
+    # `cluster_frames is None`). Explicit init keeps pyright from seeing it as
+    # possibly-unbound.
+    clusters: dict[int, dict] = {}
     with stage("cluster"):
         if _use_columnar and _columnar_pairs_df is not None:
             # Phase A columnar path: same clusters as build_clusters on the
@@ -1477,9 +1488,14 @@ def _run_dedupe_pipeline(
                 weak_cluster_threshold=weak_threshold,
                 auto_split=auto_split,
             )
-            # Rebuild the dict so stats / dupes / report / output_clusters /
-            # lineage / identity / results all see the unchanged shape.
-            clusters = cluster_frames_to_dict(cluster_frames)
+            # SP-B: do NOT rebuild the dict eagerly. stats + dupes (always-run
+            # hot path) are computed directly from the frame aggregates below;
+            # the dict is rebuilt LAZILY, only when a remaining dict consumer
+            # (adaptive refiner / lineage / identity / results / output_clusters)
+            # actually needs it, via `_clusters_dict()`. Keeping golden + stats +
+            # dupes dict-free is what lets the SP-C RSS win land once identity
+            # drops its dict use. `clusters` stays the empty-dict init on this
+            # branch until the lazy rebuild at OUTPUT time.
         else:
             clusters = build_clusters(
                 all_pairs, all_ids,
@@ -1487,15 +1503,44 @@ def _run_dedupe_pipeline(
                 weak_cluster_threshold=weak_threshold,
                 auto_split=auto_split,
             )
-    record_metrics({
-        "cluster_count": len(clusters),
-        "multi_member_cluster_count": sum(
-            1 for c in clusters.values() if c.get("size", 0) > 1
-        ),
-        "oversized_cluster_count": sum(
-            1 for c in clusters.values() if c.get("oversized")
-        ),
-    })
+    # SP-B lazy dict rebuild. On the frames-out branch `clusters` is unbound;
+    # the remaining dict consumers (adaptive refiner, lineage, identity,
+    # results["clusters"], output_clusters report/rows) go through this helper,
+    # which builds the dict from the frames AT MOST ONCE and caches it. The hot
+    # path (stats + dupes) never calls it -- those read the metadata/assignments
+    # frames directly -- so golden + stats + dupes stay dict-free.
+    _clusters_cache: list[dict[int, dict]] = []
+
+    def _clusters_dict() -> dict[int, dict]:
+        if cluster_frames is None:
+            # Gate-OFF / columnar paths bound `clusters` eagerly above.
+            return clusters
+        if not _clusters_cache:
+            _clusters_cache.append(cluster_frames_to_dict(cluster_frames))
+        return _clusters_cache[0]
+
+    if cluster_frames is not None:
+        # Stats from frame aggregates (no dict materialization). Matches the
+        # dict path's len(clusters) / size>1 / oversized counts exactly.
+        record_metrics({
+            "cluster_count": cluster_frames.metadata.height,
+            "multi_member_cluster_count": cluster_frames.metadata.filter(
+                pl.col("size") > 1
+            ).height,
+            "oversized_cluster_count": cluster_frames.metadata.filter(
+                pl.col("oversized")
+            ).height,
+        })
+    else:
+        record_metrics({
+            "cluster_count": len(clusters),
+            "multi_member_cluster_count": sum(
+                1 for c in clusters.values() if c.get("size", 0) > 1
+            ),
+            "oversized_cluster_count": sum(
+                1 for c in clusters.values() if c.get("oversized")
+            ),
+        })
 
     # ── Step 5: GOLDEN ──
     golden_records: list[dict] = []
@@ -1523,7 +1568,7 @@ def _run_dedupe_pipeline(
             )
             golden_rules = refine_golden_rules(
                 base_rules=golden_rules,
-                clusters=clusters,
+                clusters=_clusters_dict(),
                 prepared_df=collected_df,
                 column_profiles=_profiles_for_refiner,
                 memory_store=memory_store,
@@ -1568,97 +1613,102 @@ def _run_dedupe_pipeline(
                 provenance=_provenance_on,
             )
     else:
-      with stage("golden"):
-        with stage("golden_eligible_filter"):
-            eligible: list[tuple[int, dict[str, Any]]] = [
-                (cid, info) for cid, info in clusters.items()
-                if info["size"] > 1 and not info["oversized"]
-            ]
-        if eligible:
-            with stage("golden_row_to_cluster_dict"):
-                # row_id → cluster_id mapping. Members are int row IDs; one row
-                # belongs to at most one cluster, so the map is unambiguous.
-                row_to_cluster: dict[int, int] = {}
-                for cid, info in eligible:
-                    for mid in info["members"]:
-                        row_to_cluster[mid] = cid
-                member_ids_all = list(row_to_cluster.keys())
+        with stage("golden"):
+            with stage("golden_eligible_filter"):
+                eligible: list[tuple[int, dict[str, Any]]] = [
+                    (cid, info) for cid, info in clusters.items()
+                    if info["size"] > 1 and not info["oversized"]
+                ]
+            if eligible:
+                with stage("golden_row_to_cluster_dict"):
+                    # row_id → cluster_id mapping. Members are int row IDs; one
+                    # row belongs to at most one cluster, so the map is
+                    # unambiguous.
+                    row_to_cluster: dict[int, int] = {}
+                    for cid, info in eligible:
+                        for mid in info["members"]:
+                            row_to_cluster[mid] = cid
+                    member_ids_all = list(row_to_cluster.keys())
 
-            with stage("golden_multi_df_filter"):
-                multi_df = collected_df.filter(
-                    pl.col("__row_id__").is_in(member_ids_all)
-                )
-
-            # Slim projection (PR #595). v32 attribution localized the
-            # +9 GB peak jump entirely to golden_attach_cluster_id's
-            # with_columns COW -- multi_df carries every column from
-            # collected_df including __xform_*__ / __mk_*__ / __block_key__
-            # / __bucket__ internals that survivorship never reads. Drop
-            # them BEFORE the with_columns so the COW runs over a smaller
-            # frame.
-            #
-            # v33 measured: -2.6 GB peak vs v32 baseline, F1 invariant,
-            # wall flat. Default ON; opt out via
-            # GOLDENMATCH_GOLDEN_SLIM_MULTIDF=0 if any downstream golden
-            # path ever needs an internal column.
-            if os.environ.get("GOLDENMATCH_GOLDEN_SLIM_MULTIDF", "1") != "0":
-                with stage("golden_slim_multidf"):
-                    _internal_prefixes = (
-                        "__xform_", "__mk_", "__block_key__", "__bucket__",
+                with stage("golden_multi_df_filter"):
+                    multi_df = collected_df.filter(
+                        pl.col("__row_id__").is_in(member_ids_all)
                     )
-                    multi_df = multi_df.select([
-                        c for c in multi_df.columns
-                        if not any(c.startswith(p) for p in _internal_prefixes)
-                    ])
 
-            with stage("golden_attach_cluster_id"):
-                # Attach __cluster_id__ via replace_strict. The old keys/new
-                # vals lists are tiny (1 entry per member); the join itself
-                # is linear in `multi_df.height`.
-                multi_df = multi_df.with_columns(
-                    pl.col("__row_id__").replace_strict(
-                        list(row_to_cluster.keys()),
-                        list(row_to_cluster.values()),
-                        return_dtype=pl.Int64,
-                    ).alias("__cluster_id__")
-                )
-            # Batch builder: sorts by __cluster_id__ once and pre-extracts
-            # each user column to a Python list ONCE. At 5M / 1.67M
-            # multi-member clusters the previous partition_by(as_dict=True)
-            # + per-cluster build_golden_record loop allocated 1.67M tiny
-            # eager DataFrames AND called cluster_df[col].to_list() ~6.7M
-            # times. New path: 4 to_list() calls + Python list slicing.
-            # Measured: golden stage 307s -> ~30s at 5M.
-            # provenance=True (opt-in) enriches each field with source_row_id
-            # for the lineage sidecar; the golden_df builder below ignores the
-            # extra key, so the same records feed both paths (no double build).
-            #
-            # Fast path (provenance=False + uniform strategy + no quality_scores
-            # + no field_rules + no cluster_overrides): bypass the list[dict]
-            # intermediate entirely. At 10M / 2M multi-member clusters that
-            # intermediate allocates ~14 GB of CPython dict overhead;
-            # build_golden_records_df does the whole compute columnar in Polars
-            # at ~0.8 GB. Provenance + non-fast strategies still go through the
-            # list[dict] path so the existing semantics (per-field source_row_id,
-            # custom merge_field rules) stay intact.
-            _provenance_on = config.output.lineage_provenance
-            _fast_eligible = (
-                not _provenance_on
-                and _polars_native_eligible(golden_rules, quality_scores=None)
-            )
-            if _fast_eligible:
-                with stage("golden_build_records_df_fast"):
-                    golden_df = build_golden_records_df(multi_df, golden_rules)
-                # Leave golden_records empty: the provenance branch below
-                # (gated on `if config.output.lineage_provenance and golden_records`)
-                # is a no-op when provenance is off, so no metadata is lost.
-                golden_records = []
-            else:
-                with stage("golden_build_records_batch_slow"):
-                    golden_records = build_golden_records_batch(
-                        multi_df, golden_rules,
-                        provenance=_provenance_on,
+                # Slim projection (PR #595). v32 attribution localized the
+                # +9 GB peak jump entirely to golden_attach_cluster_id's
+                # with_columns COW -- multi_df carries every column from
+                # collected_df including __xform_*__ / __mk_*__ / __block_key__
+                # / __bucket__ internals that survivorship never reads. Drop
+                # them BEFORE the with_columns so the COW runs over a smaller
+                # frame.
+                #
+                # v33 measured: -2.6 GB peak vs v32 baseline, F1 invariant,
+                # wall flat. Default ON; opt out via
+                # GOLDENMATCH_GOLDEN_SLIM_MULTIDF=0 if any downstream golden
+                # path ever needs an internal column.
+                if os.environ.get("GOLDENMATCH_GOLDEN_SLIM_MULTIDF", "1") != "0":
+                    with stage("golden_slim_multidf"):
+                        _internal_prefixes = (
+                            "__xform_", "__mk_", "__block_key__", "__bucket__",
+                        )
+                        multi_df = multi_df.select([
+                            c for c in multi_df.columns
+                            if not any(c.startswith(p) for p in _internal_prefixes)
+                        ])
+
+                with stage("golden_attach_cluster_id"):
+                    # Attach __cluster_id__ via replace_strict. The old keys/new
+                    # vals lists are tiny (1 entry per member); the join itself
+                    # is linear in `multi_df.height`.
+                    multi_df = multi_df.with_columns(
+                        pl.col("__row_id__").replace_strict(
+                            list(row_to_cluster.keys()),
+                            list(row_to_cluster.values()),
+                            return_dtype=pl.Int64,
+                        ).alias("__cluster_id__")
                     )
+                # Batch builder: sorts by __cluster_id__ once and pre-extracts
+                # each user column to a Python list ONCE. At 5M / 1.67M
+                # multi-member clusters the previous partition_by(as_dict=True)
+                # + per-cluster build_golden_record loop allocated 1.67M tiny
+                # eager DataFrames AND called cluster_df[col].to_list() ~6.7M
+                # times. New path: 4 to_list() calls + Python list slicing.
+                # Measured: golden stage 307s -> ~30s at 5M.
+                # provenance=True (opt-in) enriches each field with source_row_id
+                # for the lineage sidecar; the golden_df builder below ignores
+                # the extra key, so the same records feed both paths (no double
+                # build).
+                #
+                # Fast path (provenance=False + uniform strategy + no
+                # quality_scores + no field_rules + no cluster_overrides): bypass
+                # the list[dict] intermediate entirely. At 10M / 2M multi-member
+                # clusters that intermediate allocates ~14 GB of CPython dict
+                # overhead; build_golden_records_df does the whole compute
+                # columnar in Polars at ~0.8 GB. Provenance + non-fast strategies
+                # still go through the list[dict] path so the existing semantics
+                # (per-field source_row_id, custom merge_field rules) stay intact.
+                _provenance_on = config.output.lineage_provenance
+                _fast_eligible = (
+                    not _provenance_on
+                    and _polars_native_eligible(golden_rules, quality_scores=None)
+                )
+                if _fast_eligible:
+                    with stage("golden_build_records_df_fast"):
+                        golden_df = build_golden_records_df(
+                            multi_df, golden_rules
+                        )
+                    # Leave golden_records empty: the provenance branch below
+                    # (gated on `if config.output.lineage_provenance and
+                    # golden_records`) is a no-op when provenance is off, so no
+                    # metadata is lost.
+                    golden_records = []
+                else:
+                    with stage("golden_build_records_batch_slow"):
+                        golden_records = build_golden_records_batch(
+                            multi_df, golden_rules,
+                            provenance=_provenance_on,
+                        )
 
     # Build golden DataFrame (slow path: walks the list[dict] returned by
     # build_golden_records_batch. The fast path above already populated
@@ -1688,12 +1738,25 @@ def _run_dedupe_pipeline(
         golden_df = pl.DataFrame(golden_rows, schema_overrides=schema_overrides)
 
     # Classify records
-    multi_cluster_ids = [
-        cid for cid, cinfo in clusters.items() if cinfo["size"] > 1
-    ]
-    dupe_row_ids = set()
-    for cid in multi_cluster_ids:
-        dupe_row_ids.update(clusters[cid]["members"])
+    if cluster_frames is not None:
+        # SP-B: dupe row ids from the frame aggregates -- members of every
+        # size>1 cluster. OVERSIZED-INCLUDED to match the dict path (which
+        # filters size>1 only; oversized clusters' members are still dupes).
+        dupe_row_ids = set(
+            cluster_frames.assignments.join(
+                cluster_frames.metadata.filter(pl.col("size") > 1).select(
+                    "cluster_id"
+                ),
+                on="cluster_id",
+            )["member_id"].to_list()
+        )
+    else:
+        multi_cluster_ids = [
+            cid for cid, cinfo in clusters.items() if cinfo["size"] > 1
+        ]
+        dupe_row_ids = set()
+        for cid in multi_cluster_ids:
+            dupe_row_ids.update(clusters[cid]["members"])
     unique_row_ids = set(all_ids) - dupe_row_ids
 
     dupes_df = collected_df.filter(pl.col("__row_id__").is_in(list(dupe_row_ids)))
@@ -1702,17 +1765,36 @@ def _run_dedupe_pipeline(
     # ── Step 6: REPORT ──
     report = None
     if output_report:
-        cluster_sizes = [c["size"] for c in clusters.values()]
-        oversized_count = sum(1 for c in clusters.values() if c["oversized"])
+        if cluster_frames is not None:
+            # SP-B: report stats from the metadata frame -- no dict build.
+            cluster_sizes = cluster_frames.metadata["size"].to_list()
+            oversized_count = cluster_frames.metadata.filter(
+                pl.col("oversized")
+            ).height
+            total_clusters = cluster_frames.metadata.height
+        else:
+            cluster_sizes = [c["size"] for c in clusters.values()]
+            oversized_count = sum(
+                1 for c in clusters.values() if c["oversized"]
+            )
+            total_clusters = len(clusters)
         report = generate_dedupe_report(
             total_records=len(collected_df),
-            total_clusters=len(clusters),
+            total_clusters=total_clusters,
             cluster_sizes=cluster_sizes,
             oversized_clusters=oversized_count,
             matchkeys_used=[mk.name for mk in matchkeys],
         )
 
     # ── Step 7: OUTPUT ──
+    # SP-B: from here down the remaining dict consumers (output_clusters rows,
+    # lineage, identity wiring, results["clusters"]) need the legacy dict shape.
+    # Rebuild it LAZILY now -- once -- via the cache helper. On the frames-out
+    # branch this is the FIRST and ONLY materialization; golden + stats + dupes
+    # above ran entirely off the frames. results["clusters"] forces the build
+    # unconditionally today; SP-C removes that last dict consumer so the rebuild
+    # can be skipped when no output/identity needs it.
+    clusters = _clusters_dict()
     run_name = config.output.run_name or datetime.now().strftime("%Y%m%d_%H%M%S")
     fmt = config.output.format or "csv"
     directory = config.output.directory or config.output.path or "."

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from goldenmatch.core.cluster_pairscores import ClusterPairScores
     from goldenmatch.distributed.record_store import PreparedRecordStore
 
 import polars as pl
@@ -1841,21 +1842,28 @@ def _run_dedupe_pipeline(
             logger.warning("Lineage generation failed: %s", e)
 
     # ── Step 7.6: IDENTITY GRAPH (optional) ──
-    # When the columnar-cluster-build gate is ON, feed the identity evidence-edge
-    # consumer from a ClusterPairScores view (byte-identical to the dict path,
-    # built once here). Gate via _columnar_cluster_build_enabled
-    # (GOLDENMATCH_COLUMNAR_CLUSTER_BUILD) -- NOT the _use_columnar pipeline flag,
-    # which is a different env var.
-    pair_score_view = None
+    # Feed the identity evidence-edge consumer from a ClusterPairScores view
+    # (byte-identical to the dict path, built once here) whenever the dict that
+    # reaches identity carries EMPTY per-cluster pair_scores. Two gates produce
+    # such a dict:
+    #   - _columnar_cluster_build_enabled (GOLDENMATCH_COLUMNAR_CLUSTER_BUILD):
+    #     the columnar build returns pair_scores={};
+    #   - _cluster_frames_out_enabled (GOLDENMATCH_CLUSTER_FRAMES_OUT, SP-B): the
+    #     lazily-rebuilt dict from cluster_frames_to_dict also has pair_scores={}.
+    # In BOTH cases resolve_clusters' info.get("pair_scores") fallback would yield
+    # ZERO evidence edges, so we MUST supply the view. Gate-OFF (neither env set)
+    # leaves the dict carrying real pair_scores and pair_score_view stays None --
+    # byte-identical to today.
+    pair_score_view: ClusterPairScores | None = None
     if isinstance(clusters, dict):
         from goldenmatch.core.cluster import _columnar_cluster_build_enabled
-        if _columnar_cluster_build_enabled():
+        if _columnar_cluster_build_enabled() or _cluster_frames_out_enabled():
             from goldenmatch.core.cluster_pairscores import ClusterPairScores
-            # SP4: the columnar build returns pair_scores={}, so build the view
-            # from the RAW input pairs (input-order, last-wins == the dict path's
-            # per-cluster pair_scores) + final cluster membership. NOT from
-            # results["scored_pairs"] (max-score deduped, differs on dup-scored
-            # pairs).
+            # SP4 / SP-B: the dict reaching identity has pair_scores={}, so build
+            # the view from the RAW input pairs (input-order, last-wins == the
+            # dict path's per-cluster pair_scores) + final cluster membership. NOT
+            # from results["scored_pairs"] (max-score deduped, differs on
+            # dup-scored pairs).
             pair_score_view = ClusterPairScores.from_pairs(all_pairs, clusters)
     with stage("identity_resolve"):
         identity_summary = _resolve_identities(

--- a/packages/python/goldenmatch/scripts/bench_pipeline_frames_out.py
+++ b/packages/python/goldenmatch/scripts/bench_pipeline_frames_out.py
@@ -1,0 +1,227 @@
+"""SP-B residual bench. Measures cluster_frames_to_dict(build_cluster_frames(...))
+wall + peak RSS -- the identity dict-rebuild cost SP-C removes. Recorded DATA,
+not a gate.
+
+This bench isolates TWO walls per scale point:
+  1. ``build_walls``   -- ``build_cluster_frames(...)`` (the SP-B frames-out build,
+     gate ``GOLDENMATCH_CLUSTER_FRAMES_OUT=1``).
+  2. ``rebuild_walls`` -- ``cluster_frames_to_dict(frames)`` (the residual: rebuild
+     the legacy ``dict[int, dict]`` from the two-frame columnar representation so
+     today's identity stage can still consume it).
+
+The residual (rebuild_walls) is the cost SP-C removes by teaching the identity
+stage to read frames directly. There's a single measured operation per scale
+point (no on/off variants -- this measures ONE thing), so there's NO parity
+assert. The k=5 fixture (M clusters of size 5 -> 10 pairs each) has NO oversized
+clusters, so this exercises the bulk-RSS axis (many small clusters). A fresh
+native build in CI means the columnar build hits the real Arrow kernel.
+
+Each scale point runs in its OWN subprocess (``--child``) so wall AND peak RSS
+are clean. A warm run precedes the measured runs; the reported number is the
+median wall over ``--runs`` repetitions.
+
+Local smoke: python ... --np 50000 --runs 1  (resource is unavailable on Windows
+so RSS is 0.0 -- fine).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _make_pairs_df(n_pairs_target: int):
+    """M clusters of size k=5 -> 10 pairs each. Deterministic, no RNG."""
+    import polars as pl
+
+    k = 5
+    per = k * (k - 1) // 2  # 10
+    m = max(1, n_pairs_target // per)
+    a_col: list[int] = []
+    b_col: list[int] = []
+    for c in range(m):
+        base = c * k
+        for i in range(k):
+            for j in range(i + 1, k):
+                a_col.append(base + i)
+                b_col.append(base + j)
+    s_col = [0.95] * len(a_col)
+    return pl.DataFrame(
+        {"id_a": a_col, "id_b": b_col, "score": s_col},
+        schema={"id_a": pl.Int64, "id_b": pl.Int64, "score": pl.Float64},
+    )
+
+
+def _pairs_list_from_df(pairs_df) -> list[tuple[int, int, float]]:
+    return list(
+        zip(
+            pairs_df["id_a"].to_list(),
+            pairs_df["id_b"].to_list(),
+            pairs_df["score"].to_list(),
+        )
+    )
+
+
+def _peak_rss_mb() -> float:
+    try:
+        import resource
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+    except Exception:
+        return 0.0
+
+
+def _run_child(n_pairs: int, runs: int) -> int:
+    import polars as pl  # noqa: F401
+    from goldenmatch.core.cluster import build_cluster_frames, cluster_frames_to_dict
+
+    pairs_df = _make_pairs_df(n_pairs)
+    pairs_list = _pairs_list_from_df(pairs_df)
+    actual_pairs = pairs_df.height
+
+    os.environ["GOLDENMATCH_CLUSTER_FRAMES_OUT"] = "1"
+
+    def _build():
+        return build_cluster_frames(
+            pairs_list,
+            all_ids=None,
+            max_cluster_size=100,
+            weak_cluster_threshold=0.3,
+            auto_split=True,
+        )
+
+    frames = _build()  # warm build
+    cluster_frames_to_dict(frames)  # warm rebuild
+
+    build_walls: list[float] = []
+    rebuild_walls: list[float] = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        frames = _build()
+        build_walls.append(time.perf_counter() - t0)
+
+        t1 = time.perf_counter()
+        cluster_frames_to_dict(frames)
+        rebuild_walls.append(time.perf_counter() - t1)
+
+    print(json.dumps({
+        "n_pairs": actual_pairs,
+        "build_walls": build_walls,
+        "rebuild_walls": rebuild_walls,
+        "peak_rss_mb": _peak_rss_mb(),
+    }), flush=True)
+    return 0
+
+
+def _bench_point(n: int, runs: int) -> dict[str, Any]:
+    cmd = [
+        sys.executable, os.path.abspath(__file__),
+        "--child", "--np", str(n), "--runs", str(runs),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"child np={n} exited {proc.returncode}\n"
+            f"--- stderr ---\n{proc.stderr.strip()}"
+        )
+    last_json = None
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            last_json = line
+    if last_json is None:
+        raise RuntimeError(
+            f"child np={n} produced no JSON line\n"
+            f"--- stdout ---\n{proc.stdout.strip()}"
+        )
+    return json.loads(last_json)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--np", default="1000000,5000000",
+                    help="Comma-separated target pair counts")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--output", default=None)
+    ap.add_argument("--child", action="store_true",
+                    help="Internal: run a single scale point in this process")
+    args = ap.parse_args()
+
+    runs = max(1, args.runs)
+
+    if args.child:
+        nps = [int(x.strip()) for x in args.np.split(",") if x.strip()]
+        n = nps[0] if nps else 1000000
+        return _run_child(n, runs)
+
+    nps = [int(x.strip()) for x in args.np.split(",") if x.strip()]
+
+    from goldenmatch.core._native_loader import native_available, native_module
+    print(f"native importable: {native_available()}", flush=True)
+    m = native_module()
+    print(f"build_clusters_arrow exposed: "
+          f"{bool(m) and hasattr(m, 'build_clusters_arrow')}", flush=True)
+
+    results = []
+    for n in nps:
+        print(f"  target_pairs={n:,} ...", flush=True)
+        try:
+            point = _bench_point(n, runs)
+            build_s = statistics.median(point["build_walls"])
+            rebuild_s = statistics.median(point["rebuild_walls"])
+            row = {
+                "n_pairs": point["n_pairs"],
+                "build_s": build_s,
+                "rebuild_s": rebuild_s,
+                "peak_rss_mb": point["peak_rss_mb"],
+            }
+            results.append(row)
+            print(f"    pairs={row['n_pairs']:,}  build={build_s:.3f}s  "
+                  f"rebuild={rebuild_s:.3f}s  rss={row['peak_rss_mb']:.1f}MB",
+                  flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  target_pairs={n:,}  ERROR {type(exc).__name__}: {exc}",
+                  flush=True)
+            results.append({"n_pairs": n, "error": str(exc)})
+
+    lines = [
+        "\n## bench-pipeline-frames-out\n",
+        f"| {'pairs':>12} | {'build (s)':>10} | {'rebuild (s)':>11} | "
+        f"{'peak RSS MB':>12} |",
+        f"| {'-'*12} | {'-'*10} | {'-'*11} | {'-'*12} |",
+    ]
+    for r in results:
+        if "error" in r:
+            lines.append(
+                f"| {r['n_pairs']:>12,} | {'ERROR':>10} | {'ERROR':>11} | "
+                f"{'n/a':>12} |"
+            )
+            continue
+        lines.append(
+            f"| {r['n_pairs']:>12,} | {r['build_s']:>10.3f} | "
+            f"{r['rebuild_s']:>11.3f} | {r['peak_rss_mb']:>12.1f} |"
+        )
+    table = "\n".join(lines)
+    print(table, flush=True)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        try:
+            with open(summary, "a", encoding="utf-8") as fh:
+                fh.write(table + "\n")
+        except OSError:
+            pass
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump({"results": results}, fh, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/tests/test_golden_from_frames_oversized.py
+++ b/packages/python/goldenmatch/tests/test_golden_from_frames_oversized.py
@@ -1,0 +1,106 @@
+"""SP-B Task 1: build_golden_records_from_frames must EXCLUDE oversized
+clusters, matching the dict pipeline's golden selection
+(``info["size"] > 1 and not info["oversized"]`` in pipeline.py ~:1528).
+
+Builds clusters with ``auto_split=False`` so an over-cap cluster stays
+flagged ``oversized`` instead of being split, converts to
+``ClusterFrames`` via ``cluster_dict_to_frames``, and asserts the
+from-frames golden builder drops it.
+
+Tiny hand-built fixtures, no ``dedupe_df`` calls.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.config.schemas import GoldenRulesConfig
+from goldenmatch.core.cluster import build_clusters, cluster_dict_to_frames
+from goldenmatch.core.golden import (
+    build_golden_records_batch,
+    build_golden_records_from_frames,
+)
+
+
+def _src(ids: list[int]) -> pl.DataFrame:
+    """source_df with a __row_id__ col covering the member ids + a value col."""
+    return pl.DataFrame({
+        "__row_id__": pl.Series(ids, dtype=pl.Int64),
+        "name": [f"n{i}" for i in ids],
+    })
+
+
+def _cids_from_result(result) -> set[int]:
+    """__cluster_id__ set out of whichever tuple slot is populated."""
+    golden_df, golden_records = result
+    if golden_df is not None:
+        return set(golden_df["__cluster_id__"].to_list())
+    return {r["__cluster_id__"] for r in golden_records}
+
+
+def _build() -> tuple[dict, pl.DataFrame]:
+    # {0,1,2,3} is a size-4 clique (> max_cluster_size=3 -> oversized);
+    # {10,11} is a size-2 cluster (eligible).
+    pairs = [
+        (0, 1, 0.9), (1, 2, 0.9), (0, 2, 0.9),
+        (2, 3, 0.9), (0, 3, 0.9), (1, 3, 0.9),
+        (10, 11, 0.9),
+    ]
+    clusters = build_clusters(
+        pairs,
+        all_ids=[0, 1, 2, 3, 10, 11],
+        max_cluster_size=3,
+        auto_split=False,
+    )
+    src = _src([0, 1, 2, 3, 10, 11])
+    return clusters, src
+
+
+class TestFromFramesExcludesOversized:
+    def test_oversized_cluster_excluded(self):
+        clusters, src = _build()
+
+        # Sanity: there IS an oversized multi-member cluster in the dict.
+        oversized = [
+            cid for cid, c in clusters.items()
+            if c["size"] > 1 and c["oversized"]
+        ]
+        assert oversized, "fixture did not produce an oversized cluster"
+
+        frames = cluster_dict_to_frames(clusters)
+        rules = GoldenRulesConfig(default_strategy="most_complete")
+
+        got = build_golden_records_from_frames(src, frames, rules)
+        got_cids = _cids_from_result(got)
+
+        # Reference: dict path's selection (size > 1 AND not oversized).
+        ref_dict = {
+            cid: c for cid, c in clusters.items()
+            if c["size"] > 1 and not c["oversized"]
+        }
+        # Attach __cluster_id__ to multi_df the way the dict pipeline does.
+        members_to_cid: dict[int, int] = {}
+        for cid, c in ref_dict.items():
+            for m in c["members"]:
+                members_to_cid[m] = cid
+        ref_multi = (
+            src.filter(pl.col("__row_id__").is_in(list(members_to_cid)))
+            .with_columns(
+                pl.col("__row_id__")
+                .replace_strict(
+                    list(members_to_cid.keys()),
+                    list(members_to_cid.values()),
+                    return_dtype=pl.Int64,
+                )
+                .alias("__cluster_id__")
+            )
+        )
+        ref = build_golden_records_batch(ref_multi, rules)
+        ref_cids = {r["__cluster_id__"] for r in ref}
+
+        assert got_cids == ref_cids, (
+            f"from-frames cluster ids {got_cids} != dict-path ids {ref_cids}"
+        )
+        # The oversized cluster id must NOT appear in the golden output.
+        for cid in oversized:
+            assert cid not in got_cids, (
+                f"oversized cluster {cid} leaked into golden output"
+            )

--- a/packages/python/goldenmatch/tests/test_golden_from_frames_parity.py
+++ b/packages/python/goldenmatch/tests/test_golden_from_frames_parity.py
@@ -24,6 +24,16 @@ from goldenmatch.core.golden import (
 )
 
 
+def _cids_from_frames_result(result) -> list[int]:
+    """Pull the __cluster_id__ set out of whichever slot the new
+    tuple return populated (golden_df fast path or golden_records slow
+    path)."""
+    golden_df, golden_records = result
+    if golden_df is not None:
+        return sorted(golden_df["__cluster_id__"].to_list())
+    return sorted(r["__cluster_id__"] for r in golden_records)
+
+
 def _make_source() -> pl.DataFrame:
     """Tiny 6-row people frame; 2 multi-member clusters + 1 singleton."""
     return pl.DataFrame({
@@ -84,13 +94,13 @@ class TestGoldenFromFramesParity:
             _manual_multi_df(source, frames), rules,
         )
 
+        new_cids = _cids_from_frames_result(new)
+        old_cids = sorted(r["__cluster_id__"] for r in old)
         # Same number of golden records (one per multi-member cluster)
-        assert len(new) == len(old), (
-            f"record count differs: new={len(new)}, old={len(old)}"
+        assert len(new_cids) == len(old_cids), (
+            f"record count differs: new={len(new_cids)}, old={len(old_cids)}"
         )
         # Same set of __cluster_id__ values
-        new_cids = sorted(r["__cluster_id__"] for r in new)
-        old_cids = sorted(r["__cluster_id__"] for r in old)
         assert new_cids == old_cids, (
             f"cluster ids differ: new={new_cids}, old={old_cids}"
         )
@@ -103,7 +113,7 @@ class TestGoldenFromFramesParity:
         rules = GoldenRulesConfig(default_strategy="most_complete")
 
         new = build_golden_records_from_frames(source, frames, rules)
-        cids = {r["__cluster_id__"] for r in new}
+        cids = set(_cids_from_frames_result(new))
 
         assert 100 in cids
         assert 101 in cids
@@ -119,7 +129,9 @@ class TestGoldenFromFramesParity:
         })
         frames = _make_frames()
         rules = GoldenRulesConfig(default_strategy="most_complete")
-        assert build_golden_records_from_frames(empty_source, frames, rules) == []
+        assert build_golden_records_from_frames(empty_source, frames, rules) == (
+            None, [],
+        )
 
     def test_empty_assignments(self):
         source = _make_source()
@@ -139,7 +151,9 @@ class TestGoldenFromFramesParity:
             }),
         )
         rules = GoldenRulesConfig(default_strategy="most_complete")
-        assert build_golden_records_from_frames(source, empty_frames, rules) == []
+        assert build_golden_records_from_frames(source, empty_frames, rules) == (
+            None, [],
+        )
 
     def test_missing_row_id_raises(self):
         source_no_rowid = pl.DataFrame({
@@ -165,7 +179,7 @@ class TestGoldenFromFramesParity:
         rules = GoldenRulesConfig(default_strategy="most_complete")
 
         new = build_golden_records_from_frames(source, frames, rules)
-        cids = {r["__cluster_id__"] for r in new}
+        cids = set(_cids_from_frames_result(new))
 
         # Cluster 100 (1, 2, 3) is fully present -> included
         assert 100 in cids

--- a/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
@@ -200,3 +200,143 @@ def test_frames_out_pipeline_parity_provenance_slow(monkeypatch, native):
     assert _cluster_stats(on) == _cluster_stats(off)
     assert _dupe_row_ids(on) == _dupe_row_ids(off)
     assert _golden_as_setrows(on) == _golden_as_setrows(off)
+
+
+# ── SP-B Task 3: identity-enabled parity ──────────────────────────────────
+#
+# With identity ENABLED and GOLDENMATCH_CLUSTER_FRAMES_OUT ON, the dict that
+# reaches resolve_clusters is rebuilt from the frames (cluster_frames_to_dict)
+# and carries pair_scores={}. Without Task 3's ClusterPairScores view that dict
+# yields ZERO evidence edges, so ResolveSummary.edges_added / conflicts_flagged
+# diverge from the gate-OFF dict path. This test is the gate that catches that:
+# it runs the pipeline gate-ON vs gate-OFF against identical seeded stores and
+# asserts (a) the record->entity PARTITION is identical and (b) the
+# ResolveSummary key counts match.
+
+
+def _identity_df():
+    """People shape with a strong 2-member cluster + a weak-bottleneck chain.
+
+    - Alice/Alyce Smith: strong fuzzy pair (same email) -> 2-member identity.
+    - Carl / Carla / Karl Carter: a 3-member chain where the Carl<->Karl edge
+      is the weak link (bottleneck), so the resolver flags a conflict edge --
+      exercising both the evidence-edge AND the weak-bottleneck pair_scores
+      lookups that fall back to info.get("pair_scores") when the view is absent.
+    - Dave Singleton: lone record (singleton identity).
+
+    ``source_pk_column="id"`` makes record ids deterministic (``src:<id>``),
+    so the partition can be compared across two runs without depending on the
+    random UUIDv7 entity-ids.
+    """
+    import polars as pl
+
+    return pl.DataFrame({
+        "id":    ["1", "2", "3", "4", "5", "6"],
+        "name":  [
+            "Alice Smith", "Alyce Smith",
+            "Carl Carter", "Carla Carter", "Karl Carter",
+            "Dave Singleton",
+        ],
+        "email": [
+            "a@x.com", "a@x.com",
+            "c@y.com", "c@y.com", "c@y.com",
+            "d@z.com",
+        ],
+        "zip":   ["10001", "10001", "20002", "20002", "20002", "30003"],
+    })
+
+
+def _identity_config(identity_path: str, run_name: str):
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        IdentityConfig,
+    )
+
+    return GoldenMatchConfig(
+        output=OutputConfig(run_name=run_name),
+        matchkeys=[MatchkeyConfig(
+            name="people_fuzzy",
+            type="weighted",
+            threshold=0.7,
+            fields=[
+                MatchkeyField(field="name",  scorer="jaro_winkler", weight=0.7),
+                MatchkeyField(field="email", scorer="exact",        weight=0.3),
+            ],
+        )],
+        blocking=BlockingConfig(strategy="static", keys=[
+            BlockingKeyConfig(fields=["zip"]),
+        ]),
+        identity=IdentityConfig(
+            enabled=True, path=identity_path, source_pk_column="id",
+            dataset="people-test",
+        ),
+    )
+
+
+def _record_partition(db_path: str, source: str, ids: list[str]):
+    """record->entity PARTITION as a set of frozensets of record-ids.
+
+    Entity-ids are random UUIDv7 (``new_entity_id``), so we never compare them
+    literally across runs -- we group record-ids by their resolved entity and
+    compare the resulting partition.
+    """
+    from goldenmatch.identity import IdentityStore
+
+    groups: dict[str, set[str]] = {}
+    with IdentityStore(path=db_path) as s:
+        for rid in ids:
+            record_id = f"{source}:{rid}"
+            eid = s.find_entity_by_record(record_id)
+            if eid is None:
+                continue
+            groups.setdefault(eid, set()).add(record_id)
+    return {frozenset(members) for members in groups.values()}
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_frames_out_identity_parity(monkeypatch, tmp_path, native):
+    """Identity partition + ResolveSummary key counts identical, gate ON vs OFF.
+
+    This is the Task 3 gate: catches the empty-evidence-edge bug on frames-out.
+    """
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+    _skip_if_no_native(native)
+
+    df = _identity_df()
+    ids = ["1", "2", "3", "4", "5", "6"]
+    source = "src"
+
+    # Gate OFF: identity off the dict path (real per-cluster pair_scores).
+    off_db = str(tmp_path / "identity_off.db")
+    monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    off = run_dedupe_df(
+        df, _identity_config(off_db, "off"), source_name=source,
+    )
+
+    # Gate ON: identity off the frames-rebuilt dict (pair_scores={} -> needs the
+    # ClusterPairScores view that Task 3 builds).
+    on_db = str(tmp_path / "identity_on.db")
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
+    on = run_dedupe_df(
+        df, _identity_config(on_db, "on"), source_name=source,
+    )
+
+    assert off["identity_summary"] is not None
+    assert on["identity_summary"] is not None
+
+    # Primary gate: the record->entity PARTITION is identical (frozensets of
+    # record-ids; entity-ids themselves are random and not compared).
+    off_part = _record_partition(off_db, source, ids)
+    on_part = _record_partition(on_db, source, ids)
+    assert on_part == off_part
+    # The fixture must actually produce a multi-member identity (else the
+    # evidence-edge path is never exercised).
+    assert any(len(g) > 1 for g in off_part), "fixture produced no multi-member identity"
+
+    # Secondary gate: ResolveSummary key counts match. edges_added +
+    # conflicts_flagged are the counts that collapse to 0 under the bug.
+    assert on["identity_summary"] == off["identity_summary"]
+    assert off["identity_summary"]["edges_added"] >= 1, (
+        "fixture produced no evidence edges"
+    )

--- a/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
@@ -121,7 +121,11 @@ def _config(*, max_cluster_size: int, provenance: bool):
             default=GoldenFieldRule(strategy="most_complete"),
             max_cluster_size=max_cluster_size,
             weak_cluster_threshold=0.85,
-            auto_split=True,
+            # auto_split OFF so the dense 8-row block stays a persistent
+            # oversized cluster -> exercises the golden oversized-EXCLUSION
+            # (size>1 and not oversized) on both gate paths. With auto_split on
+            # the block splits into <=max sub-clusters and 0 oversized remain.
+            auto_split=False,
         ),
     )
 

--- a/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
@@ -215,13 +215,22 @@ def test_frames_out_pipeline_parity_provenance_slow(monkeypatch, native):
 
 
 def _identity_df():
-    """People shape with a strong 2-member cluster + a weak-bottleneck chain.
+    """People shape with a strong 2-member cluster + a weak-bottleneck cluster.
 
     - Alice/Alyce Smith: strong fuzzy pair (same email) -> 2-member identity.
-    - Carl / Carla / Karl Carter: a 3-member chain where the Carl<->Karl edge
-      is the weak link (bottleneck), so the resolver flags a conflict edge --
-      exercising both the evidence-edge AND the weak-bottleneck pair_scores
-      lookups that fall back to info.get("pair_scores") when the view is absent.
+    - Carl / Carla / Karl Carter: a 3-member cluster anchored by a shared email
+      (``c@y.com``, exact -> 0.3 of the weighted score) plus similar-but-NOT-
+      identical names (Carl/Carla/Karl), so the in-cluster edges all clear the
+      0.7 matchkey threshold (the cluster reliably forms) yet the cluster
+      confidence (0.4*min_edge + 0.3*avg_edge + 0.3*connectivity) is strictly
+      below 1.0 because no name pair is identical. Paired with the config's
+      raised ``weak_confidence_threshold=0.99`` (see ``_identity_config``), that
+      sub-1.0 confidence trips the resolver's weak-bottleneck branch, which
+      emits a CONFLICTS_WITH edge (``conflicts_flagged >= 1``). That branch is
+      the SECOND view-read site on frames-out: it calls
+      ``pair_score_view.score_for(...)`` to fetch the bottleneck score (falling
+      back to ``info["pair_scores"]`` only when the view is absent, i.e. the
+      gate-OFF dict path).
     - Dave Singleton: lone record (singleton identity).
 
     ``source_pk_column="id"`` makes record ids deterministic (``src:<id>``),
@@ -270,6 +279,16 @@ def _identity_config(identity_path: str, run_name: str):
         identity=IdentityConfig(
             enabled=True, path=identity_path, source_pk_column="id",
             dataset="people-test",
+            # Raised so the weak-bottleneck branch fires reliably: any
+            # multi-member cluster whose confidence (0.4*min_edge +
+            # 0.3*avg_edge + 0.3*connectivity) is below this trips it. With the
+            # matchkey threshold pinned at 0.7, in-cluster edges can't fall
+            # below ~0.7, so the default 0.6 threshold is effectively
+            # unreachable here. 0.99 makes the Carter cluster confidently
+            # below-threshold (its confidence is strictly < 1.0 because the
+            # Carl/Carla/Karl names are not identical), so the resolver's
+            # weak-bottleneck `score_for(...)` view-read runs on frames-out.
+            weak_confidence_threshold=0.99,
         ),
     )
 
@@ -339,4 +358,12 @@ def test_frames_out_identity_parity(monkeypatch, tmp_path, native):
     assert on["identity_summary"] == off["identity_summary"]
     assert off["identity_summary"]["edges_added"] >= 1, (
         "fixture produced no evidence edges"
+    )
+    # The fixture must also exercise the resolver's weak-bottleneck branch (the
+    # SECOND view-consumption site on frames-out, via pair_score_view.score_for).
+    # Assert on the gate-OFF side -- the bug-free dict reference -- so the gate
+    # catches a frames-out view that mishandles the bottleneck score lookup.
+    # (on == off above already locks the gate-ON count to this same value.)
+    assert off["identity_summary"]["conflicts_flagged"] >= 1, (
+        "fixture did not trip the weak-bottleneck branch (score_for not exercised)"
     )

--- a/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
@@ -79,7 +79,12 @@ def _fixture_df():
 
 
 def _config(*, max_cluster_size: int, provenance: bool):
+    from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+
     return GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["zip"])]
+        ),
         matchkeys=[
             MatchkeyConfig(
                 name="fuzzy_name_zip",

--- a/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
@@ -1,0 +1,202 @@
+"""SP-B Task 2: in-memory dedupe pipeline frames-out parity.
+
+When ``GOLDENMATCH_CLUSTER_FRAMES_OUT`` is ON, ``_run_dedupe_pipeline``
+consumes the SP-A ``ClusterFrames`` for the GOLDEN + STATS + DUPES legs
+(identity stays on the dict -- Task 3). This file locks that the gate-ON
+output is byte-identical to the gate-OFF (dict) path on those legs.
+
+Asserted byte-identical (gate ON vs OFF), on a fixture that exercises
+singletons, a 2-member cluster, a weak chain, and an oversized cluster
+(via a small ``max_cluster_size`` over a dense block):
+
+- golden records: equal by content, member/list fields compared as a SET
+  (the from-frames join reorders within a cluster);
+- ``dupe_row_ids``: equal as a set (derived from ``results["clusters"]``,
+  which the pipeline rebuilds from the frames under gate-ON);
+- stats: ``cluster_count``, multi-member count, oversized count, and
+  ``cluster_sizes`` (as a sorted multiset).
+
+Native is parametrized ["1", "0"] with a skip guard when the kernel is
+absent (mirrors ``tests/test_cluster_frames_out_parity.py``). A
+provenance=True run covers the golden SLOW-path branch.
+
+The box hangs on ``import goldenmatch`` / ``import polars`` locally; this
+file is validated via ruff + py_compile and runs for real in CI.
+"""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.config.schemas import (
+    GoldenFieldRule,
+    GoldenMatchConfig,
+    GoldenRulesConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    OutputConfig,
+)
+from goldenmatch.core.pipeline import run_dedupe_df
+
+
+def _skip_if_no_native(native):
+    if native == "1":
+        from goldenmatch.core._native_loader import native_module
+
+        nm = native_module()
+        if nm is None or getattr(nm, "build_clusters_arrow", None) is None:
+            pytest.skip("native cluster kernel absent; native=1 validated in CI")
+
+
+def _fixture_df():
+    """Synthetic shape with the four cluster archetypes.
+
+    - dense block of 8 near-identical "Aaa"/"10001" rows -> one big cluster
+      that goes oversized when max_cluster_size is small;
+    - 2-member "Bob Brown" cluster;
+    - weak chain "Carl/Carla/Karl Carter" (one looser edge);
+    - two singletons (Dana, Evan).
+    """
+    import polars as pl
+
+    first = (
+        ["Aaron", "Aaron", "Aron", "Aaron", "Aaran", "Aaron", "Aaron", "Aaron"]
+        + ["Bob", "Bobby"]
+        + ["Carl", "Carla", "Karl"]
+        + ["Dana", "Evan"]
+    )
+    last = (
+        ["Aaaa"] * 8
+        + ["Brown", "Brown"]
+        + ["Carter", "Carter", "Carter"]
+        + ["Dixon", "Ellis"]
+    )
+    zips = (
+        ["10001"] * 8
+        + ["20002", "20002"]
+        + ["30003", "30003", "30003"]
+        + ["40004", "50005"]
+    )
+    return pl.DataFrame({"first_name": first, "last_name": last, "zip": zips})
+
+
+def _config(*, max_cluster_size: int, provenance: bool):
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="fuzzy_name_zip",
+                fields=[
+                    MatchkeyField(
+                        column="last_name",
+                        transforms=["lowercase", "strip"],
+                        scorer="jaro_winkler",
+                        weight=0.4,
+                    ),
+                    MatchkeyField(
+                        column="first_name",
+                        transforms=["lowercase", "strip"],
+                        scorer="jaro_winkler",
+                        weight=0.3,
+                    ),
+                    MatchkeyField(
+                        column="zip",
+                        transforms=["strip"],
+                        scorer="exact",
+                        weight=0.3,
+                    ),
+                ],
+                comparison="weighted",
+                threshold=0.7,
+            ),
+        ],
+        output=OutputConfig(
+            format="csv",
+            run_name="frames_out_parity",
+            lineage_provenance=provenance,
+        ),
+        golden_rules=GoldenRulesConfig(
+            default=GoldenFieldRule(strategy="most_complete"),
+            max_cluster_size=max_cluster_size,
+            weak_cluster_threshold=0.85,
+            auto_split=True,
+        ),
+    )
+
+
+def _run(monkeypatch, *, frames_out: str, max_cluster_size: int, provenance: bool):
+    if frames_out == "1":
+        monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
+    else:
+        monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    cfg = _config(max_cluster_size=max_cluster_size, provenance=provenance)
+    return run_dedupe_df(_fixture_df(), cfg, source_name="t")
+
+
+def _cluster_stats(results):
+    clusters = results["clusters"]
+    cluster_count = len(clusters)
+    multi = sum(1 for c in clusters.values() if c["size"] > 1)
+    oversized = sum(1 for c in clusters.values() if c["oversized"])
+    sizes = sorted(c["size"] for c in clusters.values())
+    return cluster_count, multi, oversized, sizes
+
+
+def _dupe_row_ids(results):
+    clusters = results["clusters"]
+    out: set[int] = set()
+    for c in clusters.values():
+        if c["size"] > 1:
+            out.update(int(m) for m in c["members"])
+    return out
+
+
+def _golden_as_setrows(results):
+    """Golden frame -> a comparable, order-independent structure.
+
+    The from-frames join reorders rows within a cluster, so list-valued
+    survivorship fields can differ in element order. Compare the set of
+    rows keyed by content with any list cell normalized to a frozenset.
+    """
+    golden = results.get("golden")
+    if golden is None:
+        return None
+    rows = []
+    for row in golden.iter_rows(named=True):
+        norm = {}
+        for k, v in row.items():
+            norm[k] = frozenset(v) if isinstance(v, list) else v
+        rows.append(tuple(sorted(norm.items(), key=lambda kv: kv[0])))
+    return sorted(rows, key=repr)
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_frames_out_pipeline_parity(monkeypatch, native):
+    """Golden + dupes + stats byte-identical, gate ON vs OFF (fast golden)."""
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+    _skip_if_no_native(native)
+
+    off = _run(monkeypatch, frames_out="0", max_cluster_size=4, provenance=False)
+    on = _run(monkeypatch, frames_out="1", max_cluster_size=4, provenance=False)
+
+    # Stats parity.
+    assert _cluster_stats(on) == _cluster_stats(off)
+    # An oversized cluster must actually be exercised by this fixture/config.
+    assert _cluster_stats(off)[2] >= 1, "fixture did not produce an oversized cluster"
+
+    # Dupes parity (oversized-INCLUDED, like the dict path).
+    assert _dupe_row_ids(on) == _dupe_row_ids(off)
+
+    # Golden parity (content equal; member/list fields as a set).
+    assert _golden_as_setrows(on) == _golden_as_setrows(off)
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_frames_out_pipeline_parity_provenance_slow(monkeypatch, native):
+    """Same parity with provenance=True so the golden SLOW path is covered."""
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+    _skip_if_no_native(native)
+
+    off = _run(monkeypatch, frames_out="0", max_cluster_size=4, provenance=True)
+    on = _run(monkeypatch, frames_out="1", max_cluster_size=4, provenance=True)
+
+    assert _cluster_stats(on) == _cluster_stats(off)
+    assert _dupe_row_ids(on) == _dupe_row_ids(off)
+    assert _golden_as_setrows(on) == _golden_as_setrows(off)


### PR DESCRIPTION
Phase-2 columnar cutover, SP-B (builds on SP-A's `build_cluster_frames`, merged). The in-memory dedupe pipeline consumes the `ClusterFrames` for **golden + stats + dupes** with no dict on that path; **identity** keeps working via a lazily-rebuilt dict + the `ClusterPairScores` view (the residual SP-C removes). Gated `GOLDENMATCH_CLUSTER_FRAMES_OUT` (default OFF); full pipeline output byte-identical gate-ON vs OFF.

**Tasks**
1. `build_golden_records_from_frames`: excludes oversized (matches the dict path) + preserves the fast/slow golden decision + returns `(golden_df, list)`. Fixed a latent gate bug (hardcoded `quality_scores=None` would drop survivorship).
2. Pipeline build-site gate -> `build_cluster_frames`; golden via from-frames (tuple demux); **stats/dupes from frame aggregates** (metadata/assignments); dict rebuilt **lazily/late** only for the remaining consumers -> keeps the golden stage dict-free so SP-C's RSS win can land.
3. **The durability fix:** build the `ClusterPairScores` view on frames-out (from RAW `all_pairs`) so identity's evidence edges aren't empty (the view was gated on a *different* env var). + an identity-ENABLED parity test asserting the entity **partition** (random UUIDv7 -> not literal ids) + `ResolveSummary`, with an `edges_added>=1` anti-vacuous guard and a genuine weak-bottleneck case exercising the view's `score_for`.
4. Residual bench (recorded data): `cluster_frames_to_dict` rebuild wall+RSS, the cost SP-C removes.

**Parity gate (CI):** full pipeline gate-ON vs OFF (golden content, dupes, stats, identity partition + summary), native=1 AND native=0, in the `python (goldenmatch)` lane. gate-OFF byte-identical (additive). `pipeline.py` verified pyright-strict-clean (0 errors). Box can't run pytest -> CI is the verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)