### PR TITLE
feat(identity): identity-from-frames + dict-free hot path + complete-path verdict bench (Phase-2 SP-C)

### DIFF
--- a/.github/workflows/bench-pipeline-complete-path.yml
+++ b/.github/workflows/bench-pipeline-complete-path.yml
@@ -1,0 +1,55 @@
+name: bench-pipeline-complete-path
+
+# SP-C complete-path verdict bench (workflow_dispatch only), BINDING Phase-2
+# payoff measurement. Builds the native ext fresh so the columnar build hits the
+# real Arrow kernel, then benches the COMPLETE cluster -> golden -> identity
+# stage end-to-end, legacy (frames-out OFF, dict) vs columnar (frames-out ON,
+# A+B+C dict-free), segmenting wall into build/golden/identity + overall peak
+# RSS. The pair-score view + identity store I/O + df.to_dicts() are shared on
+# both variants and frames-invariant (the >=30% RSS criterion applies to the
+# cluster-representation delta, not the store).
+#
+# NOTE: the binding 25M (RSS-delta leg) and 100M (feasibility point) scales are
+# dispatched EXPLICITLY via the `np` input (e.g. np="25000000" or
+# np="100000000"). At 100M the legacy variant is EXPECTED to OOM -- the bench
+# catches the legacy child's non-zero exit and records "legacy OOM" rather than
+# crashing, so the columnar feasibility point still reports.
+on:
+  workflow_dispatch:
+    inputs:
+      np:
+        description: "Comma-separated target pair counts (dispatch 25000000 / 100000000 for the verdict)"
+        default: "1000000,5000000"
+      runs:
+        description: "Repetitions per measurement (median)"
+        default: "3"
+
+jobs:
+  bench:
+    runs-on: large-new-64GB
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Build native extension (exposes build_clusters_arrow)
+        run: uv run python scripts/build_native.py
+      - name: Bench pipeline complete-path (legacy dict vs columnar A+B+C)
+        run: |
+          set -o pipefail
+          uv run python packages/python/goldenmatch/scripts/bench_pipeline_complete_path.py \
+            --np "${{ inputs.np }}" --runs "${{ inputs.runs }}" \
+            --output .profile_tmp/pipeline_complete_path.json | tee /tmp/pipeline_complete_path.txt
+          { echo '## bench-pipeline-complete-path'; echo '```'; cat /tmp/pipeline_complete_path.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: always()
+        with:
+          name: pipeline-complete-path
+          path: .profile_tmp/pipeline_complete_path.json
+          retention-days: 30

--- a/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
@@ -6,6 +6,24 @@ future SP that makes the build produce a columnar pair frame natively."""
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
+from typing import Any
+
+
+def _bucket_pairs(
+    pairs: Iterable[tuple[int, int, float]],
+    member_to_cid: dict[int, int],
+) -> dict[int, dict[tuple[int, int], float]]:
+    """Bucket RAW pairs into per-cluster score dicts: INPUT order, LAST-WINS
+    overwrite, keyed by ``(a, b)`` as given. A pair is kept only when BOTH
+    endpoints map to the same cid (cross-cut edges of a split cluster are
+    excluded). Shared by ``from_pairs`` and ``from_frames`` so the two paths are
+    byte-identical."""
+    by_cid: dict[int, dict[tuple[int, int], float]] = {}
+    for a, b, s in pairs:
+        ca = member_to_cid.get(a)
+        if ca is not None and ca == member_to_cid.get(b):
+            by_cid.setdefault(ca, {})[(a, b)] = s
+    return by_cid
 
 
 class ClusterPairScores:
@@ -47,12 +65,35 @@ class ClusterPairScores:
         for cid, info in clusters.items():
             for m in info.get("members", []):
                 member_to_cid[m] = cid
-        by_cid: dict[int, dict[tuple[int, int], float]] = {}
-        for a, b, s in pairs:
-            ca = member_to_cid.get(a)
-            if ca is not None and ca == member_to_cid.get(b):
-                by_cid.setdefault(ca, {})[(a, b)] = s
-        return cls(by_cid)
+        return cls(_bucket_pairs(pairs, member_to_cid))
+
+    @classmethod
+    def from_frames(
+        cls,
+        assignments: Any,
+        all_pairs: Iterable[tuple[int, int, float]],
+    ) -> ClusterPairScores:
+        """Build the view from the FINAL ``assignments`` frame + the RAW input
+        pairs -- the SP-C identity-from-frames path that drops the dict rebuild.
+        Mirrors ``from_pairs`` exactly: ``member_to_cid`` comes from the
+        ``assignments`` frame (one row per ``(cluster_id, member_id)``, singletons
+        included) instead of iterating ``clusters.items()``, then the SAME
+        bucketing runs -- INPUT order, LAST-WINS, keyed by ``(a, b)`` as given,
+        both endpoints in the same cluster. Byte-identical to
+        ``from_pairs(all_pairs, clusters)`` for every cid.
+
+        MUST be the RAW pairs (the same list fed to ``build_clusters``), NOT the
+        ``dedup_pairs_max_score`` (max-score, sorted) ``scored_pairs`` field --
+        those differ from the dict path's last-wins on different-score duplicate
+        canonical pairs.
+        """
+        member_to_cid: dict[int, int] = {}
+        for cid, mid in zip(
+            assignments["cluster_id"].to_list(),
+            assignments["member_id"].to_list(),
+        ):
+            member_to_cid[int(mid)] = int(cid)
+        return cls(_bucket_pairs(all_pairs, member_to_cid))
 
     def for_cluster(self, cid: int) -> dict[tuple[int, int], float]:
         return self._by_cid.get(cid, {})

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -258,6 +258,7 @@ def _resolve_identities(
     config: GoldenMatchConfig,
     run_name: str,
     pair_score_view: Any = None,
+    cluster_frames: ClusterFrames | None = None,
 ) -> dict | None:
     """Run identity resolution as a post-cluster step. Best-effort: failures
     log a warning and return None without affecting dedupe output.
@@ -266,6 +267,14 @@ def _resolve_identities(
     - ``dict[int, dict]`` -> in-memory resolver (default).
     - ``ray.data.Dataset`` -> distributed dispatch (Phase 6). Requires
       ``config.identity.backend == 'postgres'``.
+
+    SP-C: when ``cluster_frames`` is supplied (frames-out path), ``clusters``
+    is ``None`` and the in-memory resolver consumes the two-frame
+    ``ClusterFrames`` directly via ``resolve_clusters(cluster_frames=...)`` --
+    no dict is rebuilt for identity. ``pair_score_view`` is REQUIRED in that
+    case (the frames carry no per-cluster pair_scores). The distributed/Ray
+    branch is unreachable on the frames path (``clusters`` is ``None``, so
+    ``is_ray_dataset`` is False) and stays byte-identical.
     """
     if not config.identity or not config.identity.enabled:
         return None
@@ -314,14 +323,20 @@ def _resolve_identities(
     try:
         from goldenmatch.identity import resolve_clusters
         mk_name = matchkeys[0].name if matchkeys else None
+        # SP-C: on the frames-out path pass `cluster_frames=` (clusters is None)
+        # so resolve_clusters iterates the frames directly; otherwise pass the
+        # `clusters` dict positionally. resolve_clusters asserts exactly one of
+        # the two is supplied, so the two are mutually exclusive here.
         summary = resolve_clusters(
-            clusters, df, scored_pairs, mk_name, store,
+            None if cluster_frames is not None else clusters,
+            df, scored_pairs, mk_name, store,
             run_name=run_name,
             dataset=config.identity.dataset,
             source_pk_col=config.identity.source_pk_column,
             emit_singletons=config.identity.emit_singletons,
             weak_confidence_threshold=config.identity.weak_confidence_threshold,
             pair_score_view=pair_score_view,
+            cluster_frames=cluster_frames,
         )
         return summary.as_dict()
     except Exception as e:
@@ -1868,21 +1883,37 @@ def _run_dedupe_pipeline(
     # ZERO evidence edges, so we MUST supply the view. Gate-OFF (neither env set)
     # leaves the dict carrying real pair_scores and pair_score_view stays None --
     # byte-identical to today.
+    # SP-C: on the frames-out path build the view from the FRAMES (assignments
+    # frame + RAW all_pairs) and feed identity the `cluster_frames` directly --
+    # NOT the rebuilt dict -- so the cluster->golden->identity stage never calls
+    # `_clusters_dict()`. `from_frames(assignments, all_pairs)` is byte-identical
+    # to the columnar branch's `from_pairs(all_pairs, clusters)` (same input-order
+    # last-wins bucketing, same final membership). The columnar-build and gate-OFF
+    # branches are UNCHANGED: columnar builds the view from the dict + pairs and
+    # passes the dict; gate-OFF leaves the view None and passes the real-pair_scores
+    # dict. resolve_clusters' exactly-one assertion keeps the two mutually exclusive.
     pair_score_view: ClusterPairScores | None = None
-    if isinstance(clusters, dict):
+    if cluster_frames is not None:
+        from goldenmatch.core.cluster_pairscores import ClusterPairScores
+        pair_score_view = ClusterPairScores.from_frames(
+            cluster_frames.assignments, all_pairs
+        )
+    elif isinstance(clusters, dict):
         from goldenmatch.core.cluster import _columnar_cluster_build_enabled
-        if _columnar_cluster_build_enabled() or _cluster_frames_out_enabled():
+        if _columnar_cluster_build_enabled():
             from goldenmatch.core.cluster_pairscores import ClusterPairScores
-            # SP4 / SP-B: the dict reaching identity has pair_scores={}, so build
-            # the view from the RAW input pairs (input-order, last-wins == the
+            # SP4: the columnar-build dict reaching identity has pair_scores={}, so
+            # build the view from the RAW input pairs (input-order, last-wins == the
             # dict path's per-cluster pair_scores) + final cluster membership. NOT
             # from results["scored_pairs"] (max-score deduped, differs on
             # dup-scored pairs).
             pair_score_view = ClusterPairScores.from_pairs(all_pairs, clusters)
     with stage("identity_resolve"):
         identity_summary = _resolve_identities(
-            clusters, collected_df, all_pairs, matchkeys, config, run_name,
+            clusters if cluster_frames is None else None,
+            collected_df, all_pairs, matchkeys, config, run_name,
             pair_score_view=pair_score_view,
+            cluster_frames=cluster_frames,
         )
 
     # SP3: source scored_pairs from the pre-cluster stream, decoupled from cluster

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1470,12 +1470,15 @@ def _run_dedupe_pipeline(
     # When ON, build the two-frame ClusterFrames representation and consume it
     # DIRECTLY for GOLDEN + STATS + DUPES + REPORT below (no dict). The legacy
     # `clusters` dict is rebuilt LAZILY via `_clusters_dict()` -- at most once,
-    # as late as the OUTPUT block -- only for the remaining dict consumers
-    # (adaptive refiner if enabled, output_clusters rows, lineage, identity,
-    # results["clusters"]). Keeping golden + stats + dupes dict-free is the SP-B
-    # prerequisite for the SP-C RSS win: once identity + results stop needing the
-    # dict, the lazy rebuild simply never fires on the hot path. Identity still
-    # RECEIVES a (rebuilt) dict here; Task 3 wires its ClusterPairScores view.
+    # and each remaining dict consumer calls it at its OWN consumption site
+    # (SP-C): adaptive refiner if enabled, output_clusters rows, lineage,
+    # golden_provenance, results["clusters"]. Identity NO LONGER consumes the
+    # dict on this path -- Task 3 feeds it `cluster_frames` + a ClusterPairScores
+    # view built from the frames. So on the hot path (identity ON, output OFF)
+    # the FIRST and ONLY `_clusters_dict()` call is results["clusters"], AFTER
+    # the identity stage: cluster->golden->identity runs fully dict-free, which
+    # is the SP-C RSS win. Keeping golden + stats + dupes dict-free was the SP-B
+    # prerequisite.
     # The frames-out path is additive -- the dict path (gate OFF) below is
     # untouched and byte-identical. Mutually exclusive with the columnar
     # pair-stream branch (frames-out only fires on the non-columnar list build
@@ -1817,14 +1820,17 @@ def _run_dedupe_pipeline(
         )
 
     # ── Step 7: OUTPUT ──
-    # SP-B: from here down the remaining dict consumers (output_clusters rows,
-    # lineage, identity wiring, results["clusters"]) need the legacy dict shape.
-    # Rebuild it LAZILY now -- once -- via the cache helper. On the frames-out
-    # branch this is the FIRST and ONLY materialization; golden + stats + dupes
-    # above ran entirely off the frames. results["clusters"] forces the build
-    # unconditionally today; SP-C removes that last dict consumer so the rebuild
-    # can be skipped when no output/identity needs it.
-    clusters = _clusters_dict()
+    # SP-C: do NOT rebuild the dict eagerly here. The remaining dict consumers
+    # (output_clusters rows, lineage, golden_provenance, results["clusters"])
+    # each call `_clusters_dict()` at their OWN consumption site, so the rebuild
+    # is deferred until one actually runs. On the frames-out hot path (identity
+    # ON, output flags OFF) the FIRST `_clusters_dict()` call is now the
+    # `results["clusters"]` assignment -- AFTER the `stage("identity_resolve")`
+    # block -- so cluster->golden->identity runs with NO dict materialized
+    # (identity reads `cluster_frames`, not the dict). With output flags ON the
+    # dict builds at the first opt-in consumer (output_clusters / lineage). On
+    # gate-OFF / columnar, `_clusters_dict()` returns the already-bound real
+    # `clusters` dict cheaply -- byte-identical, no extra work.
     run_name = config.output.run_name or datetime.now().strftime("%Y%m%d_%H%M%S")
     fmt = config.output.format or "csv"
     directory = config.output.directory or config.output.path or "."
@@ -1835,7 +1841,7 @@ def _run_dedupe_pipeline(
     if output_clusters:
         # Build clusters DataFrame
         cluster_rows = []
-        for cid, cinfo in clusters.items():
+        for cid, cinfo in _clusters_dict().items():
             for member_id in cinfo["members"]:
                 cluster_rows.append({
                     "__cluster_id__": cid,
@@ -1857,12 +1863,14 @@ def _run_dedupe_pipeline(
     if output_golden or output_clusters or output_dupes:
         try:
             from goldenmatch.core.lineage import build_lineage, save_lineage
-            lineage = build_lineage(all_pairs, collected_df, matchkeys, clusters)
+            lineage = build_lineage(
+                all_pairs, collected_df, matchkeys, _clusters_dict()
+            )
             golden_provenance = None
             if config.output.lineage_provenance and golden_records:
                 from goldenmatch.core.golden import golden_records_to_provenance
                 golden_provenance = golden_records_to_provenance(
-                    golden_records, clusters, golden_rules,
+                    golden_records, _clusters_dict(), golden_rules,
                 )
             save_lineage(
                 lineage, directory, run_name, golden_provenance=golden_provenance,
@@ -1929,7 +1937,7 @@ def _run_dedupe_pipeline(
         scored_pairs = dedup_pairs_max_score(all_pairs)
 
     results = {
-        "clusters": clusters,
+        "clusters": _clusters_dict(),
         "golden": golden_df,
         "unique": unique_df,
         "dupes": dupes_df,

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 import polars as pl
 
 if TYPE_CHECKING:
+    from goldenmatch.core.cluster import ClusterFrames
     from goldenmatch.core.cluster_pairscores import ClusterPairScores
 
 from goldenmatch.core._hashing import record_fingerprint
@@ -209,13 +210,58 @@ def _cluster_confidence(cluster_info: dict[str, Any]) -> float | None:
         return None
 
 
+def _frames_iter(
+    cluster_frames: ClusterFrames,
+) -> list[tuple[int, dict[str, Any]]]:
+    """Yield ``(cluster_id, info)`` pairs from a ``ClusterFrames`` in
+    ASCENDING cluster_id order, where ``info`` carries ONLY the keys the
+    resolution body reads: ``members``, ``confidence``, ``bottleneck_pair``.
+
+    Ascending cluster_id reproduces the dict path's insertion order (build
+    emits 1..N, splits append higher cids), so brand-new clusters mint entity
+    ids in the identical order. ``bottleneck_pair`` maps ``(a, b) == (0, 0)``
+    to ``None`` EXACTLY as ``cluster_frames_to_dict`` does (``cluster.py``) --
+    a raw ``(0, 0)`` 2-tuple would wrongly trip the weak-conflict guard.
+    """
+    assignments = cluster_frames.assignments
+    metadata = cluster_frames.metadata
+
+    # members per cid (assignments is one row per (cluster_id, member_id)).
+    members_by_cid: dict[int, list[int]] = {}
+    if not assignments.is_empty():
+        grouped = assignments.group_by("cluster_id").agg(
+            pl.col("member_id")
+        )
+        for cid, mids in zip(
+            grouped["cluster_id"].to_list(),
+            grouped["member_id"].to_list(),
+            strict=True,
+        ):
+            members_by_cid[int(cid)] = [int(m) for m in mids]
+
+    rows: list[tuple[int, dict[str, Any]]] = []
+    for row in metadata.iter_rows(named=True):
+        cid = int(row["cluster_id"])
+        bot = (int(row["bottleneck_pair_a"]), int(row["bottleneck_pair_b"]))
+        rows.append((
+            cid,
+            {
+                "members": members_by_cid.get(cid, []),
+                "confidence": float(row["confidence"]),
+                "bottleneck_pair": bot if bot != (0, 0) else None,
+            },
+        ))
+    rows.sort(key=lambda kv: kv[0])
+    return rows
+
+
 def resolve_clusters(
-    clusters: dict[int, dict],
-    df: pl.DataFrame,
-    scored_pairs: list[tuple[int, int, float]],
-    matchkey_name: str | None,
-    store: IdentityStore,
-    run_name: str,
+    clusters: dict[int, dict] | None = None,
+    df: pl.DataFrame | None = None,
+    scored_pairs: list[tuple[int, int, float]] | None = None,
+    matchkey_name: str | None = None,
+    store: IdentityStore | None = None,
+    run_name: str = "",
     *,
     dataset: str | None = None,
     source_pk_col: str | None = None,
@@ -223,14 +269,51 @@ def resolve_clusters(
     emit_singletons: bool = True,
     weak_confidence_threshold: float = 0.6,
     pair_score_view: ClusterPairScores | None = None,
+    cluster_frames: ClusterFrames | None = None,
 ) -> ResolveSummary:
     """Resolve run-local clusters to durable identities.
 
+    The cluster partition is supplied EITHER as the legacy ``clusters``
+    ``dict[int, dict]`` OR as the SP-A ``cluster_frames`` two-frame
+    ``ClusterFrames`` (exactly one). The frames path lets the pipeline stop
+    rebuilding the dict; it iterates the same ``(cluster_id, info)`` pairs in
+    ascending-cluster_id order (= the dict's insertion order) and runs the
+    UNCHANGED resolution body. When ``cluster_frames`` is given,
+    ``pair_score_view`` MUST be supplied -- the frames carry no per-cluster
+    ``pair_scores``, so without the view every evidence edge would be empty.
+
     See module docstring for high-level flow.
     """
+    if (clusters is None) == (cluster_frames is None):
+        raise ValueError(
+            "resolve_clusters requires exactly one of `clusters` / "
+            "`cluster_frames`"
+        )
+    if cluster_frames is not None and pair_score_view is None:
+        raise ValueError(
+            "resolve_clusters(cluster_frames=...) requires `pair_score_view` "
+            "(the frames carry no per-cluster pair_scores; evidence edges "
+            "would be empty otherwise)"
+        )
+    if df is None or store is None:
+        raise ValueError("resolve_clusters requires `df` and `store`")
+    if scored_pairs is None:
+        scored_pairs = []
+
     summary = ResolveSummary()
     if df.is_empty():
         return summary
+
+    # Iteration source: ascending-cluster_id ``(cluster_id, info)`` pairs.
+    # For the dict path this is ``clusters.items()`` (insertion order = build's
+    # ascending 1..N, splits appended higher). For the frames path we rebuild
+    # the same ascending-cid stream from the two frames (see ``_frames_iter``)
+    # so brand-new clusters mint entity ids in the identical order.
+    cluster_items: Any = (
+        clusters.items()
+        if clusters is not None
+        else _frames_iter(cluster_frames)  # type: ignore[arg-type]
+    )
 
     # 1. Build row_id -> record_id mapping + ensure source_records are upserted.
     #
@@ -334,7 +417,7 @@ def resolve_clusters(
     bulk_cluster_ids: set = set()
 
     # 3. Iterate clusters.
-    for cluster_id, info in clusters.items():
+    for cluster_id, info in cluster_items:
         members: list[int] = list(info.get("members") or [])
         if not members:
             continue

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -229,6 +229,11 @@ def _frames_iter(
     # members per cid (assignments is one row per (cluster_id, member_id)).
     members_by_cid: dict[int, list[int]] = {}
     if not assignments.is_empty():
+        # group_by does NOT preserve member order, and that's intentional:
+        # the resolution body is member-order-independent (members compared
+        # as a set, per PR #598), so do NOT "fix" this into a sorted agg. The
+        # ascending-cid ``rows.sort`` below IS load-bearing (mint order) and
+        # must stay.
         grouped = assignments.group_by("cluster_id").agg(
             pl.col("member_id")
         )

--- a/packages/python/goldenmatch/scripts/bench_pipeline_complete_path.py
+++ b/packages/python/goldenmatch/scripts/bench_pipeline_complete_path.py
@@ -1,0 +1,495 @@
+"""SP-C complete-path verdict bench (BINDING Phase-2 payoff measurement).
+
+Measures the COMPLETE-PATH (A+B+C) end-to-end peak RSS + wall of the
+cluster -> golden -> identity stage, legacy (frames-out OFF, dict) vs columnar
+(frames-out ON, dict-free stage), at scale. This is the binding measurement
+that decides whether Phase-2's columnar cutover lands the RSS win.
+
+Two variants, each in its OWN subprocess (clean peak RSS):
+
+  * ``columnar`` (GOLDENMATCH_CLUSTER_FRAMES_OUT=1): build pairs ->
+    ``build_cluster_frames`` -> ``build_golden_records_from_frames`` ->
+    ``resolve_clusters(cluster_frames=..., pair_score_view=ClusterPairScores
+    .from_frames(...))``. No per-cluster ``dict[int, dict]`` is materialized in
+    the stage.
+
+  * ``legacy`` (no gate): build pairs -> ``build_clusters`` (dict) ->
+    ``build_golden_records_batch`` -> ``resolve_clusters(clusters_dict, ...,
+    pair_score_view=ClusterPairScores.from_pairs(...))``. The dict is live for
+    the whole stage.
+
+CONFOUND CONTROL (from the SP-C spec). The pair-score view
+(``from_pairs`` / ``from_frames``) AND the identity store I/O + ``df.to_dicts()``
+inside ``resolve_clusters`` are present on BOTH variants and are
+frames-INVARIANT -- they don't bias the columnar-vs-legacy DELTA but they can
+DOMINATE/MASK it. We therefore segment the stage wall into build / golden /
+identity and report each, plus the overall peak RSS, and print a note that the
+store I/O + view are shared. The >=30% RSS criterion applies to the
+cluster-representation delta (build + golden + identity cluster-iteration), NOT
+the store.
+
+At 100M the ``legacy`` variant is EXPECTED to OOM. The legacy child's non-zero
+exit / OOM is CAUGHT and recorded as ``"legacy OOM"`` in the table rather than
+crashing the whole bench, so the columnar feasibility point still reports.
+
+Parity is NOT re-proven here (SP-A/B/C parity gates already proved
+byte-identical). A cheap membership sanity check (columnar vs legacy cluster
+count) runs once before the perf loop.
+
+Default ``--np 1000000,5000000``; the workflow dispatch passes ``25000000`` (the
+RSS-delta leg) and ``100000000`` (the feasibility point) explicitly.
+
+Local smoke: python ... --np 50000 --runs 1 (resource is unavailable on Windows
+so RSS is 0.0 -- fine). DO NOT run the real bench locally (box hangs on import).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _make_pairs_df(n_pairs_target: int):
+    """M clusters of size k=5 -> 10 pairs each. Deterministic, no RNG.
+
+    Mirrors the SP-A/SP-B benches so the cluster shape (many small clusters, no
+    oversized) is identical -- this exercises the bulk-RSS axis, which is where
+    the dict-vs-frames cluster representation delta lives.
+    """
+    import polars as pl
+
+    k = 5
+    per = k * (k - 1) // 2  # 10
+    m = max(1, n_pairs_target // per)
+    a_col: list[int] = []
+    b_col: list[int] = []
+    for c in range(m):
+        base = c * k
+        for i in range(k):
+            for j in range(i + 1, k):
+                a_col.append(base + i)
+                b_col.append(base + j)
+    s_col = [0.95] * len(a_col)
+    return pl.DataFrame(
+        {"id_a": a_col, "id_b": b_col, "score": s_col},
+        schema={"id_a": pl.Int64, "id_b": pl.Int64, "score": pl.Float64},
+    )
+
+
+def _pairs_list_from_df(pairs_df) -> list[tuple[int, int, float]]:
+    return list(
+        zip(
+            pairs_df["id_a"].to_list(),
+            pairs_df["id_b"].to_list(),
+            pairs_df["score"].to_list(),
+        )
+    )
+
+
+def _make_source_df(n_members: int):
+    """Source frame for golden + identity: one row per member id (0..n-1) with a
+    ``__row_id__`` aligned to the pair member ids, ``__source__``, and a couple of
+    payload columns so survivorship + the identity record hash have content."""
+    import polars as pl
+
+    ids = list(range(n_members))
+    return pl.DataFrame(
+        {
+            "__row_id__": ids,
+            "__source__": ["bench"] * n_members,
+            "name": [f"rec{i}" for i in ids],
+            "email": [f"rec{i}@example.com" for i in ids],
+        },
+        schema={
+            "__row_id__": pl.Int64,
+            "__source__": pl.Utf8,
+            "name": pl.Utf8,
+            "email": pl.Utf8,
+        },
+    )
+
+
+def _max_member_id(pairs_df) -> int:
+    if pairs_df.is_empty():
+        return 0
+    return int(max(pairs_df["id_a"].max(), pairs_df["id_b"].max()))
+
+
+def _peak_rss_mb() -> float:
+    try:
+        import resource
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+    except Exception:
+        return 0.0
+
+
+def _golden_rules():
+    from goldenmatch.config.schemas import GoldenRulesConfig
+    return GoldenRulesConfig(default_strategy="most_complete")
+
+
+def _run_child(variant: str, n_pairs: int, runs: int) -> int:
+    """Drive the real cluster -> golden -> identity stage for one variant, once
+    per measured run, segmenting the wall into build / golden / identity."""
+    import tempfile
+
+    import polars as pl  # noqa: F401
+    from goldenmatch.core.cluster import (
+        build_cluster_frames,
+        build_clusters,
+    )
+    from goldenmatch.core.cluster_pairscores import ClusterPairScores
+    from goldenmatch.core.golden import (
+        build_golden_records_batch,
+        build_golden_records_from_frames,
+    )
+    from goldenmatch.identity.resolve import resolve_clusters
+    from goldenmatch.identity.store import IdentityStore
+
+    pairs_df = _make_pairs_df(n_pairs)
+    pairs_list = _pairs_list_from_df(pairs_df)
+    actual_pairs = pairs_df.height
+    n_members = _max_member_id(pairs_df) + 1
+    source_df = _make_source_df(n_members)
+    rules = _golden_rules()
+
+    columnar = variant == "columnar"
+    if columnar:
+        os.environ["GOLDENMATCH_CLUSTER_FRAMES_OUT"] = "1"
+    else:
+        os.environ.pop("GOLDENMATCH_CLUSTER_FRAMES_OUT", None)
+        os.environ.pop("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", None)
+
+    def _one_run() -> tuple[float, float, float]:
+        """Returns (build_s, golden_s, identity_s) for a single stage pass.
+
+        A fresh tmp SQLite IdentityStore per pass so identity write I/O is
+        measured the same way on both variants and runs don't accumulate state.
+        """
+        store_dir = tempfile.mkdtemp(prefix="gm_bench_id_")
+        store_path = os.path.join(store_dir, "identity.db")
+        store = IdentityStore(backend="sqlite", path=store_path)
+        try:
+            if columnar:
+                # --- build (frames) ---
+                t0 = time.perf_counter()
+                frames = build_cluster_frames(
+                    pairs_list,
+                    all_ids=None,
+                    max_cluster_size=100,
+                    weak_cluster_threshold=0.3,
+                    auto_split=True,
+                )
+                build_s = time.perf_counter() - t0
+
+                # --- golden (from frames) ---
+                t1 = time.perf_counter()
+                build_golden_records_from_frames(
+                    source_df, frames, rules,
+                    quality_scores=None, provenance=False,
+                )
+                golden_s = time.perf_counter() - t1
+
+                # --- identity (frames + from_frames view) ---
+                # The view + store I/O + df.to_dicts() are SHARED with legacy and
+                # frames-invariant (confound control note in the module docstring).
+                view = ClusterPairScores.from_frames(
+                    frames.assignments, pairs_list,
+                )
+                t2 = time.perf_counter()
+                resolve_clusters(
+                    cluster_frames=frames,
+                    df=source_df,
+                    store=store,
+                    run_name="bench",
+                    pair_score_view=view,
+                )
+                identity_s = time.perf_counter() - t2
+            else:
+                # --- build (dict) ---
+                t0 = time.perf_counter()
+                clusters = build_clusters(
+                    pairs_list,
+                    max_cluster_size=100,
+                    weak_cluster_threshold=0.3,
+                    auto_split=True,
+                )
+                build_s = time.perf_counter() - t0
+
+                # --- golden (dict -> multi_df) ---
+                t1 = time.perf_counter()
+                eligible = [
+                    (cid, info) for cid, info in clusters.items()
+                    if info["size"] > 1 and not info["oversized"]
+                ]
+                row_to_cluster: dict[int, int] = {}
+                for cid, info in eligible:
+                    for mid in info["members"]:
+                        row_to_cluster[mid] = cid
+                if row_to_cluster:
+                    multi_df = source_df.filter(
+                        pl.col("__row_id__").is_in(list(row_to_cluster.keys()))
+                    ).with_columns(
+                        pl.col("__row_id__").replace_strict(
+                            list(row_to_cluster.keys()),
+                            list(row_to_cluster.values()),
+                            return_dtype=pl.Int64,
+                        ).alias("__cluster_id__")
+                    )
+                    build_golden_records_batch(
+                        multi_df, rules, provenance=False,
+                    )
+                golden_s = time.perf_counter() - t1
+
+                # --- identity (dict + from_pairs view) ---
+                view = ClusterPairScores.from_pairs(pairs_list, clusters)
+                t2 = time.perf_counter()
+                resolve_clusters(
+                    clusters=clusters,
+                    df=source_df,
+                    store=store,
+                    run_name="bench",
+                    pair_score_view=view,
+                )
+                identity_s = time.perf_counter() - t2
+            return build_s, golden_s, identity_s
+        finally:
+            try:
+                store.close()
+            except Exception:
+                pass
+
+    _one_run()  # warm
+
+    build_walls: list[float] = []
+    golden_walls: list[float] = []
+    identity_walls: list[float] = []
+    for _ in range(runs):
+        b, g, i = _one_run()
+        build_walls.append(b)
+        golden_walls.append(g)
+        identity_walls.append(i)
+
+    print(json.dumps({
+        "variant": variant,
+        "n_pairs": actual_pairs,
+        "n_members": n_members,
+        "build_walls": build_walls,
+        "golden_walls": golden_walls,
+        "identity_walls": identity_walls,
+        "peak_rss_mb": _peak_rss_mb(),
+    }), flush=True)
+    return 0
+
+
+def _membership_sanity(n_pairs: int) -> tuple[bool, int, int]:
+    """Cheap membership check: columnar cluster count == legacy cluster count.
+    NOT a parity gate (SP-A/B/C already proved byte-identical) -- a smoke that
+    the two variants build the same partition before we trust their perf."""
+    from goldenmatch.core.cluster import (
+        build_cluster_frames,
+        build_clusters,
+    )
+
+    pairs_df = _make_pairs_df(n_pairs)
+    pairs_list = _pairs_list_from_df(pairs_df)
+
+    os.environ.pop("GOLDENMATCH_CLUSTER_FRAMES_OUT", None)
+    os.environ.pop("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", None)
+    clusters = build_clusters(
+        pairs_list,
+        max_cluster_size=100,
+        weak_cluster_threshold=0.3,
+        auto_split=True,
+    )
+    legacy_count = len(clusters)
+
+    os.environ["GOLDENMATCH_CLUSTER_FRAMES_OUT"] = "1"
+    frames = build_cluster_frames(
+        pairs_list,
+        all_ids=None,
+        max_cluster_size=100,
+        weak_cluster_threshold=0.3,
+        auto_split=True,
+    )
+    columnar_count = frames.metadata.height
+    os.environ.pop("GOLDENMATCH_CLUSTER_FRAMES_OUT", None)
+    return (columnar_count == legacy_count), legacy_count, columnar_count
+
+
+def _bench_variant(variant: str, n: int, runs: int) -> dict[str, Any]:
+    """Run a single variant in a child process. Returns a parsed result dict, or
+    a ``{"oom": True}`` marker when the child OOMs / exits non-zero (the 100M
+    legacy leg)."""
+    cmd = [
+        sys.executable, os.path.abspath(__file__),
+        "--child", variant, "--np", str(n), "--runs", str(runs),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    last_json = None
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            last_json = line
+    if proc.returncode != 0 or last_json is None:
+        # OOM / SIGKILL (-9) / any non-zero exit, or no JSON emitted -> treat as
+        # an infeasibility data point, NOT a crash of the whole bench.
+        return {
+            "oom": True,
+            "returncode": proc.returncode,
+            "stderr_tail": proc.stderr.strip()[-2000:],
+        }
+    return json.loads(last_json)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--np", default="1000000,5000000",
+                    help="Comma-separated target pair counts")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--output", default=None)
+    ap.add_argument("--child", choices=["legacy", "columnar"], default=None,
+                    help="Internal: run a single variant in this process")
+    args = ap.parse_args()
+
+    runs = max(1, args.runs)
+
+    if args.child is not None:
+        nps = [int(x.strip()) for x in args.np.split(",") if x.strip()]
+        n = nps[0] if nps else 1000000
+        return _run_child(args.child, n, runs)
+
+    nps = [int(x.strip()) for x in args.np.split(",") if x.strip()]
+
+    from goldenmatch.core._native_loader import native_available, native_module
+    print(f"native importable: {native_available()}", flush=True)
+    m = native_module()
+    print(f"build_clusters_arrow exposed: "
+          f"{bool(m) and hasattr(m, 'build_clusters_arrow')}", flush=True)
+
+    print("recorded DATA; binding Phase-2 verdict (legacy dict vs columnar "
+          "A+B+C complete path).", flush=True)
+    print("NOTE: the pair-score view + identity store I/O + df.to_dicts() are "
+          "SHARED on both variants and frames-invariant; the >=30% RSS "
+          "criterion applies to the cluster-representation delta (build + "
+          "golden + identity cluster-iteration), not the store.", flush=True)
+
+    sane_n = 2000
+    print(f"membership sanity (np={sane_n:,}) ...", flush=True)
+    ok, legacy_count, columnar_count = _membership_sanity(sane_n)
+    if ok:
+        print(f"membership OK (both {legacy_count:,} clusters)", flush=True)
+    else:
+        # Not a kill gate -- record it and proceed; parity is already proven by
+        # the SP-A/B/C gates, this is only a smoke.
+        print(f"membership MISMATCH: legacy={legacy_count:,} "
+              f"columnar={columnar_count:,} (proceeding; perf still recorded)",
+              flush=True)
+
+    results = []
+    for n in nps:
+        print(f"  target_pairs={n:,} ...", flush=True)
+        try:
+            legacy = _bench_variant("legacy", n, runs)
+            columnar = _bench_variant("columnar", n, runs)
+            row: dict[str, Any] = {"n_pairs": n}
+
+            if columnar.get("oom"):
+                # Columnar OOM at this scale is itself a verdict (Phase-2 didn't
+                # land the feasibility win).
+                row["columnar"] = {"oom": True,
+                                   "returncode": columnar.get("returncode")}
+            else:
+                row["n_pairs"] = columnar["n_pairs"]
+                row["columnar"] = {
+                    "build_s": statistics.median(columnar["build_walls"]),
+                    "golden_s": statistics.median(columnar["golden_walls"]),
+                    "identity_s": statistics.median(columnar["identity_walls"]),
+                    "peak_rss_mb": columnar["peak_rss_mb"],
+                }
+
+            if legacy.get("oom"):
+                row["legacy"] = {"oom": True,
+                                 "returncode": legacy.get("returncode")}
+                print(f"    pairs={n:,}  legacy OOM "
+                      f"(rc={legacy.get('returncode')})", flush=True)
+            else:
+                row["legacy"] = {
+                    "build_s": statistics.median(legacy["build_walls"]),
+                    "golden_s": statistics.median(legacy["golden_walls"]),
+                    "identity_s": statistics.median(legacy["identity_walls"]),
+                    "peak_rss_mb": legacy["peak_rss_mb"],
+                }
+
+            results.append(row)
+
+            def _fmt(v: dict[str, Any]) -> str:
+                if v.get("oom"):
+                    return "OOM"
+                return (f"build={v['build_s']:.3f} golden={v['golden_s']:.3f} "
+                        f"identity={v['identity_s']:.3f} "
+                        f"rss={v['peak_rss_mb']:.1f}MB")
+
+            print(f"    legacy:   {_fmt(row['legacy'])}", flush=True)
+            print(f"    columnar: {_fmt(row['columnar'])}", flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  target_pairs={n:,}  ERROR {type(exc).__name__}: {exc}",
+                  flush=True)
+            results.append({"n_pairs": n, "error": str(exc)})
+
+    def _cell(v: dict[str, Any] | None) -> tuple[str, str, str, str]:
+        if v is None or "build_s" not in v:
+            tag = "OOM" if (v and v.get("oom")) else "n/a"
+            return tag, tag, tag, tag
+        return (
+            f"{v['build_s']:.3f}", f"{v['golden_s']:.3f}",
+            f"{v['identity_s']:.3f}", f"{v['peak_rss_mb']:.1f}",
+        )
+
+    lines = [
+        "\n## bench-pipeline-complete-path\n",
+        "Per-variant stage wall (build / golden / identity seconds) + overall "
+        "peak RSS. legacy = dict; columnar = frames-out (A+B+C). The view + "
+        "store I/O + df.to_dicts() are shared/frames-invariant.\n",
+        f"| {'pairs':>12} | {'variant':>8} | {'build s':>9} | {'golden s':>9} "
+        f"| {'identity s':>10} | {'peak RSS MB':>12} |",
+        f"| {'-'*12} | {'-'*8} | {'-'*9} | {'-'*9} | {'-'*10} | {'-'*12} |",
+    ]
+    for r in results:
+        if "error" in r:
+            lines.append(
+                f"| {r['n_pairs']:>12,} | {'ERROR':>8} | {'ERROR':>9} | "
+                f"{'ERROR':>9} | {'ERROR':>10} | {'n/a':>12} |"
+            )
+            continue
+        for variant in ("legacy", "columnar"):
+            b, g, i, rss = _cell(r.get(variant))
+            lines.append(
+                f"| {r['n_pairs']:>12,} | {variant:>8} | {b:>9} | {g:>9} | "
+                f"{i:>10} | {rss:>12} |"
+            )
+    table = "\n".join(lines)
+    print(table, flush=True)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        try:
+            with open(summary, "a", encoding="utf-8") as fh:
+                fh.write(table + "\n")
+        except OSError:
+            pass
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, "w", encoding="utf-8") as fh:
+            json.dump({"results": results}, fh, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/tests/test_cluster_pairscores.py
+++ b/packages/python/goldenmatch/tests/test_cluster_pairscores.py
@@ -46,6 +46,45 @@ def test_from_pairs_reproduces_cluster_pair_scores():
         assert view.for_cluster(cid) == info["pair_scores"]
 
 
+def test_from_frames_equals_from_pairs():
+    # from_frames(assignments, raw pairs) must be BYTE-IDENTICAL to
+    # from_pairs(raw pairs, clusters) for every cid -- incl. singletons and
+    # auto-split sub-clusters. Native is irrelevant (off-native build is fine).
+    from goldenmatch.core.cluster import build_clusters, cluster_dict_to_frames
+
+    # Adversarial pair set:
+    #  - singleton (id 9, no edge) -> appears only as an assignments row
+    #  - multi-member cluster (1,2,3)
+    #  - duplicate canonical pair (4,5) with DIFFERENT scores -> locks last-wins
+    #  - a dense star that build_clusters will auto-split when oversized
+    pairs = [
+        (1, 2, 0.91),
+        (2, 3, 0.88),
+        (4, 5, 0.40),   # first write
+        (4, 5, 0.95),   # last-wins -> 0.95
+        (5, 6, 0.82),
+        # dense star around 10 to trigger oversize+split
+        (10, 11, 0.9), (10, 12, 0.9), (10, 13, 0.9), (10, 14, 0.9),
+        (10, 15, 0.9), (10, 16, 0.9), (11, 12, 0.5), (13, 14, 0.5),
+        (15, 16, 0.5),
+    ]
+    # ensure a true singleton exists in the assignments frame
+    clusters = build_clusters(pairs, auto_split=True)
+    # inject a singleton cluster (no pairs) so assignments carries a lone member
+    next_cid = (max(clusters) + 1) if clusters else 0
+    clusters[next_cid] = {
+        "members": [9], "size": 1, "oversized": False,
+        "pair_scores": {}, "confidence": 0.0, "bottleneck_pair": None,
+        "cluster_quality": "strong",
+    }
+    frames = cluster_dict_to_frames(clusters)
+
+    v_pairs = ClusterPairScores.from_pairs(pairs, clusters)
+    v_frames = ClusterPairScores.from_frames(frames.assignments, pairs)
+    for cid in clusters:
+        assert v_frames.for_cluster(cid) == v_pairs.for_cluster(cid)
+
+
 def test_from_pairs_last_wins_and_excludes_cross_cluster():
     clusters = {
         1: {"members": [0, 1], "size": 2, "pair_scores": {}},

--- a/packages/python/goldenmatch/tests/test_identity_from_frames_parity.py
+++ b/packages/python/goldenmatch/tests/test_identity_from_frames_parity.py
@@ -1,0 +1,251 @@
+"""SP-C durability gate: ``resolve_clusters(cluster_frames=..., pair_score_view=...)``
+must resolve run-local clusters to durable identities BYTE-IDENTICALLY to the legacy
+``resolve_clusters(clusters_dict, ...)`` path. Identity entity-ids are the durable
+contract, so any divergence between the two iteration sources splits/merges identities
+differently across the cutover -- this test locks them.
+
+Two assertions:
+  - PARTITION equality (entity_id is a random UUIDv7, so compare the
+    record_id -> entity_id *partition*, not literal ids).
+  - Literal equality under a deterministic mint (monkeypatch ``new_entity_id``
+    to a counter) -- locks ResolveSummary + the literal record->entity map.
+
+The fixture exercises absorb/merge/legacy-fallback (PRIOR-run seeded entities),
+a weak-bottleneck conflict cluster, and an oversized-split cluster. Native leg
+SKIPS locally, runs in CI (mirrors ``test_cluster_frames_out_parity``).
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.core.cluster import (
+    build_cluster_frames,
+    cluster_frames_to_dict,
+)
+from goldenmatch.core.cluster_pairscores import ClusterPairScores
+from goldenmatch.identity import IdentityStore, resolve_clusters
+
+
+def _skip_if_no_native(native):
+    if native == "1":
+        from goldenmatch.core._native_loader import native_module
+        nm = native_module()
+        if nm is None or getattr(nm, "build_clusters_arrow", None) is None:
+            pytest.skip("native cluster kernel absent; native=1 validated in CI")
+
+
+# Records 0..15. No-PK (content-hash ids via source_pk_col=None) so the
+# absorb/merge/legacy paths key off the h1 fingerprint -- the durability-
+# critical case. Distinct names keep each record's fingerprint unique.
+_NAMES = [
+    "Alice", "Alyce", "Bob", "Bobby", "Carol", "Caroline", "Dave", "Davy",
+    "Eve", "Eva", "Frank", "Franklin", "Grace", "Gracie", "Heidi", "Heidy",
+]
+
+
+def _df(member_ids=None):
+    ids = list(range(16)) if member_ids is None else member_ids
+    return pl.DataFrame({
+        "__row_id__": ids,
+        "__source__": ["src"] * len(ids),
+        "name": [_NAMES[i] for i in ids],
+    })
+
+
+def _pairs():
+    """Pairs feeding build_cluster_frames. Shapes:
+      - {0,1} simple merge-into-existing (seeded as two priors below)
+      - {2,3} simple absorb (one prior covers record 2)
+      - {4,5,6} weak chain -> weak bottleneck (4-6 edge below threshold)
+      - {10..16}-ish oversized barbell that auto-splits (max_cluster_size=4)
+      - 8, 9 singletons
+    """
+    pairs = [
+        (0, 1, 0.95),                                   # merge cluster
+        (2, 3, 0.95),                                   # absorb cluster
+        (4, 5, 0.99), (5, 6, 0.40),                     # weak chain bottleneck
+        # barbell {10,11,12} - {13,14,15}, weak bridge 12-13 -> splits
+        (10, 11, 0.99), (11, 12, 0.99), (10, 12, 0.99),
+        (13, 14, 0.99), (14, 15, 0.99), (13, 15, 0.99),
+        (12, 13, 0.31),
+    ]
+    all_ids = list(range(16))
+    return pairs, all_ids
+
+
+def _build(monkeypatch, native):
+    """Build frames + dict + raw-pairs view under a consistent gate setup."""
+    pairs, all_ids = _pairs()
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+    _skip_if_no_native(native)
+    kw = dict(all_ids=all_ids, max_cluster_size=4,
+              weak_cluster_threshold=0.3, auto_split=True)
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
+    monkeypatch.setenv("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "1")
+    frames = build_cluster_frames(pairs, **kw)
+    clusters_dict = cluster_frames_to_dict(frames)
+    view = ClusterPairScores.from_frames(frames.assignments, pairs)
+    return frames, clusters_dict, view, pairs
+
+
+def _seed_one(store, orig_id, run_name):
+    """Seed a singleton identity for the record whose payload matches original
+    row ``orig_id`` (no-PK h1 fingerprint is payload-derived, so the mini-df's
+    __row_id__ is irrelevant -- only name+source determine the record id)."""
+    df = pl.DataFrame({
+        "__row_id__": [0],
+        "__source__": ["src"],
+        "name": [_NAMES[orig_id]],
+    })
+    resolve_clusters(
+        {0: {"members": [0], "size": 1, "oversized": False,
+             "pair_scores": {}, "confidence": 1.0}},
+        df, [], "seed", store, run_name=run_name, source_pk_col=None,
+    )
+
+
+def _seed_priors(store, run_name="seed-run"):
+    """Seed PRIOR-run identities so the current run exercises merge + absorb.
+    Records 0 and 1 each get their OWN identity (so the current {0,1} cluster
+    MERGES the two); record 2 gets an identity (so {2,3} ABSORBS record 3)."""
+    _seed_one(store, 0, run_name + "-a")
+    _seed_one(store, 1, run_name + "-b")
+    _seed_one(store, 2, run_name + "-c")
+
+
+def _record_to_entity(store) -> dict[str, str]:
+    """record_id -> entity_id over all ACTIVE + retired records in the store."""
+    out: dict[str, str] = {}
+    for node in store.list_identities():
+        for rec in store.get_records_for_entity(node.entity_id):
+            out[rec.record_id] = rec.entity_id
+    return out
+
+
+def _partition(rec_to_eid: dict[str, str]) -> set[frozenset]:
+    by_eid: dict[str, set] = {}
+    for rid, eid in rec_to_eid.items():
+        by_eid.setdefault(eid, set()).add(rid)
+    return {frozenset(v) for v in by_eid.values()}
+
+
+def _make_store(tmp_path, name):
+    return IdentityStore(path=str(tmp_path / name))
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_frames_path_partition_matches_dict_path(tmp_path, monkeypatch, native):
+    frames, clusters_dict, view, pairs = _build(monkeypatch, native)
+    df = _df()
+
+    # DICT path against a freshly-seeded store.
+    store_a = _make_store(tmp_path, "dict.db")
+    try:
+        _seed_priors(store_a)
+        sum_a = resolve_clusters(
+            clusters_dict, df, pairs, "wd", store_a, run_name="run-x",
+            source_pk_col=None, pair_score_view=view,
+        )
+        part_a = _partition(_record_to_entity(store_a))
+    finally:
+        store_a.close()
+
+    # FRAMES path against an IDENTICALLY freshly-seeded store.
+    store_b = _make_store(tmp_path, "frames.db")
+    try:
+        _seed_priors(store_b)
+        sum_b = resolve_clusters(
+            cluster_frames=frames, df=df, scored_pairs=pairs,
+            matchkey_name="wd", store=store_b, run_name="run-x",
+            source_pk_col=None, pair_score_view=view,
+        )
+        part_b = _partition(_record_to_entity(store_b))
+    finally:
+        store_b.close()
+
+    assert part_a == part_b, f"partition diverged:\n dict={part_a}\n frames={part_b}"
+    # Summary counts (no entity-id literals) must match too.
+    assert sum_a == sum_b
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_frames_path_literal_identical_under_deterministic_mint(
+    tmp_path, monkeypatch, native,
+):
+    import goldenmatch.identity.resolve as resolve_mod
+
+    frames, clusters_dict, view, pairs = _build(monkeypatch, native)
+    df = _df()
+
+    def _det_minter():
+        counter = {"n": 0}
+
+        def _mint():
+            counter["n"] += 1
+            return f"det-entity-{counter['n']:04d}"
+
+        return _mint
+
+    # DICT path with deterministic mint.
+    monkeypatch.setattr(resolve_mod, "new_entity_id", _det_minter())
+    store_a = _make_store(tmp_path, "dict_det.db")
+    try:
+        _seed_priors(store_a)
+        sum_a = resolve_clusters(
+            clusters_dict, df, pairs, "wd", store_a, run_name="run-x",
+            source_pk_col=None, pair_score_view=view,
+        )
+        map_a = _record_to_entity(store_a)
+    finally:
+        store_a.close()
+
+    # FRAMES path with a FRESH deterministic mint (same starting counter).
+    monkeypatch.setattr(resolve_mod, "new_entity_id", _det_minter())
+    store_b = _make_store(tmp_path, "frames_det.db")
+    try:
+        _seed_priors(store_b)
+        sum_b = resolve_clusters(
+            cluster_frames=frames, df=df, scored_pairs=pairs,
+            matchkey_name="wd", store=store_b, run_name="run-x",
+            source_pk_col=None, pair_score_view=view,
+        )
+        map_b = _record_to_entity(store_b)
+    finally:
+        store_b.close()
+
+    assert map_a == map_b, (
+        "literal record->entity map diverged under deterministic mint:\n"
+        f" only dict={set(map_a.items()) - set(map_b.items())}\n"
+        f" only frames={set(map_b.items()) - set(map_a.items())}"
+    )
+    assert sum_a == sum_b
+
+
+def test_frames_path_requires_pair_score_view(tmp_path, monkeypatch):
+    frames, _clusters_dict, _view, pairs = _build(monkeypatch, "0")
+    df = _df()
+    store = _make_store(tmp_path, "noview.db")
+    try:
+        with pytest.raises(ValueError, match="pair_score_view"):
+            resolve_clusters(
+                cluster_frames=frames, df=df, scored_pairs=pairs,
+                matchkey_name="wd", store=store, run_name="run-x",
+                source_pk_col=None,
+            )
+    finally:
+        store.close()
+
+
+def test_resolve_clusters_rejects_both_sources(tmp_path, monkeypatch):
+    frames, clusters_dict, view, pairs = _build(monkeypatch, "0")
+    df = _df()
+    store = _make_store(tmp_path, "both.db")
+    try:
+        with pytest.raises(ValueError, match="exactly one"):
+            resolve_clusters(
+                clusters_dict, df, pairs, "wd", store, run_name="run-x",
+                source_pk_col=None, pair_score_view=view,
+                cluster_frames=frames,
+            )
+    finally:
+        store.close()

--- a/packages/python/goldenmatch/tests/test_identity_from_frames_parity.py
+++ b/packages/python/goldenmatch/tests/test_identity_from_frames_parity.py
@@ -129,6 +129,25 @@ def _partition(rec_to_eid: dict[str, str]) -> set[frozenset]:
     return {frozenset(v) for v in by_eid.values()}
 
 
+def _assert_nonvacuous(summary, partition: set[frozenset]) -> None:
+    """Guard the durability gate against a vacuous pass.
+
+    ``part_a == part_b`` / ``sum_a == sum_b`` are byte-equal even when BOTH
+    runs degenerate to all-singletons or empty stores. Assert the REFERENCE
+    (dict-path) run actually produced a multi-record entity AND did real
+    resolution work, so a fixture regression can't make the gate pass empty.
+
+    ``ResolveSummary.edges_added`` is the evidence-edge count -- this fixture
+    seeds a merge ({0,1}), an absorb ({2,3}), a weak-bottleneck chain
+    ({4,5,6}), and an oversized barbell that auto-splits, so every multi-member
+    cluster contributes >= 1 edge. edges_added is reliably well >= 1.
+    """
+    assert any(len(s) > 1 for s in partition), \
+        "fixture produced no multi-record entity"
+    assert summary.edges_added >= 1, \
+        f"reference run did no resolution work: {summary.as_dict()}"
+
+
 def _make_store(tmp_path, name):
     return IdentityStore(path=str(tmp_path / name))
 
@@ -163,6 +182,9 @@ def test_frames_path_partition_matches_dict_path(tmp_path, monkeypatch, native):
     finally:
         store_b.close()
 
+    # Anti-vacuous: the reference run must be non-trivial (multi-record entity
+    # + real resolution work), else two degenerate runs pass byte-equal.
+    _assert_nonvacuous(sum_a, part_a)
     assert part_a == part_b, f"partition diverged:\n dict={part_a}\n frames={part_b}"
     # Summary counts (no entity-id literals) must match too.
     assert sum_a == sum_b
@@ -213,6 +235,9 @@ def test_frames_path_literal_identical_under_deterministic_mint(
     finally:
         store_b.close()
 
+    # Anti-vacuous: reference run must be non-trivial (multi-record entity +
+    # real resolution work) so the literal-map equality can't pass empty.
+    _assert_nonvacuous(sum_a, _partition(map_a))
     assert map_a == map_b, (
         "literal record->entity map diverged under deterministic mint:\n"
         f" only dict={set(map_a.items()) - set(map_b.items())}\n"

--- a/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
@@ -469,3 +469,119 @@ def test_frames_out_identity_consumes_cluster_frames_directly(
     assert on_call["clusters_is_dict"] is False
     assert isinstance(on_call["cluster_frames"], ClusterFrames)
     assert on_call["pair_score_view"] is not None
+
+
+# ── SP-C Task 3b: deferred dict rebuild past the identity stage ────────────
+#
+# Task 3b makes the eager `clusters = _clusters_dict()` at the OUTPUT block go
+# away: each remaining dict consumer (output_clusters rows, lineage,
+# golden_provenance, results["clusters"]) now calls `_clusters_dict()` at its
+# OWN consumption site, so on the frames-out hot path (identity ON, output OFF)
+# the dict materializes for the FIRST time at results["clusters"] -- AFTER the
+# identity stage. This leg turns the deferred output_clusters + lineage
+# consumers ON (output_clusters=True, output_golden=True) so the deferral is
+# actually exercised on the frames-out path, and asserts the gate-ON dict the
+# deferred consumers produce is byte-identical to the gate-OFF dict.
+
+
+def _config_with_output(directory: str, *, max_cluster_size: int):
+    """`_config` variant pointing output at a tmp directory (provenance ON).
+
+    provenance=True so the lineage block's golden_provenance consumer
+    (`golden_records_to_provenance(..., _clusters_dict(), ...)`) also fires --
+    a third deferred `_clusters_dict()` call site beyond output_clusters rows
+    and `build_lineage`.
+    """
+    cfg = _config(max_cluster_size=max_cluster_size, provenance=True)
+    cfg.output.directory = directory
+    return cfg
+
+
+def _clusters_partition(results):
+    """results["clusters"] as an order-independent partition + per-cluster shape.
+
+    Cluster-ids are not compared across runs (the rebuild can renumber); we
+    compare the membership PARTITION (frozensets of member ids) plus the
+    (size, oversized) shape multiset, which is what every deferred dict
+    consumer reads.
+    """
+    clusters = results["clusters"]
+    partition = {frozenset(int(m) for m in c["members"]) for c in clusters.values()}
+    shapes = sorted((c["size"], bool(c["oversized"])) for c in clusters.values())
+    return partition, shapes
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_frames_out_output_on_deferred_dict_parity(monkeypatch, tmp_path, native):
+    """Deferred output_clusters + lineage consumers: gate-ON dict == gate-OFF.
+
+    Turns the opt-in output consumers ON so the deferred `_clusters_dict()`
+    calls (output_clusters rows, build_lineage, golden_provenance) actually run
+    on the frames-out path. Asserts (a) both runs succeed and write output, and
+    (b) the gate-ON vs gate-OFF results["clusters"] partition is identical --
+    proving the deferred-build consumers produce the same dict the eager rebuild
+    used to.
+    """
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+    _skip_if_no_native(native)
+
+    off_dir = tmp_path / "off"
+    on_dir = tmp_path / "on"
+    off_dir.mkdir()
+    on_dir.mkdir()
+
+    monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    off = run_dedupe_df(
+        _fixture_df(),
+        _config_with_output(str(off_dir), max_cluster_size=4),
+        source_name="t",
+        output_golden=True,
+        output_clusters=True,
+    )
+
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
+    on = run_dedupe_df(
+        _fixture_df(),
+        _config_with_output(str(on_dir), max_cluster_size=4),
+        source_name="t",
+        output_golden=True,
+        output_clusters=True,
+    )
+
+    # Deferred-build dict parity (the core SP-C 3b invariant): the dict the
+    # deferred output_clusters + lineage + results consumers produce on the
+    # frames-out path matches the gate-OFF dict.
+    assert _clusters_partition(on) == _clusters_partition(off)
+    # Also keep the existing golden/dupes/stats parity locked with output on.
+    assert _cluster_stats(on) == _cluster_stats(off)
+    assert _dupe_row_ids(on) == _dupe_row_ids(off)
+    assert _golden_as_setrows(on) == _golden_as_setrows(off)
+
+    # The deferred output_clusters consumer actually wrote the clusters file on
+    # both gate paths (proves the deferral didn't skip the consumer). The
+    # written clusters partition must also match across gates.
+    on_clusters = _read_written_clusters(on_dir)
+    off_clusters = _read_written_clusters(off_dir)
+    assert on_clusters is not None and off_clusters is not None
+    assert on_clusters == off_clusters
+
+
+def _read_written_clusters(directory):
+    """Read the written `clusters` CSV back into a member->cluster partition.
+
+    Returns None if no clusters file was written. The cluster-id labels differ
+    across runs (rebuild renumbering), so we compare the partition of
+    __row_id__ grouped by __cluster_id__, not the raw ids.
+    """
+    import glob
+
+    import polars as pl
+
+    matches = glob.glob(str(directory / "*clusters*"))
+    if not matches:
+        return None
+    df = pl.read_csv(matches[0])
+    groups: dict[object, set[int]] = {}
+    for row in df.iter_rows(named=True):
+        groups.setdefault(row["__cluster_id__"], set()).add(int(row["__row_id__"]))
+    return {frozenset(v) for v in groups.values()}

--- a/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
@@ -1,9 +1,13 @@
 """SP-B Task 2: in-memory dedupe pipeline frames-out parity.
 
 When ``GOLDENMATCH_CLUSTER_FRAMES_OUT`` is ON, ``_run_dedupe_pipeline``
-consumes the SP-A ``ClusterFrames`` for the GOLDEN + STATS + DUPES legs
-(identity stays on the dict -- Task 3). This file locks that the gate-ON
-output is byte-identical to the gate-OFF (dict) path on those legs.
+consumes the SP-A ``ClusterFrames`` for the GOLDEN + STATS + DUPES legs.
+SP-C extends this so IDENTITY also consumes the frames directly
+(``resolve_clusters(cluster_frames=...)``) -- the dict materializes only at
+the OUTPUT block, after the cluster->golden->identity stage. This file locks
+that the gate-ON output is byte-identical to the gate-OFF (dict) path on those
+legs (golden + dupes + stats + identity) and that the SP-C wiring actually
+feeds identity the frames (not a rebuilt dict).
 
 Asserted byte-identical (gate ON vs OFF), on a fixture that exercises
 singletons, a 2-member cluster, a weak chain, and an oversized cluster
@@ -376,3 +380,92 @@ def test_frames_out_identity_parity(monkeypatch, tmp_path, native):
     assert off["identity_summary"]["conflicts_flagged"] >= 1, (
         "fixture did not trip the weak-bottleneck branch (score_for not exercised)"
     )
+
+
+# ── SP-C Task 3: identity consumes ClusterFrames DIRECTLY ─────────────────
+#
+# SP-B (Task 3 above) fed identity a dict REBUILT from the frames
+# (cluster_frames_to_dict) + a from_pairs view. SP-C changes the frames-out
+# branch so identity receives the `cluster_frames` directly (clusters=None) and
+# the view is built via `ClusterPairScores.from_frames(assignments, all_pairs)`
+# -- so the cluster->golden->identity stage never forces `_clusters_dict()`.
+# These two legs prove (a) the full public pipeline's frames-path identity is
+# byte-identical end to end and (b) resolve_clusters is actually called with
+# `cluster_frames=` (not a dict) on the frames-out branch.
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_frames_out_identity_consumes_cluster_frames_directly(
+    monkeypatch, tmp_path, native
+):
+    """SP-C: on frames-out, resolve_clusters gets cluster_frames= (clusters=None).
+
+    Spies on ``goldenmatch.identity.resolve_clusters`` (the symbol
+    ``_resolve_identities`` imports) and asserts the frames-out call passes a
+    ``ClusterFrames`` via ``cluster_frames=`` with ``clusters`` None + a
+    non-None ``pair_score_view``, while the gate-OFF call passes a dict via
+    ``clusters`` and no frames. The byte-identical end-to-end partition is
+    already locked by ``test_frames_out_identity_parity``; this leg pins the
+    SP-C wiring so a regression to the dict-rebuild path is caught directly.
+    """
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+    _skip_if_no_native(native)
+
+    from goldenmatch.core.cluster import ClusterFrames
+
+    df = _identity_df()
+    source = "src"
+
+    captured: dict[str, dict] = {}
+
+    import goldenmatch.identity as identity_mod
+
+    real_resolve = identity_mod.resolve_clusters
+
+    def _spy(clusters=None, *args, **kwargs):
+        # Record the shape identity was called with for this leg, then defer to
+        # the real resolver so the partition/summary still materialize.
+        leg = captured["leg"]
+        captured[leg] = {
+            "clusters_is_none": clusters is None,
+            "clusters_is_dict": isinstance(clusters, dict),
+            "cluster_frames": kwargs.get("cluster_frames"),
+            "pair_score_view": kwargs.get("pair_score_view"),
+        }
+        return real_resolve(clusters, *args, **kwargs)
+
+    # ``_resolve_identities`` does ``from goldenmatch.identity import
+    # resolve_clusters`` at call time, so patching the package attribute is
+    # sufficient.
+    monkeypatch.setattr(identity_mod, "resolve_clusters", _spy)
+
+    # Gate OFF -> dict path.
+    captured["leg"] = "off"
+    off_db = str(tmp_path / "sp_c_off.db")
+    monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    off = run_dedupe_df(df, _identity_config(off_db, "off"), source_name=source)
+
+    # Gate ON -> frames-out path.
+    captured["leg"] = "on"
+    on_db = str(tmp_path / "sp_c_on.db")
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
+    on = run_dedupe_df(df, _identity_config(on_db, "on"), source_name=source)
+
+    assert off["identity_summary"] is not None
+    assert on["identity_summary"] is not None
+    # End-to-end summary parity (anti-vacuous: real evidence edges exist).
+    assert on["identity_summary"] == off["identity_summary"]
+    assert off["identity_summary"]["edges_added"] >= 1
+
+    off_call = captured["off"]
+    on_call = captured["on"]
+
+    # Gate-OFF: dict in, no frames.
+    assert off_call["clusters_is_dict"] is True
+    assert off_call["cluster_frames"] is None
+
+    # Gate-ON (SP-C): frames in, clusters None, view supplied.
+    assert on_call["clusters_is_none"] is True
+    assert on_call["clusters_is_dict"] is False
+    assert isinstance(on_call["cluster_frames"], ClusterFrames)
+    assert on_call["pair_score_view"] is not None


### PR DESCRIPTION
Phase-2 columnar cutover, SP-C (builds on SP-A+SP-B, both merged). Completes the dict-free cluster→golden→identity hot path and adds the binding verdict bench.

**Tasks**
1. `ClusterPairScores.from_frames(assignments, all_pairs)` — builds the score view from the frames' assignments instead of a dict (shared `_bucket_pairs` helper so it can't drift from `from_pairs`).
2. `resolve_clusters(cluster_frames=...)` — identity consumes `ClusterFrames` directly; the `:337` loop iterates frames in ascending cluster_id (`(0,0)→None` bottleneck sentinel), resolution body unchanged. Durability parity test: entity **partition** (random UUIDv7 → not literal ids) + deterministic-mint literal equality + `ResolveSummary`, anti-vacuous (`edges_added>=1`), seeded priors (merge/absorb), weak-bottleneck + oversized-split.
3. Pipeline feeds identity the frames + a `from_frames` view; **deferred the lazy dict rebuild past the identity stage** so on a frames-out + no-output run the dict materializes only at `results["clusters"]` (after identity) → the cluster→golden→identity stage is **dict-free**. Gate-OFF/columnar byte-identical. Parity legs with output ON (deferred consumers) + identity-frames wiring.
4. Complete-path verdict bench (`bench-pipeline-complete-path`): legacy dict vs columnar A+B+C, segmented build/golden/identity wall + peak RSS, **25M (RSS-delta) + 100M (legacy-OOM-feasibility, caught)**; store-I/O/view confound noted. Recorded data — the binding Phase-2 proceed/stop decision.

**Gates (CI):** durability parity (partition + deterministic-mint, native 1/0) + full-pipeline identity parity + the deferred-dict output-on parity. Gate-OFF byte-identical (additive). `pipeline.py` pyright-strict-clean (0 errors).

After this lands, dispatch `bench-pipeline-complete-path` at 25M/100M from main for the verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)