### PR TITLE
docs(sail): spec + roadmap the Sail tier (distributed, Sail-native, replaces Ray)

### DIFF
--- a/context-network/architecture/sail-tier.md
+++ b/context-network/architecture/sail-tier.md
@@ -1,0 +1,46 @@
+# Sail Tier (distributed, Sail-native — replaces Ray)
+
+The distributed sibling of the one-box DataFusion spine. Re-expresses the spine's
+relational plan against **Sail** (LakeSail — a Rust Spark drop-in built on DataFusion,
+programmed via **Spark Connect / PySpark**) to run across nodes, computes connected
+components distributed (removing the one-box UF island), and ultimately retires the
+existing Ray distributed stack.
+
+**Status:** specced 2026-06-03 (approved, pre-build). **Spec:**
+`docs/superpowers/specs/2026-06-03-sail-tier-design.md`.
+**Why it matters:** Stage E showed one-box spill-survival is non-binding
+([../decisions/0003-stage-e-spill-honest-null.md](../decisions/0003-stage-e-spill-honest-null.md))
+— the distributed path is where the value is.
+
+## The defining constraint
+Sail is **Spark Connect (PySpark DataFrame/SQL)**, not the `datafusion` Python API. So the
+one-box `run_spine` does NOT port — the Sail tier is a **re-expression of the same
+algorithm** in a new `goldenmatch.sail` package, with native scorers rebound as Spark
+**Arrow UDFs**. Shared algorithm, new code, self-parity-gated against the one-box spine
+(Sail's own compat checker doesn't verify behavioral parity).
+
+## Three load-bearing decisions (see the spec for detail)
+1. **WCC on Sail (the holdout — Sail has no native graph):** port the proven two-phase
+   WCC to Spark Connect (Phase A partition-UF via `mapInArrow`; Phase B driver-side
+   boundary merge). Fallback: large-star/small-star SQL. **Trap:** seed isolated nodes
+   from a distributed frame, NOT a driver-side `list[int]` (the WCC-rehydration OOM).
+2. **Scorer:** native `score-core` kernel as a Spark Arrow UDF; pure-Python rapidfuzz
+   Arrow UDF as the floor + parity reference.
+3. **Staged build** S1→S4, WCC as the gate; Ray stays default until S4 binds.
+
+## Relationship to existing code
+- **Replaces** `goldenmatch/distributed/` (the Ray Phases 1-6) — but only after S4's
+  binding 100M+ multi-node bench passes (one-release deprecation window).
+- **Parallels** `backends/datafusion_spine.py` (the one-box spine — unchanged; it is the
+  parity reference for S1/S2/S3).
+- Reuses the algorithm of `distributed/clustering.py::two_phase_wcc` (re-expressed) and
+  the `score-core` kernel (rebound as an Arrow UDF).
+
+## Verification
+- CI smoke: a local `sail spark server` runs the same plan single-process for small-scale
+  parity (deps: `pysail` + `pyspark` client).
+- Binding bench (S4): BYO multi-node cluster via a `SAIL_REMOTE` secret (docs-not-bootstrap,
+  mirrors the Ray phase5 `RAY_ADDRESS` posture); 100M dataset from the phase5 generator.
+
+---
+**Classification:** architecture/planned • **Last updated:** 2026-06-03

--- a/context-network/decisions/0004-sail-tier-scope.md
+++ b/context-network/decisions/0004-sail-tier-scope.md
@@ -1,0 +1,34 @@
+# 0004 — Sail tier scope: full, buildable, Sail-native, replaces Ray
+
+**Status:** accepted (2026-06-03, Ben) • **Spec:** `docs/superpowers/specs/2026-06-03-sail-tier-design.md`
+
+## Context
+After the Stage E honest-null ([0003](0003-stage-e-spill-honest-null.md)), the distributed
+(Sail) path is the real value. Three scoping forks were put to Ben; he chose the ambitious
+option on all three.
+
+## Decision
+- **Nature:** a **buildable implementation spec now** (not a spike-first, not paper-only).
+  Mitigation: the build is staged S1→S4 with the load-bearing WCC de-risk as S1+S2, so the
+  riskiest unknown is proven before the rest — the spike is folded into the build, not skipped.
+- **Vs Ray:** **Sail-native everything, replace the Ray distributed stack** — including a
+  Sail-native connected-components (no native graph in Sail → port two-phase WCC). Ray is
+  NOT retired until S4's binding 100M+ bench passes (one-release deprecation window).
+- **Scope:** **full spine-on-Sail** — load → block → score → dedup → WCC → golden (incl.
+  custom field-rules) → identity.
+
+## Consequences / honest flags
+- "Buildable now" is real, but Sail is **Spark Connect**, so this is a re-expression (new
+  `goldenmatch.sail` code), not a port of `run_spine`. Every stage self-parity-gates vs the
+  one-box spine.
+- **WCC-on-Sail (S2) is the gate.** If it can't be made native + correct, the
+  Sail-native-everything premise is in question and we escalate; Ray stays.
+- No `mode` default-flip and no Ray retirement on faith — both gated on S4.
+
+## Alternatives not taken
+- Spike-first / design-on-paper (declined — folded the de-risk into S1+S2 instead).
+- Sail owns relational + Ray keeps the UF holdout (declined — chose full Sail-native).
+- Minimal binding proof only (declined — chose full spine scope).
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-06-03

--- a/context-network/discovery.md
+++ b/context-network/discovery.md
@@ -9,11 +9,13 @@ links rather than reading everything.
 
 ## Architecture (active technical knowledge)
 - [architecture/datafusion-spine.md](architecture/datafusion-spine.md) — the embedded-DataFusion "scale mode" spine (Stages A-E); current status + entry points.
+- [architecture/sail-tier.md](architecture/sail-tier.md) — the distributed Sail-native tier (Spark Connect) that replaces Ray; specced, build not started.
 
 ## Decisions (records with no other home)
 - [decisions/0001-gate-reframe-engine-portability.md](decisions/0001-gate-reframe-engine-portability.md) — retire one-box RSS as the gate; engine portability is the destination.
 - [decisions/0002-scale-mode-contract.md](decisions/0002-scale-mode-contract.md) — `mode={standard,scale}`, opt-in, semantically-correct-not-bit-identical.
 - [decisions/0003-stage-e-spill-honest-null.md](decisions/0003-stage-e-spill-honest-null.md) — one-box spill-survival does not bind (the UF island); default stays opt-in.
+- [decisions/0004-sail-tier-scope.md](decisions/0004-sail-tier-scope.md) — Sail tier: full, buildable, Sail-native, replaces Ray; WCC-on-Sail is the gate.
 
 ## Processes (how work is done here)
 - [processes/development-workflow.md](processes/development-workflow.md) — spec → plan → execute → review → CI → merge, plus the hard environment constraints.

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,13 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-03 — Sail tier specced + roadmapped
+- Added the Sail-tier design (`docs/superpowers/specs/2026-06-03-sail-tier-design.md`,
+  spec-reviewer approved) — the distributed Sail-native pipeline that replaces Ray.
+- New nodes: [../architecture/sail-tier.md](../architecture/sail-tier.md),
+  [../decisions/0004-sail-tier-scope.md](../decisions/0004-sail-tier-scope.md); promoted
+  the Sail tier in [../planning/roadmap.md](../planning/roadmap.md) (S1-S4, WCC as the gate).
+
 ## 2026-06-03 — Network created
 - Seeded the context network and the root `.context-network.md` discovery file.
 - Captured the DataFusion-spine workstream end-to-end: Stages A-E status

--- a/context-network/planning/roadmap.md
+++ b/context-network/planning/roadmap.md
@@ -14,10 +14,21 @@ see [../decisions/0001-gate-reframe-engine-portability.md](../decisions/0001-gat
 - **Flip `mode` default to `"scale"`** — blocked: the one-box-survival gate is not met
   (Stage E). Revisit when the Sail tier removes the UF island.
 
-## Next candidates (not yet specced/scheduled)
-- **Sail / distributed tier** — route the Union-Find cluster build to distributed
-  label-prop (≥50M), removing the in-memory pair-collection island. This is the lever
-  that unlocks beyond-one-box scale and would let the default flip.
+## Next — the Sail tier (SPECCED 2026-06-03, build not started)
+**The real value of the arc** (Stage E showed one-box is non-binding). A Sail-native
+distributed pipeline (Spark Connect / PySpark) that re-expresses the spine's relational
+plan across nodes, computes connected components distributed (removing the one-box UF
+island), and ultimately REPLACES the Ray distributed stack. See
+[../architecture/sail-tier.md](../architecture/sail-tier.md) +
+[../decisions/0004-sail-tier-scope.md](../decisions/0004-sail-tier-scope.md).
+Spec: `docs/superpowers/specs/2026-06-03-sail-tier-design.md`. Staged, each a gate:
+- **S1** — Sail harness + scorer Arrow UDF + score/dedup (parity vs one-box spine).
+- **S2** — **WCC on Sail** (port two-phase WCC to Spark Connect) — THE GATE.
+- **S3** — golden (incl. custom rules) + identity on Sail.
+- **S4** — binding 100M+ multi-node bench + Ray retirement. Kill criterion: completes
+  where one-box can't, per-node RSS bounded, wall scales with nodes.
+
+## Other candidates (not specced)
 - **Relational-stages-only spill bench** — score+dedup under a cgroup `MemoryMax` cap,
   excluding the UF collection, to show relational spill survival crisply in isolation.
 - **Fix the pre-existing empty/all-singleton `run_spine` SchemaError** (frames-out tail,

--- a/docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md
+++ b/docs/superpowers/specs/2026-06-01-arrow-native-finish-line-design.md
@@ -528,6 +528,13 @@ where in-memory matrices OOM while the spine's above-threshold output stays smal
 the only one-box shape that could bind, and only if such a workload is
 representative. Both are deferred.
 
+**The real next step (specced 2026-06-03):** the **Sail tier** —
+`docs/superpowers/specs/2026-06-03-sail-tier-design.md`. A Sail-native (Spark Connect)
+distributed pipeline that re-expresses the spine's relational plan across nodes, computes
+connected components distributed (removing the one-box UF island), and replaces the Ray
+distributed stack. Staged S1-S4 with WCC-on-Sail as the gate; binding criterion = 100M+
+multi-node completes where one-box can't.
+
 ## Gate reframe: engine portability, not one-box RSS (2026-06-03, supersedes the RSS gate for this track)
 
 **The Arrow-native arc's destination is engine portability** — making every

--- a/docs/superpowers/specs/2026-06-03-sail-tier-design.md
+++ b/docs/superpowers/specs/2026-06-03-sail-tier-design.md
@@ -1,0 +1,178 @@
+# Sail tier — full spine-on-Sail, Sail-native distributed (replaces Ray)
+
+**Date:** 2026-06-03
+**Status:** design (approved by Ben; pre-spec-review)
+**Parent:** `2026-06-01-arrow-native-finish-line-design.md` § "Gate reframe: engine
+portability" + `2026-06-03-datafusion-spine-design.md` (the one-box spine). Stage E of
+the spine recorded HONEST-NULL on one-box spill survival — the UF pair-collection island
+dominates on one box — so **the real value is the distributed (Sail) path**, exactly as
+Ben framed the arc ("DataFusion embedded one box + Sail distributed, later").
+
+**Goal:** A Sail-native distributed entity-resolution pipeline — the spine's relational
+plan (score → dedup → cluster → golden → identity) re-expressed against Sail and executed
+across nodes — that **completes where the one-box pipeline cannot** and **scales out**.
+It removes the in-memory Union-Find island (the one-box binding constraint) by computing
+connected components distributed. The target **replaces** the existing Ray distributed
+stack (`goldenmatch/distributed/`, Phases 1-6) once parity-green and the binding bench
+passes.
+
+---
+
+## The reframe that shapes everything: Sail is Spark Connect, not datafusion-python
+
+Sail (LakeSail, v0.6.x, May 2026) is a Rust drop-in Spark replacement built ON DataFusion
+but **programmed via the Spark Connect protocol** — PySpark `DataFrame` / Spark SQL, with
+Python / Pandas / **Arrow UDFs** (same conventions as Spark), plus UDAF/UDWF/UDTF. You
+start a driver (`sail spark server --port 50051`, or K8s for cluster mode) and connect
+with `SparkSession.builder.remote("sc://<driver>")`.
+
+**Consequence:** the one-box spine's code does NOT port. `run_spine` is written against
+the `datafusion` Python API (`SessionContext`, the Stage-B FFI `ScalarUDF` PyCapsule).
+The Sail tier is a **re-expression of the same relational ALGORITHM against PySpark**, with
+the native scorers rebound as Spark **Arrow UDFs**. The embedded one-box spine stays as-is;
+Sail is the distributed sibling that shares the algorithm, not the code. Sail's own
+compatibility checker is experimental and "does NOT verify behavioral parity" — so every
+stage is **self-parity-gated** against the one-box spine / in-memory pipeline.
+
+## Scope guard
+
+IN: a new `goldenmatch.sail` package — distributed load → block → score → dedup → WCC →
+golden (incl. custom field-rules) → identity, all Sail-native (Spark Connect); the native
+scorer as an Arrow UDF; a connected-components implementation on Sail (the holdout); a
+BYO-cluster binding bench at 100M+; retirement of the Ray distributed stack at the end.
+
+OUT: bootstrapping/owning a Sail cluster (BYO, docs-not-bootstrap, mirrors the Ray phase5
+posture); the embedded one-box spine (unchanged); flipping `mode` defaults (separate
+decision); LLM/rerank/boost/NE/exotic matchkeys (same reduced surface as scale mode).
+
+## Architecture — `goldenmatch.sail` (new module)
+
+```
+spark = SparkSession.builder.remote(os.environ["SAIL_REMOTE"]).getOrCreate()
+
+load     df = spark.read.parquet(input)                         # distributed, lazy
+block    df = df.withColumn("__block_key__", block_expr)        # soundex/exact, Spark cols
+score    pairs = (df.alias("a").join(df.alias("b"),
+                   on=(a.__block_key__==b.__block_key__) & (a.__row_id__<b.__row_id__))
+                 .select(a.__row_id__, b.__row_id__,
+                         score_udf(a.__value__, b.__value__).alias("score"))
+                 .where("score >= threshold"))                  # distributed shuffle-join
+dedup    pairs = pairs.groupBy("a","b").agg(max("score"))       # distributed
+WCC      assignments = connected_components(pairs, all_ids)     # THE HOLDOUT (below)
+golden   golden = assignments.join(df).groupBy("cluster_id").applyInArrow(survivorship)
+identity edges  = emit per-cluster evidence edges; resolve against the identity store
+```
+
+Every stage is a Spark `DataFrame` op Sail plans + distributes; the driver never
+materializes the full frame. This is the same relational shape as the one-box spine — the
+difference is the engine owns partitioning/shuffle/spill across nodes, and **WCC is
+computed distributed instead of collected to the driver** (removing the one-box island).
+
+### Module layout (mirrors `goldenmatch/distributed/`, which it will replace)
+- `sail/session.py` — `SparkSession` connect helper (`SAIL_REMOTE` env / arg), config.
+- `sail/scoring.py` — block self-join + the scorer Arrow UDF + dedup.
+- `sail/scorers.py` — native scorer as a Spark Arrow UDF (decision 2).
+- `sail/clustering.py` — connected components on Sail (decision 1).
+- `sail/golden.py` — survivorship as `applyInArrow` group aggregation (incl. custom rules).
+- `sail/identity.py` — distributed edge emit + resolve.
+- `sail/pipeline.py` — `run_sail_pipeline(input, config)` threading the stages.
+
+## The three load-bearing decisions
+
+### Decision 1 — Connected components on Sail (the holdout, the S2 gate)
+Sail/Spark Connect has NO native connected-components (no GraphFrames). **Port the proven
+in-repo two-phase WCC** (`distributed/clustering.py::two_phase_wcc`, Iverson et al.):
+- **Phase A** — per-partition local Union-Find via `mapInArrow` / an Arrow UDTF over each
+  partition's edge batch (embarrassingly parallel).
+- **Phase B** — cross-partition boundary-edge merge via a driver-side super-graph Union-Find
+  over only the boundary components (small: bounded by #partitions × boundary degree).
+
+Rationale: reuses the ALGORITHM already validated at 50M chain-adversarial scale (Ray,
+run 26172859442: 120.4s), and the GraphFrames maintainer explicitly endorsed two-phase /
+randomized-contraction over label-propagation (chains are label-prop's worst case;
+ER graphs are chain-heavy — see memory `reference_graphframes_maintainer_advice`).
+**This is a re-expression, NOT code reuse:** the existing `two_phase_wcc` is written against
+the Ray Dataset API (`map_batches`, `ray.put`, `from_arrow`) and `core.cluster.UnionFind`;
+on Spark Connect the Phase A partition-UF (`mapInArrow`/UDTF) and the Phase B driver-side
+merge are new code that shares the algorithm and is parity-tested against the one-box
+reference (same posture as the scorer in decision 2).
+**Carry forward the WCC-rehydration-OOM lesson (the load-bearing trap):** seed the
+isolated/singleton nodes from a DISTRIBUTED frame (a Spark `DataFrame` of `__row_id__`s
+left-joined to assignments), NOT a driver-side `list[int]` of every record id — the parent
+spine spec flags this exact trap for `all_ids: list[int]`, and the Ray Phase B seeds
+isolated nodes from `all_ids`, so the naive port would silently reintroduce the OOM at
+100M. The driver must never hold a per-record Python list.
+**Fallback if `mapInArrow` partition-UF can't be expressed on Sail v0.6.x:** large-star /
+small-star iterative connected-components as Spark SQL self-joins (more shuffles, but pure
+relational). **If neither works, S2 fails the gate → escalate** (the Sail-native-everything
+premise is then in question; Ray is NOT retired).
+
+### Decision 2 — Native scorer as a Spark Arrow UDF
+Rebind the existing `score-core` rapidfuzz kernel (already compiled into `_native` /
+`goldenmatch_native`) as a **vectorized Spark Arrow UDF** (Sail runs Arrow UDFs zero-copy).
+Reuses the proven kernel, zero new Rust. **Fallback:** a pure-Python `rapidfuzz` Arrow UDF
+(no native dep, slower) — kept as the always-available path and the parity reference (it IS
+rapidfuzz; `test_native_parity` proves rust==python rapidfuzz at 1e-9).
+
+### Decision 3 — Staged build (full target, load-bearing-risk-first)
+The target is the full Sail-native pipeline replacing Ray, but the BUILD is staged and each
+stage is gated on the prior's measured result (mirrors the spine's A→E and Ben's
+scale-substrate rule). See "Stages" below.
+
+## Stages (each independently testable; each a gate)
+
+- **S1 — Sail harness + score/dedup.** `sail/session.py` + `sail/scorers.py` (Arrow UDF) +
+  `sail/scoring.py`. GATE: against a local `sail spark server`, the score+dedup output
+  matches the one-box spine's `raw_pairs` set on a fixture (parity); the scorer UDF equals
+  python rapidfuzz (1e-9).
+- **S2 — WCC on Sail (THE GATE).** `sail/clustering.py` (two-phase WCC, decision 1). GATE:
+  the cluster PARTITION is identical (Rand 1.0) to the one-box spine's `build_cluster_frames`
+  on a fixture INCLUDING a chain archetype (label-prop's worst case) and a cascading-split
+  archetype (the runtime-bug class that bit the one-box frames-out work). The one-box
+  reference partition for these fixtures is CAPTURED/pinned (Stage C of the spine already
+  produces it) so S2 isn't diffing against a moving target. If WCC can't be made correct +
+  distributable on Sail, STOP and escalate.
+- **S3 — golden + identity on Sail.** `sail/golden.py` (survivorship incl. custom field-rules
+  via `applyInArrow`) + `sail/identity.py`. GATE: golden content parity per multi-member
+  cluster; identity edge-set parity vs the one-box path.
+- **S4 — binding multi-node bench + Ray retirement.** `run_sail_pipeline` end-to-end on a
+  BYO multi-node Sail cluster at 100M+ rows. GATE (kill criterion): completes where the
+  one-box pipeline cannot, per-node peak RSS bounded (< node memory), wall scales across
+  nodes. ONLY on PASS: deprecate + remove `goldenmatch/distributed/` (the Ray stack) in a
+  one-release window.
+
+## Verification
+
+- **CI smoke (every stage):** a local `sail spark server` (single process) powers
+  small-scale parity tests in a dedicated lane (install `pysail` + `pyspark` client). No
+  cluster needed for correctness — Sail runs the same plan locally.
+- **Binding bench (S4):** `workflow_dispatch`, BYO cluster via a `SAIL_REMOTE` secret
+  (mirrors the Ray phase5 `RAY_ADDRESS` pattern — docs not bootstrap). 100M dataset reused
+  from the phase5 generator. Commit numbers to the roadmap.
+- **Parity is the gate, not bit-identity:** scale-mode semantics (deterministic +
+  semantically correct, not bit-identical; MAX dedup) carry over. Compare partition SETS,
+  golden content, edge sets — never raw float equality.
+
+## Kill criterion (the whole tier)
+
+100M-row end-to-end on a multi-node Sail cluster: **completes where one-box OOMs/can't**,
+per-node RSS bounded, wall improves with node count. If S2 (WCC) can't be made native, or
+S4 doesn't bind, the honest output is "Sail is not yet the substrate" — Ray stays, and the
+arc reassesses. No Ray retirement, no default-flip, until S4 is green.
+
+## Risks
+
+- **WCC-on-Sail (S2)** — the load-bearing unknown; no native graph in Sail. Two-phase WCC
+  port is the plan; large-star/small-star is the fallback; escalate if both fail.
+- **Sail v0.6.x behavioral parity** — their compat checker doesn't verify it; we self-parity
+  -gate every stage against the one-box spine.
+- **Spark-Connect re-expression cost** — this is a parallel implementation, not a port;
+  the algorithm is shared (and tested against the one-box reference), the code is new.
+- **Replacing Ray is multi-subsystem** — staged S1→S4, Ray stays default until S4 binds.
+- **Arrow UDF perf on Sail** — measure the scorer UDF throughput; pure-Python fallback is
+  the floor, the native-kernel Arrow UDF is the target.
+
+## What this explicitly does NOT do
+
+- Bootstrap/own a Sail cluster (BYO). Touch the embedded one-box spine. Flip `mode`
+  defaults. Retire Ray before S4 binds. Support LLM/rerank/boost/NE/exotic matchkeys.


### PR DESCRIPTION
Specs and roadmaps the **Sail tier** — the distributed sibling of the one-box DataFusion spine. After Stage E's honest-null (one-box spill-survival doesn't bind), the distributed path is where the value is.

**What it is:** a Sail-native (Spark Connect / PySpark) pipeline that re-expresses the spine's relational plan across nodes, computes connected components distributed (removing the one-box UF island), and ultimately replaces the Ray distributed stack.

**Key reality:** Sail is programmed via Spark Connect, not datafusion-python, so this is a re-expression (new `goldenmatch.sail` package), not a port — every stage self-parity-gates vs the one-box spine.

**Staged S1-S4, WCC-on-Sail is the gate:** S1 harness+scorer+score/dedup, S2 WCC (port two-phase WCC; the make-or-break), S3 golden+identity, S4 binding 100M+ multi-node bench + Ray retirement. Ray stays default until S4 binds.

Docs-only: the spec (`docs/superpowers/specs/2026-06-03-sail-tier-design.md`, spec-reviewer approved) + context-network nodes (architecture/sail-tier, decision 0004, roadmap S1-S4).