### PR TITLE
perf(cluster): id_prep as group_by.agg (engine-plannable)

### DIFF
--- a/.github/workflows/bench-pipeline-complete-path.yml
+++ b/.github/workflows/bench-pipeline-complete-path.yml
@@ -23,11 +23,14 @@ on:
       runs:
         description: "Repetitions per measurement (median)"
         default: "3"
+      prof:
+        description: "true = cProfile both variants at np[0] (hotspot hunting; no perf table)"
+        default: "false"
 
 jobs:
   bench:
     runs-on: large-new-64GB
-    timeout-minutes: 30
+    timeout-minutes: 85
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
@@ -45,6 +48,7 @@ jobs:
           set -o pipefail
           uv run python packages/python/goldenmatch/scripts/bench_pipeline_complete_path.py \
             --np "${{ inputs.np }}" --runs "${{ inputs.runs }}" \
+            ${{ inputs.prof == 'true' && '--profile' || '' }} \
             --output .profile_tmp/pipeline_complete_path.json | tee /tmp/pipeline_complete_path.txt
           { echo '## bench-pipeline-complete-path'; echo '```'; cat /tmp/pipeline_complete_path.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
@@ -29,21 +29,26 @@ def _bucket_pairs(
 
 
 class ClusterPairScores:
-    __slots__ = ("_by_cid", "_partitions")
+    __slots__ = ("_by_cid", "_agg_frame", "_cid_to_row")
 
     def __init__(
         self,
         by_cid: dict[int, dict[tuple[int, int], float]] | None = None,
-        partitions: dict[int, Any] | None = None,
+        agg_frame: Any | None = None,
+        cid_to_row: dict[int, int] | None = None,
     ):
         # Two backings, mutually exclusive in practice:
         #  - _by_cid: legacy resident dict-of-dicts (from_pairs/from_cluster_dict)
-        #  - _partitions: Stage-2 frame-backed, one small Polars frame per cid;
-        #    accessors build the per-cid dict on demand so the global
-        #    100M-entry dict-of-dicts is NEVER resident.
-        # __slots__ raises on unset access, so set BOTH every time.
+        #  - _agg_frame + _cid_to_row: engine-plannable frame-backed view. ONE
+        #    group_by("cid").agg(...) frame (one row per cid, edges as list-columns
+        #    in first-occurrence order) PLUS a cheap cid->row-index dict
+        #    (num_clusters entries). Accessors slice the row and build the per-cid
+        #    dict on demand, so the global 100M-entry dict-of-dicts is NEVER
+        #    resident and no per-cid frame partition is materialized at build time.
+        # __slots__ raises on unset access, so set ALL three every time.
         self._by_cid = by_cid
-        self._partitions = partitions
+        self._agg_frame = agg_frame
+        self._cid_to_row = cid_to_row
 
     @classmethod
     def from_cluster_dict(cls, clusters: dict[int, dict]) -> ClusterPairScores:
@@ -101,11 +106,18 @@ class ClusterPairScores:
         canonical pairs.
 
         Stage-1: vectorized via a Polars join instead of the ``_bucket_pairs``
-        Python loop (10x faster at 100M pairs). Builds the SAME ``_by_cid`` dict:
+        Python loop (10x faster at 100M pairs). Selects the SAME kept edges:
         a pair is kept iff BOTH endpoints map to the same cid; key is ``(a, b)``
         EXACTLY as given (NEVER canonicalized); key insertion order = first
         occurrence; value = score at the LAST occurrence (LAST-WINS, NOT max);
         self-pairs ``(a, a)`` are kept.
+
+        Stage-2: the VIEW BUILD is a single engine-plannable
+        ``group_by("cid").agg(...)`` producing ONE frame -- one row per cid, edges
+        as list-columns in first-occurrence order -- plus a cheap
+        ``cid -> row-index`` dict. Per-cluster dict materialization is DEFERRED to
+        the accessors (built on demand, O(cluster size)). The global dict-of-dicts
+        is NEVER resident.
         """
         # all_pairs is the raw list[(a,b,s)] AS-GIVEN. NEVER canonicalize.
         a_col, b_col, s_col = [], [], []
@@ -138,43 +150,52 @@ class ClusterPairScores:
                 pl.col("__i__").min().alias("first_i"),
                 # LAST-WINS: score at the last occurrence by input order.
                 # NEVER pl.col("s").max().
-                pl.col("s").sort_by("__i__").last().alias("last_score"),
+                pl.col("s").sort_by("__i__").last().alias("last_s"),
             )
             # REQUIRED: group_by output order is undefined; first-occurrence
             # insertion order is part of the byte-identical contract.
             .sort("cid", "first_i")
         )
-        # Stage-2: STOP materializing the global dict-of-dicts. Keep one small
-        # Polars frame per cid; the accessors build the per-cid dict on demand.
-        # ``g`` is already deduped (group_by) + ordered (sort cid, first_i), so
-        # dropping first_i and partitioning by cid preserves first-occurrence
-        # row order and last-wins scores -- byte-identical to Stage-1 / from_pairs.
-        view_df = g.select("cid", "a", "b", pl.col("last_score").alias("s"))
-        raw = view_df.partition_by("cid", as_dict=True)
-        # Normalize key shape across Polars versions (current=tuple (cid,),
-        # older=scalar cid) so lookups always use a scalar int cid.
-        partitions = {
-            int(k[0] if isinstance(k, tuple) else k): v for k, v in raw.items()
-        }
-        return cls(partitions=partitions)
+        # Stage-2 (engine-plannable): collapse the per-pair rows into ONE frame,
+        # one row per cid, edges as list-columns. ``maintain_order=True`` preserves
+        # the prior ``sort("cid", "first_i")`` row order, so within each cid the
+        # a/b/last_s lists are in first-occurrence order -- byte-identical to
+        # Stage-1 / from_pairs. The BUILD cost is just this group_by + a small
+        # cid->row index; the per-cid dict is built lazily in the accessors. The
+        # global dict-of-dicts is NEVER resident and NO per-cid frame partition is
+        # materialized.
+        agg = g.group_by("cid", maintain_order=True).agg(
+            pl.col("a"), pl.col("b"), pl.col("last_s")
+        )
+        # num_clusters ints (cheap). Do NOT .to_list() the edge list-columns here;
+        # the accessors slice them on demand.
+        cid_to_row = dict(zip(agg["cid"].to_list(), range(agg.height)))
+        return cls(agg_frame=agg, cid_to_row=cid_to_row)
+
+    def _row_edges(self, row: int) -> tuple[list, list, list]:
+        # Slice ONE row of the agg frame and pull its three edge list-columns.
+        # The lists are in first-occurrence order (maintain_order=True at build).
+        r = self._agg_frame.row(row, named=True)
+        return r["a"], r["b"], r["last_s"]
 
     def for_cluster(self, cid: int) -> dict[tuple[int, int], float]:
-        if self._partitions is not None:
-            f = self._partitions.get(int(cid))
-            if f is None:
+        if self._agg_frame is not None:
+            row = self._cid_to_row.get(int(cid))
+            if row is None:
                 return {}
-            d: dict[tuple[int, int], float] = {}
-            for a, b, s in f.select("a", "b", "s").iter_rows():
-                d[(int(a), int(b))] = float(s)
-            return d
+            al, bl, sl = self._row_edges(row)
+            # list order == first-occurrence order; last value within a key
+            # already collapsed by the build (last-wins).
+            return {(int(a), int(b)): float(s) for a, b, s in zip(al, bl, sl)}
         return self._by_cid.get(cid, {})
 
     def iter_clusters(self) -> Iterator[tuple[int, Iterable[tuple[int, int, float]]]]:
-        if self._partitions is not None:
-            for cid, f in self._partitions.items():
+        if self._agg_frame is not None:
+            for cid, al, bl, sl in self._agg_frame.select(
+                "cid", "a", "b", "last_s"
+            ).iter_rows():
                 yield int(cid), [
-                    (int(a), int(b), float(s))
-                    for a, b, s in f.select("a", "b", "s").iter_rows()
+                    (int(a), int(b), float(s)) for a, b, s in zip(al, bl, sl)
                 ]
         else:
             for cid, ps in self._by_cid.items():
@@ -182,7 +203,7 @@ class ClusterPairScores:
 
     def score_for(self, cid: int, a: int, b: int) -> float | None:
         key = (min(a, b), max(a, b))
-        if self._partitions is not None:
+        if self._agg_frame is not None:
             # Canonical QUERY key vs AS-GIVEN stored keys: a pair stored (7,3)
             # is intentionally MISSED by score_for(cid, 3, 7) -> None. Preserved.
             return self.for_cluster(cid).get(key)

--- a/packages/python/goldenmatch/scripts/bench_pipeline_complete_path.py
+++ b/packages/python/goldenmatch/scripts/bench_pipeline_complete_path.py
@@ -8,25 +8,26 @@ that decides whether Phase-2's columnar cutover lands the RSS win.
 Two variants, each in its OWN subprocess (clean peak RSS):
 
   * ``columnar`` (GOLDENMATCH_CLUSTER_FRAMES_OUT=1): build pairs ->
-    ``build_cluster_frames`` -> ``build_golden_records_from_frames`` ->
-    ``resolve_clusters(cluster_frames=..., pair_score_view=ClusterPairScores
-    .from_frames(...))``. No per-cluster ``dict[int, dict]`` is materialized in
-    the stage.
+    ``build_cluster_frames`` -> ``build_golden_records_from_frames`` -> identity
+    cluster-rep prep (``ClusterPairScores.from_frames`` + per-cluster member iter
+    via ``assignments.group_by``). No per-cluster ``dict[int, dict]`` is
+    materialized in the stage.
 
   * ``legacy`` (no gate): build pairs -> ``build_clusters`` (dict) ->
-    ``build_golden_records_batch`` -> ``resolve_clusters(clusters_dict, ...,
-    pair_score_view=ClusterPairScores.from_pairs(...))``. The dict is live for
-    the whole stage.
+    ``build_golden_records_batch`` -> identity cluster-rep prep
+    (``ClusterPairScores.from_pairs`` + ``clusters.items()`` iter). The dict is
+    live for the whole stage.
 
-CONFOUND CONTROL (from the SP-C spec). The pair-score view
-(``from_pairs`` / ``from_frames``) AND the identity store I/O + ``df.to_dicts()``
-inside ``resolve_clusters`` are present on BOTH variants and are
-frames-INVARIANT -- they don't bias the columnar-vs-legacy DELTA but they can
-DOMINATE/MASK it. We therefore segment the stage wall into build / golden /
-identity and report each, plus the overall peak RSS, and print a note that the
-store I/O + view are shared. The >=30% RSS criterion applies to the
-cluster-representation delta (build + golden + identity cluster-iteration), NOT
-the store.
+CONFOUND CONTROL (from the SP-C spec). The ``id_prep`` segment measures ONLY the
+identity CLUSTER-REPRESENTATION work SP-C changed (the view + the per-cluster
+member iteration the resolver loop drives). The full ``resolve_clusters`` +
+``IdentityStore`` resolution is DELIBERATELY EXCLUDED: its store I/O is a shared,
+frames-invariant confound that DOMINATES wall (a near-quadratic SQLite upsert
+path -- it ran ~20 min at 1M before this reshape) and would MASK the
+cluster-representation delta. Identity byte-identical parity is already proven by
+the SP-C gates; the verdict axis here is the peak RSS over build + golden +
+id_prep (where the dict-vs-frames representation delta lives), plus the 100M
+feasibility (does columnar complete where the legacy dict OOMs).
 
 At 100M the ``legacy`` variant is EXPECTED to OOM. The legacy child's non-zero
 exit / OOM is CAUGHT and recorded as ``"legacy OOM"`` in the table rather than
@@ -62,20 +63,22 @@ def _make_pairs_df(n_pairs_target: int):
     oversized) is identical -- this exercises the bulk-RSS axis, which is where
     the dict-vs-frames cluster representation delta lives.
     """
+    import numpy as np
     import polars as pl
 
     k = 5
     per = k * (k - 1) // 2  # 10
     m = max(1, n_pairs_target // per)
-    a_col: list[int] = []
-    b_col: list[int] = []
-    for c in range(m):
-        base = c * k
-        for i in range(k):
-            for j in range(i + 1, k):
-                a_col.append(base + i)
-                b_col.append(base + j)
-    s_col = [0.95] * len(a_col)
+    # VECTORIZED (the pure-Python c*i*j loop was ~20 min at 100M). The 10 within-
+    # cluster upper-triangle (i,j) offsets, in the SAME cluster-major order the
+    # loop emitted, broadcast over `base = arange(m)*k` -> byte-identical pair
+    # order to the loop, no Python iteration.
+    ioff = np.array([i for i in range(k) for _j in range(i + 1, k)], dtype=np.int64)
+    joff = np.array([j for i in range(k) for j in range(i + 1, k)], dtype=np.int64)
+    base = (np.arange(m, dtype=np.int64) * k)[:, None]
+    a_col = (base + ioff[None, :]).ravel()
+    b_col = (base + joff[None, :]).ravel()
+    s_col = np.full(m * per, 0.95, dtype=np.float64)
     return pl.DataFrame(
         {"id_a": a_col, "id_b": b_col, "score": s_col},
         schema={"id_a": pl.Int64, "id_b": pl.Int64, "score": pl.Float64},
@@ -134,10 +137,12 @@ def _golden_rules():
     return GoldenRulesConfig(default_strategy="most_complete")
 
 
-def _run_child(variant: str, n_pairs: int, runs: int) -> int:
+def _run_child(variant: str, n_pairs: int, runs: int, profile: bool = False) -> int:
     """Drive the real cluster -> golden -> identity stage for one variant, once
-    per measured run, segmenting the wall into build / golden / identity."""
-    import tempfile
+    per measured run, segmenting the wall into build / golden / id_prep.
+
+    profile=True: cProfile a single _one_run and dump the top cumulative- and
+    self-time functions instead of the perf loop (hotspot hunting)."""
 
     import polars as pl  # noqa: F401
     from goldenmatch.core.cluster import (
@@ -149,8 +154,13 @@ def _run_child(variant: str, n_pairs: int, runs: int) -> int:
         build_golden_records_batch,
         build_golden_records_from_frames,
     )
-    from goldenmatch.identity.resolve import resolve_clusters
-    from goldenmatch.identity.store import IdentityStore
+    # NOTE: identity is measured as its CLUSTER-REPRESENTATION prep only -- the
+    # ClusterPairScores view (from_frames vs from_pairs) + the per-cluster member
+    # iteration SP-C changed. The full resolve_clusters store I/O is DELIBERATELY
+    # excluded: it's a shared, frames-invariant confound that dominates wall (near-
+    # quadratic SQLite upserts at scale) and masks the cluster-representation RSS
+    # delta this bench measures. Identity byte-identical parity is already proven by
+    # the SP-C gates; here we only need the representation cost.
 
     pairs_df = _make_pairs_df(n_pairs)
     pairs_list = _pairs_list_from_df(pairs_df)
@@ -167,105 +177,106 @@ def _run_child(variant: str, n_pairs: int, runs: int) -> int:
         os.environ.pop("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", None)
 
     def _one_run() -> tuple[float, float, float]:
-        """Returns (build_s, golden_s, identity_s) for a single stage pass.
+        """Returns (build_s, golden_s, id_prep_s) for a single stage pass.
 
-        A fresh tmp SQLite IdentityStore per pass so identity write I/O is
-        measured the same way on both variants and runs don't accumulate state.
+        id_prep = the identity CLUSTER-REPRESENTATION work SP-C changed: the
+        ClusterPairScores view (from_frames vs from_pairs) + the per-cluster
+        member iteration the resolver loop drives (frames group_by vs
+        clusters.items()). NO IdentityStore / resolve_clusters: the store I/O is a
+        shared, frames-invariant confound (near-quadratic SQLite upserts at scale)
+        that masks the representation delta. Peak RSS over build+golden+id_prep is
+        the cluster-representation cost -- the verdict axis.
         """
-        store_dir = tempfile.mkdtemp(prefix="gm_bench_id_")
-        store_path = os.path.join(store_dir, "identity.db")
-        store = IdentityStore(backend="sqlite", path=store_path)
-        try:
-            if columnar:
-                # --- build (frames) ---
-                t0 = time.perf_counter()
-                frames = build_cluster_frames(
-                    pairs_list,
-                    all_ids=None,
-                    max_cluster_size=100,
-                    weak_cluster_threshold=0.3,
-                    auto_split=True,
-                )
-                build_s = time.perf_counter() - t0
+        if columnar:
+            # --- build (frames) ---
+            t0 = time.perf_counter()
+            frames = build_cluster_frames(
+                pairs_list,
+                all_ids=None,
+                max_cluster_size=100,
+                weak_cluster_threshold=0.3,
+                auto_split=True,
+            )
+            build_s = time.perf_counter() - t0
 
-                # --- golden (from frames) ---
-                t1 = time.perf_counter()
-                build_golden_records_from_frames(
-                    source_df, frames, rules,
-                    quality_scores=None, provenance=False,
-                )
-                golden_s = time.perf_counter() - t1
+            # --- golden (from frames) ---
+            t1 = time.perf_counter()
+            build_golden_records_from_frames(
+                source_df, frames, rules,
+                quality_scores=None, provenance=False,
+            )
+            golden_s = time.perf_counter() - t1
 
-                # --- identity (frames + from_frames view) ---
-                # The view + store I/O + df.to_dicts() are SHARED with legacy and
-                # frames-invariant (confound control note in the module docstring).
-                view = ClusterPairScores.from_frames(
-                    frames.assignments, pairs_list,
-                )
-                t2 = time.perf_counter()
-                resolve_clusters(
-                    cluster_frames=frames,
-                    df=source_df,
-                    store=store,
-                    run_name="bench",
-                    pair_score_view=view,
-                )
-                identity_s = time.perf_counter() - t2
-            else:
-                # --- build (dict) ---
-                t0 = time.perf_counter()
-                clusters = build_clusters(
-                    pairs_list,
-                    max_cluster_size=100,
-                    weak_cluster_threshold=0.3,
-                    auto_split=True,
-                )
-                build_s = time.perf_counter() - t0
+            # --- identity cluster-rep prep (view + per-cluster member iter) ---
+            t2 = time.perf_counter()
+            view = ClusterPairScores.from_frames(frames.assignments, pairs_list)
+            _agg = frames.assignments.group_by("cluster_id").agg(pl.col("member_id"))
+            members_by_cid = dict(
+                zip(_agg["cluster_id"].to_list(), _agg["member_id"].to_list())
+            )
+            id_prep_s = time.perf_counter() - t2
+            _keepalive = (frames, view, members_by_cid)  # hold the rep for peak RSS
+            del _keepalive
+        else:
+            # --- build (dict) ---
+            t0 = time.perf_counter()
+            clusters = build_clusters(
+                pairs_list,
+                max_cluster_size=100,
+                weak_cluster_threshold=0.3,
+                auto_split=True,
+            )
+            build_s = time.perf_counter() - t0
 
-                # --- golden (dict -> multi_df) ---
-                t1 = time.perf_counter()
-                eligible = [
-                    (cid, info) for cid, info in clusters.items()
-                    if info["size"] > 1 and not info["oversized"]
-                ]
-                row_to_cluster: dict[int, int] = {}
-                for cid, info in eligible:
-                    for mid in info["members"]:
-                        row_to_cluster[mid] = cid
-                if row_to_cluster:
-                    multi_df = source_df.filter(
-                        pl.col("__row_id__").is_in(list(row_to_cluster.keys()))
-                    ).with_columns(
-                        pl.col("__row_id__").replace_strict(
-                            list(row_to_cluster.keys()),
-                            list(row_to_cluster.values()),
-                            return_dtype=pl.Int64,
-                        ).alias("__cluster_id__")
-                    )
-                    build_golden_records_batch(
-                        multi_df, rules, provenance=False,
-                    )
-                golden_s = time.perf_counter() - t1
-
-                # --- identity (dict + from_pairs view) ---
-                view = ClusterPairScores.from_pairs(pairs_list, clusters)
-                t2 = time.perf_counter()
-                resolve_clusters(
-                    clusters=clusters,
-                    df=source_df,
-                    store=store,
-                    run_name="bench",
-                    pair_score_view=view,
+            # --- golden (dict -> multi_df) ---
+            t1 = time.perf_counter()
+            eligible = [
+                (cid, info) for cid, info in clusters.items()
+                if info["size"] > 1 and not info["oversized"]
+            ]
+            row_to_cluster: dict[int, int] = {}
+            for cid, info in eligible:
+                for mid in info["members"]:
+                    row_to_cluster[mid] = cid
+            if row_to_cluster:
+                multi_df = source_df.filter(
+                    pl.col("__row_id__").is_in(list(row_to_cluster.keys()))
+                ).with_columns(
+                    pl.col("__row_id__").replace_strict(
+                        list(row_to_cluster.keys()),
+                        list(row_to_cluster.values()),
+                        return_dtype=pl.Int64,
+                    ).alias("__cluster_id__")
                 )
-                identity_s = time.perf_counter() - t2
-            return build_s, golden_s, identity_s
-        finally:
-            try:
-                store.close()
-            except Exception:
-                pass
+                build_golden_records_batch(multi_df, rules, provenance=False)
+            golden_s = time.perf_counter() - t1
+
+            # --- identity cluster-rep prep (view + clusters.items() iter) ---
+            t2 = time.perf_counter()
+            view = ClusterPairScores.from_pairs(pairs_list, clusters)
+            members_by_cid = {cid: info["members"] for cid, info in clusters.items()}
+            id_prep_s = time.perf_counter() - t2
+            _keepalive = (clusters, view, members_by_cid)  # hold the rep for peak RSS
+            del _keepalive
+        return build_s, golden_s, id_prep_s
 
     _one_run()  # warm
+
+    if profile:
+        import cProfile
+        import io
+        import pstats
+        pr = cProfile.Profile()
+        pr.enable()
+        _one_run()
+        pr.disable()
+        for sort, n in (("cumulative", 35), ("tottime", 25)):
+            s = io.StringIO()
+            pstats.Stats(pr, stream=s).sort_stats(sort).print_stats(n)
+            print(f"=== PROFILE [{variant}] np={actual_pairs:,} ({sort}) ===",
+                  flush=True)
+            print(s.getvalue(), flush=True)
+        return 0
 
     build_walls: list[float] = []
     golden_walls: list[float] = []
@@ -356,6 +367,9 @@ def main() -> int:
     ap.add_argument("--output", default=None)
     ap.add_argument("--child", choices=["legacy", "columnar"], default=None,
                     help="Internal: run a single variant in this process")
+    ap.add_argument("--profile", action="store_true",
+                    help="cProfile both variants at np[0] + dump top "
+                         "cumulative/self-time functions (hotspot hunting).")
     args = ap.parse_args()
 
     runs = max(1, args.runs)
@@ -363,7 +377,16 @@ def main() -> int:
     if args.child is not None:
         nps = [int(x.strip()) for x in args.np.split(",") if x.strip()]
         n = nps[0] if nps else 1000000
-        return _run_child(args.child, n, runs)
+        return _run_child(args.child, n, runs, profile=args.profile)
+
+    if args.profile:
+        nps = [int(x.strip()) for x in args.np.split(",") if x.strip()]
+        n = nps[0] if nps else 5000000
+        print(f"=== HOTSPOT PROFILE @ np={n:,} (columnar then legacy) ===",
+              flush=True)
+        _run_child("columnar", n, 1, profile=True)
+        _run_child("legacy", n, 1, profile=True)
+        return 0
 
     nps = [int(x.strip()) for x in args.np.split(",") if x.strip()]
 
@@ -375,10 +398,11 @@ def main() -> int:
 
     print("recorded DATA; binding Phase-2 verdict (legacy dict vs columnar "
           "A+B+C complete path).", flush=True)
-    print("NOTE: the pair-score view + identity store I/O + df.to_dicts() are "
-          "SHARED on both variants and frames-invariant; the >=30% RSS "
-          "criterion applies to the cluster-representation delta (build + "
-          "golden + identity cluster-iteration), not the store.", flush=True)
+    print("NOTE: id_prep = identity cluster-rep prep (view + per-cluster iter) "
+          "ONLY; the full resolve_clusters + IdentityStore I/O is EXCLUDED "
+          "(shared, frames-invariant, near-quadratic at scale). The >=30% RSS "
+          "criterion applies to the cluster-representation delta (build + golden "
+          "+ id_prep), plus the 100M legacy-OOM feasibility.", flush=True)
 
     sane_n = 2000
     print(f"membership sanity (np={sane_n:,}) ...", flush=True)
@@ -401,10 +425,15 @@ def main() -> int:
             row: dict[str, Any] = {"n_pairs": n}
 
             if columnar.get("oom"):
-                # Columnar OOM at this scale is itself a verdict (Phase-2 didn't
-                # land the feasibility win).
-                row["columnar"] = {"oom": True,
-                                   "returncode": columnar.get("returncode")}
+                # rc in (-9, 137) is a real OOM (SIGKILL). Any other non-zero is a
+                # CODE ERROR -- surface the child stderr so it isn't mislabeled.
+                _rc = columnar.get("returncode")
+                _kind = "OOM" if _rc in (-9, 137) else "ERROR"
+                row["columnar"] = {"oom": True, "returncode": _rc, "kind": _kind}
+                print(f"    pairs={n:,}  columnar {_kind} (rc={_rc})", flush=True)
+                if _kind == "ERROR":
+                    print(f"--- columnar child stderr ---\n"
+                          f"{columnar.get('stderr_tail', '')}", flush=True)
             else:
                 row["n_pairs"] = columnar["n_pairs"]
                 row["columnar"] = {
@@ -415,10 +444,13 @@ def main() -> int:
                 }
 
             if legacy.get("oom"):
-                row["legacy"] = {"oom": True,
-                                 "returncode": legacy.get("returncode")}
-                print(f"    pairs={n:,}  legacy OOM "
-                      f"(rc={legacy.get('returncode')})", flush=True)
+                _rc = legacy.get("returncode")
+                _kind = "OOM" if _rc in (-9, 137) else "ERROR"
+                row["legacy"] = {"oom": True, "returncode": _rc, "kind": _kind}
+                print(f"    pairs={n:,}  legacy {_kind} (rc={_rc})", flush=True)
+                if _kind == "ERROR":
+                    print(f"--- legacy child stderr ---\n"
+                          f"{legacy.get('stderr_tail', '')}", flush=True)
             else:
                 row["legacy"] = {
                     "build_s": statistics.median(legacy["build_walls"]),
@@ -454,11 +486,12 @@ def main() -> int:
 
     lines = [
         "\n## bench-pipeline-complete-path\n",
-        "Per-variant stage wall (build / golden / identity seconds) + overall "
-        "peak RSS. legacy = dict; columnar = frames-out (A+B+C). The view + "
-        "store I/O + df.to_dicts() are shared/frames-invariant.\n",
+        "Per-variant stage wall (build / golden / id_prep seconds) + overall "
+        "peak RSS. legacy = dict; columnar = frames-out (A+B+C). id_prep = "
+        "identity cluster-rep prep (view + iter); full store resolution "
+        "EXCLUDED (shared, frames-invariant, near-quadratic).\n",
         f"| {'pairs':>12} | {'variant':>8} | {'build s':>9} | {'golden s':>9} "
-        f"| {'identity s':>10} | {'peak RSS MB':>12} |",
+        f"| {'id_prep s':>10} | {'peak RSS MB':>12} |",
         f"| {'-'*12} | {'-'*8} | {'-'*9} | {'-'*9} | {'-'*10} | {'-'*12} |",
     ]
     for r in results:


### PR DESCRIPTION
Rewrites from_frames' view build as a single group_by(cluster_id).agg(...) -> one frame, per-cluster materialization deferred to accessors. The relational shape a query engine can plan (the enabling step for DataFusion+Sail), NOT another RSS micro-opt. Last-wins parity preserved (existing gate). Re-running the §1 complete-path bench to confirm id_prep collapses + 100M flips to ~2x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)