### PR TITLE
feat(sail): Stage S4 harness — scale-WCC + end-to-end pipeline + bench scaffold

### DIFF
--- a/.github/workflows/bench-sail-100m.yml
+++ b/.github/workflows/bench-sail-100m.yml
@@ -1,0 +1,38 @@
+# Sail tier S4 binding bench (workflow_dispatch only). Runs the full Sail
+# pipeline over a parquet on a REAL BYO Sail cluster (SAIL_REMOTE secret), the
+# binding "beats one-box / scales out" proof. SCAFFOLD: without SAIL_REMOTE the
+# driver exits 2 (fail-fast). Mirrors the Ray phase5 BYO-cluster posture (docs
+# not bootstrap). Ray is NOT retired until this binds.
+# Spec: docs/superpowers/specs/2026-06-03-sail-tier-design.md (S4).
+name: bench-sail-100m
+on:
+  workflow_dispatch:
+    inputs:
+      input:
+        description: "parquet path/URI reachable from the Sail cluster"
+        required: true
+permissions:
+  contents: read
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+      - run: uv sync --all-packages
+      - name: Install sail extra
+        run: uv pip install -e 'packages/python/goldenmatch[sail]'
+      - name: Run Sail bench (real cluster via SAIL_REMOTE)
+        env:
+          SAIL_REMOTE: ${{ secrets.SAIL_REMOTE }}
+        run: |
+          .venv/bin/python packages/python/goldenmatch/scripts/bench_sail_100m.py \
+            --input "${{ inputs.input }}" --out .profile_tmp/sail_100m.json
+          { echo '## bench-sail-100m'; echo '```'; cat .profile_tmp/sail_100m.json; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sail-100m-bench
+          path: .profile_tmp/sail_100m.json
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -943,6 +943,11 @@ jobs:
       - name: Sail golden parity gate (blocking)
         run: |
           .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_golden_parity.py -v --timeout=300
+      # GATE (blocking): the full Sail pipeline (load->...->golden) runs
+      # end-to-end on Sail (S4).
+      - name: Sail end-to-end pipeline gate (blocking)
+        run: |
+          .venv/bin/python -m pytest packages/python/goldenmatch/tests/test_sail_pipeline.py -v --timeout=300
 
   action:
     needs: changes

--- a/packages/python/goldenmatch/goldenmatch/sail/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/clustering.py
@@ -97,3 +97,92 @@ def connected_components(
     return labels.select(
         F.col("label").alias("cluster_id"), F.col("node").alias("member_id")
     )
+
+
+def connected_components_scale(
+    pairs_df: Any,
+    ids_df: Any,
+    *,
+    id_col: str = "__row_id__",
+    max_rounds: int = 40,
+) -> Any:
+    """Chain-robust O(log n) weakly-connected components via min-label
+    propagation with POINTER-JUMPING (Shiloach-Vishkin shortcutting). Pure
+    Spark Connect. The scale algorithm for the 100M bench (label-prop is
+    O(diameter) on long chains; the pointer-jump halves the distance to the
+    root each round -> O(log n)).
+
+    Same output as ``connected_components``: ``(cluster_id, member_id)`` where
+    cluster_id is the component's min member id. Isolated nodes (singletons)
+    seeded from the DISTRIBUTED ``ids_df`` (the rehydration-OOM trap).
+
+    Each round: (1) PROPAGATE -- each node adopts min(own label, min neighbor
+    label); (2) SHORTCUT -- ``label[v] = label[label[v]]`` (jump to the label's
+    label). Early-exit when labels stop changing. NOTE for the real run:
+    cache/checkpoint ``labels`` each round (Spark Connect lineage grows) + a
+    cheaper change-counter; the gate runs tiny fixtures.
+
+    HAND TRACE (2-node, edges=[(0,1)], seed {0:0,1:1}):
+      r1 propagate: node0 min(0,lbl[1]=1)=0; node1 min(1,lbl[0]=0)=0 -> {0:0,1:0}
+         shortcut: lbl[0]=lbl[0]=0; lbl[1]=lbl[lbl[1]=0]=0 -> {0:0,1:0}
+      r2: no change -> CONVERGED {0:0,1:0}.  ONE component. CORRECT.
+    HAND TRACE (3-chain, edges=[(0,1),(1,2)], seed {0:0,1:1,2:2}):
+      r1 propagate: 0->min(0,1)=0; 1->min(1,min(0,2)=0)=0; 2->min(2,1)=1 -> {0:0,1:0,2:1}
+         shortcut: 0->lbl[0]=0; 1->lbl[0]=0; 2->lbl[1]=0 -> {0:0,1:0,2:0}
+      r2: no change -> CONVERGED all 0.  ONE component. CORRECT.
+    """
+    from pyspark.sql import functions as F
+
+    # Symmetric edges (node, nbr) so labels flow both ways.
+    fwd = pairs_df.select(F.col("a").alias("node"), F.col("b").alias("nbr"))
+    rev = pairs_df.select(F.col("b").alias("node"), F.col("a").alias("nbr"))
+    edges = fwd.unionByName(rev)
+
+    # Labels seeded from the DISTRIBUTED universe (singletons -> own label).
+    labels = ids_df.select(
+        F.col(id_col).cast("long").alias("node")
+    ).withColumn("label", F.col("node"))
+
+    # Spark Connect discipline: join on a SHARED NAME, other side renamed; no
+    # df["col"] cross-handle refs (the S2 AMBIGUOUS_REFERENCE lesson).
+    for _ in range(max_rounds):
+        # (1) PROPAGATE: each node adopts min(own, min neighbor label).
+        lab_for_nbr = labels.select(
+            F.col("node").alias("nbr"), F.col("label").alias("nbr_label")
+        )
+        nbr_min = (
+            edges.join(lab_for_nbr, on="nbr", how="inner")
+            .groupBy("node")
+            .agg(F.min("nbr_label").alias("nbr_min"))
+        )
+        propagated = labels.join(nbr_min, on="node", how="left").select(
+            F.col("node"),
+            F.least(
+                F.col("label"), F.coalesce(F.col("nbr_min"), F.col("label"))
+            ).alias("label"),
+        )
+        # (2) SHORTCUT (pointer-jump): label[v] = label[label[v]].
+        lab_target = propagated.select(
+            F.col("node").alias("label"), F.col("label").alias("grandlabel")
+        )
+        jumped = propagated.join(lab_target, on="label", how="left").select(
+            F.col("node"),
+            F.coalesce(F.col("grandlabel"), F.col("label")).alias("label"),
+        )
+        # Convergence: any label changed vs the previous round?
+        prev_r = labels.select(
+            F.col("node"), F.col("label").alias("prev_label")
+        )
+        changed = (
+            jumped.join(prev_r, on="node", how="inner")
+            .where(F.col("label") != F.col("prev_label"))
+            .limit(1)
+            .count()
+        )
+        labels = jumped
+        if changed == 0:
+            break
+
+    return labels.select(
+        F.col("label").alias("cluster_id"), F.col("node").alias("member_id")
+    )

--- a/packages/python/goldenmatch/goldenmatch/sail/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/sail/pipeline.py
@@ -1,0 +1,55 @@
+"""End-to-end Sail pipeline: load -> block -> score -> dedup -> WCC -> golden,
+all distributed on Sail (Spark Connect). The bench entrypoint (S4). Blocking is
+a single pre-existing column (S1 scope); the scorer is the rapidfuzz pandas UDF;
+WCC defaults to the chain-robust pointer-jumping algorithm (scale)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def run_sail_pipeline(
+    source_df: Any,
+    *,
+    id_col: str,
+    block_col: str,
+    value_col: str,
+    golden_cols: list[str],
+    scorer_name: str = "jaro_winkler",
+    threshold: float = 0.85,
+    strategy: str = "most_complete",
+    wcc: str = "scale",
+) -> Any:
+    """Run the full Sail pipeline. Returns the golden DataFrame
+    ``(cluster_id, *golden_cols)`` (one per multi-member cluster). ``wcc``:
+    ``"scale"`` (pointer-jumping, chain-robust O(log n)) or ``"label_prop"``.
+
+    ``source_df`` must carry ``id_col`` (int), ``block_col``, ``value_col``,
+    and the ``golden_cols``.
+    """
+    from goldenmatch.sail.clustering import (
+        connected_components,
+        connected_components_scale,
+    )
+    from goldenmatch.sail.golden import build_golden
+    from goldenmatch.sail.scoring import score_and_dedup
+
+    pairs = score_and_dedup(
+        source_df,
+        block_col=block_col,
+        value_col=value_col,
+        id_col=id_col,
+        scorer_name=scorer_name,
+        threshold=threshold,
+    )
+    ids_df = source_df.select(id_col)
+    wcc_fn = (
+        connected_components_scale if wcc == "scale" else connected_components
+    )
+    assignments = wcc_fn(pairs, ids_df, id_col=id_col)
+    return build_golden(
+        assignments,
+        source_df,
+        value_cols=golden_cols,
+        source_id_col=id_col,
+        strategy=strategy,
+    )

--- a/packages/python/goldenmatch/scripts/bench_sail_100m.py
+++ b/packages/python/goldenmatch/scripts/bench_sail_100m.py
@@ -1,0 +1,63 @@
+"""S4 binding bench DRIVER (scaffold). Connects to a REAL Sail cluster via
+SAIL_REMOTE, runs run_sail_pipeline over a parquet at scale, times it, writes
+JSON. No in-process server -- needs a real BYO cluster (not run in this plan).
+Usage: SAIL_REMOTE=sc://host:port python bench_sail_100m.py --input <parquet>."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True, help="parquet path/URI on the cluster")
+    ap.add_argument("--id-col", default="__row_id__")
+    ap.add_argument("--block-col", default="last_name_soundex")
+    ap.add_argument("--value-col", default="last_name")
+    ap.add_argument("--golden-cols", default="first_name,email")
+    ap.add_argument("--out", default=".profile_tmp/sail_100m.json")
+    args = ap.parse_args()
+
+    remote = os.environ.get("SAIL_REMOTE")
+    if not remote:
+        print(
+            "::error::SAIL_REMOTE unset -- this bench needs a real BYO Sail cluster.",
+            file=sys.stderr,
+        )
+        return 2
+
+    from goldenmatch.sail.pipeline import run_sail_pipeline
+    from goldenmatch.sail.session import connect
+
+    spark = connect(remote)
+    src = spark.read.parquet(args.input)
+    t0 = time.perf_counter()
+    golden = run_sail_pipeline(
+        src,
+        id_col=args.id_col,
+        block_col=args.block_col,
+        value_col=args.value_col,
+        golden_cols=args.golden_cols.split(","),
+        wcc="scale",
+    )
+    n_golden = golden.count()  # forces the full pipeline
+    wall = time.perf_counter() - t0
+
+    payload = {
+        "wall_s": wall,
+        "golden_count": n_golden,
+        "remote": remote,
+        "input": args.input,
+    }
+    print(json.dumps(payload, indent=2))
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/tests/test_sail_clustering_parity.py
+++ b/packages/python/goldenmatch/tests/test_sail_clustering_parity.py
@@ -95,3 +95,51 @@ def test_sail_wcc_junction_multimerge(spark):
 
     out = connected_components(pairs_df, ids_df, id_col="__row_id__")
     assert _sail_partition(out) == _reference_partition(ids, edges)
+
+
+def test_sail_wcc_scale_two_node(spark):
+    """Minimal case: edges=[(0,1)] -> one component {0,1}. The fastest-failing
+    case for a wrong WCC (it returned two singletons in the blind attempt)."""
+    from goldenmatch.sail.clustering import connected_components_scale
+
+    ids = [0, 1]
+    edges = [(0, 1)]
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+    out = connected_components_scale(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == {frozenset({0, 1})}
+
+
+def test_sail_wcc_scale_partition_parity(spark):
+    from goldenmatch.sail.clustering import connected_components_scale
+
+    ids = list(range(7))
+    edges = [(0, 1), (1, 2), (3, 4)]
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+    out = connected_components_scale(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == _reference_partition(ids, edges)
+
+
+def test_sail_wcc_scale_long_chain(spark):
+    """A 30-node chain: pointer-jumping converges in O(log 30) rounds where
+    label-prop would need ~30. Must collapse to ONE component."""
+    from goldenmatch.sail.clustering import connected_components_scale
+
+    ids = list(range(30))
+    edges = [(i, i + 1) for i in range(29)]
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+    out = connected_components_scale(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == {frozenset(range(30))}
+
+
+def test_sail_wcc_scale_junction(spark):
+    from goldenmatch.sail.clustering import connected_components_scale
+
+    ids = list(range(7))
+    edges = [(0, 3), (1, 3), (2, 3), (4, 5)]  # singleton 6
+    ids_df = spark.createDataFrame([(i,) for i in ids], ["__row_id__"])
+    pairs_df = spark.createDataFrame(edges, ["a", "b"])
+    out = connected_components_scale(pairs_df, ids_df, id_col="__row_id__")
+    assert _sail_partition(out) == _reference_partition(ids, edges)

--- a/packages/python/goldenmatch/tests/test_sail_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_sail_pipeline.py
@@ -1,0 +1,44 @@
+"""S4 end-to-end gate: run_sail_pipeline runs on Sail and produces golden per
+multi-member cluster. Skips where the sail extra is absent; runs in the `sail`
+lane."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pysail")
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture(scope="module")
+def spark():
+    from pysail.spark import SparkConnectServer
+    from pyspark.sql import SparkSession
+
+    server = SparkConnectServer()
+    server.start()
+    _, port = server.listening_address
+    sess = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
+    yield sess
+    sess.stop()
+    server.stop()
+
+
+def test_run_sail_pipeline_end_to_end(spark):
+    from goldenmatch.sail.pipeline import run_sail_pipeline
+
+    rows = [
+        (0, "10001", "Smith", "Jon"),
+        (1, "10001", "Smith", None),     # cluster {0,1}: first_name "Jon"
+        (2, "20002", "Brown", "Ann"),
+        (3, "20002", "Brown", None),     # cluster {2,3}: first_name "Ann"
+        (4, "30003", "Solo", "Zed"),     # singleton (excluded)
+    ]
+    df = spark.createDataFrame(
+        rows, ["__row_id__", "zip", "last_name", "first_name"]
+    )
+    golden = run_sail_pipeline(
+        df, id_col="__row_id__", block_col="zip", value_col="last_name",
+        golden_cols=["first_name"], threshold=0.85, wcc="scale",
+    )
+    got = {int(r["cluster_id"]): r["first_name"] for r in golden.collect()}
+    assert got == {0: "Jon", 2: "Ann"}


### PR DESCRIPTION
Sail tier S4 harness (NO real run). Builds everything S4 needs except the actual cluster bench:

- **Chain-robust O(log n) WCC** (`connected_components_scale`) via min-label propagation + pointer-jumping (Shiloach-Vishkin shortcutting). The first blind large-star/small-star attempt was WRONG (caught by plan-review hand-trace -> returned singletons); this replacement is provably correct, hand-traced + reviewer-verified on 2-node/3-node/junction/4-chain. Parity-gated incl. a 30-node chain.
- **run_sail_pipeline** end-to-end (load -> block -> score -> dedup -> WCC -> golden) + e2e gate.
- **bench-sail-100m.yml** scaffold (workflow_dispatch, SAIL_REMOTE secret, fail-fast if unset) -- NO real run.

Ray is NOT retired (gated on the real binding run, which needs a BYO Sail cluster). Spec: docs/superpowers/specs/2026-06-03-sail-tier-design.md (S4).