### PR TITLE
fix(native): stale goldenmatch-native wheel triggers 44x bucket_score slowdown (#688)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -44,6 +44,35 @@ from goldenmatch.core.blocker import _build_block_key_expr
 
 logger = logging.getLogger(__name__)
 
+# One-time guard so the stale-native-wheel warning (issue #688) fires at most
+# once per process instead of once per score_buckets call.
+_WARNED_STALE_NATIVE_WHEEL = False
+
+
+def _warn_stale_native_wheel_once(n_exclude: int) -> None:
+    """Warn (once) when the loaded native wheel predates build_exclude_set.
+
+    The published ``goldenmatch-native 0.1.0`` wheel (2026-05-27) shipped one
+    day before ``build_exclude_set`` / ``ExcludeSet`` landed (#552, 2026-05-28),
+    so any env that pip-installs it instead of building in-tree hits the legacy
+    exclude path. Surface the skew instead of silently degrading -- this was the
+    root cause of issue #688's 44x bucket_score slowdown.
+    """
+    global _WARNED_STALE_NATIVE_WHEEL
+    if _WARNED_STALE_NATIVE_WHEEL:
+        return
+    _WARNED_STALE_NATIVE_WHEEL = True
+    logger.warning(
+        "goldenmatch-native is loaded but lacks build_exclude_set (pre-#552 "
+        "wheel; the published goldenmatch-native 0.1.0 is such a wheel). The "
+        "block scorer is using its exclude-set fallback (empty exclude + Python "
+        "post-filter over %d excluded pairs) -- still fast, but upgrading "
+        "goldenmatch-native or rebuilding in-tree (scripts/build_native.py) "
+        "restores the native Arc-handle path. See issue #688.",
+        n_exclude,
+    )
+
+
 # Scorers the native fast-path kernel (goldenmatch._native.score_block_pairs)
 # implements, with the ids it expects. A field whose scorer isn't here forces
 # the Python per-pair loop for that bucket.
@@ -487,6 +516,10 @@ def score_buckets(
                 f"{time.perf_counter()-_t_eb:.2f}s",
                 flush=True,
             )
+        elif _build is None and frozen_exclude:
+            # Stale/old native wheel: no Arc-handle path available. The worker
+            # falls back to empty-exclude + Python post-filter (see below).
+            _warn_stale_native_wheel_once(len(frozen_exclude))
 
     def _apply_match_mode_filter(
         pairs: list[tuple[int, int, float]],
@@ -582,11 +615,29 @@ def score_buckets(
                     exclude_set=native_exclude_handle,
                 )
             else:
+                # Legacy/stale native wheel (pre-#552: no build_exclude_set, so
+                # native_exclude_handle is None). Passing the full exclude as a
+                # fresh Vec on EVERY bucket call makes the kernel rebuild a
+                # HashSet per call -- O(buckets * |exclude|), the #552 pathology
+                # and the root cause of issue #688's 44x slowdown on the
+                # published goldenmatch-native 0.1.0 wheel. Pass an EMPTY exclude
+                # and drop excluded pairs in Python after emit instead: the
+                # kernel emits only >= threshold pairs (few), so the post-filter
+                # is O(emitted), and the wasted scoring of excluded intra-block
+                # pairs is cheap rapidfuzz-rs work. The emitted ids are canonical
+                # (min, max) (kernel pair_key), matching frozen_exclude's keying,
+                # so the output pair set is identical to the handle path: a pair
+                # in frozen_exclude that scores >= threshold is emitted then
+                # removed here; one that scores < threshold is dropped either way.
                 pairs = native_module().score_block_pairs_arrow(
                     row_ids_arrow, field_arrays_arrow, size_list,
                     native_scorer_ids, weights, total_weight, threshold,
-                    list(frozen_exclude),
+                    [],
                 )
+                if frozen_exclude:
+                    pairs = [
+                        p for p in pairs if (p[0], p[1]) not in frozen_exclude
+                    ]
             local_blocks = sum(1 for s in size_list if s >= 2)
             # Match-mode post-filter (native path doesn't know about
             # source_lookup or target_ids; apply in Python after emit).

--- a/packages/python/goldenmatch/tests/test_score_buckets_stale_wheel_exclude.py
+++ b/packages/python/goldenmatch/tests/test_score_buckets_stale_wheel_exclude.py
@@ -1,0 +1,114 @@
+"""Issue #688 regression: the native block scorer must stay correct AND fast
+when the loaded goldenmatch-native wheel predates ``build_exclude_set`` (#552).
+
+The published ``goldenmatch-native 0.1.0`` wheel (2026-05-27) shipped one day
+before ``build_exclude_set`` / ``ExcludeSet`` (#552, 2026-05-28). Against that
+wheel the caller's ``native_module().build_exclude_set`` raises AttributeError
+and the worker takes the legacy exclude branch. The old legacy branch passed the
+full exclude as a fresh Vec on every bucket call, making the kernel rebuild a
+HashSet per call -- O(buckets * |exclude|), the 44x slowdown reported in #688.
+
+The fix: on that branch, pass an EMPTY exclude to the kernel and drop excluded
+pairs in Python after emit. This test pins the correctness invariant of that
+fallback (excluded pairs never leak; output equals the Arc-handle path) by
+simulating a wheel without ``build_exclude_set``.
+
+Requires the native kernel (score_block_pairs_arrow); skipped on pure-Python.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.backends import score_buckets as sb
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core._native_loader import native_available, native_module
+from goldenmatch.core.matchkey import _xform_sig
+
+_NATIVE_ARROW = native_available() and hasattr(
+    native_module(), "score_block_pairs_arrow"
+)
+pytestmark = pytest.mark.skipif(
+    not _NATIVE_ARROW,
+    reason="needs the native score_block_pairs_arrow kernel",
+)
+
+
+class _NoExcludeSetModule:
+    """Proxy over the real native module that hides ``build_exclude_set``,
+    simulating the pre-#552 published wheel."""
+
+    def __init__(self, real):
+        self._real = real
+
+    def __getattr__(self, name):
+        if name in ("build_exclude_set", "ExcludeSet"):
+            raise AttributeError(name)
+        return getattr(self._real, name)
+
+
+def _prepared() -> pl.DataFrame:
+    # One block of four identical names -> all 6 intra-block pairs score 1.0 on
+    # jaro_winkler, so every pair is above threshold and emitted.
+    mk_field = MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)
+    name_col = _xform_sig(mk_field)
+    names = ["alice", "alice", "alice", "alice"]
+    return pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "name": names,
+        name_col: names,
+        "__block_key__": ["b"] * 4,
+    })
+
+
+def _mk() -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="t", type="weighted", threshold=0.5,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+    )
+
+
+def _blocking() -> BlockingConfig:
+    return BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["name"])])
+
+
+def _keys(pairs):
+    return sorted((min(a, b), max(a, b)) for a, b, _ in pairs)
+
+
+def _run(monkeypatch, *, stale: bool, matched):
+    if stale:
+        real = native_module()
+        monkeypatch.setattr(sb, "native_module", lambda: _NoExcludeSetModule(real))
+    return sb.score_buckets(_prepared(), _blocking(), _mk(), matched_pairs=set(matched))
+
+
+def test_no_exclude_all_pairs_emitted(monkeypatch):
+    """Sanity: with no exclude, both paths emit all 6 pairs of the 4-row block."""
+    handle = _run(monkeypatch, stale=False, matched=set())
+    assert len(handle) == 6
+    stale = _run(monkeypatch, stale=True, matched=set())
+    assert _keys(stale) == _keys(handle)
+
+
+def test_stale_wheel_still_excludes_matched_pair(monkeypatch):
+    """The legacy (stale-wheel) branch must still drop an excluded pair -- the
+    empty-exclude + Python post-filter fallback, not a silent regression."""
+    excluded = {(0, 1)}
+    stale = _run(monkeypatch, stale=True, matched=excluded)
+    assert (0, 1) not in _keys(stale), "excluded pair leaked on the stale-wheel path"
+    assert len(stale) == 5
+
+
+def test_stale_and_handle_paths_agree(monkeypatch):
+    """Output pair set is identical between the Arc-handle path (current wheel)
+    and the empty-exclude fallback (stale wheel) for the same exclude."""
+    excluded = {(0, 1), (2, 3)}
+    handle = _run(monkeypatch, stale=False, matched=excluded)
+    stale = _run(monkeypatch, stale=True, matched=excluded)
+    assert _keys(stale) == _keys(handle)
+    assert (0, 1) not in _keys(stale) and (2, 3) not in _keys(stale)

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldenmatch-native"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-native"
-version = "0.1.0"
+version = "0.1.2"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Root cause (confirmed by binary inspection)

#688 is not an OS issue. It is a **stale published wheel vs current in-tree build**.

Timeline:
- `score_block_pairs_arrow` (zero-copy arrow kernel) landed #514 on 2026-05-26 -> the wheel has it.
- `goldenmatch-native 0.1.0` published to PyPI on **2026-05-27**.
- `build_exclude_set` / `ExcludeSet` landed #552 on **2026-05-28** -> the wheel is missing it by one day.

I downloaded the actual `manylinux_2_28_x86_64` wheel and grepped the `.so`: `score_block_pairs_arrow` = 10 hits, `build_exclude_set` / `ExcludeSet` = **0**.

So against the published wheel, the caller's `try: native_module().build_exclude_set` raises `AttributeError`, `native_exclude_handle` stays `None`, and the bucket worker falls to the legacy branch that passed `list(frozen_exclude)` as a fresh `Vec` on **every bucket call**. The kernel then rebuilds a `HashSet` per call: O(buckets x |exclude|). That is the exact pathology #552 was written to kill ("~1170s of 1370s observed bucket_score wall" at scale).

- Ben's Windows box loads the in-tree `goldenmatch._native` (current source, has the symbol) -> O(1) `Arc` handle -> ~3s.
- Linux CI pip-installs the stale 0.1.0 wheel -> per-call rebuild -> ~192s.

This explains every observation in the issue: version swaps don't help (0.1.0 is the only `goldenmatch-native` on PyPI), single == multi-threaded (per-call exclude marshaling is serial; scoring is rayon either way), and the rapidfuzz microbench was a red herring (the kernel uses rapidfuzz-rs, compiled in, not the Python rapidfuzz wheel).

## Changes

**Primary remedy:** republish the wheel. Bump `goldenmatch-native` to `0.1.2` (pyproject was 0.1.0 / Cargo was 0.1.1; maturin reads pyproject, so a republish without the bump builds 0.1.0 and `skip-existing` no-ops). Tag `goldenmatch-native-v0.1.2` to fire `publish-goldenmatch-native.yml`.

**Defense-in-depth** so a stale/old wheel can never silently regress again:
- The legacy branch now passes an **empty** exclude to the kernel and drops excluded pairs in Python after emit. The kernel emits only `>= threshold` pairs (few), so the post-filter is O(emitted) and the per-call HashSet rebuild is gone. Output pair set is identical to the Arc-handle path (canonical `(min, max)` keys).
- One-time warning when the loaded native wheel lacks `build_exclude_set`, so the caller/wheel skew is visible instead of silently 44x slow.

## Test plan

- New `tests/test_score_buckets_stale_wheel_exclude.py` simulates the pre-#552 wheel by hiding `build_exclude_set` and asserts excluded pairs never leak and the fallback output equals the handle path. Runs on the `python (goldenmatch)` lane (native built).
- `py_compile` + ruff (E9/F63/F7) pass locally. Could not run the native test on the Windows dev box (no in-tree build in the worktree); CI native lane is the verifier.

Fixes #688

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>