### PR TITLE
perf(native): sequential block-scoring path to dodge rayon LockLatch park (#688)

### DIFF
--- a/packages/python/goldenmatch/tests/test_native_block_seq_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_block_seq_parity.py
@@ -1,0 +1,96 @@
+"""Issue #688 follow-up: the native block kernel's sequential path and rayon
+path must emit byte-identical pairs.
+
+The kernel (`score_block_pairs_arrow`) now scores small/medium calls in the
+calling thread (no rayon) and only fans out to rayon above a candidate-pair
+threshold, because rayon's blocking `collect` parked the calling thread on a
+futex `LockLatch` for ~190s on some Linux runners (the 44x slowdown). The
+threshold is overridable via `GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS` (0 = always
+rayon, huge = always sequential), which lets this test exercise BOTH paths on
+the same input and assert they agree -- and that both agree with the Python
+slow path (the source of truth).
+
+Requires the native kernel; skipped on pure-Python.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.backends.score_buckets import score_buckets
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core._native_loader import native_available, native_module
+from goldenmatch.core.matchkey import _xform_sig
+from goldenmatch.core.scorer import find_fuzzy_matches
+
+_NATIVE_ARROW = native_available() and hasattr(
+    native_module(), "score_block_pairs_arrow"
+)
+pytestmark = pytest.mark.skipif(
+    not _NATIVE_ARROW,
+    reason="needs the native score_block_pairs_arrow kernel",
+)
+
+
+def _prepared() -> pl.DataFrame:
+    # Three blocks of near-duplicate names so each block emits several pairs,
+    # plus a few non-matches so the threshold actually filters.
+    field = MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)
+    col = _xform_sig(field)
+    names = [
+        "alice", "alica", "alise",      # block A (similar -> pairs)
+        "robert", "robbert", "rupert",  # block B
+        "xavier", "yvonne", "zelda",    # block C (dissimilar -> few/no pairs)
+    ]
+    blocks = ["A", "A", "A", "B", "B", "B", "C", "C", "C"]
+    return pl.DataFrame({
+        "__row_id__": list(range(len(names))),
+        "name": names,
+        col: names,
+        "__block_key__": blocks,
+    })
+
+
+def _mk() -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="t", type="weighted", threshold=0.7,
+        fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+    )
+
+
+def _blocking() -> BlockingConfig:
+    return BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["name"])])
+
+
+def _run(monkeypatch, min_pairs: str) -> list[tuple[int, int, float]]:
+    monkeypatch.setenv("GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS", min_pairs)
+    return score_buckets(_prepared(), _blocking(), _mk(), matched_pairs=set())
+
+
+def _keys(pairs):
+    return sorted((min(a, b), max(a, b)) for a, b, _ in pairs)
+
+
+def test_sequential_and_rayon_paths_agree(monkeypatch):
+    rayon = _run(monkeypatch, "0")          # 0 -> always rayon
+    seq = _run(monkeypatch, "100000000000")  # huge -> always sequential
+    assert _keys(seq) == _keys(rayon), (
+        f"seq vs rayon pair-set mismatch:\n  seq={seq}\n  rayon={rayon}"
+    )
+    # Scores agree pair-for-pair too.
+    for (sa, sb, ss), (ra, rb, rs) in zip(sorted(seq), sorted(rayon)):
+        assert (sa, sb) == (ra, rb)
+        assert ss == pytest.approx(rs, abs=1e-9)
+
+
+def test_both_paths_match_slow_path(monkeypatch):
+    """Both kernel paths must match find_fuzzy_matches (the source of truth)."""
+    df = _prepared()
+    slow = find_fuzzy_matches(df, _mk(), exclude_pairs=frozenset(), pre_scored_pairs=None)
+    slow_keys = _keys(slow)
+    assert _keys(_run(monkeypatch, "0")) == slow_keys
+    assert _keys(_run(monkeypatch, "100000000000")) == slow_keys

--- a/packages/python/goldenmatch/tests/test_native_block_seq_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_block_seq_parity.py
@@ -10,6 +10,13 @@ rayon, huge = always sequential), which lets this test exercise BOTH paths on
 the same input and assert they agree -- and that both agree with the Python
 slow path (the source of truth).
 
+The fixture is a SINGLE block (constant blocking key) with mixed similar /
+dissimilar names. score_buckets rebuilds __block_key__ from the blocking config,
+so a constant key puts every row in one block -> the block is the whole frame,
+directly comparable to find_fuzzy_matches (which scores the whole frame). Names
+differ within the block so scoring is non-trivial and the threshold actually
+filters.
+
 Requires the native kernel; skipped on pure-Python.
 """
 from __future__ import annotations
@@ -37,21 +44,16 @@ pytestmark = pytest.mark.skipif(
 
 
 def _prepared() -> pl.DataFrame:
-    # Three blocks of near-duplicate names so each block emits several pairs,
-    # plus a few non-matches so the threshold actually filters.
+    # One block (constant "blk") of mixed names: alice/alica/alise are mutually
+    # similar (jw > 0.7 -> pairs), robert/robbert pair, xavier matches nobody.
     field = MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)
     col = _xform_sig(field)
-    names = [
-        "alice", "alica", "alise",      # block A (similar -> pairs)
-        "robert", "robbert", "rupert",  # block B
-        "xavier", "yvonne", "zelda",    # block C (dissimilar -> few/no pairs)
-    ]
-    blocks = ["A", "A", "A", "B", "B", "B", "C", "C", "C"]
+    names = ["alice", "alica", "alise", "robert", "robbert", "xavier"]
     return pl.DataFrame({
         "__row_id__": list(range(len(names))),
         "name": names,
         col: names,
-        "__block_key__": blocks,
+        "blk": ["X"] * len(names),
     })
 
 
@@ -63,7 +65,8 @@ def _mk() -> MatchkeyConfig:
 
 
 def _blocking() -> BlockingConfig:
-    return BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["name"])])
+    # Block on the constant column so the whole frame is one block.
+    return BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["blk"])])
 
 
 def _run(monkeypatch, min_pairs: str) -> list[tuple[int, int, float]]:
@@ -76,8 +79,9 @@ def _keys(pairs):
 
 
 def test_sequential_and_rayon_paths_agree(monkeypatch):
-    rayon = _run(monkeypatch, "0")          # 0 -> always rayon
+    rayon = _run(monkeypatch, "0")           # 0 -> always rayon
     seq = _run(monkeypatch, "100000000000")  # huge -> always sequential
+    assert _keys(rayon), "fixture must emit pairs or the parity check is vacuous"
     assert _keys(seq) == _keys(rayon), (
         f"seq vs rayon pair-set mismatch:\n  seq={seq}\n  rayon={rayon}"
     )
@@ -88,9 +92,13 @@ def test_sequential_and_rayon_paths_agree(monkeypatch):
 
 
 def test_both_paths_match_slow_path(monkeypatch):
-    """Both kernel paths must match find_fuzzy_matches (the source of truth)."""
-    df = _prepared()
-    slow = find_fuzzy_matches(df, _mk(), exclude_pairs=frozenset(), pre_scored_pairs=None)
+    """Both kernel paths must match find_fuzzy_matches (the source of truth).
+    Valid here because the single-block fixture makes score_buckets score the
+    whole frame, exactly what find_fuzzy_matches does."""
+    slow = find_fuzzy_matches(
+        _prepared(), _mk(), exclude_pairs=frozenset(), pre_scored_pairs=None
+    )
     slow_keys = _keys(slow)
+    assert slow_keys, "fixture must emit pairs or the parity check is vacuous"
     assert _keys(_run(monkeypatch, "0")) == slow_keys
     assert _keys(_run(monkeypatch, "100000000000")) == slow_keys

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "goldenmatch-native"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "arrow",
  "blake2",

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldenmatch-native"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-native"
-version = "0.1.2"
+version = "0.1.3"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -11,4 +11,13 @@ separately and is pulled in via ``pip install goldenmatch[native]``.
 from . import _native as _native  # the compiled abi3 extension module
 
 __all__ = ["_native"]
-__version__ = "0.1.0"
+
+# Read the version from the installed distribution metadata (maturin sets it
+# from pyproject `[project].version`) so it can never drift from the wheel --
+# a hardcoded literal reported 0.1.0 on the 0.1.2 wheel (issue #688 follow-up).
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("goldenmatch-native")
+except PackageNotFoundError:  # source checkout without installed dist metadata
+    __version__ = "0.1.3"

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -313,41 +313,85 @@ pub fn score_block_pairs_arrow(
         offset += size;
     }
 
-    Ok(py.allow_threads(|| {
-        spans
-            .par_iter()
-            .flat_map_iter(|&(offset, size)| {
-                let mut local: Vec<(i64, i64, f64)> = Vec::new();
-                if size >= 2 {
-                    let end = offset + size;
-                    for i in offset..end - 1 {
-                        let ri = row_ids.value(i);
-                        for j in (i + 1)..end {
-                            let rj = row_ids.value(j);
-                            let pair_key = if ri < rj { (ri, rj) } else { (rj, ri) };
-                            if exclude_ref.contains(&pair_key) {
-                                continue;
-                            }
-                            let mut score_sum = 0.0_f64;
-                            let mut weight_sum = 0.0_f64;
-                            for f in 0..n_fields {
-                                if let (Some(a), Some(b)) = (fields[f].get(i), fields[f].get(j)) {
-                                    score_sum += score_one(scorer_ids[f], a, b) * weights[f];
-                                    weight_sum += weights[f];
-                                }
-                            }
-                            if weight_sum > 0.0 {
-                                let combined = score_sum / total_weight;
-                                if combined >= threshold {
-                                    local.push((pair_key.0, pair_key.1, combined));
-                                }
-                            }
+    // Per-block scorer, shared by the sequential and rayon paths so the two can
+    // never diverge. Borrows only Sync data (the arrow arrays, the exclude set,
+    // the weight/scorer slices) and holds no mutable state, so it is safe to
+    // call from rayon workers AND from a plain sequential loop.
+    let score_span = |offset: usize, size: usize| -> Vec<(i64, i64, f64)> {
+        let mut local: Vec<(i64, i64, f64)> = Vec::new();
+        if size >= 2 {
+            let end = offset + size;
+            for i in offset..end - 1 {
+                let ri = row_ids.value(i);
+                for j in (i + 1)..end {
+                    let rj = row_ids.value(j);
+                    let pair_key = if ri < rj { (ri, rj) } else { (rj, ri) };
+                    if exclude_ref.contains(&pair_key) {
+                        continue;
+                    }
+                    let mut score_sum = 0.0_f64;
+                    let mut weight_sum = 0.0_f64;
+                    for f in 0..n_fields {
+                        if let (Some(a), Some(b)) = (fields[f].get(i), fields[f].get(j)) {
+                            score_sum += score_one(scorer_ids[f], a, b) * weights[f];
+                            weight_sum += weights[f];
+                        }
+                    }
+                    if weight_sum > 0.0 {
+                        let combined = score_sum / total_weight;
+                        if combined >= threshold {
+                            local.push((pair_key.0, pair_key.1, combined));
                         }
                     }
                 }
-                local
-            })
-            .collect()
+            }
+        }
+        local
+    };
+
+    // issue #688: rayon's blocking `collect` parks the calling thread on a
+    // `LockLatch` futex that makes near-zero forward progress on some Linux
+    // runners (ubuntu-latest-xlarge / EPYC) -- a sub-second scoring job turned
+    // into ~190s of futex wait with zero CPU. The kernel's internal rayon is
+    // also redundant in the common case: the Python caller (`score_buckets`)
+    // already fans buckets across a ThreadPoolExecutor with the GIL released
+    // here, so each kernel call is one of N concurrent calls. So score
+    // small/medium calls in the CALLING thread (no rayon, no latch), and only
+    // dispatch to rayon when a single call carries enough intra-call work that
+    // the parallel speedup outweighs the dispatch (the rare few-huge-buckets
+    // shape). Gate on the candidate-pair count; tune/override via
+    // GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS (default 20M, 0 = always rayon, a very
+    // large value = always sequential). Both paths walk spans in order, so the
+    // emitted (min,max) pair sequence is byte-identical either way (parity
+    // asserted in tests/test_native_block_seq_parity.py).
+    let total_pairs: u128 = block_sizes
+        .iter()
+        .map(|&s| {
+            let s = s as u128;
+            if s >= 2 {
+                s * (s - 1) / 2
+            } else {
+                0
+            }
+        })
+        .sum();
+    let rayon_min_pairs: u128 = std::env::var("GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(20_000_000);
+
+    Ok(py.allow_threads(|| {
+        if total_pairs >= rayon_min_pairs {
+            spans
+                .par_iter()
+                .flat_map_iter(|&(offset, size)| score_span(offset, size))
+                .collect()
+        } else {
+            spans
+                .iter()
+                .flat_map(|&(offset, size)| score_span(offset, size))
+                .collect()
+        }
     }))
 }
 


### PR DESCRIPTION
## The real root cause of #688

The stale-wheel fix (#689, republished 0.1.2) shipped correctly but **did not move the wall** — confirmed in [the issue](https://github.com/benseverndev-oss/goldenmatch/issues/688#issuecomment-4608134587) by py-spy `--native` on `ubuntu-latest-xlarge` (EPYC 9V74): ~419s (the entire `bucket_score` wall) parked in `rayon_core::latch::LockLatch::wait_and_reset` (a futex), with **zero CPU work** anywhere. `score_one` barely registers in the flamegraph. The Arc-handle exclude path was already engaged on 0.1.2, so the per-call HashSet rebuild was never the bottleneck.

The kernel's internal `par_iter().collect()` blocks the calling thread on a latch that makes near-zero forward progress on this Linux env, turning a sub-second scoring job into ~190s.

Note: the 25M bench that "worked" (bucket_score 39s) is dated 2026-05-19; `score_block_pairs_arrow` landed 2026-05-26 (#514) — so that bench never used this kernel. The kernel's rayon path has only ever been **parity**-validated, never **perf**-validated on a Linux runner.

## Fix

The kernel's internal rayon is redundant in the common case: the Python caller (`score_buckets`) already fans buckets across a `ThreadPoolExecutor` with the GIL released here, so each kernel call is one of N concurrent calls.

- Factor the per-block scorer into one closure shared by both paths (they can't diverge).
- Score small/medium calls **in the calling thread** (no rayon, no latch); dispatch to rayon only above a candidate-pair threshold (default 20M, tunable via `GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS`; `0` = always rayon, huge = always sequential). Both paths walk spans in order → byte-identical `(min,max)` pairs.
- `goldenmatch_native.__version__` now reads from installed dist metadata (was a hardcoded `0.1.0` that reported stale on the 0.1.2 wheel — flagged in the issue).
- Bump to `0.1.3` (pyproject + Cargo) for the republish.

**Refutes** the GIL-reacquire-in-rayon-closure hypothesis: the closure touches zero Python objects (arrow arrays, Rust `HashSet`, rapidfuzz-rs), so there's no GIL for a worker to re-enter.

## Verification status

- ✅ `cargo check --release` + `cargo clippy` pass.
- ✅ `tests/test_native_block_seq_parity.py` forces each path via the env gate and asserts the sequential and rayon paths (and `find_fuzzy_matches`) emit identical pairs.
- ⏳ **NOT yet perf-verified on Linux.** The 44x wall fix needs a Linux run of the #688 repro (or a CI bench) before this is claimed resolved. **Holding merge until that measurement exists** — not repeating the "verified it shipped ≠ verified it works" miss from #689.

Refs #688