### PR TITLE
feat(sail): Stage S2 — connected components on Sail (the WCC gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -933,6 +933,11 @@ jobs:
       - name: Sail score/dedup parity gate (blocking)
         run: |
           .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_score_parity.py -v --timeout=300
+      # GATE (blocking): connected-components partition parity -- the make-or-
+      # break S2 gate (the Union-Find holdout, computed distributed on Sail).
+      - name: Sail WCC parity gate (blocking)
+        run: |
+          .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_clustering_parity.py -v --timeout=300
 
   action:
     needs: changes

--- a/packages/python/goldenmatch/goldenmatch/sail/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/clustering.py
@@ -1,0 +1,99 @@
+"""Weakly-connected components on Sail (Spark Connect) -- the Union-Find
+holdout, computed distributed via min-label propagation.
+
+S2 uses min-label propagation (pure Spark DataFrame joins to a fixpoint):
+each node starts labeled with its own id (seeded from a DISTRIBUTED ids
+frame -- NEVER a driver list[int], the WCC-rehydration OOM trap), then
+adopts the min label among itself + its neighbors until nothing changes.
+Each component converges to label = its min member id. Correct + genuinely
+Sail-native; the chain-SCALE-robust large-star/small-star is an S4
+prerequisite (label-prop is O(diameter) iterations on long chains -- fine
+at S2's correctness-gate scale, not at 100M)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def connected_components(
+    pairs_df: Any,
+    ids_df: Any,
+    *,
+    id_col: str = "__row_id__",
+) -> Any:
+    """Distributed weakly-connected components.
+
+    Args:
+        pairs_df: Spark DataFrame of edges with ``a`` and ``b`` (int) columns
+            (canonical ``a < b`` from ``score_and_dedup``; not required).
+        ids_df: Spark DataFrame of the FULL node universe with ``id_col``
+            (every record id, singletons included). DISTRIBUTED -- never a
+            driver list. Singletons surface as their own component. By
+            contract every id in ``pairs_df`` is also in ``ids_df``.
+        id_col: the id column name in ``ids_df``.
+
+    Returns:
+        Spark DataFrame ``(cluster_id, member_id)`` -- one row per node;
+        ``cluster_id`` is the component's min member id (a stable, label-
+        independent partition). Matches ``build_cluster_frames.assignments``.
+    """
+    from pyspark.sql import functions as F
+
+    # Symmetric edges so labels flow both ways: (src, dst) for both
+    # orientations. Self-loops are harmless (a < b avoids them anyway).
+    fwd = pairs_df.select(F.col("a").alias("src"), F.col("b").alias("dst"))
+    rev = pairs_df.select(F.col("b").alias("src"), F.col("a").alias("dst"))
+    edges = fwd.unionByName(rev)
+
+    # Seed: every node labeled with itself (from the DISTRIBUTED universe).
+    labels = ids_df.select(F.col(id_col).cast("long").alias("node")).withColumn(
+        "label", F.col("node")
+    )
+
+    # Iterate to fixpoint. Bounded by component diameter; at S2 fixture scale
+    # this is 2-3 rounds. The convergence count is a driver scalar (cheap).
+    # NOTE for S4: cache/checkpoint `labels` each round + swap in large-star/
+    # small-star -- label-prop's O(diameter) won't bind at 100M chains.
+    #
+    # Spark Connect discipline: every join is on a SHARED COLUMN NAME (auto-
+    # coalesced, no duplicate-column ambiguity), and the other side is RENAMED
+    # before the join so no two inputs share a non-key name. We NEVER reference
+    # a column via the ``df["col"]`` handle across a self-similar join (the
+    # AMBIGUOUS_REFERENCE / CANNOT_RESOLVE footgun across iterations).
+    max_rounds = 100
+    for _ in range(max_rounds):
+        # Each node's neighbor-min label. Join edges.dst == labels.node by
+        # renaming labels -> (dst, dst_label) and joining on the shared "dst".
+        lab_for_nbr = labels.select(
+            F.col("node").alias("dst"), F.col("label").alias("dst_label")
+        )
+        nbr_min = (
+            edges.join(lab_for_nbr, on="dst", how="inner")
+            .groupBy("src")
+            .agg(F.min("dst_label").alias("nbr_min"))
+            .select(F.col("src").alias("node"), F.col("nbr_min"))
+        )
+        # Update: node adopts min(own label, neighbor-min). Left join on the
+        # shared "node"; nodes with no neighbor keep their label (coalesce).
+        new_labels = labels.join(nbr_min, on="node", how="left").select(
+            F.col("node"),
+            F.least(
+                F.col("label"), F.coalesce(F.col("nbr_min"), F.col("label"))
+            ).alias("label"),
+        )
+        # Convergence: compare new vs old on the shared "node"; old renamed.
+        old_for_cmp = labels.select(
+            F.col("node"), F.col("label").alias("old_label")
+        )
+        changed = (
+            new_labels.join(old_for_cmp, on="node", how="inner")
+            .where(F.col("label") != F.col("old_label"))
+            .limit(1)
+            .count()
+        )
+        labels = new_labels
+        if changed == 0:
+            break
+
+    return labels.select(
+        F.col("label").alias("cluster_id"), F.col("node").alias("member_id")
+    )

--- a/packages/python/goldenmatch/tests/test_sail_clustering_parity.py
+++ b/packages/python/goldenmatch/tests/test_sail_clustering_parity.py
@@ -1,0 +1,97 @@
+"""S2 gate: Sail connected_components produces a cluster PARTITION identical
+to a reference Union-Find on fixtures including a chain, a multi-merge
+junction, and a singleton. Self-contained; skips where the sail extra is
+absent; runs in the `sail` lane."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysail")
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    from pysail.spark import SparkConnectServer
+    from pyspark.sql import SparkSession
+
+    server = SparkConnectServer()
+    server.start()
+    _, port = server.listening_address
+    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+    yield sess
+    sess.stop()
+    server.stop()
+
+
+def _reference_partition(ids, edges):
+    """Canonical connected components via plain Union-Find -> set of
+    frozensets of member ids (singletons included)."""
+    parent = {i: i for i in ids}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b in edges:
+        parent[find(a)] = find(b)
+    comp = {}
+    for i in ids:
+        comp.setdefault(find(i), set()).add(i)
+    return {frozenset(v) for v in comp.values()}
+
+
+def _sail_partition(out_df):
+    """assignments DataFrame -> set of frozensets of member ids per cluster_id."""
+    from collections import defaultdict
+
+    by_cid = defaultdict(set)
+    for r in out_df.collect():
+        by_cid[r["cluster_id"]].add(int(r["member_id"]))
+    return {frozenset(v) for v in by_cid.values()}
+
+
+def test_sail_wcc_partition_parity(spark):
+    from goldenmatch.sail.clustering import connected_components
+
+    # ids 0..6: chain {0-1-2}, pair {3-4}, singletons {5},{6}.
+    ids = list(range(7))
+    edges = [(0, 1), (1, 2), (3, 4)]  # canonical a<b
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+
+    out = connected_components(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == _reference_partition(ids, edges)
+
+
+def test_sail_wcc_deep_chain_converges(spark):
+    """A longer chain 0-1-2-...-9 must collapse to ONE component (label-prop
+    across many hops -- the correctness analog of the chain concern)."""
+    from goldenmatch.sail.clustering import connected_components
+
+    ids = list(range(10))
+    edges = [(i, i + 1) for i in range(9)]
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+
+    out = connected_components(pairs_df, ids_df, id_col="__row_id__")
+    part = _sail_partition(out)
+    assert part == {frozenset(range(10))}
+
+
+def test_sail_wcc_junction_multimerge(spark):
+    """The spec-named multi-merge archetype: branches 0,1,2 all merge at a
+    junction node 3 (min-propagation arrives from multiple neighbors in one
+    round), a separate pair {4,5}, and a singleton {6}. Stresses the case
+    most likely to surface a subtle min-propagation bug."""
+    from goldenmatch.sail.clustering import connected_components
+
+    ids = list(range(7))
+    edges = [(0, 3), (1, 3), (2, 3), (4, 5)]  # canonical a<b
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+
+    out = connected_components(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == _reference_partition(ids, edges)


### PR DESCRIPTION
Sail tier Stage S2 (spec: docs/superpowers/specs/2026-06-03-sail-tier-design.md). The make-or-break gate: computes weakly-connected components (the Union-Find holdout) **distributed on Sail** via min-label propagation (pure Spark Connect DataFrame joins to a fixpoint), partition-parity-gated (Rand 1.0) vs a reference Union-Find on chain + multi-merge-junction + singleton fixtures.

Closes the existential 'can WCC be done correctly + distributed on Sail at all' risk. Isolated nodes seeded from a DISTRIBUTED frame (not a driver list[int] — the rehydration-OOM trap). Spark Connect discipline: join-on-shared-name + rename-before-join (no df[col] cross-handle refs).

Leads with label-prop because S2's gate is correctness; the chain-SCALE-robust algorithm (large-star/small-star) is a recorded S4 prerequisite (label-prop is O(diameter) on long chains).