### PR TITLE
feat(sail): Stage S1 — harness + scorer UDF + score/dedup (Sail tier)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -928,6 +928,11 @@ jobs:
         run: |
           .venv/bin/python -c "import pysail, pyspark; print('pyspark', pyspark.__version__)"
           .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_connectivity.py -v --timeout=300
+      # GATE (blocking): the S1 score/dedup pair-set parity vs a python-rapidfuzz
+      # reference -- the reason this lane exists at S1.
+      - name: Sail score/dedup parity gate (blocking)
+        run: |
+          .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_score_parity.py -v --timeout=300
 
   action:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       native: ${{ steps.filter.outputs.native }}
       goldenembed: ${{ steps.filter.outputs.goldenembed }}
       distributed: ${{ steps.filter.outputs.distributed }}
+      sail: ${{ steps.filter.outputs.sail }}
       readme_callouts: ${{ steps.filter.outputs.readme_callouts }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -164,6 +165,13 @@ jobs:
               - 'packages/python/goldenmatch/tests/test_distributed_*.py'
               - 'packages/python/goldenmatch/goldenmatch/core/cluster.py'
               - 'packages/python/goldenmatch/goldenmatch/backends/ray_backend.py'
+            sail:
+              # Sail tier (distributed, Spark Connect). The main `python` job
+              # installs without the `sail` extra, so tests/test_sail_*.py SKIP
+              # there (pytest.importorskip). The `sail` job installs
+              # goldenmatch[sail] (pysail + pyspark[connect]) so they run.
+              - 'packages/python/goldenmatch/goldenmatch/sail/**'
+              - 'packages/python/goldenmatch/tests/test_sail_*.py'
             action:
               - 'packages/actions/**'
             readme_callouts:
@@ -889,6 +897,38 @@ jobs:
             --ignore=packages/python/goldenmatch/tests/test_distributed_clustering.py \
             --timeout=300 --durations=20 -v
 
+  # Sail tier (distributed, Spark Connect). The Sail tier re-expresses the
+  # one-box DataFusion spine's relational plan against PySpark/Spark Connect.
+  # This lane installs goldenmatch[sail] (pysail + pyspark[connect]) and runs
+  # tests/test_sail_*.py against an in-process Sail Spark Connect server (they
+  # SKIP everywhere else via pytest.importorskip). Spec:
+  # docs/superpowers/specs/2026-06-03-sail-tier-design.md (Stage S1).
+  sail:
+    needs: changes
+    if: needs.changes.outputs.sail == 'true' || needs.changes.outputs.ci_workflow == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      # Sail (Spark Connect) optional stack. NO Java: pyspark[connect] is a
+      # pure-gRPC client (no py4j/JVM launch) and the Sail server is Rust.
+      # Install VIA THE EXTRA so the pyproject [sail] entry is exercised.
+      - name: Install sail extra
+        run: uv pip install -e 'packages/python/goldenmatch[sail]'
+      # Run with the venv python directly (NOT `uv run`): the Sail server
+      # spawns in-process; mirror the ray lane's venv-python discipline.
+      - name: Sail connectivity gate (blocking)
+        run: |
+          .venv/bin/python -c "import pysail, pyspark; print('pyspark', pyspark.__version__)"
+          .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_connectivity.py -v --timeout=300
+
   action:
     needs: changes
     if: needs.changes.outputs.action == 'true' || needs.changes.outputs.ci_workflow == 'true'
@@ -1128,6 +1168,7 @@ jobs:
       - native_wheel
       - goldenembed
       - distributed
+      - sail
       - pyright
       - readme_callouts
     if: always()

--- a/packages/python/goldenmatch/goldenmatch/sail/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/__init__.py
@@ -1,0 +1,10 @@
+"""Sail tier (distributed, Spark Connect) -- the distributed sibling of the
+one-box DataFusion spine.
+
+Sail (LakeSail) is programmed via the Spark Connect protocol (PySpark
+DataFrame/SQL), NOT the datafusion Python API. This package re-expresses the
+spine's relational algorithm against PySpark; it is a parallel implementation,
+not a port. Opt-in via ``pip install goldenmatch[sail]``.
+
+Spec: docs/superpowers/specs/2026-06-03-sail-tier-design.md
+"""

--- a/packages/python/goldenmatch/goldenmatch/sail/scorers.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/scorers.py
@@ -1,0 +1,43 @@
+"""Scorers as Spark pandas UDFs (S1: pure-Python rapidfuzz -- the floor +
+parity reference; the native-kernel Arrow UDF is a later perf task).
+
+The same rapidfuzz the one-box spine's FFI scorer delegates to
+(rust-rapidfuzz == python-rapidfuzz at 1e-9), so this is the exact parity
+reference, not an approximation."""
+from __future__ import annotations
+
+from typing import Any
+
+# SQL-callable names (match the matchkey scorer names the spine supports).
+_SUPPORTED = ("jaro_winkler", "levenshtein", "token_sort")
+
+
+def make_scorer_udf(scorer_name: str) -> Any:
+    """Return a Spark ``pandas_udf`` (double) scoring two string columns in
+    [0, 1] via rapidfuzz."""
+    if scorer_name not in _SUPPORTED:
+        raise NotImplementedError(
+            f"Sail S1 supports scorers {_SUPPORTED}; got {scorer_name!r}."
+        )
+    from pyspark.sql.functions import pandas_udf
+
+    @pandas_udf("double")
+    def _udf(a, b):  # a, b: pandas Series[str]
+        import pandas as pd
+        from rapidfuzz import fuzz
+        from rapidfuzz.distance import JaroWinkler, Levenshtein
+
+        def score(x: str, y: str) -> float:
+            x = x or ""
+            y = y or ""
+            if scorer_name == "jaro_winkler":
+                return JaroWinkler.normalized_similarity(x, y)
+            if scorer_name == "levenshtein":
+                return Levenshtein.normalized_similarity(x, y)
+            # token_sort: rapidfuzz fuzz.token_sort_ratio / 100 (repo convention
+            # for normalizing the 0-100 ratio scorers to [0, 1]).
+            return fuzz.token_sort_ratio(x, y) / 100.0
+
+        return pd.Series([score(x, y) for x, y in zip(a, b)])
+
+    return _udf

--- a/packages/python/goldenmatch/goldenmatch/sail/scoring.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/scoring.py
@@ -1,0 +1,51 @@
+"""S1 score+dedup on Sail (Spark Connect): a block self-join scored by a
+rapidfuzz pandas UDF, threshold-filtered, then deduped via GROUP BY max.
+Returns the RAW above-threshold canonical (a < b) pair set.
+
+This is the same relational shape as the one-box spine's score+dedup, re-
+expressed against PySpark/Spark Connect (Sail distributes the join + GROUP BY
+across nodes)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def score_and_dedup(
+    df: Any,
+    *,
+    block_col: str,
+    value_col: str,
+    id_col: str,
+    scorer_name: str,
+    threshold: float,
+) -> Any:
+    """Score + dedup a single weighted field over a block self-join.
+
+    ``df`` is a Spark DataFrame with ``id_col`` (int), ``value_col`` (the
+    scored field) and ``block_col`` (the blocking key). Returns a Spark
+    DataFrame of ``(a, b, score)`` with ``a < b``, ``score >= threshold``,
+    deduped to ``max(score)`` per canonical pair. The self-join + scorer UDF +
+    GROUP BY are all Spark ops Sail distributes.
+    """
+    from pyspark.sql import functions as F
+
+    from goldenmatch.sail.scorers import make_scorer_udf
+
+    udf = make_scorer_udf(scorer_name)
+    a = df.alias("a")
+    b = df.alias("b")
+    pairs = (
+        a.join(
+            b,
+            (F.col(f"a.{block_col}") == F.col(f"b.{block_col}"))
+            & (F.col(f"a.{id_col}") < F.col(f"b.{id_col}")),
+        )
+        .select(
+            F.col(f"a.{id_col}").alias("a"),
+            F.col(f"b.{id_col}").alias("b"),
+            udf(F.col(f"a.{value_col}"), F.col(f"b.{value_col}")).alias("score"),
+        )
+        .where(F.col("score") >= F.lit(threshold))
+    )
+    # Dedup: max(score) per canonical (a, b) -- the scale-mode MAX contract.
+    return pairs.groupBy("a", "b").agg(F.max("score").alias("score"))

--- a/packages/python/goldenmatch/goldenmatch/sail/session.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/session.py
@@ -1,0 +1,24 @@
+"""Sail (Spark Connect) session helpers. Sail is programmed via PySpark /
+Spark Connect, NOT the datafusion Python API -- this is a re-expression of
+the one-box spine's algorithm, not a port."""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def connect(remote: str | None = None) -> Any:
+    """Return a SparkSession connected to a Sail server.
+
+    ``remote`` (or the ``SAIL_REMOTE`` env var) is an ``sc://host:port`` URL.
+    Raises if neither is set -- the Sail tier has no implicit cluster
+    bootstrap (bring-your-own).
+    """
+    from pyspark.sql import SparkSession
+
+    url = remote or os.environ.get("SAIL_REMOTE")
+    if not url:
+        raise RuntimeError(
+            "No Sail remote: pass remote='sc://host:port' or set SAIL_REMOTE."
+        )
+    return SparkSession.builder.remote(url).getOrCreate()

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -132,6 +132,14 @@ ray = [
 datafusion = [
     "datafusion>=53,<54",
 ]
+# Sail tier (distributed, Spark Connect). Spec: docs/superpowers/specs/
+# 2026-06-03-sail-tier-design.md. Sail is programmed via PySpark/Spark
+# Connect (NOT datafusion-python). pyspark may need pinning to pysail's
+# targeted Spark Connect protocol version -- see the S1 plan.
+sail = [
+    "pysail>=0.6",
+    "pyspark[connect]>=3.5",
+]
 agent = [
     "aiohttp>=3.9",
 ]

--- a/packages/python/goldenmatch/tests/test_sail_connectivity.py
+++ b/packages/python/goldenmatch/tests/test_sail_connectivity.py
@@ -1,0 +1,25 @@
+"""S1 de-risk: prove the Sail (Spark Connect) harness runs in CI before any
+pipeline is built on it. Skips where the sail extra is absent; runs in the
+`sail` CI lane (goldenmatch[sail] installed)."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysail")
+pytest.importorskip("pyspark")
+
+
+def test_sail_local_server_runs_trivial_query():
+    from pysail.spark import SparkConnectServer
+    from pyspark.sql import SparkSession
+
+    server = SparkConnectServer()
+    server.start()  # background
+    try:
+        _, port = server.listening_address
+        spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+        rows = spark.sql("SELECT 1 + 1 AS two").collect()
+        assert rows[0]["two"] == 2
+        spark.stop()
+    finally:
+        server.stop()

--- a/packages/python/goldenmatch/tests/test_sail_score_parity.py
+++ b/packages/python/goldenmatch/tests/test_sail_score_parity.py
@@ -1,0 +1,84 @@
+"""S1 gate: the Sail score/dedup pipeline's emitted pair SET matches a
+python-rapidfuzz reference. Self-contained (no datafusion). Skips where the
+sail extra is absent; runs in the `sail` CI lane."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysail")
+pytest.importorskip("pyspark")
+pytest.importorskip("polars")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    from pysail.spark import SparkConnectServer
+    from pyspark.sql import SparkSession
+
+    server = SparkConnectServer()
+    server.start()
+    _, port = server.listening_address
+    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+    yield sess
+    sess.stop()
+    server.stop()
+
+
+def _fixture_rows():
+    """Mirror the one-box parity fixture: dense / 2-member / 3-chain /
+    singletons on last_name, block on zip. Returns list of (row_id, last, zip).
+    All within-block strings are identical -> every pair scores 1.0 (0.15
+    margin over the 0.85 threshold), so no pair is near-threshold."""
+    last = (["Aaaa"] * 5 + ["Brown", "Brown"]
+            + ["Carter", "Carter", "Carter"] + ["Dixon", "Ellis"])
+    zips = (["10001"] * 5 + ["20002"] * 2 + ["30003"] * 3 + ["40004", "50005"])
+    return [(i, last[i], zips[i]) for i in range(len(last))]
+
+
+def test_sail_scorer_udf_matches_rapidfuzz(spark):
+    from goldenmatch.sail.scorers import make_scorer_udf
+    from rapidfuzz.distance import JaroWinkler
+
+    df = spark.createDataFrame([("Aaaa", "Aaaa"), ("Brown", "Browne")], ["a", "b"])
+    udf = make_scorer_udf("jaro_winkler")
+    got = {
+        (r["a"], r["b"]): r["s"]
+        for r in df.select("a", "b", udf("a", "b").alias("s")).collect()
+    }
+    for (a, b), s in got.items():
+        assert abs(s - JaroWinkler.normalized_similarity(a, b)) < 1e-9
+
+
+def _reference_pairs(rows, threshold):
+    """python-rapidfuzz brute-force within block (mirror _inmemory_comparand):
+    canonical (min, max) above-threshold pairs. The SAME rapidfuzz the Sail UDF
+    uses -> exact set parity is the gate."""
+    from collections import defaultdict
+
+    from rapidfuzz.distance import JaroWinkler
+
+    by_block = defaultdict(list)
+    for rid, last, z in rows:
+        by_block[z].append((rid, last))
+    out = set()
+    for members in by_block.values():
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                (ida, va), (idb, vb) = members[i], members[j]
+                if JaroWinkler.normalized_similarity(va, vb) >= threshold:
+                    out.add((min(ida, idb), max(ida, idb)))
+    return out
+
+
+def test_sail_score_dedup_pair_set_parity(spark):
+    from goldenmatch.sail.scoring import score_and_dedup
+
+    rows = _fixture_rows()
+    threshold = 0.85
+    sdf = spark.createDataFrame(rows, ["__row_id__", "last_name", "zip"])
+    out = score_and_dedup(
+        sdf, block_col="zip", value_col="last_name", id_col="__row_id__",
+        scorer_name="jaro_winkler", threshold=threshold,
+    )
+    sail_pairs = {(min(r["a"], r["b"]), max(r["a"], r["b"])) for r in out.collect()}
+    assert sail_pairs == _reference_pairs(rows, threshold)


### PR DESCRIPTION
Sail tier Stage S1 (spec: docs/superpowers/specs/2026-06-03-sail-tier-design.md). First Sail-native gate: the goldenmatch[sail] extra, a goldenmatch.sail package (session connect helper, rapidfuzz scorer pandas UDF, block self-join -> score -> GROUP BY max dedup), and a new path-filtered `sail` CI lane that spins up an in-process Sail Spark Connect server.

Building risk-first: this first push is the **connectivity de-risk** (Task 1) — prove pysail + pyspark[connect] + the Spark Connect handshake run in CI before the pipeline is built on them. Scorer UDF + score/dedup + parity gate follow once connectivity is green.