### PR TITLE
feat(df-udf): datafusion-ffi ScalarUDF feasibility gate (spine SP2 Stage A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
               # tests/test_datafusion_ffi_udf.py. A crate-only change must
               # re-trigger that lane so the FFI feasibility gate re-runs.
               - 'packages/rust/extensions/datafusion-udf/**'
+              # Stage B: the FFI scorer UDFs delegate to the shared score-core
+              # crate. A score-core-only change must re-trigger this lane so the
+              # FFI scorer-parity test (vs native) re-runs.
+              - 'packages/rust/extensions/score-core/**'
             python_goldenmatch_postgres:
               - 'packages/python/goldenmatch/tests/test_db.py'
               - 'packages/python/goldenmatch/tests/test_reconcile.py'
@@ -128,6 +132,10 @@ jobs:
               # the Python files it's wired into + the build script.
               - 'packages/rust/extensions/native/**'
               - 'packages/rust/extensions/fingerprint-core/**'
+              # Stage B: the native scorers are now thin shims over the shared
+              # score-core crate. A score-core change alters native behavior, so
+              # re-run the native build + parity suite.
+              - 'packages/rust/extensions/score-core/**'
               - 'packages/python/goldenmatch/goldenmatch/core/_native_loader.py'
               - 'packages/python/goldenmatch/goldenmatch/core/_hashing.py'
               - 'packages/python/goldenmatch/goldenmatch/core/cluster.py'
@@ -238,15 +246,18 @@ jobs:
       # matrix package (the gated files are goldenmatch-only).
       - if: matrix.pkg == 'goldenmatch'
         run: uv run python scripts/check_map_elements.py
-      # DataFusion FFI ScalarUDF feasibility gate (Stage A). Build the
-      # standalone `datafusion-udf` crate into the project venv and install
-      # the Python `datafusion` runtime so tests/test_datafusion_ffi_udf.py can
-      # register the add_one UDF via the PyCapsule FFI bridge. The test HARD-
-      # imports goldenmatch_datafusion_udf (no importorskip), so a build break
-      # here surfaces as a test FAILURE, not a skip — that's the loud guard for
-      # the whole DataFusion spine. goldenmatch-only (the only lane with the
-      # test) and a Rust compile, not a Python import, so it can't trip the
-      # box's import-hang.
+      # DataFusion FFI ScalarUDF gate (Stage B). Build the standalone
+      # `datafusion-udf` crate into the project venv and install the Python
+      # `datafusion` runtime so tests/test_datafusion_ffi_udf.py can register the
+      # native string-scorer UDFs (jaro_winkler / token_sort / levenshtein) via
+      # the PyCapsule FFI bridge and diff them against the `goldenmatch._native`
+      # per-pair scorers (both delegate to the shared score-core crate). The test
+      # HARD-imports goldenmatch_datafusion_udf (no importorskip), so a build
+      # break here surfaces as a test FAILURE, not a skip — that's the loud guard
+      # for the whole DataFusion spine. goldenmatch-only (the only lane with the
+      # test) and a Rust compile, not a Python import, so it can't trip the box's
+      # import-hang. The in-tree `_native` ext (which the parity test HARD-
+      # asserts) is built in a follow-on step below.
       - if: matrix.pkg == 'goldenmatch'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
@@ -267,6 +278,15 @@ jobs:
           uv run --with maturin maturin build --release \
             --manifest-path packages/rust/extensions/datafusion-udf/Cargo.toml --out dist-dfudf
           uv pip install dist-dfudf/*.whl
+      # Stage B: tests/test_datafusion_ffi_udf.py diffs the FFI string scorers
+      # against the per-pair `goldenmatch._native` scorers (both delegate to the
+      # shared score-core crate). The test HARD-asserts native_available(), so
+      # this lane must ALSO build the in-tree `_native` ext — without it the
+      # parity test FAILS (by design). goldenmatch-only; a Rust compile, not a
+      # Python import, so it can't trip the box's import-hang.
+      - name: Build the in-tree native ext for the FFI scorer-parity test (goldenmatch only)
+        if: matrix.pkg == 'goldenmatch'
+        run: uv run python scripts/build_native.py
       # Per-package --ignore lists mirror the pre-fold tuning each repo had
       # (documented in each package's own CLAUDE.md). Without these, packages with
       # known-skip tests would make CI perpetually red and train people to ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,14 +279,10 @@ jobs:
             --manifest-path packages/rust/extensions/datafusion-udf/Cargo.toml --out dist-dfudf
           uv pip install dist-dfudf/*.whl
       # Stage B: tests/test_datafusion_ffi_udf.py diffs the FFI string scorers
-      # against the per-pair `goldenmatch._native` scorers (both delegate to the
-      # shared score-core crate). The test HARD-asserts native_available(), so
-      # this lane must ALSO build the in-tree `_native` ext — without it the
-      # parity test FAILS (by design). goldenmatch-only; a Rust compile, not a
-      # Python import, so it can't trip the box's import-hang.
-      - name: Build the in-tree native ext for the FFI scorer-parity test (goldenmatch only)
-        if: matrix.pkg == 'goldenmatch'
-        run: uv run python scripts/build_native.py
+      # against the Python `rapidfuzz` package (the FFI UDFs delegate to the
+      # shared score-core crate = rapidfuzz 0.5.0; test_native_parity already
+      # proves rust-rapidfuzz == python-rapidfuzz). So this lane does NOT build
+      # `_native` — doing so would pull native-only schema tests into this lane.
       # Per-package --ignore lists mirror the pre-fold tuning each repo had
       # (documented in each package's own CLAUDE.md). Without these, packages with
       # known-skip tests would make CI perpetually red and train people to ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
               - 'uv.lock'
             python_goldenmatch:
               - 'packages/python/goldenmatch/**'
+              # Stage A: the standalone datafusion-ffi UDF crate is built into
+              # the goldenmatch venv in the `python` lane and exercised by
+              # tests/test_datafusion_ffi_udf.py. A crate-only change must
+              # re-trigger that lane so the FFI feasibility gate re-runs.
+              - 'packages/rust/extensions/datafusion-udf/**'
             python_goldenmatch_postgres:
               - 'packages/python/goldenmatch/tests/test_db.py'
               - 'packages/python/goldenmatch/tests/test_reconcile.py'
@@ -233,6 +238,33 @@ jobs:
       # matrix package (the gated files are goldenmatch-only).
       - if: matrix.pkg == 'goldenmatch'
         run: uv run python scripts/check_map_elements.py
+      # DataFusion FFI ScalarUDF feasibility gate (Stage A). Build the
+      # standalone `datafusion-udf` crate into the project venv and install
+      # the Python `datafusion` runtime so tests/test_datafusion_ffi_udf.py can
+      # register the add_one UDF via the PyCapsule FFI bridge. The test HARD-
+      # imports goldenmatch_datafusion_udf (no importorskip), so a build break
+      # here surfaces as a test FAILURE, not a skip — that's the loud guard for
+      # the whole DataFusion spine. goldenmatch-only (the only lane with the
+      # test) and a Rust compile, not a Python import, so it can't trip the
+      # box's import-hang.
+      - if: matrix.pkg == 'goldenmatch'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          components: clippy
+      - if: matrix.pkg == 'goldenmatch'
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/datafusion-udf
+      - name: Install the datafusion runtime + build the FFI UDF crate (goldenmatch only)
+        if: matrix.pkg == 'goldenmatch'
+        run: |
+          uv pip install 'datafusion>=53,<54'
+          # maturin develop drops the compiled goldenmatch_datafusion_udf ext
+          # straight into the active uv venv (mirrors how the standalone
+          # datafusion-ffi-example is built). --uv keeps it inside the venv uv
+          # manages; abi3 means one ext spans 3.11-3.13.
+          uv run --with maturin maturin develop --release \
+            --manifest-path packages/rust/extensions/datafusion-udf/Cargo.toml --uv
       # Per-package --ignore lists mirror the pre-fold tuning each repo had
       # (documented in each package's own CLAUDE.md). Without these, packages with
       # known-skip tests would make CI perpetually red and train people to ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,12 +259,14 @@ jobs:
         if: matrix.pkg == 'goldenmatch'
         run: |
           uv pip install 'datafusion>=53,<54'
-          # maturin develop drops the compiled goldenmatch_datafusion_udf ext
-          # straight into the active uv venv (mirrors how the standalone
-          # datafusion-ffi-example is built). --uv keeps it inside the venv uv
-          # manages; abi3 means one ext spans 3.11-3.13.
-          uv run --with maturin maturin develop --release \
-            --manifest-path packages/rust/extensions/datafusion-udf/Cargo.toml --uv
+          # Build a wheel, then `uv pip install` it into the project .venv (the
+          # env `uv run pytest` uses). `maturin develop` under `uv run --with
+          # maturin` installs into maturin's EPHEMERAL --with overlay env, NOT
+          # .venv -> ModuleNotFound at test time. Mirror the native_wheel lane:
+          # build the abi3 wheel, then install it into .venv.
+          uv run --with maturin maturin build --release \
+            --manifest-path packages/rust/extensions/datafusion-udf/Cargo.toml --out dist-dfudf
+          uv pip install dist-dfudf/*.whl
       # Per-package --ignore lists mirror the pre-fold tuning each repo had
       # (documented in each package's own CLAUDE.md). Without these, packages with
       # known-skip tests would make CI perpetually red and train people to ignore

--- a/packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py
+++ b/packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py
@@ -1,0 +1,27 @@
+"""Stage A feasibility gate: a Rust-crate ScalarUDF registers into the Python
+``datafusion`` SessionContext via datafusion-ffi (PyCapsule).
+
+``pyarrow`` and ``datafusion`` are soft deps (skip if absent), but
+``goldenmatch_datafusion_udf`` is a HARD import on purpose: the CI lane builds
+that crate before pytest, so an import failure here means the build broke and
+MUST surface as a test FAILURE, not a silent skip. This is the loud guard for
+the whole DataFusion spine.
+"""
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+datafusion = pytest.importorskip("datafusion")
+import goldenmatch_datafusion_udf  # noqa: E402,F401  HARD import (loud guard, no importorskip)
+
+
+def test_ffi_scalar_udf_registers_and_evaluates():
+    from datafusion import SessionContext, udf
+    from goldenmatch_datafusion_udf import AddOneUDF
+
+    ctx = SessionContext()
+    ctx.register_udf(udf(AddOneUDF()))
+    ctx.from_arrow(pa.table({"x": pa.array([1, 2, 3], pa.int64())}), name="t")
+    batches = ctx.sql("SELECT add_one(x) AS y FROM t ORDER BY x").collect()
+    got = [v for b in batches for v in b.column(0).to_pylist()]
+    assert got == [2, 3, 4]

--- a/packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py
+++ b/packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py
@@ -20,7 +20,6 @@ pa = pytest.importorskip("pyarrow")
 datafusion = pytest.importorskip("datafusion")
 rapidfuzz = pytest.importorskip("rapidfuzz")  # noqa: F841  core dep; present
 import goldenmatch_datafusion_udf  # noqa: E402,F401  HARD import (loud guard, no importorskip)
-
 from rapidfuzz import fuzz  # noqa: E402
 from rapidfuzz.distance import JaroWinkler, Levenshtein  # noqa: E402
 

--- a/packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py
+++ b/packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py
@@ -1,11 +1,19 @@
-"""Stage A feasibility gate: a Rust-crate ScalarUDF registers into the Python
-``datafusion`` SessionContext via datafusion-ffi (PyCapsule).
+"""Stage B parity gate: the native string scorers, exposed as Rust-crate FFI
+ScalarUDFs, register into the Python ``datafusion`` SessionContext via
+datafusion-ffi (PyCapsule) and score byte-identically to the per-pair
+``goldenmatch._native`` scorers.
 
 ``pyarrow`` and ``datafusion`` are soft deps (skip if absent), but
 ``goldenmatch_datafusion_udf`` is a HARD import on purpose: the CI lane builds
 that crate before pytest, so an import failure here means the build broke and
 MUST surface as a test FAILURE, not a silent skip. This is the loud guard for
 the whole DataFusion spine.
+
+The native ext is ALSO required (not importorskip): the FFI UDFs and the native
+per-pair scorers both delegate to the shared ``goldenmatch-score-core`` crate,
+so the whole point of this test is to diff the two surfaces. If ``_native`` is
+missing the parity assertion is meaningless, so we FAIL rather than skip — the
+CI lane builds ``_native`` (``scripts/build_native.py``) before pytest.
 """
 
 import pytest
@@ -13,15 +21,78 @@ import pytest
 pa = pytest.importorskip("pyarrow")
 datafusion = pytest.importorskip("datafusion")
 import goldenmatch_datafusion_udf  # noqa: E402,F401  HARD import (loud guard, no importorskip)
+from goldenmatch.core import _native_loader  # noqa: E402
+
+# HARD requirement (not importorskip): the parity diff is meaningless without
+# the native scorers to diff against. The native CI lane builds the ext.
+assert _native_loader.native_available() is True, (
+    "goldenmatch._native must be built for the FFI scorer-parity test "
+    "(build via scripts/build_native.py)"
+)
+
+# Fixture covering: identical, single-char typo, reordered tokens, empty string,
+# NULL (None -> "" convention), unicode, and fully-disjoint strings.
+PAIRS = [
+    ("john smith", "john smith"),
+    ("john smith", "john smyth"),
+    ("john michael smith", "smith john michael"),
+    ("", ""),
+    (None, "john smith"),
+    ("jöhn smîth", "john smith"),
+    ("abcdef", "zyxwvu"),
+]
 
 
-def test_ffi_scalar_udf_registers_and_evaluates():
+def _pairs_table():
+    a = [p[0] for p in PAIRS]
+    b = [p[1] for p in PAIRS]
+    return pa.table({"a": pa.array(a, pa.string()), "b": pa.array(b, pa.string())})
+
+
+def test_ffi_string_scorers_match_native():
     from datafusion import SessionContext, udf
-    from goldenmatch_datafusion_udf import AddOneUDF
+    from goldenmatch_datafusion_udf import JaroWinklerUDF, LevenshteinUDF, TokenSortUDF
+
+    native = _native_loader.native_module()
+    assert native is not None
 
     ctx = SessionContext()
-    ctx.register_udf(udf(AddOneUDF()))
-    ctx.from_arrow(pa.table({"x": pa.array([1, 2, 3], pa.int64())}), name="t")
-    batches = ctx.sql("SELECT add_one(x) AS y FROM t ORDER BY x").collect()
-    got = [v for b in batches for v in b.column(0).to_pylist()]
-    assert got == [2, 3, 4]
+    ctx.register_udf(udf(JaroWinklerUDF()))
+    ctx.register_udf(udf(TokenSortUDF()))
+    ctx.register_udf(udf(LevenshteinUDF()))
+    ctx.from_arrow(_pairs_table(), name="pairs")
+
+    # Row order is not guaranteed across collect(); carry the inputs through so
+    # we compare each FFI row against the native score for the SAME pair.
+    batches = ctx.sql(
+        "SELECT a, b, "
+        "jaro_winkler(a, b) AS jw, "
+        "token_sort(a, b) AS ts, "
+        "levenshtein(a, b) AS lev "
+        "FROM pairs"
+    ).collect()
+
+    rows = []
+    for batch in batches:
+        cols = {name: batch.column(i).to_pylist() for i, name in enumerate(batch.schema.names)}
+        for i in range(batch.num_rows):
+            rows.append((cols["a"][i], cols["b"][i], cols["jw"][i], cols["ts"][i], cols["lev"][i]))
+
+    assert len(rows) == len(PAIRS)
+
+    for a, b, jw, ts, lev in rows:
+        # NULL -> "" convention, matching both the FFI UDF and native.py's gate.
+        sa = "" if a is None else a
+        sb = "" if b is None else b
+
+        # jaro_winkler / levenshtein are [0, 1] on both sides.
+        assert jw == pytest.approx(
+            native.jaro_winkler_similarity(sa, sb), abs=1e-6
+        ), f"jaro_winkler mismatch for {(a, b)!r}"
+        assert lev == pytest.approx(
+            native.levenshtein_similarity(sa, sb), abs=1e-6
+        ), f"levenshtein mismatch for {(a, b)!r}"
+        # native token_sort_ratio is 0-100; the FFI token_sort is 0-1.
+        assert ts == pytest.approx(
+            native.token_sort_ratio(sa, sb) / 100.0, abs=1e-6
+        ), f"token_sort mismatch for {(a, b)!r}"

--- a/packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py
+++ b/packages/python/goldenmatch/tests/test_datafusion_ffi_udf.py
@@ -1,34 +1,28 @@
 """Stage B parity gate: the native string scorers, exposed as Rust-crate FFI
 ScalarUDFs, register into the Python ``datafusion`` SessionContext via
-datafusion-ffi (PyCapsule) and score byte-identically to the per-pair
-``goldenmatch._native`` scorers.
+datafusion-ffi (PyCapsule) and score correctly.
 
-``pyarrow`` and ``datafusion`` are soft deps (skip if absent), but
-``goldenmatch_datafusion_udf`` is a HARD import on purpose: the CI lane builds
-that crate before pytest, so an import failure here means the build broke and
-MUST surface as a test FAILURE, not a silent skip. This is the loud guard for
-the whole DataFusion spine.
+``pyarrow``/``datafusion`` are soft deps (skip if absent), but
+``goldenmatch_datafusion_udf`` is a HARD import: the CI lane builds that crate
+before pytest, so an import failure means the build broke and MUST surface as a
+test FAILURE, not a silent skip. This is the loud guard for the DataFusion spine.
 
-The native ext is ALSO required (not importorskip): the FFI UDFs and the native
-per-pair scorers both delegate to the shared ``goldenmatch-score-core`` crate,
-so the whole point of this test is to diff the two surfaces. If ``_native`` is
-missing the parity assertion is meaningless, so we FAIL rather than skip — the
-CI lane builds ``_native`` (``scripts/build_native.py``) before pytest.
+The FFI UDFs delegate to the shared ``goldenmatch-score-core`` crate
+(rapidfuzz 0.5.0) -- the SAME algorithms the Python ``rapidfuzz`` package wraps --
+so we diff the FFI scores against ``rapidfuzz`` directly (``test_native_parity``
+already proves rust-rapidfuzz == python-rapidfuzz at 1e-9). This needs no
+``_native`` build, so it does not pull native-only tests into this lane.
 """
 
 import pytest
 
 pa = pytest.importorskip("pyarrow")
 datafusion = pytest.importorskip("datafusion")
+rapidfuzz = pytest.importorskip("rapidfuzz")  # noqa: F841  core dep; present
 import goldenmatch_datafusion_udf  # noqa: E402,F401  HARD import (loud guard, no importorskip)
-from goldenmatch.core import _native_loader  # noqa: E402
 
-# HARD requirement (not importorskip): the parity diff is meaningless without
-# the native scorers to diff against. The native CI lane builds the ext.
-assert _native_loader.native_available() is True, (
-    "goldenmatch._native must be built for the FFI scorer-parity test "
-    "(build via scripts/build_native.py)"
-)
+from rapidfuzz import fuzz  # noqa: E402
+from rapidfuzz.distance import JaroWinkler, Levenshtein  # noqa: E402
 
 # Fixture covering: identical, single-char typo, reordered tokens, empty string,
 # NULL (None -> "" convention), unicode, and fully-disjoint strings.
@@ -49,12 +43,9 @@ def _pairs_table():
     return pa.table({"a": pa.array(a, pa.string()), "b": pa.array(b, pa.string())})
 
 
-def test_ffi_string_scorers_match_native():
+def test_ffi_string_scorers_match_rapidfuzz():
     from datafusion import SessionContext, udf
     from goldenmatch_datafusion_udf import JaroWinklerUDF, LevenshteinUDF, TokenSortUDF
-
-    native = _native_loader.native_module()
-    assert native is not None
 
     ctx = SessionContext()
     ctx.register_udf(udf(JaroWinklerUDF()))
@@ -63,7 +54,7 @@ def test_ffi_string_scorers_match_native():
     ctx.from_arrow(_pairs_table(), name="pairs")
 
     # Row order is not guaranteed across collect(); carry the inputs through so
-    # we compare each FFI row against the native score for the SAME pair.
+    # we compare each FFI row against the rapidfuzz score for the SAME pair.
     batches = ctx.sql(
         "SELECT a, b, "
         "jaro_winkler(a, b) AS jw, "
@@ -81,18 +72,19 @@ def test_ffi_string_scorers_match_native():
     assert len(rows) == len(PAIRS)
 
     for a, b, jw, ts, lev in rows:
-        # NULL -> "" convention, matching both the FFI UDF and native.py's gate.
+        # NULL -> "" convention, matching the FFI UDF (and native.py's gate).
         sa = "" if a is None else a
         sb = "" if b is None else b
 
-        # jaro_winkler / levenshtein are [0, 1] on both sides.
+        # score-core jaro_winkler / levenshtein are normalized_similarity [0, 1];
+        # the FFI UDF returns [0, 1] -> compare to rapidfuzz directly.
         assert jw == pytest.approx(
-            native.jaro_winkler_similarity(sa, sb), abs=1e-6
+            JaroWinkler.normalized_similarity(sa, sb), abs=1e-6
         ), f"jaro_winkler mismatch for {(a, b)!r}"
         assert lev == pytest.approx(
-            native.levenshtein_similarity(sa, sb), abs=1e-6
+            Levenshtein.normalized_similarity(sa, sb), abs=1e-6
         ), f"levenshtein mismatch for {(a, b)!r}"
-        # native token_sort_ratio is 0-100; the FFI token_sort is 0-1.
+        # FFI token_sort is [0, 1]; rapidfuzz fuzz.token_sort_ratio is [0, 100].
         assert ts == pytest.approx(
-            native.token_sort_ratio(sa, sb) / 100.0, abs=1e-6
+            fuzz.token_sort_ratio(sa, sb) / 100.0, abs=1e-6
         ), f"token_sort mismatch for {(a, b)!r}"

--- a/packages/rust/extensions/datafusion-udf/Cargo.toml
+++ b/packages/rust/extensions/datafusion-udf/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Ben Severn <benzsevern@gmail.com>"]
-description = "DataFusion FFI ScalarUDF feasibility gate (add_one) for GoldenMatch"
+description = "DataFusion FFI ScalarUDFs (native string scorers) for GoldenMatch"
 publish = false
 
 [lib]
@@ -31,6 +31,10 @@ datafusion-ffi = "53"
 arrow = { version = "58", features = ["ffi"] }
 arrow-array = "58"
 arrow-schema = "58"
+# Canonical string scorers shared pyo3-free with the `native` ext, so the FFI
+# UDFs score byte-identically to the per-pair native scorers (parity by
+# construction — one source of truth).
+goldenmatch-score-core = { path = "../score-core" }
 # extension-module: don't link libpython (this .so is imported BY CPython).
 # abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13 (matches the
 # sibling `native` crate; the example uses abi3-py310 but we floor at 3.11).

--- a/packages/rust/extensions/datafusion-udf/Cargo.toml
+++ b/packages/rust/extensions/datafusion-udf/Cargo.toml
@@ -1,0 +1,44 @@
+# Standalone workspace (empty [workspace]) so pyo3's `extension-module` feature
+# here is NOT unified with the `bridge` crate's `auto-initialize` feature — the
+# two are mutually incompatible (ext-module must NOT link libpython; embedding
+# must). Same isolation rationale as the sibling `native` crate.
+[workspace]
+
+[package]
+name = "goldenmatch-datafusion-udf"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "DataFusion FFI ScalarUDF feasibility gate (add_one) for GoldenMatch"
+publish = false
+
+[lib]
+# Produces lib_goldenmatch_datafusion_udf; the #[pymodule] is
+# `goldenmatch_datafusion_udf`, so the init symbol is
+# PyInit_goldenmatch_datafusion_udf. cdylib only (imported BY CPython).
+name = "goldenmatch_datafusion_udf"
+crate-type = ["cdylib"]
+
+[dependencies]
+# Versions mirror apache/datafusion-python @ 53.0.0's workspace pins verbatim:
+# datafusion-* = 53, arrow stack = 58, pyo3 = 0.28. These are the exact
+# versions the canonical datafusion-ffi-example compiles against, so the
+# FFI_ScalarUDF / ScalarUDFImpl / PyCapsule contract lines up by construction.
+datafusion-common = { version = "53", default-features = false }
+datafusion-expr = "53"
+datafusion-ffi = "53"
+arrow = { version = "58", features = ["ffi"] }
+arrow-array = "58"
+arrow-schema = "58"
+# extension-module: don't link libpython (this .so is imported BY CPython).
+# abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13 (matches the
+# sibling `native` crate; the example uses abi3-py310 but we floor at 3.11).
+pyo3 = { version = "0.28", features = ["extension-module", "abi3", "abi3-py311"] }
+
+[build-dependencies]
+pyo3-build-config = "0.28"
+
+[profile.release]
+opt-level = 3
+lto = "thin"

--- a/packages/rust/extensions/datafusion-udf/pyproject.toml
+++ b/packages/rust/extensions/datafusion-udf/pyproject.toml
@@ -1,0 +1,26 @@
+# goldenmatch-datafusion-udf — the datafusion-ffi ScalarUDF feasibility gate,
+# shipped as a maturin/abi3 extension module (mirrors the sibling `native`
+# crate's packaging and the canonical datafusion-ffi-example's maturin backend).
+# This crate IS the package (no cross-tree problem), so maturin is the backend.
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "goldenmatch-datafusion-udf"
+version = "0.1.0"
+description = "DataFusion FFI ScalarUDF feasibility gate (add_one) for GoldenMatch"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Ben Severn", email = "ben@bensevern.dev" }]
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3 :: Only",
+]
+
+[tool.maturin]
+# Pure-Rust layout: the compiled abi3 ext lands at goldenmatch_datafusion_udf
+# (pymodule name == [lib] name, so no Rust rename is needed). extension-module
+# (no libpython link) is set explicitly to match the canonical example.
+module-name = "goldenmatch_datafusion_udf"
+features = ["pyo3/extension-module"]

--- a/packages/rust/extensions/datafusion-udf/pyproject.toml
+++ b/packages/rust/extensions/datafusion-udf/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 [project]
 name = "goldenmatch-datafusion-udf"
 version = "0.1.0"
-description = "DataFusion FFI ScalarUDF feasibility gate (add_one) for GoldenMatch"
+description = "DataFusion FFI ScalarUDFs (native string scorers) for GoldenMatch"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Ben Severn", email = "ben@bensevern.dev" }]

--- a/packages/rust/extensions/datafusion-udf/rust-toolchain.toml
+++ b/packages/rust/extensions/datafusion-udf/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Pin the toolchain so CI reproduces the environment this crate was verified
+# against. The datafusion 53 / arrow 58 crates use Rust edition 2024, which
+# requires rustc >= 1.85; 1.94.1 matches the sibling `native` crate's pin and
+# is comfortably past that floor. Bump deliberately (and re-verify) rather than
+# floating @stable, whose newer clippy can flag code under -D warnings.
+[toolchain]
+channel = "1.94.1"
+components = ["clippy"]

--- a/packages/rust/extensions/datafusion-udf/src/lib.rs
+++ b/packages/rust/extensions/datafusion-udf/src/lib.rs
@@ -1,17 +1,21 @@
-// goldenmatch_datafusion_udf — the datafusion-ffi feasibility-gate extension
-// module. Registers AddOneUDF so a Python `datafusion` SessionContext can
-// import it and register it via the PyCapsule FFI bridge. Module-name matches
-// the [lib] name + maturin module-name so PyInit_goldenmatch_datafusion_udf is
-// the init symbol.
+// goldenmatch_datafusion_udf — the datafusion-ffi extension module. Registers
+// the native string scorers (jaro_winkler / token_sort / levenshtein) as FFI
+// ScalarUDFs so a Python `datafusion` SessionContext can import them and
+// register them via the PyCapsule FFI bridge. Each delegates per-pair scoring
+// to the shared `goldenmatch-score-core` crate, the SAME source of truth the
+// `goldenmatch._native` per-pair scorers use. Module-name matches the [lib] name
+// + maturin module-name so PyInit_goldenmatch_datafusion_udf is the init symbol.
 
 use pyo3::prelude::*;
 
-use crate::scalar_udf::AddOneUDF;
+use crate::scalar_udf::{JaroWinklerUDF, LevenshteinUDF, TokenSortUDF};
 
 pub(crate) mod scalar_udf;
 
 #[pymodule]
 fn goldenmatch_datafusion_udf(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<AddOneUDF>()?;
+    m.add_class::<JaroWinklerUDF>()?;
+    m.add_class::<TokenSortUDF>()?;
+    m.add_class::<LevenshteinUDF>()?;
     Ok(())
 }

--- a/packages/rust/extensions/datafusion-udf/src/lib.rs
+++ b/packages/rust/extensions/datafusion-udf/src/lib.rs
@@ -1,0 +1,17 @@
+// goldenmatch_datafusion_udf — the datafusion-ffi feasibility-gate extension
+// module. Registers AddOneUDF so a Python `datafusion` SessionContext can
+// import it and register it via the PyCapsule FFI bridge. Module-name matches
+// the [lib] name + maturin module-name so PyInit_goldenmatch_datafusion_udf is
+// the init symbol.
+
+use pyo3::prelude::*;
+
+use crate::scalar_udf::AddOneUDF;
+
+pub(crate) mod scalar_udf;
+
+#[pymodule]
+fn goldenmatch_datafusion_udf(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<AddOneUDF>()?;
+    Ok(())
+}

--- a/packages/rust/extensions/datafusion-udf/src/scalar_udf.rs
+++ b/packages/rust/extensions/datafusion-udf/src/scalar_udf.rs
@@ -1,16 +1,31 @@
-// AddOneUDF — a trivial Int64 -> Int64 scalar UDF used as the datafusion-ffi
-// feasibility gate. Mirrors the IsNullUDF in apache/datafusion-python @ 53.0.0
-// examples/datafusion-ffi-example/src/scalar_udf.rs verbatim for every FFI-API
-// detail (trait-method signatures, the cr"datafusion_scalar_udf" capsule name,
-// the FFI_ScalarUDF::from(Arc::new(ScalarUDF::from(self.clone()))) chain);
-// only the body (Any->Bool null check) is swapped for Int64 + 1.
+// Native string scorers exposed as datafusion-ffi ScalarUDFs over
+// (Utf8, Utf8) -> Float64. Each UDF delegates per-pair scoring to the
+// pyo3-free `goldenmatch-score-core` crate — the SAME source of truth the
+// `goldenmatch._native` per-pair scorers use — so the FFI path scores
+// byte-identically to native by construction (parity asserted end-to-end in
+// tests/test_datafusion_ffi_udf.py).
+//
+// Every FFI-API detail (trait-method signatures, the cr"datafusion_scalar_udf"
+// capsule name, the FFI_ScalarUDF::from(Arc::new(ScalarUDF::from(self.clone())))
+// chain) mirrors the Stage-A AddOneUDF, which in turn mirrors the IsNullUDF in
+// apache/datafusion-python @ 53.0.0 examples/datafusion-ffi-example verbatim.
+//
+// NULL CONVENTION: a NULL Utf8 input is scored as the empty string `""` (not
+// null-propagated), matching the Python `string_similarity` gate in
+// goldenmatch/native.py (`"" if a is None else str(a)`). So every output row is
+// a non-null Float64.
+//
+// SCALE: jaro_winkler / levenshtein return [0, 1]. token_sort here returns
+// [0, 1] (score-core's `score_one`-style fuzz::ratio scale), i.e. the native
+// `token_sort_ratio` 0-100 value divided by 100 — the test accounts for the
+// /100 between the two surfaces.
 
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow_array::{Array, Int64Array};
+use arrow_array::cast::AsArray;
+use arrow_array::Float64Array;
 use arrow_schema::DataType;
-use datafusion_common::ScalarValue;
 use datafusion_common::error::Result as DataFusionResult;
 use datafusion_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
@@ -19,71 +34,108 @@ use datafusion_ffi::udf::FFI_ScalarUDF;
 use pyo3::types::PyCapsule;
 use pyo3::{Bound, PyResult, Python, pyclass, pymethods};
 
-#[pyclass(
-    from_py_object,
-    name = "AddOneUDF",
-    module = "goldenmatch_datafusion_udf",
-    subclass
-)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct AddOneUDF {
-    signature: Signature,
+/// Build a `Float64Array` by scoring each (a, b) pair from two Utf8 columns,
+/// mapping NULL -> "" before scoring (see NULL CONVENTION above). `args` are
+/// collapsed Scalar-or-Array values; `values_to_arrays` expands any Scalar to an
+/// Array of `number_rows` so the two-arg zip is always well-formed.
+fn invoke_pair_scorer(
+    args: ScalarFunctionArgs,
+    score: fn(&str, &str) -> f64,
+) -> DataFusionResult<ColumnarValue> {
+    let arrs = ColumnarValue::values_to_arrays(&args.args)?;
+    let a = arrs[0].as_string::<i32>();
+    let b = arrs[1].as_string::<i32>();
+    let out: Float64Array = a
+        .iter()
+        .zip(b.iter())
+        .map(|(oa, ob)| Some(score(oa.unwrap_or(""), ob.unwrap_or(""))))
+        .collect();
+    Ok(ColumnarValue::Array(Arc::new(out)))
 }
 
-#[pymethods]
-impl AddOneUDF {
-    #[new]
-    fn new() -> Self {
-        Self {
-            signature: Signature::exact(vec![DataType::Int64], Volatility::Immutable),
+macro_rules! string_scorer_udf {
+    ($udf:ident, $py_name:literal, $sql_name:literal, $score:path) => {
+        #[pyclass(
+            from_py_object,
+            name = $py_name,
+            module = "goldenmatch_datafusion_udf",
+            subclass
+        )]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        pub(crate) struct $udf {
+            signature: Signature,
         }
-    }
 
-    fn __datafusion_scalar_udf__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyCapsule>> {
-        let name = cr"datafusion_scalar_udf".into();
-
-        let func = Arc::new(ScalarUDF::from(self.clone()));
-        let provider = FFI_ScalarUDF::from(func);
-
-        PyCapsule::new(py, provider, Some(name))
-    }
-}
-
-impl ScalarUDFImpl for AddOneUDF {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn name(&self) -> &str {
-        "add_one"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        Ok(DataType::Int64)
-    }
-
-    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
-        let input = &args.args[0];
-
-        Ok(match input {
-            ColumnarValue::Array(arr) => {
-                let arr = arr
-                    .as_any()
-                    .downcast_ref::<Int64Array>()
-                    .expect("add_one expects an Int64 array");
-                let out: Int64Array = arr.iter().map(|v| v.map(|x| x + 1)).collect();
-                ColumnarValue::Array(Arc::new(out))
-            }
-            ColumnarValue::Scalar(sv) => match sv {
-                ScalarValue::Int64(Some(x)) => {
-                    ColumnarValue::Scalar(ScalarValue::Int64(Some(x + 1)))
+        #[pymethods]
+        impl $udf {
+            #[new]
+            fn new() -> Self {
+                Self {
+                    signature: Signature::exact(
+                        vec![DataType::Utf8, DataType::Utf8],
+                        Volatility::Immutable,
+                    ),
                 }
-                _ => ColumnarValue::Scalar(ScalarValue::Int64(None)),
-            },
-        })
-    }
+            }
+
+            fn __datafusion_scalar_udf__<'py>(
+                &self,
+                py: Python<'py>,
+            ) -> PyResult<Bound<'py, PyCapsule>> {
+                let name = cr"datafusion_scalar_udf".into();
+                let func = Arc::new(ScalarUDF::from(self.clone()));
+                let provider = FFI_ScalarUDF::from(func);
+                PyCapsule::new(py, provider, Some(name))
+            }
+        }
+
+        impl ScalarUDFImpl for $udf {
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+
+            fn name(&self) -> &str {
+                $sql_name
+            }
+
+            fn signature(&self) -> &Signature {
+                &self.signature
+            }
+
+            fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+                Ok(DataType::Float64)
+            }
+
+            fn invoke_with_args(
+                &self,
+                args: ScalarFunctionArgs,
+            ) -> DataFusionResult<ColumnarValue> {
+                invoke_pair_scorer(args, $score)
+            }
+        }
+    };
 }
+
+string_scorer_udf!(
+    JaroWinklerUDF,
+    "JaroWinklerUDF",
+    "jaro_winkler",
+    goldenmatch_score_core::jaro_winkler_similarity
+);
+
+// token_sort here is the [0, 1] form (native token_sort_ratio / 100). We call
+// score-core's `score_one` with id=2 (the UNSCALED fuzz::ratio) rather than
+// `token_sort_ratio` (which is *100), so the FFI scale is [0, 1]. The test
+// asserts this equals native.token_sort_ratio(a, b) / 100.0.
+fn token_sort_unit(a: &str, b: &str) -> f64 {
+    goldenmatch_score_core::score_one(2, a, b)
+}
+
+string_scorer_udf!(TokenSortUDF, "TokenSortUDF", "token_sort", token_sort_unit);
+
+string_scorer_udf!(
+    LevenshteinUDF,
+    "LevenshteinUDF",
+    "levenshtein",
+    goldenmatch_score_core::levenshtein_similarity
+);

--- a/packages/rust/extensions/datafusion-udf/src/scalar_udf.rs
+++ b/packages/rust/extensions/datafusion-udf/src/scalar_udf.rs
@@ -1,0 +1,89 @@
+// AddOneUDF — a trivial Int64 -> Int64 scalar UDF used as the datafusion-ffi
+// feasibility gate. Mirrors the IsNullUDF in apache/datafusion-python @ 53.0.0
+// examples/datafusion-ffi-example/src/scalar_udf.rs verbatim for every FFI-API
+// detail (trait-method signatures, the cr"datafusion_scalar_udf" capsule name,
+// the FFI_ScalarUDF::from(Arc::new(ScalarUDF::from(self.clone()))) chain);
+// only the body (Any->Bool null check) is swapped for Int64 + 1.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow_array::{Array, Int64Array};
+use arrow_schema::DataType;
+use datafusion_common::ScalarValue;
+use datafusion_common::error::Result as DataFusionResult;
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_ffi::udf::FFI_ScalarUDF;
+use pyo3::types::PyCapsule;
+use pyo3::{Bound, PyResult, Python, pyclass, pymethods};
+
+#[pyclass(
+    from_py_object,
+    name = "AddOneUDF",
+    module = "goldenmatch_datafusion_udf",
+    subclass
+)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct AddOneUDF {
+    signature: Signature,
+}
+
+#[pymethods]
+impl AddOneUDF {
+    #[new]
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::Int64], Volatility::Immutable),
+        }
+    }
+
+    fn __datafusion_scalar_udf__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyCapsule>> {
+        let name = cr"datafusion_scalar_udf".into();
+
+        let func = Arc::new(ScalarUDF::from(self.clone()));
+        let provider = FFI_ScalarUDF::from(func);
+
+        PyCapsule::new(py, provider, Some(name))
+    }
+}
+
+impl ScalarUDFImpl for AddOneUDF {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "add_one"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(DataType::Int64)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
+        let input = &args.args[0];
+
+        Ok(match input {
+            ColumnarValue::Array(arr) => {
+                let arr = arr
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("add_one expects an Int64 array");
+                let out: Int64Array = arr.iter().map(|v| v.map(|x| x + 1)).collect();
+                ColumnarValue::Array(Arc::new(out))
+            }
+            ColumnarValue::Scalar(sv) => match sv {
+                ScalarValue::Int64(Some(x)) => {
+                    ColumnarValue::Scalar(ScalarValue::Int64(Some(x + 1)))
+                }
+                _ => ColumnarValue::Scalar(ScalarValue::Int64(None)),
+            },
+        })
+    }
+}

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -28,7 +28,11 @@ blake2 = "0.10"
 # Canonical record fingerprint canonicalizer (sha256 + JSON parsing live here),
 # shared pyo3-free with the pgrx `postgres` crate so both compute the same id.
 goldenmatch-fingerprint-core = { path = "../fingerprint-core" }
-rapidfuzz = "0.5.0"
+# Canonical string scorers (jaro_winkler / levenshtein / token_sort / score_one),
+# shared pyo3-free with the `datafusion-udf` FFI crate so both surfaces score
+# identically by construction. The #[pyfunction] scorers below are thin shims
+# over this crate; score_one is re-imported verbatim.
+goldenmatch-score-core = { path = "../score-core" }
 rayon = "1.12.0"
 # Arrow C Data Interface for zero-copy kernel input (see score.rs
 # score_block_pairs_arrow). `pyarrow` brings the PyArrowType FFI bridge;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -13,10 +13,9 @@ use arrow::array::{Array, ArrayData, Int64Array, LargeStringArray, StringArray};
 use arrow::datatypes::DataType;
 use arrow::pyarrow::PyArrowType;
 use numpy::{IntoPyArray, PyArray2};
+use goldenmatch_score_core::score_one;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use rapidfuzz::distance::{jaro_winkler, levenshtein};
-use rapidfuzz::fuzz;
 use rayon::prelude::*;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -66,59 +65,31 @@ pub fn build_exclude_set(pairs: Vec<(i64, i64)>) -> ExcludeSet {
     ExcludeSet { set: Arc::new(set) }
 }
 
-/// `rapidfuzz.fuzz.token_sort_ratio` preprocessing: split on whitespace, sort
-/// the tokens, rejoin with a single space. (Then `fuzz::ratio` on the result.)
-fn token_sort_string(s: &str) -> String {
-    let mut toks: Vec<&str> = s.split_whitespace().collect();
-    toks.sort_unstable();
-    toks.join(" ")
-}
-
 // ---- PyO3 surface (scale matches score_buckets._resolve_score_pair_callable:
 //      jaro_winkler/levenshtein on 0-1, token_sort_ratio on 0-100) ----
+//
+// The scorers + token_sort preprocessing + `score_one` dispatch live in the
+// pyo3-free `goldenmatch-score-core` crate (one source of truth shared with the
+// DataFusion FFI UDFs). These are thin #[pyfunction] SHIMS delegating into it —
+// a bare `use` of the core fns won't satisfy lib.rs's `wrap_pyfunction!`, so the
+// shims are required. `score_one` is re-imported verbatim above (no shim: it's
+// called only from Rust by score_block_pairs / score_block_pairs_arrow /
+// score_field_matrix, which stay in this crate).
 
 #[pyfunction]
 pub fn jaro_winkler_similarity(a: &str, b: &str) -> f64 {
-    // rapidfuzz JaroWinkler default prefix_weight = 0.1.
-    jaro_winkler::normalized_similarity(a.chars(), b.chars())
+    goldenmatch_score_core::jaro_winkler_similarity(a, b)
 }
 
 #[pyfunction]
 pub fn levenshtein_similarity(a: &str, b: &str) -> f64 {
-    // rapidfuzz Levenshtein default uniform weights (1, 1, 1).
-    levenshtein::normalized_similarity(a.chars(), b.chars())
+    goldenmatch_score_core::levenshtein_similarity(a, b)
 }
 
 /// token_sort_ratio on the 0-100 scale (score_field divides by 100).
 #[pyfunction]
 pub fn token_sort_ratio(a: &str, b: &str) -> f64 {
-    let sa = token_sort_string(a);
-    let sb = token_sort_string(b);
-    // rapidfuzz-rs fuzz::ratio returns [0, 1]; Python fuzz.ratio is [0, 100].
-    fuzz::ratio(sa.chars(), sb.chars()) * 100.0
-}
-
-/// Scorer dispatch matching `score_buckets._resolve_score_pair_callable`'s
-/// fast-path scale, all on [0, 1]. ids: 0=jaro_winkler, 1=levenshtein,
-/// 2=token_sort, 3=exact.
-fn score_one(scorer_id: u8, a: &str, b: &str) -> f64 {
-    match scorer_id {
-        0 => jaro_winkler::normalized_similarity(a.chars(), b.chars()),
-        1 => levenshtein::normalized_similarity(a.chars(), b.chars()),
-        2 => {
-            let sa = token_sort_string(a);
-            let sb = token_sort_string(b);
-            fuzz::ratio(sa.chars(), sb.chars())
-        }
-        3 => {
-            if a == b {
-                1.0
-            } else {
-                0.0
-            }
-        }
-        _ => 0.0,
-    }
+    goldenmatch_score_core::token_sort_ratio(a, b)
 }
 
 /// Native port of `score_buckets._score_one_bucket_fast`'s per-pair loop.

--- a/packages/rust/extensions/score-core/Cargo.toml
+++ b/packages/rust/extensions/score-core/Cargo.toml
@@ -1,0 +1,23 @@
+# Standalone workspace so this pyo3-free core can be a path dependency of BOTH
+# the `native` crate (its own workspace, extension-module) and the
+# `datafusion-udf` crate (its own workspace, extension-module) without either
+# workspace claiming it. Same isolation rationale as the sibling
+# `fingerprint-core` crate. NO rust-toolchain.toml here on purpose: the crate
+# inherits each parent crate's toolchain when built as a path dep.
+[workspace]
+
+[package]
+name = "goldenmatch-score-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "Canonical string scorers (jaro_winkler / levenshtein / token_sort, no pyo3) shared across the native ext and the DataFusion FFI UDFs"
+
+[lib]
+name = "goldenmatch_score_core"
+
+[dependencies]
+# Same pin the `native` crate uses, so the scorers are byte-identical across the
+# native ext and the FFI UDFs (parity by construction — one source of truth).
+rapidfuzz = "0.5.0"

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -1,0 +1,72 @@
+//! Canonical string scorers backed by the `rapidfuzz` Rust crate — the single
+//! source of truth shared (by construction) between the `goldenmatch._native`
+//! PyO3 extension and the `datafusion-udf` FFI ScalarUDFs. Both link this crate,
+//! so the per-pair scoring is identical across surfaces; parity is structural,
+//! not asserted after the fact.
+//!
+//! This crate is intentionally pyo3-free. The `native` crate keeps thin
+//! `#[pyfunction]` shims that delegate here; the FFI UDFs call these `pub fn`s
+//! directly. All functions operate on Unicode chars (codepoints), matching
+//! rapidfuzz.
+use rapidfuzz::distance::{jaro_winkler, levenshtein};
+use rapidfuzz::fuzz;
+
+/// `rapidfuzz.fuzz.token_sort_ratio` preprocessing: split on whitespace, sort
+/// the tokens, rejoin with a single space. (Then `fuzz::ratio` on the result.)
+/// Private: its only callers (`token_sort_ratio` + `score_one`) live in this
+/// crate.
+fn token_sort_string(s: &str) -> String {
+    let mut toks: Vec<&str> = s.split_whitespace().collect();
+    toks.sort_unstable();
+    toks.join(" ")
+}
+
+// ---- Scorer surface (scale matches score_buckets._resolve_score_pair_callable:
+//      jaro_winkler/levenshtein on 0-1, token_sort_ratio on 0-100) ----
+
+pub fn jaro_winkler_similarity(a: &str, b: &str) -> f64 {
+    // rapidfuzz JaroWinkler default prefix_weight = 0.1.
+    jaro_winkler::normalized_similarity(a.chars(), b.chars())
+}
+
+pub fn levenshtein_similarity(a: &str, b: &str) -> f64 {
+    // rapidfuzz Levenshtein default uniform weights (1, 1, 1).
+    levenshtein::normalized_similarity(a.chars(), b.chars())
+}
+
+/// token_sort_ratio on the 0-100 scale (score_field divides by 100).
+pub fn token_sort_ratio(a: &str, b: &str) -> f64 {
+    let sa = token_sort_string(a);
+    let sb = token_sort_string(b);
+    // rapidfuzz-rs fuzz::ratio returns [0, 1]; Python fuzz.ratio is [0, 100].
+    fuzz::ratio(sa.chars(), sb.chars()) * 100.0
+}
+
+/// Scorer dispatch matching `score_buckets._resolve_score_pair_callable`'s
+/// fast-path scale, all on [0, 1]. ids: 0=jaro_winkler, 1=levenshtein,
+/// 2=token_sort, 3=exact.
+///
+/// NOTE: id=2 returns the UNSCALED `fuzz::ratio` ([0,1], NOT *100). This is
+/// deliberate and must not be reconciled with `token_sort_ratio`'s *100 form:
+/// `score_field_matrix` (native) depends on the unscaled value (it divides
+/// token-sort by 100 only in the PyO3-exposed path, never here). Changing this
+/// is a silent-drift trap.
+pub fn score_one(scorer_id: u8, a: &str, b: &str) -> f64 {
+    match scorer_id {
+        0 => jaro_winkler::normalized_similarity(a.chars(), b.chars()),
+        1 => levenshtein::normalized_similarity(a.chars(), b.chars()),
+        2 => {
+            let sa = token_sort_string(a);
+            let sb = token_sort_string(b);
+            fuzz::ratio(sa.chars(), sb.chars())
+        }
+        3 => {
+            if a == b {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        _ => 0.0,
+    }
+}


### PR DESCRIPTION
Stage A hard gate for the DataFusion spine: a Rust add_one ScalarUDF in a new isolated maturin crate, exported via datafusion-ffi as a PyCapsule, registered into datafusion-python 53 and proven by SELECT add_one(x). Mirrors apache/datafusion-python examples/datafusion-ffi-example @ 53.0.0 verbatim. Pins: datafusion* 53.1, arrow 58.3, pyo3 0.28. CI builds the crate + a HARD import guard => build/FFI break is a test FAILURE not a skip. If green, the B2 spine is feasible; if the FFI boundary fails on v53, we fall back to B1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)