### PR TITLE
feat(spine): scale-mode contract — mode field, feature gate, determinism gate (Stage D)

### DIFF
--- a/docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md
+++ b/docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md
@@ -207,6 +207,331 @@ First sweep run (`arrow-finish-line-sweep.yml`, `large-new-64GB`). Source runs:
 **Cutover order decision:** Phase 1 first (substrate + proven-untenable legacy), then Phase 3
 dedup (clean win) while build_clusters/fingerprints get the hold-and-optimize treatment.
 
+## Phase-2 parity policy (2026-06-03 amendment)
+
+**Why this amendment exists.** The recurring Phase-2 parity traps and a chunk of
+the perf regressions trace to one root cause: we have been enforcing **bit-exact
+ARTIFACT parity** with the legacy Python dict path, not just **SEMANTIC parity**.
+Artifact parity (reproducing float summation order, last-wins dedup, pair-fill
+order, first-in-pairs-order tie-breaks) is self-defeating for a columnar cutover:
+bit-exact float confidence FORBIDS re-association (sort / vectorize / parallel
+reduce), which is exactly the operation that makes columnar fast and memory-light.
+The team already relaxed one artifact correctly — member order → members-as-set
+(#598), because native UF order is arbitrary. That is the template for the rest.
+
+This policy classifies each dict artifact keep-semantic vs relax-to-semantic,
+grounded in the actual code path (read 2026-06-03, current through #693).
+
+### The parity-policy table (grounded in code)
+
+| Artifact | Code path | Currently pinned by | Classify | Resolution |
+|---|---|---|---|---|
+| cluster partition / membership | members `list` w/ order declared non-load-bearing (`cluster.py:800-814`); `_frames_iter` group_by-agg, set-compared (`resolve.py:231-245`) | `test_cluster_frames_out_parity.py:17-21` (`_norm`→`frozenset`); Rand index | **keep-semantic** | strict: set equality / Rand 1.0. Already relaxed (#598). |
+| golden record content / entity IDs | `build_golden_records_from_frames` delegates to shared `build_golden_records_df` (`golden.py:1089-1171`); `new_entity_id` UUIDv7 (`store.py:110-122`) | `test_golden_from_frames_parity.py`; `test_identity_from_frames_parity.py` (partition + det-mint legs) | **keep-semantic** | strict: golden content equality; entity = **partition** equality (random id) + deterministic-mint leg for literal |
+| multi-matchkey pair dedup | MAX: `dedup_pairs_max_score` (`pairs.py:35-48`) → `scored_pairs` ONLY (`pipeline.py:1932-1937`). LAST-WINS: `_bucket_pairs` (`cluster_pairscores.py:21-26`) + dict fill (`cluster.py:816-819`), both over RAW `all_pairs` | **No test truly pins last-wins** — every dup fixture puts the higher score last, so last-wins==max on value (`test_columnar_drop_pairscores_parity.py:27`, `test_cluster_frames_out_parity.py:53`). Contract only *documented* (`cluster_pairscores.py:59-62`) | **RELAX → canonical MAX** | switch cluster `pair_scores` fill to MAX so both pipeline halves agree. **OUTPUT-CHANGING — sign-off + count below.** |
+| confidence float value | `confidence = 0.4*min_edge + 0.3*avg_edge + 0.3*connectivity` (`cluster.py:1261`); `avg_edge = sum(scores)/len` (`:1251`) | `test_columnar_cluster_build_parity.py` (EXACT float, `_norm` keeps `confidence`); `test_native_cluster_orchestration_parity.py` (`approx, abs=1e-5`) | **RELAX → ε-parity** | order-free reduction; ε tolerance. `min_edge`/`connectivity` already order-free; only `avg_edge` sum is order-dependent. EXACT handling reserved for the threshold boundary (next row). |
+| pair-fill / sequential-sum order | dict fill `cluster.py:816-819`; off-native `replace_strict`-for-order `cluster.py:1177-1190` (comment: "matching the dict path") | implied by the confidence-EXACT tests | **RELAX → order-free** | vectorize `avg_edge` (multiset sum is deterministic regardless of order, just ≠ the sequential sum by ≤~1e-9 f64 / ~1e-6 f32); drop the `replace_strict`-for-order machinery |
+| bottleneck tie-break | `min(pair_scores.items(), key=itemgetter(1))` = **first-in-pairs-order** on ties (`cluster.py:1258`); MST weakest edge `min(mst,...)` + stable score-desc sort (`cluster.py:144,179`) — tie picks first-in-pairs-order, and can change WHICH edge is cut → **split membership** | `test_cluster.py:217` (no tie); `test_native_cluster_orchestration_parity.py:82-85` encodes first-in-order as contract | **INVESTIGATE → define order-free rule** | replace first-in-pairs-order with a **deterministic order-free** tie-break, e.g. lexicographic `(min_id, max_id)`, applied to BOTH bottleneck selection and MST equal-weight edge choice, so split membership is pair-order-independent. **OUTPUT-CHANGING on ties — sign-off + count.** |
+
+### The one genuinely SEMANTIC float boundary (ε-parity must pin it)
+
+`cluster.py:954` (and frames twins `:677`, dict-via-frames `:943`):
+`(avg_edge - min_edge) > weak_cluster_threshold` (default 0.3) → `cluster_quality`
+`"weak"`/`"strong"` + `confidence *= 0.7`. `min_edge` is order-free; `avg_edge` is
+the order-dependent sum. A ≤1e-9 reassociation can flip the label for any cluster
+whose `(avg_edge - min_edge)` sits within ε of 0.3. **The label flip is semantic
+even though it is gated on a float artifact.** ε-parity rule: compute `avg_edge`
+order-free (deterministic), and treat the weak/strong LABEL as a semantic
+invariant — the count below measures how many clusters actually sit in the ε-band.
+
+### THE RESIDUAL — confirmed absent (the cutover can show the RSS win)
+
+Traced (Agent, 2026-06-03): with `GOLDENMATCH_CLUSTER_FRAMES_OUT=1` (identity ON,
+output flags OFF), cluster→golden→identity runs **dict-free**. No `dict[int,dict]`
+is rebuilt on the hot path: golden goes `build_golden_records_from_frames` (frame
+in), identity consumes `_frames_iter(cluster_frames)` directly (`resolve.py:317`),
+`pair_score_view` is `from_frames` (`pipeline.py:1904-1908`). The only `dict[int,
+dict]` materializations are (a) the oversized-split minority inside
+`build_cluster_frames`, and (b) the terminal `results["clusters"]` rebuild at
+`pipeline.py:1940` — **after** the identity stage. So the dict-rebuild residual
+that would hide the -30% RSS @25M win is absent on the measured window, PROVIDED
+the bench does not force `results["clusters"]` into that window.
+
+### Gate re-framing (supersedes the blanket "byte-identical" parity discipline for Phase 2)
+
+The "Parity discipline" section above said "byte-identical pairs/fingerprints …
+identical golden output" as a blanket cutover gate. For Phase 2 specifically,
+split it:
+
+- **Intermediate / per-SP gates = SEMANTIC parity + FEASIBILITY.** Rand index 1.0
+  on partition, identical golden content, entity-partition equality — PLUS "does
+  it run / not-OOM at scale." NOT float-exact confidence, NOT artifact (dedup
+  order, fill order, tie order). A half-cutover's small-N RSS is a guaranteed
+  false negative (pays for frames AND dict) and does NOT gate.
+- **The RSS/wall VERDICT moves to the COMPLETE path at 25M+** — the roadmap's
+  -30% RSS @25M criterion — measured on the most-complete frames path
+  (`GOLDENMATCH_CLUSTER_FRAMES_OUT=1`), accounting for the terminal-dict residual
+  (exclude `results["clusters"]` from the measured window).
+- **`cluster_quality` label and the weak/strong boundary stay SEMANTIC** (ε-parity
+  pins behavior at the 0.3 boundary; everything else about confidence is ε).
+
+### Output-changing items awaiting explicit human sign-off (DO NOT ship silently)
+
+Each is a customer-facing behavior change. Blast radius = count of affected
+rows/clusters at 1M and 5M (measurement dispatched 2026-06-03; table filled on
+return). NONE is implemented until reviewed.
+
+1. **Cluster `pair_scores` LAST-WINS → MAX.** Aligns cluster metadata with the
+   already-MAX `scored_pairs`. Affects: `confidence`, `bottleneck_pair`,
+   `cluster_quality` (via `avg_edge`/`min_edge`), MST-split membership, and
+   identity evidence-edge scores (`resolve.py:493/660`). Blast radius = clusters
+   containing a different-score duplicate canonical pair. **Count @1M/5M: PENDING.**
+2. **Order-free `avg_edge` (ε vs bit-exact confidence).** Affects: `confidence`
+   float on every multi-edge cluster (≤~1e-6); `cluster_quality` LABEL flips ONLY
+   for clusters within ε of the 0.3 weak boundary. Blast radius = clusters in the
+   ε-band of the boundary. **Count of label flips @1M/5M: PENDING.**
+3. **Order-free bottleneck / MST tie-break (lexicographic).** Affects:
+   `bottleneck_pair` on min-edge ties; split partition membership on MST
+   equal-weight ties. Blast radius = clusters with a tied min-edge or tied MST
+   weight. **Count @1M/5M: PENDING.**
+
+Items 1-3 are coupled (all flow from relaxing pair-order artifact parity); the
+count script measures all three in one pass. **No cluster code changes until this
+table is filled and the three items are signed off.**
+
+## Scale mode decision (2026-06-03)
+
+**Decision:** stop chasing bit-identical parity between the Arrow path and the
+legacy Python dict path. Reframe `GOLDENMATCH_CLUSTER_FRAMES_OUT` into an
+explicit, documented **mode** — `mode="scale"` vs `mode="standard"` — with
+`"standard"` (today's mature exact path) remaining the default. Scale mode is the
+frames-out complete path with relaxed *artifact* parity, dropped exotic features,
+and a HARD determinism requirement.
+
+**Why this is the right bar, not a cop-out.** At the scale this path is FOR, the
+legacy dict path OOMs and produces NO output, so "bit-identical to legacy" is
+*undefined* there. And no scale-oriented ER product offers identity at scale:
+Splink guarantees reproducibility only given a fixed backend (results differ
+across Spark/DuckDB/SQLite); Spark float aggregations are order-non-deterministic
+unless forced. Holding the Arrow path to bit-identity was holding it to a bar no
+competitor in the category meets. The win we keep: **the partition (membership)
+stays exact** — connected components are order-free, so scale mode yields the
+*identical clusters* as standard mode, deterministically, with only confidence
+within ε. That is a contract *stronger* than Splink (whose clusters can shift
+across backends): we match the category where identity is impossible (floats) and
+beat it where customers care (membership).
+
+### The scale-mode contract
+
+| Property | Contract | Grounded in |
+|---|---|---|
+| Cluster **partition** / membership | **Strict — Rand index 1.0** | order-free (UF); members-as-set already (#598); `test_cluster_frames_out_parity.py:17-21` (frozenset) |
+| record→cluster, entity-ID stability **within a run** | **Strict** | identity partition + det-mint legs (`test_identity_from_frames_parity.py`) |
+| golden record content | **Strict (semantic)** | shared `build_golden_records_df` (`golden.py:1162`) |
+| confidence floats | **ε-tolerance, order-free reduction; EXACT only at the weak/quality boundary** | only `avg_edge=sum/len` is order-dependent (`cluster.py:1251`); the boundary `(avg_edge-min_edge)>0.3` (`cluster.py:954`) is semantic |
+| multi-matchkey dedup | **MAX (`dedup_pairs_max_score`)**, not last-wins | resolves the MAX≠LAST contradiction toward the canonical `scored_pairs` (`pairs.py:35` vs `cluster_pairscores.py:25`) |
+| bottleneck tie-break, member order, pair-fill order | **Deterministic order-free rules** (e.g. lexicographic `(min_id,max_id)`) | frees vectorization; current rule is first-in-pairs-order (`cluster.py:1258`) |
+| LLM/rerank/boost, NE post-filters, exotic matchkeys | **Drop EXPLICITLY** — error or warn, never silent | mirror the DataFusion-backend `NotImplementedError`-on-out-of-scope pattern |
+| **Determinism** | **HARD requirement: same input → same output across runs AND across `--workers`** | the one property we must not lose |
+
+**Determinism trap (must verify, not assume):** "deterministic per run" is
+insufficient — it must survive `--workers` changes. The native kernel accumulates
+`avg_edge` in f32 and `bucket_score` runs `max_workers=16`; parallel float
+reduction changes the reduction-tree shape with worker count and can drift the
+output. Pin the reduction order (sort-then-reduce or order-independent
+accumulation) so parallelism cannot change results. **Gate: run twice at
+different `--workers`, assert identical partition + ε-equal confidence.**
+
+### Gates (replace the bit-identical parity gate)
+
+- **Correctness gate** = partition Rand index 1.0 + golden-record validity +
+  **deterministic (run twice, incl. across `--workers`, → identical)** + every
+  dropped feature errors/warns. NOT byte-identical confidence/pair_scores.
+- **Perf verdict** = SP-C complete-path bench at **25M and 100M**, on the
+  **post-#691/#692 stack** (zero-copy round-trip removed, rayon park fixed),
+  numbers **committed back here**. First clean test of the thesis.
+
+#### Verdict — RECORDED 2026-06-03 (run 26878555131, dict-backed view, post-#691/#692)
+
+| pairs | variant | build s | golden s | id_prep s | peak RSS MB |
+|---|---|---|---|---|---|
+| 25M | legacy | 65.2 | 13.4 | 11.8 | 16,169 |
+| 25M | columnar | 31.4 | 0.92 | 45.8 | **14,155 (−12.5%)** |
+| 100M | legacy | 284.8 | 56.7 | 47.6 | 61,082 |
+| 100M | columnar | 136.8 | 3.87 | 566.0 | **56,333 (−7.8%)** |
+
+**Honest read (the first clean test, and it's mixed):**
+1. **RSS win CONFIRMED but MODEST.** −12.5% @25M, −7.8% @100M — real and
+   consistent, but **below the −30% @25M target**. The shortfall is the residual
+   we still pay: the per-pair view dict-of-dicts is *still materialized* (this is
+   the half-state, not the complete path). The −12.5% is what's left after the
+   build skips legacy's `pair_scores`-into-clusters fill; the view is the rest.
+2. **The OOM trump card did NOT fire.** The legacy dict **fit at 100M** (61 GB on
+   the 64 GB box) — it did not OOM. So "the dict doesn't finish" is **unproven at
+   this scale**; the cluster-dict OOM cliff is beyond 100M pairs / 64 GB. Either
+   the workload must push past it, or the RSS win is real-but-non-binding at
+   operating scale (the §6 question, now empirical).
+3. **Wall splits on scale.** Columnar build 2.1× + golden 14.6× are large and
+   real. But `id_prep` (the view-build) is **super-linear near the memory
+   ceiling**: 45.8s @25M (far from ceiling) → 566s @100M (near 56 GB). So
+   **columnar wins total wall at 25M (+13.6%) but loses 1.8× at 100M.** Legacy
+   `from_pairs` id_prep stays linear (11.8→47.6); the columnar `from_frames`
+   view-build is intrinsically ~4× slower AND blows up under memory pressure.
+4. **The view-build is the limiter on BOTH axes** — it is the residual RSS AND
+   the wall regression. Eliminating it (identity emits evidence edges per-cluster
+   directly from frames, never a `dict[int,dict]` view) is the single lever that
+   removes the 566s wall and pushes RSS past the remaining view cost toward −30%.
+
+**Decision impact:** this verdict does **NOT** clear the −30% gate and does NOT
+demonstrate the OOM trump card, so it does **not** justify flipping the default by
+itself. It confirms direction (RSS down, build/golden fast) and identifies the
+unlock (view-elimination). Recommend: build scale mode WITH view-elimination as a
+first-class component (not a follow-on), then re-verdict at a scale/box that
+actually stresses the cluster dict to settle binding-vs-non-binding.
+
+### Feature matrix (scale mode supported / dropped) — SHIPPED (Stage D)
+
+Enforced by `backends/datafusion_spine.py::_validate_scale_mode_supported`
+(called first in `run_spine`); raises `NotImplementedError` on every ❌ row and
+`ValueError` when invoked without `config.mode == "scale"`. Tests:
+`tests/test_datafusion_spine_scale_mode.py`.
+
+| Capability | standard | scale | Note |
+|---|---|---|---|
+| exact + fuzzy matchkeys (jw/token_sort/ensemble) | ✅ | ✅ | the columnar fast path (`_resolve_fast_path`) covers these |
+| weighted multi-field matchkey | ✅ | ✅ | single combined score (no dup canonical pairs — see counts) |
+| multiple independent matchkeys | ✅ | ✅ (MAX dedup) | dedup switches last-wins → MAX |
+| auto-config / controller | ✅ | ✅ | unchanged |
+| cluster partition + golden + identity (within-run) | ✅ | ✅ | partition strict; identity from frames |
+| confidence / cluster_quality | ✅ exact | ✅ ε + exact-at-boundary | label semantic, float ε |
+| LLM scorer / cluster | ✅ | ❌ explicit error | not vectorizable; out of scale scope (`llm_scorer.enabled`, `llm_auto`) |
+| cross-encoder rerank, boost (active-learning) | ✅ | ❌ explicit error | model bootstrap; out of scope (`mk.rerank`, `llm_boost`) |
+| negative-evidence post-filters | ✅ | ❌ explicit error | per-pair Python post-filter; drop-loud (`mk.negative_evidence`) |
+| PPRL / probabilistic / domain-extraction matchkeys | ✅ | ❌ explicit error | exotic; non-weighted `mk.type` + `domain.enabled` error |
+
+### A measurement finding that shapes the verdict (verify-don't-trust)
+
+The frames-out RSS win is real but it is **sensitive to the view representation**,
+and the #693 default is the *wrong* one. At 100M (post-#691/#692):
+
+| view backing | id_prep wall | peak RSS vs legacy |
+|---|---|---|
+| #693 `partition_by(as_dict=True)` | 257s | **+1% (regression)** |
+| simple dict-backed (`_by_cid`) | 539s | **−7.8% (the win)** |
+
+`partition_by(as_dict=True)` at ~33M size-3 clusters makes ~33M tiny Arrow frames;
+per-frame overhead dwarfs a single dict → it *increased* RSS. The lean dict-backed
+view is what shows the thesis (−7.8%). **Implication for scale mode:** use the
+dict-backed view, NOT the partition-backed one #693 shipped. **Bigger lever (out
+of scale-mode-as-relabel scope, flagged):** the view is materialized at all only
+because identity emits one evidence edge per pair from a `dict[int,dict]`. The id_prep
+wall (257–539s, the whole columnar wall regression) IS the view-build. Eliminating
+the view — identity reads per-cluster pairs directly from frames — removes that wall
+AND drops RSS further. Scale-mode-as-relabel banks the RSS win and keeps the wall;
+killing the view is the follow-on that also wins wall. Recommend sequencing the
+relabel first (it's the verdict), then the view-elimination as a distinct unit.
+
+### Human sign-off — APPROVED 2026-06-03
+
+Ben approved the scale-mode decision + the §7 contract + the feature matrix + the
+three product items below. Remaining gate before flipping the default (per the
+handoff): the perf verdict recorded + determinism verified.
+
+1. **Feature matrix** (above) — APPROVED. The two ⚠️ (NE post-filters;
+   PPRL/probabilistic/domain matchkeys) resolve to **explicit error in scale
+   mode** unless a later need surfaces (conservative: drop-loud, not silent).
+2. **Customer-facing statement** — APPROVED: "scale mode is deterministic and
+   semantically correct (identical clusters, ε-equal confidence) but not
+   bit-identical to standard mode." Document at the mode's public entry point +
+   the scale-mode section of the README/docs. **SHIPPED (Stage D):** the
+   statement now lives in code as the `mode` field docstring
+   (`config/schemas.py::GoldenMatchConfig.mode`) and the
+   `ValueError`/`NotImplementedError` messages in
+   `_validate_scale_mode_supported`. Determinism is enforced by
+   `tests/test_datafusion_spine_parity.py::test_spine_deterministic_across_target_partitions`
+   (pair set + cluster partition + id_prep edges identical across
+   `target_partitions ∈ {1,3,17}`). The MAX-dedup contract (item 3) is the
+   scale-mode dedup; on the default single-weighted-matchkey path MAX≡last-wins
+   (R1=0), so the switch is a no-op there and only differs on explicit
+   multi-matchkey configs.
+3. **MAX vs last-wins** dedup switch — APPROVED (blast radius ≈ 0; 50k R1=0,
+   1M/5M confirming). Gated behind scale mode; standard keeps last-wins.
+
+**Blast radius (measured, `count_max_vs_last.py`):**
+- **R1 (last-wins → MAX):** 50k = **0 clusters** (the default single-weighted-
+  matchkey path produces NO duplicate canonical pairs; MAX≡LAST). Non-zero only
+  for explicit multi-matchkey configs, where MAX is the principled choice anyway.
+- **R2 (order-free confidence):** 50k = **0 label flips** (closest cluster 0.254
+  from the 0.30 boundary; nothing in the ε-band).
+- **R3 (tie-break):** 50k = **1.0% min-edge ties**, semantically inert (no weak
+  clusters → bottleneck feeds only explanations). MST-tie leg 0 (fixture has no
+  oversized clusters — denser fixture needed if that artifact matters).
+- 1M/5M: PENDING (re-dispatched with `confidence_required=False`).
+
+## Gate reframe: engine portability, not one-box RSS (2026-06-03, supersedes the RSS gate for this track)
+
+**The Arrow-native arc's destination is engine portability** — making every
+pipeline stage a frames-in/frames-out relational operation a query engine
+(DataFusion single-box out-of-core; Sail distributed) can plan, spill, and
+distribute. One-box peak RSS was always tactical. **RETIRE the Phase-2 "RSS
+−30% @25M" gate for this track** (it measured the wrong axis for a distributed
+destination — Splink/Spark/Sail scale *out*; one box always has a ceiling). The
+compact columnar representation is NOT wasted: at distributed scale it reappears
+as shuffle/spill efficiency (packed Arrow frames shuffle/spill far cheaper than
+dict-of-dicts).
+
+**Replacement gate:**
+1. **Engine-portability** — every stage is a relational plan an engine can own
+   (or, for the one non-relational stage, routes to label-prop — below).
+2. **Out-of-core / distributed throughput** — wall holds at 100M out-of-core
+   (DataFusion spill) and scales across nodes (Sail).
+
+### Engine-portability map
+
+| Stage | Relational? | DataFusion + Sail |
+|---|---|---|
+| score / block / dedup | ✅ | rides the engine; native scorers as Arrow UDFs (`datafusion_backend.py`) |
+| golden | ✅ | rides the engine (already 14.6× as a frame op) |
+| **id_prep** | ✅ **only after the group-by rewrite** | the ENABLING step (below) |
+| **Union-Find cluster build** | ❌ not relational | the genuine holdout — routes to the EXISTING distributed **label-propagation** path (`goldenmatch.distributed.clustering`, Splink-style ≥50M routing), NOT DataFusion. By nature, not a gap. |
+
+### id_prep-as-group-by is the critical-path ENABLING step (not a perf detour)
+
+The §1 verdict (recorded above) showed `id_prep` is the columnar wall regression:
+566s at 100M = 80% of the columnar wall; flips 100M end-to-end from a 2.07× win
+to a 1.8× loss. Root cause: SP4 relocated the per-cluster `pair_scores` fill into
+id_prep as a per-pair Python dict-of-dicts build — **un-distributable**. A Python
+per-cluster/per-pair loop cannot ride DataFusion or Sail; a
+`group_by("cluster_id").agg(...)` can. So the rewrite is not "optimize id_prep for
+RSS" — it is **"make id_prep plannable."** The ~2× end-to-end win is just the
+local proof it's now in the right shape.
+
+**Status (2026-06-03): PROVEN.** `ClusterPairScores.from_frames` rewritten as a
+`group_by("cluster_id", maintain_order=True).agg(...)` view with deferred
+per-cluster materialization (PR #696, last-wins parity GREEN). §1 complete-path
+re-run (run 26888605952, post-#691/#692, dict-free frames path):
+
+| pairs | variant | build s | golden s | id_prep s | peak RSS MB |
+|---|---|---|---|---|---|
+| 25M | legacy | 78.7 | 16.6 | 13.3 | 16,216 |
+| 25M | columnar | 39.6 | 0.93 | **8.2** | 19,307 |
+| 100M | legacy | 357.1 | 68.2 | 56.8 | 61,089 |
+| 100M | columnar | 190.4 | 4.23 | **34.3** | 61,554 |
+
+- **id_prep collapsed 566s → 34.3s @100M (16.5×), now BELOW legacy** (34 vs 57). The
+  un-distributable per-pair dict-of-dicts is gone; the stage is a vectorized
+  group-by — i.e. **plannable.**
+- **100M end-to-end flipped from a 1.8× loss to a 2.11× win** (columnar 229s vs
+  legacy 482s); 25M = 2.23×. Validates the thesis on every stage the columnar path
+  owns (build 1.9×, golden 16×, id_prep now a win).
+- RSS ≈ parity @100M (+0.8%), +19% @25M — NO LONGER THE GATE (engine-portability
+  gate above); at distributed scale this is shuffle/spill efficiency.
+
+**Consequence:** score/golden/id_prep are now ALL relational/plannable. The
+load-bearing precondition ("id_prep plannable BEFORE DataFusion") is MET →
+green-light the DataFusion spine (PR #695, the edge-group-by) as step 2. UF
+clustering still routes to label-prop (non-relational holdout, by nature).
+
 ## What this plan explicitly does NOT do
 
 - Re-open the phase definitions or kill criteria (unchanged from the original).

--- a/packages/python/goldenmatch/goldenmatch/backends/datafusion_spine.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/datafusion_spine.py
@@ -327,9 +327,11 @@ def run_spine(
         target_partitions: pins ``SessionConfig.with_target_partitions``.
 
     Returns:
-        ``(golden_df, assignments_df)`` where ``assignments_df`` is
-        ``cluster_frames.assignments`` (one row per ``(cluster_id,
-        member_id)``, singletons included).
+        ``(golden_df, assignments_df, raw_pairs)`` where ``assignments_df``
+        is ``cluster_frames.assignments`` (one row per ``(cluster_id,
+        member_id)``, singletons included) and ``raw_pairs`` is the RAW
+        above-threshold ``(a, b, score)`` list (a < b) the identity stage
+        rebuilds the id_prep view from.
     """
     from goldenmatch.core.cluster import build_cluster_frames
     from goldenmatch.core.cluster_pairscores import ClusterPairScores

--- a/packages/python/goldenmatch/goldenmatch/backends/datafusion_spine.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/datafusion_spine.py
@@ -148,6 +148,69 @@ def _golden_rules_knobs(config) -> tuple[int, float, bool, Any]:
     return max_cluster_size, weak_threshold, auto_split, golden_rules
 
 
+def _validate_scale_mode_supported(config) -> None:
+    """Hard-gate the scale-mode feature surface. Raise EXPLICITLY (never
+    silently ignore) when ``mode="scale"`` is paired with an unsupported
+    feature, so a customer never gets a silently-degraded result. Mirrors
+    ``datafusion_backend._validate_matchkey``'s NotImplementedError-on-
+    out-of-scope contract.
+
+    Supported scale-mode surface: a single-field ``weighted`` matchkey with
+    a supported scorer (jaro_winkler / levenshtein / token_sort), static
+    blocking, golden rules. Everything below is OUT and errors.
+    """
+    if getattr(config, "mode", "standard") != "scale":
+        raise ValueError(
+            "DataFusion spine requires mode='scale' (the opt-in to the "
+            "out-of-core, MAX-dedup, reduced-feature path). Set "
+            "config.mode='scale' to use run_spine; standard mode runs the "
+            "in-memory pipeline."
+        )
+
+    if getattr(config, "llm_boost", False):
+        raise NotImplementedError(
+            "DataFusion spine (mode='scale') does not support LLM boost "
+            "(config.llm_boost=True). Drop it or use standard mode."
+        )
+    if getattr(config, "llm_auto", False):
+        raise NotImplementedError(
+            "DataFusion spine (mode='scale') does not support LLM auto "
+            "(config.llm_auto=True). Drop it or use standard mode."
+        )
+    llm_scorer = getattr(config, "llm_scorer", None)
+    if llm_scorer is not None and getattr(llm_scorer, "enabled", False):
+        raise NotImplementedError(
+            "DataFusion spine (mode='scale') does not support the LLM "
+            "scorer/cluster (config.llm_scorer.enabled=True). Drop it or "
+            "use standard mode."
+        )
+    domain = getattr(config, "domain", None)
+    if domain is not None and getattr(domain, "enabled", False):
+        raise NotImplementedError(
+            "DataFusion spine (mode='scale') does not support domain "
+            "extraction / exotic domain matchkeys (config.domain.enabled="
+            "True). Drop it or use standard mode."
+        )
+
+    for mk in config.get_matchkeys():
+        if getattr(mk, "type", None) != "weighted":
+            raise NotImplementedError(
+                "DataFusion spine (mode='scale') supports only single-field "
+                f"weighted matchkeys; matchkey {mk.name!r} has "
+                f"type={mk.type!r} (probabilistic/exact/exotic out of scope)."
+            )
+        if getattr(mk, "rerank", False):
+            raise NotImplementedError(
+                "DataFusion spine (mode='scale') does not support "
+                f"rerank/cross-encoder (matchkey {mk.name!r} rerank=True)."
+            )
+        if getattr(mk, "negative_evidence", None):
+            raise NotImplementedError(
+                "DataFusion spine (mode='scale') does not support "
+                f"negative-evidence post-filters (matchkey {mk.name!r})."
+            )
+
+
 def _resolve_single_weighted_matchkey(config) -> Any:
     """Pick the single weighted matchkey the spine scores. The spine
     scope mirrors ``score_blocks_datafusion`` (single-field weighted,
@@ -271,6 +334,9 @@ def run_spine(
     from goldenmatch.core.cluster import build_cluster_frames
     from goldenmatch.core.cluster_pairscores import ClusterPairScores
     from goldenmatch.core.golden import build_golden_records_from_frames
+
+    # ── Stage D: scale-mode feature gate (error, never silently ignore) ─
+    _validate_scale_mode_supported(config)
 
     # ── C1: ctx + score + dedup ───────────────────────────────────────
     mk = _resolve_single_weighted_matchkey(config)

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -722,6 +722,13 @@ class GoldenMatchConfig(BaseModel):
     llm_auto: bool = False
     domain: DomainConfig | None = None
     backend: str | None = None  # None (default Polars), "ray", "duckdb"
+    # Execution mode. "standard" (default) = the in-memory/Ray pipeline,
+    # bit-identical artifacts. "scale" = the DataFusion spine (out-of-core,
+    # deterministic + semantically correct but NOT bit-identical to standard;
+    # MAX dedup, reduced feature surface). The spine entry
+    # (backends/datafusion_spine.run_spine) enforces the scale-mode feature
+    # gate; this field is the opt-in signal.
+    mode: Literal["standard", "scale"] = "standard"
     memory: MemoryConfig | None = None
     identity: IdentityConfig | None = None
     exclude_columns: list[str] = Field(

--- a/packages/python/goldenmatch/tests/test_config.py
+++ b/packages/python/goldenmatch/tests/test_config.py
@@ -393,3 +393,26 @@ def test_golden_rules_cluster_quality_defaults():
     assert config.auto_split is True
     assert config.quality_weighting is True
     assert config.weak_cluster_threshold == 0.3
+
+
+# ── mode field (Stage D: scale-mode contract) ───────────────────────────────
+
+
+def test_config_mode_defaults_to_standard():
+    cfg = GoldenMatchConfig()
+    assert cfg.mode == "standard"
+
+
+def test_config_mode_accepts_scale():
+    cfg = GoldenMatchConfig(mode="scale")
+    assert cfg.mode == "scale"
+
+
+def test_config_mode_rejects_unknown_value():
+    with pytest.raises(ValidationError):
+        GoldenMatchConfig(mode="turbo")
+
+
+def test_config_mode_round_trips_through_model_dump():
+    cfg = GoldenMatchConfig(mode="scale")
+    assert GoldenMatchConfig(**cfg.model_dump()).mode == "scale"

--- a/packages/python/goldenmatch/tests/test_datafusion_spine_parity.py
+++ b/packages/python/goldenmatch/tests/test_datafusion_spine_parity.py
@@ -84,6 +84,7 @@ def _config(*, max_cluster_size: int) -> GoldenMatchConfig:
     ``zip`` so each archetype lands in its own block.
     """
     return GoldenMatchConfig(
+        mode="scale",
         blocking=BlockingConfig(
             strategy="static", keys=[BlockingKeyConfig(fields=["zip"])],
         ),

--- a/packages/python/goldenmatch/tests/test_datafusion_spine_parity.py
+++ b/packages/python/goldenmatch/tests/test_datafusion_spine_parity.py
@@ -318,3 +318,52 @@ def test_spine_idprep_edge_parity(monkeypatch, native):
     spine_edges = _edge_sets_by_partition(spine[1], spine[2])
     comp_edges = _edge_sets_by_partition(comp[1], comp[2])
     assert spine_edges == comp_edges
+
+
+# ── Stage D: determinism across target_partitions ────────────────────────────
+
+
+def _run_spine_tp(blocks, config, target_partitions):
+    from goldenmatch.backends.datafusion_spine import run_spine
+    return run_spine(blocks, config, target_partitions=target_partitions)
+
+
+def test_spine_deterministic_across_target_partitions():
+    """Stage D gate: the emitted pair SET, the cluster PARTITION, and the
+    id_prep edge sets are identical across target_partitions {1,3,17}.
+
+    Compared as SETS/PARTITIONS (label- and order-independent), NOT raw f32
+    float equality. The fixture's within-block strings are identical, so every
+    pair scores exactly 1.0 (threshold 0.85 -> 0.15 margin): no pair is within
+    1e-6 of the cutoff, so this measures partition determinism, not threshold
+    flapping (spec Stage D). avg_edge is intentionally NOT asserted: run_spine
+    does not return cluster metadata, and with uniform 1.0 scores avg_edge is a
+    deterministic function of the (proven-identical) edge sets, so it cannot
+    drift independently.
+    """
+    df = _fixture_df()
+    config = _config(max_cluster_size=100)
+
+    results = {}
+    for tp in (1, 3, 17):
+        # Rebuild blocks per run so each run is independent (build_blocks may
+        # yield a lazy frame consumed once).
+        blocks_tp = _prepared_blocks(df, config)
+        _golden, assign, raw_pairs = _run_spine_tp(blocks_tp, config, tp)
+        results[tp] = {
+            "pairset": frozenset((min(a, b), max(a, b)) for a, b, _ in raw_pairs),
+            "partition": _partition(assign),
+            "edges": _edge_sets_by_partition(assign, raw_pairs),
+        }
+
+    base = results[1]
+    for tp in (3, 17):
+        assert results[tp]["pairset"] == base["pairset"], (
+            f"pair set diverged at target_partitions={tp}"
+        )
+        assert results[tp]["partition"] == base["partition"], (
+            f"cluster partition diverged at target_partitions={tp}"
+        )
+        assert results[tp]["edges"] == base["edges"], (
+            f"id_prep edge sets diverged at target_partitions={tp}"
+        )

--- a/packages/python/goldenmatch/tests/test_datafusion_spine_scale_mode.py
+++ b/packages/python/goldenmatch/tests/test_datafusion_spine_scale_mode.py
@@ -1,0 +1,128 @@
+"""Stage D: scale-mode feature-gate. ``run_spine`` must raise an explicit
+error (never silently ignore) when ``mode="scale"`` is paired with an
+unsupported surface, and must refuse a non-scale config."""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    NegativeEvidenceField,
+)
+
+
+def _base_config(**overrides) -> GoldenMatchConfig:
+    """Valid single-field weighted scale-mode config (the supported shape).
+    ``overrides`` patch top-level fields; matchkey-level surfaces are set by
+    mutating the returned config's matchkey in the test."""
+    cfg = GoldenMatchConfig(
+        mode="scale",
+        blocking=BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["zip"])],
+        ),
+        matchkeys=[
+            MatchkeyConfig(
+                name="fuzzy_last",
+                fields=[MatchkeyField(
+                    column="last_name", scorer="jaro_winkler", weight=1.0,
+                )],
+                comparison="weighted",
+                threshold=0.85,
+            ),
+        ],
+    )
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _run(cfg):
+    from goldenmatch.backends.datafusion_spine import run_spine
+    return run_spine([], cfg)
+
+
+def test_gate_rejects_non_scale_mode():
+    cfg = _base_config()
+    cfg.mode = "standard"
+    with pytest.raises(ValueError, match="mode='scale'"):
+        _run(cfg)
+
+
+def test_gate_rejects_llm_boost():
+    with pytest.raises(NotImplementedError, match="boost"):
+        _run(_base_config(llm_boost=True))
+
+
+def test_gate_rejects_llm_auto():
+    with pytest.raises(NotImplementedError, match="LLM"):
+        _run(_base_config(llm_auto=True))
+
+
+def test_gate_rejects_llm_scorer_enabled():
+    from goldenmatch.config.schemas import LLMScorerConfig
+    with pytest.raises(NotImplementedError, match="LLM"):
+        _run(_base_config(llm_scorer=LLMScorerConfig(enabled=True)))
+
+
+def test_gate_allows_llm_scorer_present_but_disabled():
+    # A disabled LLM scorer is inert -> must NOT trip the gate. It proceeds
+    # past the gate and hits the empty-blocks no-op path, returning normally.
+    from goldenmatch.config.schemas import LLMScorerConfig
+    _run(_base_config(llm_scorer=LLMScorerConfig(enabled=False)))
+
+
+def test_gate_rejects_domain_enabled():
+    from goldenmatch.config.schemas import DomainConfig
+    with pytest.raises(NotImplementedError, match="domain"):
+        _run(_base_config(domain=DomainConfig(enabled=True)))
+
+
+def test_gate_rejects_rerank():
+    cfg = _base_config()
+    cfg.get_matchkeys()[0].rerank = True
+    with pytest.raises(NotImplementedError, match="rerank"):
+        _run(cfg)
+
+
+def test_gate_rejects_negative_evidence():
+    cfg = _base_config()
+    cfg.get_matchkeys()[0].negative_evidence = [
+        NegativeEvidenceField(
+            field="phone", scorer="exact", threshold=0.9, penalty=0.5,
+        )
+    ]
+    with pytest.raises(NotImplementedError, match="negative.evidence"):
+        _run(cfg)
+
+
+def test_gate_rejects_probabilistic_matchkey():
+    # A weighted matchkey plus a stray probabilistic one: the gate iterates
+    # ALL matchkeys (never silently ignores the extra), so it errors.
+    cfg = GoldenMatchConfig(
+        mode="scale",
+        blocking=BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["zip"])],
+        ),
+        matchkeys=[
+            MatchkeyConfig(
+                name="fuzzy_last",
+                fields=[MatchkeyField(
+                    column="last_name", scorer="jaro_winkler", weight=1.0,
+                )],
+                comparison="weighted",
+                threshold=0.85,
+            ),
+            MatchkeyConfig(
+                name="prob_mk",
+                fields=[MatchkeyField(
+                    column="last_name", scorer="jaro_winkler",
+                )],
+                comparison="probabilistic",
+            ),
+        ],
+    )
+    with pytest.raises(NotImplementedError, match="weighted"):
+        _run(cfg)

--- a/packages/python/goldenmatch/tests/test_datafusion_spine_scale_mode.py
+++ b/packages/python/goldenmatch/tests/test_datafusion_spine_scale_mode.py
@@ -68,10 +68,17 @@ def test_gate_rejects_llm_scorer_enabled():
 
 
 def test_gate_allows_llm_scorer_present_but_disabled():
-    # A disabled LLM scorer is inert -> must NOT trip the gate. It proceeds
-    # past the gate and hits the empty-blocks no-op path, returning normally.
+    # A disabled LLM scorer is inert -> must NOT trip the gate. Assert the
+    # gate itself (its precise unit boundary) returns without raising; we
+    # don't drive the full empty-blocks pipeline here (that path hits an
+    # unrelated pre-existing empty-input SchemaError in the frames-out tail).
+    from goldenmatch.backends.datafusion_spine import (
+        _validate_scale_mode_supported,
+    )
     from goldenmatch.config.schemas import LLMScorerConfig
-    _run(_base_config(llm_scorer=LLMScorerConfig(enabled=False)))
+
+    cfg = _base_config(llm_scorer=LLMScorerConfig(enabled=False))
+    assert _validate_scale_mode_supported(cfg) is None
 
 
 def test_gate_rejects_domain_enabled():


### PR DESCRIPTION
Stage D of the DataFusion spine. Adds the `mode={standard,scale}` config field, a hard feature-gate at `run_spine` entry (errors on LLM boost/auto/scorer, domain, rerank, negative-evidence, non-weighted matchkeys, and non-scale mode — never silently ignores), and a determinism gate across `target_partitions {1,3,17}` (pair set + cluster partition + id_prep edges identical). Finalizes the scale-mode sign-off + feature matrix in the roadmap.

Spec: `docs/superpowers/specs/2026-06-03-datafusion-spine-design.md` (Stage D). Builds on #700 (Stage C).

Gate: green `python (goldenmatch)` lane (builds the datafusion-udf FFI wheel + installs datafusion>=53). Does NOT flip the mode default — that stays gated on Stage E's spill verdict.