### PR TITLE
docs(network): mark Sail tier S3 (golden) shipped

### DIFF
--- a/context-network/architecture/sail-tier.md
+++ b/context-network/architecture/sail-tier.md
@@ -6,10 +6,10 @@ programmed via **Spark Connect / PySpark**) to run across nodes, computes connec
 components distributed (removing the one-box UF island), and ultimately retires the
 existing Ray distributed stack.
 
-**Status:** S1+S2 SHIPPED 2026-06-03 (PRs #709, #712); S3 next. The
-make-or-break WCC-on-Sail risk is CLOSED. **Spec:**
-`docs/superpowers/specs/2026-06-03-sail-tier-design.md`. **Plans:**
-`docs/superpowers/plans/2026-06-03-sail-tier-stage-{s1,s2}.md`.
+**Status:** S1+S2+S3(golden) SHIPPED 2026-06-03 (PRs #709, #712, #714);
+identity stage + S4 next. The make-or-break WCC-on-Sail risk is CLOSED.
+**Spec:** `docs/superpowers/specs/2026-06-03-sail-tier-design.md`. **Plans:**
+`docs/superpowers/plans/2026-06-03-sail-tier-stage-{s1,s2,s3}.md`.
 **Why it matters:** Stage E showed one-box spill-survival is non-binding
 ([../decisions/0003-stage-e-spill-honest-null.md](../decisions/0003-stage-e-spill-honest-null.md))
 — the distributed path is where the value is.
@@ -49,8 +49,13 @@ algorithm** in a new `goldenmatch.sail` package, with native scorers rebound as 
   partition-parity-green vs reference UF (chain + junction + singleton). Existential "WCC-on-Sail"
   risk CLOSED. Deliberate spec deviation: led with label-prop (correctness gate); large-star/
   small-star is an S4 prerequisite (label-prop is O(diameter) on 100M chains).
-- **S3 — NEXT:** golden (incl. custom rules) + identity on Sail.  **S4:** 100M+ bench +
-  large-star/small-star swap + Ray retire.
+- **S3 (golden) — SHIPPED (PR #714).** `golden.build_golden` = distributed survivorship via
+  `groupBy + collect_list` + a scalar pandas UDF calling the one-box `merge_field` (parity by
+  construction). Content-parity-green per multi-member cluster. SCOPE: golden only; **identity
+  SPLIT to its own next stage** (stateful entity store, not a relational op). Uniform most_complete;
+  order-dependent/custom/oversized/provenance deferred (in-memory fallback, like Ray).
+- **Identity-on-Sail — NEXT** (split from S3).  **S4:** 100M+ multi-node bench (REAL BYO cluster) +
+  large-star/small-star WCC swap + Ray retire.
 
 ## Verification
 - CI smoke: a local Sail Spark Connect server (`pysail.spark.SparkConnectServer`) runs the same

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,13 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-03 — Sail tier Stage S3 (golden) shipped
+- S3 golden merged (PR #714): distributed survivorship on Sail (collect_list + merge_field UDF),
+  content-parity green. SCOPE DECISION: S3 scoped to golden only; identity split to its own next
+  stage (stateful graph subsystem, not a relational op). Updated
+  [../architecture/sail-tier.md](../architecture/sail-tier.md) +
+  [../planning/roadmap.md](../planning/roadmap.md). Identity-on-Sail is next, then S4 (real cluster).
+
 ## 2026-06-03 — Sail tier Stage S2 shipped (make-or-break gate)
 - S2 merged (PR #712): WCC on Sail via min-label propagation, partition-parity green. The
   existential "WCC-on-Sail at all" risk is CLOSED. Marked S2 done in

--- a/context-network/planning/roadmap.md
+++ b/context-network/planning/roadmap.md
@@ -27,8 +27,12 @@ Spec: `docs/superpowers/specs/2026-06-03-sail-tier-design.md`. Staged, each a ga
 - **S2 — SHIPPED (PR #712, 2026-06-03)** — **WCC on Sail** via min-label propagation; partition-
   parity green (chain + junction + singleton). The make-or-break gate; existential risk CLOSED.
   (Led with label-prop; large-star/small-star is an S4 prerequisite.)
-- **S3 — golden (incl. custom rules) + identity on Sail. ← next.**
-- **S4 — binding 100M+ multi-node bench + large-star/small-star swap + Ray retirement.**
+- **S3 (golden) — SHIPPED (PR #714, 2026-06-03)** — distributed survivorship via
+  `collect_list` + a scalar pandas UDF calling the one-box `merge_field`; content-parity green.
+  Scoped to golden; identity split to its own stage.
+- **Identity on Sail — next** (split from S3; stateful entity store, not a relational op).
+- **S4 — binding 100M+ multi-node bench (REAL BYO cluster) + large-star/small-star WCC swap +
+  Ray retirement.** The only stage needing a real cluster.
 - **S3** — golden (incl. custom rules) + identity on Sail.
 - **S4** — binding 100M+ multi-node bench + Ray retirement. Kill criterion: completes
   where one-box can't, per-node RSS bounded, wall scales with nodes.


### PR DESCRIPTION
Context network update: Sail tier S3 golden merged (PR #714); identity split to its own next stage. Architecture + roadmap + updates. Docs-only.