### PR TITLE
docs: add context network (navigable knowledge + decision layer)

### DIFF
--- a/.context-network.md
+++ b/.context-network.md
@@ -1,0 +1,26 @@
+# Context Network Discovery
+
+This project keeps its planning, architecture, decisions, and durable knowledge in a
+**context network** under `context-network/`. That directory is the navigable "brain"
+for the repo; the code under `packages/` is the build artifact the network is about.
+
+> **Agents & contributors:** start at `context-network/discovery.md`. Do NOT scatter
+> planning/decision notes into source directories — they belong in the network.
+
+## Relationship to the other context sources
+
+This repo predates the context network and already carries rich context. The network
+**organizes and points to** these; it does not replace or duplicate them:
+
+- **`CLAUDE.md` (root + per-package)** — the authoritative, code-level operational
+  notes (build/test commands, perf numbers, gotchas, architecture index). Loaded into
+  every agent session. The network references it; it stays the source of truth for
+  "how the code/tooling actually behaves."
+- **`docs/superpowers/specs/` + `docs/superpowers/plans/`** — the spec→plan artifacts
+  for each workstream (design docs, implementation plans). The network's decision and
+  planning nodes link to these.
+- **User-level memory** (`~/.claude/projects/.../memory/`) — cross-session facts for
+  the agent. Overlaps the network's status notes; the network is the committed,
+  shared view.
+
+Created 2026-06-03.

--- a/context-network/architecture/datafusion-spine.md
+++ b/context-network/architecture/datafusion-spine.md
@@ -1,0 +1,60 @@
+# DataFusion Spine (scale mode)
+
+The embedded-DataFusion path: thread the relational ER stages through ONE Python
+`datafusion.SessionContext` with out-of-core spill, the native string scorers as a Rust
+`ScalarUDF` via `datafusion-ffi`, and Union-Find routed to the existing label-prop path.
+Opt-in behind `mode="scale"`.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-datafusion-spine-design.md`
+**Parent/roadmap:** `docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md`
+
+## Shape
+```
+[ one datafusion.SessionContext, fair_spill_pool(memory_limit) ]
+   score:  block self-join (a.__block_key__=b.__block_key__ AND a.__row_id__<b.__row_id__),
+           FFI scorer UDF over __value__, threshold-filter
+   dedup:  SELECT a,b,max(score) GROUP BY a,b   (in-ctx, spills)
+   -> RAW scored pairs
+[ mirror the in-memory frames-out tail, Ray-free ]
+   build_cluster_frames(RAW pairs, all_ids)  -> assignments + metadata   <-- UF break (NOT relational)
+   ClusterPairScores.from_frames(...)         [id_prep]
+   build_golden_records_from_frames(...)      [golden]
+```
+The UF break collects pairs to the driver — an **in-memory island the spill pool does
+NOT cover**. This is the load-bearing fact behind the Stage E verdict
+([../decisions/0003-stage-e-spill-honest-null.md](../decisions/0003-stage-e-spill-honest-null.md)).
+
+## Entry points
+- `backends/datafusion_spine.py::run_spine(blocked_candidates, config, *, memory_limit=None, target_partitions=None)` → `(golden_df, assignments, raw_pairs)`.
+- `_validate_scale_mode_supported(config)` — the Stage D feature gate (called first).
+- `backends/datafusion_backend.py` — `_validate_matchkey`, `_make_score_udf` (B1 Python UDF fallback), `_materialize_blocks_to_arrow`.
+- `config/schemas.py::GoldenMatchConfig.mode` — the `{standard,scale}` opt-in.
+- FFI crate: `packages/rust/extensions/datafusion-udf/`.
+
+## Status by stage (all merged on `main` as of 2026-06-03)
+| Stage | What | State |
+|---|---|---|
+| A | FFI ScalarUDF feasibility (add_one PyCapsule) | merged |
+| B | native scorers as FFI ScalarUDFs (score-core) | merged |
+| C | `run_spine` orchestration; parity-gated (Rand 1.0 + golden + edges) | merged (#700) |
+| D | scale-mode contract: `mode` field, feature gate, determinism gate | merged (#702) |
+| E | out-of-core spill bench | merged (#705 harness, #706 verdict) — **HONEST-NULL** |
+
+## Key constraints (verify before extending)
+- `run_spine` REQUIRES `config.mode == "scale"` (the gate raises `ValueError` otherwise).
+- Scale mode supports ONLY single-field weighted matchkeys w/ supported scorers
+  (jaro_winkler / levenshtein / token_sort); LLM/rerank/boost/NE/exotic/domain all
+  raise `NotImplementedError`. See [../decisions/0002-scale-mode-contract.md](../decisions/0002-scale-mode-contract.md).
+- The CI `python (goldenmatch)` lane builds the FFI UDF wheel + installs `datafusion>=53`;
+  it does NOT build `_native`, so spine tests compare against python `rapidfuzz`.
+- Known pre-existing bug (flagged, unfixed): `run_spine` on empty/all-singleton input
+  hits a `SchemaError` in the frames-out tail (null vs i64 join key).
+
+## Open follow-ups
+- Relational-stages-only spill bench (score+dedup under a cgroup `MemoryMax` cap,
+  excluding the UF collection) — to show relational spill survival crisply.
+- Sail tier: route the UF break to distributed label-prop (≥50M), removing the in-memory
+  island — the only thing that unlocks beyond-one-box scale + would let the default flip.
+
+---
+**Classification:** architecture/active • **Last updated:** 2026-06-03

--- a/context-network/decisions/0001-gate-reframe-engine-portability.md
+++ b/context-network/decisions/0001-gate-reframe-engine-portability.md
@@ -1,0 +1,31 @@
+# 0001 — Gate reframe: engine portability, not one-box RSS
+
+**Status:** accepted (2026-06-03) • **Supersedes:** the Phase-2 "RSS −30% @25M" gate for this track
+
+## Context
+The Arrow-native cutover was originally gated on one-box peak-RSS reduction. But the
+destination is a distributed engine (DataFusion single-box out-of-core; Sail distributed)
+which scales *out* — one box always has a ceiling, so RSS measured the wrong axis.
+
+## Decision
+Retire the one-box RSS gate for the Arrow-native track. Replace with:
+1. **Engine portability** — every stage is a relational plan an engine can own (the one
+   non-relational stage, Union-Find cluster build, routes to label-prop, not DataFusion).
+2. **Out-of-core / distributed throughput** — wall holds out-of-core (DataFusion spill)
+   and scales across nodes (Sail).
+
+The compact columnar representation isn't wasted: at distributed scale it reappears as
+shuffle/spill efficiency (packed Arrow frames beat dict-of-dicts).
+
+## Consequences
+- The DataFusion spine ([../architecture/datafusion-spine.md](../architecture/datafusion-spine.md))
+  is the concrete step-2 work (step 1, id_prep-as-group-by, was proven in #696).
+- The Union-Find cluster build is the named non-relational holdout — by nature, not a gap.
+- This reframe is what makes the Stage E honest-null result
+  ([0003-stage-e-spill-honest-null.md](0003-stage-e-spill-honest-null.md)) a *non-failure*:
+  the value claimed is portability, not one-box survival.
+
+**Source:** roadmap doc § "Gate reframe: engine portability".
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-06-03

--- a/context-network/decisions/0002-scale-mode-contract.md
+++ b/context-network/decisions/0002-scale-mode-contract.md
@@ -1,0 +1,34 @@
+# 0002 — Scale-mode contract
+
+**Status:** accepted + shipped (2026-06-03, PR #702) • **Human sign-off:** Ben, 2026-06-03
+
+## Context
+The DataFusion spine is semantically correct but NOT bit-identical to the standard
+in-memory pipeline (parallel float reductions; MAX-vs-last-wins dedup; a reduced feature
+surface). Shipping it as a silent behavior change would be wrong.
+
+## Decision
+Introduce an explicit, opt-in execution mode: `GoldenMatchConfig.mode: {"standard","scale"}`,
+default `"standard"`.
+
+- **Customer statement (approved):** "scale mode is deterministic and semantically correct
+  (identical clusters, ε-equal confidence) but not bit-identical to standard mode."
+- **Dedup:** scale mode uses MAX (`dedup_pairs_max_score`); standard keeps last-wins. On
+  the default single-weighted-matchkey path MAX≡last-wins (blast radius R1=0), so it only
+  differs on explicit multi-matchkey configs (where MAX is the principled choice).
+- **Hard feature gate** at `run_spine` entry (`_validate_scale_mode_supported`): raises
+  `ValueError` if `mode!="scale"`, `NotImplementedError` (explicit, never silent) on
+  llm_boost / llm_auto / llm_scorer.enabled / domain.enabled / mk.rerank /
+  mk.negative_evidence / non-weighted matchkeys.
+- **Determinism gate:** identical pair SET + cluster PARTITION + id_prep edges across
+  `target_partitions {1,3,17}` (compared as sets, not float equality).
+
+## Consequences
+- `mode` default is NOT flipped to `"scale"` — that is a separate decision gated on the
+  Stage E verdict + sign-off; the Stage E result keeps it opt-in
+  ([0003-stage-e-spill-honest-null.md](0003-stage-e-spill-honest-null.md)).
+- Enforced in code: `config/schemas.py` (field) + `backends/datafusion_spine.py` (gate);
+  tested in `tests/test_datafusion_spine_scale_mode.py` + the determinism test.
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-06-03

--- a/context-network/decisions/0003-stage-e-spill-honest-null.md
+++ b/context-network/decisions/0003-stage-e-spill-honest-null.md
@@ -1,0 +1,42 @@
+# 0003 — Stage E spill verdict: HONEST-NULL on one-box survival
+
+**Status:** accepted (2026-06-03, PRs #705 harness + #706 verdict)
+**Evidence:** bench run `26911207018` on `large-new-64GB`
+
+## Context
+Stage E asked: does the spine's relational spill let it SURVIVE where the in-memory
+pipeline OOMs? Measured 3 variants (in-memory `bucket` / `spine_nospill` / `spine_spill`)
+via `scripts/bench_datafusion_spine_spill.py` + `bench-datafusion-spine-spill.yml`.
+
+## What was measured (200K rows, soundex-on-last_name, jw≥0.85, pool 2GB)
+| variant | wall | peak RSS | pairs/dupes | clusters |
+|---|---|---|---|---|
+| bucket | 17.6s | 3572 MB | 199,979 dupes | 5628 |
+| spine_nospill | 108.1s | 4765 MB | 5,203,861 raw pairs | 5606 |
+| spine_spill | 111.0s | 4820 MB | 5,203,861 raw pairs | 5606 |
+
+At 1M rows the spine was OOM-killed (job exit 143, runner-level OOM).
+
+## Decision / verdict
+- **The relational spill path is CORRECT:** `spine_spill` == `spine_nospill` output,
+  byte-identical, at bounded ~4.8GB RSS. The fair-spill pool works.
+- **One-box survival does NOT bind.** The spine emits ~5.2M raw above-threshold pairs at
+  200K (~26/row), collected driver-side to feed the UF break — the in-memory island the
+  spill pool doesn't cover. With soundex blocking that island grows ~O(N²) and OOMs the
+  64GB box at ~1M rows, BEFORE the in-memory `bucket` comparand (3.5GB at 200K) would.
+- **Architecturally precluded on one box:** `bucket` OOMs only on large blocks (its
+  O(block²) score matrix), but large blocks also explode the spine's pair set → the UF
+  island OOMs first. No reachable sub-50M-pair one-box scale shows "in-memory dies, spine
+  survives" for this workload. This is exactly the spec's anticipated honest-null.
+
+## Consequences
+- **Do NOT flip the `mode` default** on a one-box survival claim. The relational-spill +
+  determinism gates are met; the one-box-survival gate is not (and can't be here).
+- The spine's value is **engine portability / Sail**, not one-box survival — consistent
+  with [0001-gate-reframe-engine-portability.md](0001-gate-reframe-engine-portability.md).
+- Process gotcha learned: a full-box OOM SIGTERMs the WHOLE GitHub job (exit 143); it is
+  NOT a catchable per-child SIGKILL. Robust per-variant OOM testing needs a per-child
+  cgroup `MemoryMax` cap (a scoped follow-up).
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-06-03

--- a/context-network/discovery.md
+++ b/context-network/discovery.md
@@ -1,0 +1,29 @@
+# Context Network — Discovery Hub
+
+The navigation entry point. Each node below is focused and cross-linked; follow the
+links rather than reading everything.
+
+## Foundation (what this is)
+- [foundation/project-definition.md](foundation/project-definition.md) — what the Golden Suite / goldenmatch is, and the gate that governs the current arc.
+- [foundation/structure.md](foundation/structure.md) — the polyglot monorepo layout and where the authoritative context lives (CLAUDE.md files).
+
+## Architecture (active technical knowledge)
+- [architecture/datafusion-spine.md](architecture/datafusion-spine.md) — the embedded-DataFusion "scale mode" spine (Stages A-E); current status + entry points.
+
+## Decisions (records with no other home)
+- [decisions/0001-gate-reframe-engine-portability.md](decisions/0001-gate-reframe-engine-portability.md) — retire one-box RSS as the gate; engine portability is the destination.
+- [decisions/0002-scale-mode-contract.md](decisions/0002-scale-mode-contract.md) — `mode={standard,scale}`, opt-in, semantically-correct-not-bit-identical.
+- [decisions/0003-stage-e-spill-honest-null.md](decisions/0003-stage-e-spill-honest-null.md) — one-box spill-survival does not bind (the UF island); default stays opt-in.
+
+## Processes (how work is done here)
+- [processes/development-workflow.md](processes/development-workflow.md) — spec → plan → execute → review → CI → merge, plus the hard environment constraints.
+
+## Planning (where it's going)
+- [planning/roadmap.md](planning/roadmap.md) — the Arrow-native arc and what's next.
+
+## Meta (keeping the network alive)
+- [meta/updates.md](meta/updates.md) — chronological change log for the network.
+- [meta/maintenance.md](meta/maintenance.md) — how to keep nodes accurate and small.
+
+---
+**Classification:** navigation • **Last updated:** 2026-06-03

--- a/context-network/foundation/project-definition.md
+++ b/context-network/foundation/project-definition.md
@@ -1,0 +1,31 @@
+# Project Definition
+
+## What it is
+**Golden Suite** is a polyglot monorepo of data-quality / entity-resolution tooling.
+**goldenmatch** is the flagship: an entity-resolution (ER / dedupe / record-linkage)
+toolkit — zero-config auto-configuration, a fuzzy + probabilistic matching pipeline,
+clustering, golden-record survivorship, and a durable identity graph. Sibling packages:
+goldencheck (quality), goldenflow (transforms), goldenpipe (pipeline framework),
+infermap (type inference).
+
+- **GitHub:** `benseverndev-oss/goldenmatch` (auth as personal `benzsevern`, not work).
+- **Distribution:** PyPI `goldenmatch`, npm `goldenmatch` (TS port), DuckDB/Postgres extensions.
+- The pipeline: ingest → column_map → auto_fix → validate → standardize → matchkeys →
+  block → score → cluster → golden → output.
+
+## The governing arc (current)
+**Arrow-native → engine portability.** The destination is making every pipeline stage a
+frames-in/frames-out relational op a query engine can plan, spill, and distribute
+(DataFusion single-box out-of-core; Sail distributed). One-box peak RSS was retired as
+the gate — see [../decisions/0001-gate-reframe-engine-portability.md](../decisions/0001-gate-reframe-engine-portability.md).
+
+The active concrete work is the **DataFusion spine** —
+[../architecture/datafusion-spine.md](../architecture/datafusion-spine.md).
+
+## Authoritative detail lives elsewhere
+This node is deliberately thin. Code-level behavior, perf numbers, and gotchas are in
+the `CLAUDE.md` files (see [structure.md](structure.md)); designs are in
+`docs/superpowers/specs/`.
+
+---
+**Classification:** foundation/stable • **Last updated:** 2026-06-03

--- a/context-network/foundation/structure.md
+++ b/context-network/foundation/structure.md
@@ -1,0 +1,36 @@
+# Repository Structure & Where Context Lives
+
+## Layout
+```
+packages/
+  python/{goldenmatch,goldencheck,goldenflow,goldenpipe,infermap,goldencheck-types}
+  rust/extensions/{native,datafusion-udf,score-core,postgres}
+  typescript/goldenmatch        # TS port (npm)
+  dbt/ , actions/
+docs/superpowers/{specs,plans}  # design docs + implementation plans (workstream artifacts)
+scripts/                        # build + bench drivers
+.github/workflows/              # CI (ci.yml) + many workflow_dispatch benches
+context-network/                # THIS network
+```
+
+## Where the authoritative context is (do not duplicate into the network)
+- **Root `CLAUDE.md`** — monorepo-wide ops: TS/pnpm+turbo, CI structure + path filters,
+  Railway services, ghcr, GitHub auth dance, merge SOP, publish workflows, gotchas.
+- **`packages/python/CLAUDE.md`** — uv workspace rules + cross-package friction.
+- **`packages/python/goldenmatch/CLAUDE.md`** — the big one: goldenmatch architecture
+  index, the full performance history (scale-audit numbers, bucket/ray/duckdb backends,
+  the Splink-Spark distributed roadmap phases), accuracy strategy, code patterns,
+  gotchas. **Start here for any goldenmatch code question.**
+- Each other package has its own `CLAUDE.md`.
+
+## Rust extension crates (relevant to the spine)
+- `extensions/native` — the `_native` abi3 kernel (bucket scorer, fingerprints). Built
+  via `scripts/build_native.py`. Uses `arrow = 55`.
+- `extensions/score-core` — shared rapidfuzz scorers; single source of truth for
+  `_native` and the FFI crate.
+- `extensions/datafusion-udf` — `goldenmatch_datafusion_udf`: the FFI `ScalarUDF`
+  string scorers for the DataFusion spine. Pins `datafusion/datafusion-ffi = 53.x`,
+  `arrow = 58` (the arrow-major divergence is WHY it's a separate crate from `native`).
+
+---
+**Classification:** foundation/semi-stable • **Last updated:** 2026-06-03

--- a/context-network/meta/maintenance.md
+++ b/context-network/meta/maintenance.md
@@ -1,0 +1,29 @@
+# Network Maintenance
+
+## Principles
+- **Point, don't copy.** Code-level facts live in `CLAUDE.md`; designs live in
+  `docs/superpowers/`. Nodes here link to those, not duplicate them. When they conflict,
+  the source-of-truth wins and the node is wrong — fix the node.
+- **Small, focused nodes.** One concern per file. If a node grows past ~1 screen, split it.
+- **Cross-link liberally.** Every node should be reachable from
+  [../discovery.md](../discovery.md) and link to its neighbors.
+- **Classification footer** on every node: `domain/stability` + last-updated date.
+
+## When to update
+- After a workstream milestone (PR merged that changes status/decisions): update the
+  relevant architecture/decision node + add an [updates.md](updates.md) entry.
+- When a decision is made that has no code home (trade-offs, "why we didn't"): add a
+  numbered record under `../decisions/`.
+- When the foundation changes (new package, structural move): update `../foundation/`.
+
+## What does NOT belong here
+- Secrets, tokens (those are gitignored elsewhere).
+- Transient task state or one-session scratch notes (use TodoWrite / user memory).
+- Duplicates of CLAUDE.md operational detail.
+
+## Committing
+The network is meant to be committed (shared brain), but commit only when the user asks.
+It is not currently in `.gitignore`; confirm before `git add`.
+
+---
+**Classification:** meta/process • **Last updated:** 2026-06-03

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -1,0 +1,19 @@
+# Network Updates Log
+
+Newest first. One entry per meaningful change to the network.
+
+## 2026-06-03 — Network created
+- Seeded the context network and the root `.context-network.md` discovery file.
+- Captured the DataFusion-spine workstream end-to-end: Stages A-E status
+  ([../architecture/datafusion-spine.md](../architecture/datafusion-spine.md)), and the
+  three decisions that had no prior home:
+  - [0001 gate reframe — engine portability](../decisions/0001-gate-reframe-engine-portability.md)
+  - [0002 scale-mode contract](../decisions/0002-scale-mode-contract.md) (PR #702)
+  - [0003 Stage E spill HONEST-NULL](../decisions/0003-stage-e-spill-honest-null.md) (PRs #705/#706)
+- Recorded the development workflow + environment constraints
+  ([../processes/development-workflow.md](../processes/development-workflow.md)) and the
+  roadmap ([../planning/roadmap.md](../planning/roadmap.md)).
+- Committed to git on branch `chore/context-network`.
+
+---
+**Classification:** meta/log • **Last updated:** 2026-06-03

--- a/context-network/planning/roadmap.md
+++ b/context-network/planning/roadmap.md
@@ -1,0 +1,32 @@
+# Roadmap — Arrow-native arc
+
+The destination is **engine portability** (DataFusion single-box → Sail distributed) —
+see [../decisions/0001-gate-reframe-engine-portability.md](../decisions/0001-gate-reframe-engine-portability.md).
+
+## Done
+- **Step 1 — id_prep plannable (#696).** `ClusterPairScores.from_frames` rewritten as a
+  group-by; id_prep 566→34s @100M; end-to-end flips to 2.11×.
+- **Step 2 — DataFusion spine, Stages A-E.** Merged. Scale-mode contract shipped
+  (#702); Stage E spill verdict recorded as HONEST-NULL on one-box survival (#706).
+  See [../architecture/datafusion-spine.md](../architecture/datafusion-spine.md).
+
+## Decided NOT to do (now)
+- **Flip `mode` default to `"scale"`** — blocked: the one-box-survival gate is not met
+  (Stage E). Revisit when the Sail tier removes the UF island.
+
+## Next candidates (not yet specced/scheduled)
+- **Sail / distributed tier** — route the Union-Find cluster build to distributed
+  label-prop (≥50M), removing the in-memory pair-collection island. This is the lever
+  that unlocks beyond-one-box scale and would let the default flip.
+- **Relational-stages-only spill bench** — score+dedup under a cgroup `MemoryMax` cap,
+  excluding the UF collection, to show relational spill survival crisply in isolation.
+- **Fix the pre-existing empty/all-singleton `run_spine` SchemaError** (frames-out tail,
+  null vs i64 join key) — flagged during Stage D, out of scope there.
+
+## Related larger arcs (in `packages/python/goldenmatch/CLAUDE.md`)
+- The Splink-Spark parity roadmap (Ray Phases 1-6) — distributed loader → controller →
+  clustering → golden → multi-node → identity. Mostly plumbing-complete, gated behind
+  `GOLDENMATCH_ENABLE_DISTRIBUTED_RAY=1`.
+
+---
+**Classification:** planning/active • **Last updated:** 2026-06-03

--- a/context-network/processes/development-workflow.md
+++ b/context-network/processes/development-workflow.md
@@ -1,0 +1,42 @@
+# Development Workflow
+
+## The discipline (used for the spine work, paid off every stage)
+**spec → spec-review → plan → plan-review → execute → code-review → CI → merge.**
+- Specs land in `docs/superpowers/specs/`, plans in `docs/superpowers/plans/`.
+- Reviewers (plan-document-reviewer, code-reviewer) catch real blockers — e.g. a stale
+  branch premise, a wrong test invariant. Use them; don't skip.
+- Execute via subagent-driven-development where parallelizable; otherwise power through
+  task-by-task, committing each.
+
+## Hard environment constraints (non-negotiable here)
+- **The dev box HANGS on `import goldenmatch` / `polars` / `datafusion`**, and large
+  benches OOM it. **Do NOT run pytest or the bench locally.** Validate Python with
+  `ruff check` + `python -m py_compile` ONLY. **CI is the only test verifier.**
+- `ruff check packages/python/goldenmatch` must exit 0 before EVERY commit (I001 import
+  order). Never pipe through `tail` (masks exit code).
+- pyright slice (`pyrightconfig.json`) covers only core/ + config/ + _api.py + utils —
+  NOT backends/, scripts/, or tests/. Diagnostics there don't gate CI.
+- Zombie python processes accumulate from import/uv attempts and starve the box; kill via
+  `Get-Process python | Stop-Process -Force` (PowerShell).
+
+## GitHub / CI
+- Auth dance: `GH_TOKEN=$(gh auth token --user benzsevern)` for push/PR/merge/`gh run`.
+  NEVER `benzsevern-mjh`. Switch back after.
+- Branch off `origin/main` (local `main` goes stale fast). PRs: squash-merge.
+- Merge cosmetic failures to ignore: `cannot delete branch ... used by worktree` and the
+  502 "already merged" — the remote merge lands; only local cleanup failed.
+- `UNSTABLE` mergeStateStatus is usually a `continue-on-error` lane or pending non-gating
+  check (`claude-review`, CodeQL); `ci-required` is the gate.
+- **`gh workflow run <file> --ref <branch>` CANNOT dispatch a workflow that isn't on the
+  default branch yet** — GitHub only registers `workflow_dispatch` from the default
+  branch. Merge the workflow first, then dispatch from `main`.
+- Benches are `workflow_dispatch` on `large-new-64GB` (16c/64GB) — billable; smoke-green
+  the harness in CI before dispatching the heavy run.
+
+## Memory & this network
+- Cross-session agent facts → user-level memory. Committed shared knowledge → this network.
+- After a workstream milestone, update [../meta/updates.md](../meta/updates.md) and the
+  relevant architecture/decision node.
+
+---
+**Classification:** process/stable • **Last updated:** 2026-06-03


### PR DESCRIPTION
Adds a context network under `context-network/` (+ root `.context-network.md` discovery file): a navigable hub for the project's planning, architecture, and decisions.

It POINTS to the authoritative sources (CLAUDE.md for code-level ops, docs/superpowers for designs) rather than duplicating them. Unique value-add: a discovery hub, decision records (which had no home before), and a consolidated status/roadmap.

Seeded with real current state: the DataFusion-spine workstream (Stages A-E), three decision records (gate reframe to engine portability; the scale-mode contract #702; the Stage E spill HONEST-NULL #705/#706), the dev workflow + environment constraints, and the roadmap.

Docs-only.