### PR TITLE
feat(sail): Stage S3 — golden survivorship on Sail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -938,6 +938,11 @@ jobs:
       - name: Sail WCC parity gate (blocking)
         run: |
           .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_clustering_parity.py -v --timeout=300
+      # GATE (blocking): golden survivorship content parity per multi-member
+      # cluster vs the one-box merge_field primitive (S3).
+      - name: Sail golden parity gate (blocking)
+        run: |
+          .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_golden_parity.py -v --timeout=300
 
   action:
     needs: changes

--- a/packages/python/goldenmatch/goldenmatch/sail/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/golden.py
@@ -1,0 +1,91 @@
+"""Golden-record survivorship on Sail (Spark Connect), distributed.
+
+Joins the S2 ``assignments`` (cluster_id, member_id) to the source records,
+filters to multi-member clusters, then for each field collects the cluster's
+values (``collect_list``) and merges them with the ONE-BOX
+``core.golden.merge_field`` primitive via a scalar pandas UDF -- reusing the
+exact survivorship logic guarantees semantic parity; Sail distributes the
+group-and-merge. Pure-relational (collect_list + scalar UDF), building on S1's
+proven pandas_udf mechanism (not grouped-map applyInPandas).
+
+S3 scope: the uniform, order-INDEPENDENT case (default ``most_complete`` over
+multi-member clusters). Order-dependent strategies (most_recent/source_priority),
+custom plugin strategies, oversized exclusion, and provenance are deferred
+(mirrors the Ray distributed golden's in-memory fallback for those)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def make_merge_udf(strategy: str) -> Any:
+    """A scalar pandas UDF mapping an array-of-values column (one cluster's
+    collected field values) to the survivor value via ``merge_field``."""
+    from pyspark.sql.functions import pandas_udf
+
+    @pandas_udf("string")
+    def _udf(col):  # col: pandas Series; each element is the collected list
+        import pandas as pd
+
+        from goldenmatch.config.schemas import GoldenFieldRule
+        from goldenmatch.core.golden import merge_field
+
+        rule = GoldenFieldRule(strategy=strategy)
+        out = []
+        for vals in col:
+            # ``vals`` arrives as a python list OR a numpy ndarray (Spark array
+            # column); list(...) handles both -- do NOT assume a python list.
+            values = list(vals) if vals is not None else []
+            merged, _conf, _src = merge_field(values, rule)
+            out.append(None if merged is None else str(merged))
+        return pd.Series(out)
+
+    return _udf
+
+
+def build_golden(
+    assignments_df: Any,
+    source_df: Any,
+    *,
+    value_cols: list[str],
+    source_id_col: str = "__row_id__",
+    strategy: str = "most_complete",
+) -> Any:
+    """Build one golden record per multi-member cluster, distributed.
+
+    Args:
+        assignments_df: Spark DataFrame ``(cluster_id, member_id)`` (from S2).
+        source_df: Spark DataFrame with ``source_id_col`` + the ``value_cols``.
+        value_cols: the fields to survivor-merge.
+        source_id_col: the id column in ``source_df`` (joined to ``member_id``).
+        strategy: survivorship strategy (S3: order-independent, default
+            ``most_complete``).
+
+    Returns:
+        Spark DataFrame ``(cluster_id, *value_cols)`` -- one golden row per
+        multi-member cluster, each field survivor-merged.
+    """
+    from pyspark.sql import functions as F
+
+    # Join on a SHARED name (rename source's id col -> member_id); no df["col"]
+    # cross-handle refs (the S2 AMBIGUOUS_REFERENCE lesson).
+    src = source_df.withColumnRenamed(source_id_col, "member_id")
+    joined = assignments_df.join(src, on="member_id", how="inner")
+
+    # Multi-member clusters only (golden is the multi-member rollup; singletons
+    # are "unique", not golden).
+    multi = (
+        assignments_df.groupBy("cluster_id")
+        .count()
+        .where(F.col("count") > 1)
+        .select("cluster_id")
+    )
+    joined = joined.join(multi, on="cluster_id", how="inner")
+
+    # Collect each field's values per cluster, then merge via the UDF.
+    agg = joined.groupBy("cluster_id").agg(
+        *[F.collect_list(c).alias(c) for c in value_cols]
+    )
+    merge_udf = make_merge_udf(strategy)
+    for c in value_cols:
+        agg = agg.withColumn(c, merge_udf(F.col(c)))
+    return agg

--- a/packages/python/goldenmatch/tests/test_sail_golden_parity.py
+++ b/packages/python/goldenmatch/tests/test_sail_golden_parity.py
@@ -1,0 +1,100 @@
+"""S3 gate: Sail build_golden produces per-cluster golden field values
+identical to the one-box merge_field over the same members (multi-member
+clusters only). Both call merge_field -> parity by construction; the gate
+proves the Sail join/group/collect_list plumbing assembles the right per-
+cluster inputs. Small-N by design (production never collects golden to the
+driver). Skips where the sail extra is absent; runs in the `sail` lane."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysail")
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    from pysail.spark import SparkConnectServer
+    from pyspark.sql import SparkSession
+
+    server = SparkConnectServer()
+    server.start()
+    _, port = server.listening_address
+    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+    yield sess
+    sess.stop()
+    server.stop()
+
+
+_VALUE_COLS = ["first_name", "email"]
+
+
+def _source_rows():
+    """(row_id, first_name, email). Each multi-member cluster has a clear
+    most_complete winner per field (one non-null, or a unique-longest value),
+    so the survivor is order-independent under collect_list's arbitrary order."""
+    return [
+        # cluster A (members 0,1): first_name winner "Jonathan" (vs null),
+        #   email winner "jon@x.com" (vs null).
+        (0, "Jonathan", None),
+        (1, None, "jon@x.com"),
+        # cluster B (members 2,3,4): first_name "Margaret" (unique-longest vs
+        #   "Marg", None), email "marg@y.com" (vs None, None).
+        (2, "Marg", None),
+        (3, "Margaret", "marg@y.com"),
+        (4, None, None),
+        # singleton (member 5): excluded from golden.
+        (5, "Solo", "solo@z.com"),
+    ]
+
+
+def _assignments():
+    # (cluster_id, member_id). cluster_id = min member id (S2 convention).
+    return [(0, 0), (0, 1), (2, 2), (2, 3), (2, 4), (5, 5)]
+
+
+def _reference_golden(rows, assignments, value_cols, strategy):
+    from collections import defaultdict
+
+    from goldenmatch.config.schemas import GoldenFieldRule
+    from goldenmatch.core.golden import merge_field
+
+    by_id = {r[0]: dict(zip(["__row_id__", *value_cols], r)) for r in rows}
+    members = defaultdict(list)
+    for cid, mid in assignments:
+        members[cid].append(mid)
+    rule = GoldenFieldRule(strategy=strategy)
+    out = {}
+    for cid, mids in members.items():
+        if len(mids) < 2:
+            continue
+        rec = {}
+        for c in value_cols:
+            merged, _c, _s = merge_field([by_id[m][c] for m in mids], rule)
+            rec[c] = None if merged is None else str(merged)
+        out[cid] = rec
+    return out
+
+
+def _sail_golden(out_df, value_cols):
+    return {
+        int(r["cluster_id"]): {c: r[c] for c in value_cols}
+        for r in out_df.collect()
+    }
+
+
+def test_sail_golden_content_parity(spark):
+    from goldenmatch.sail.golden import build_golden
+
+    rows = _source_rows()
+    assignments = _assignments()
+    source_df = spark.createDataFrame(rows, ["__row_id__", *_VALUE_COLS])
+    assign_df = spark.createDataFrame(assignments, ["cluster_id", "member_id"])
+
+    out = build_golden(assign_df, source_df, value_cols=_VALUE_COLS)
+    got = _sail_golden(out, _VALUE_COLS)
+    expected = _reference_golden(rows, assignments, _VALUE_COLS, "most_complete")
+    assert got == expected
+    # Singleton cluster 5 excluded (redundant with the dict equality; explicit
+    # intent marker).
+    assert 5 not in got


### PR DESCRIPTION
Sail tier Stage S3 (spec: docs/superpowers/specs/2026-06-03-sail-tier-design.md, golden half). Builds golden records distributed on Sail via groupBy + collect_list + a scalar pandas UDF that calls the one-box core.golden.merge_field primitive -- reusing the exact survivorship logic gives content parity by construction; Sail distributes the group-and-merge. Content-parity-gated per multi-member cluster vs merge_field.

Scope: uniform most_complete (order-independent). Identity is SPLIT to its own later stage (stateful graph subsystem, not a relational op). Order-dependent strategies / custom rules / oversized exclusion deferred (in-memory fallback, like the Ray path).