### PR TITLE
docs(network): Sail tier S4 harness shipped (buildable tier complete)

### DIFF
--- a/context-network/architecture/sail-tier.md
+++ b/context-network/architecture/sail-tier.md
@@ -6,10 +6,11 @@ programmed via **Spark Connect / PySpark**) to run across nodes, computes connec
 components distributed (removing the one-box UF island), and ultimately retires the
 existing Ray distributed stack.
 
-**Status:** S1+S2+S3(golden) SHIPPED 2026-06-03 (PRs #709, #712, #714);
-identity stage + S4 next. The make-or-break WCC-on-Sail risk is CLOSED.
-**Spec:** `docs/superpowers/specs/2026-06-03-sail-tier-design.md`. **Plans:**
-`docs/superpowers/plans/2026-06-03-sail-tier-stage-{s1,s2,s3}.md`.
+**Status:** the BUILDABLE Sail tier is COMPLETE — S1+S2+S3(golden)+S4-harness
+SHIPPED (PRs #709, #712, #714, #717). Only the real 100M cluster run + Ray
+retirement remain (need a BYO Sail cluster). **Spec:**
+`docs/superpowers/specs/2026-06-03-sail-tier-design.md`. **Plans:**
+`docs/superpowers/plans/2026-06-03-sail-tier-stage-{s1,s2,s3,s4-harness}.md`.
 **Why it matters:** Stage E showed one-box spill-survival is non-binding
 ([../decisions/0003-stage-e-spill-honest-null.md](../decisions/0003-stage-e-spill-honest-null.md))
 — the distributed path is where the value is.
@@ -54,8 +55,16 @@ algorithm** in a new `goldenmatch.sail` package, with native scorers rebound as 
   construction). Content-parity-green per multi-member cluster. SCOPE: golden only; **identity
   SPLIT to its own next stage** (stateful entity store, not a relational op). Uniform most_complete;
   order-dependent/custom/oversized/provenance deferred (in-memory fallback, like Ray).
-- **Identity-on-Sail — NEXT** (split from S3).  **S4:** 100M+ multi-node bench (REAL BYO cluster) +
-  large-star/small-star WCC swap + Ray retire.
+- **S4 harness — SHIPPED (PR #717).** (a) `clustering.connected_components_scale` = chain-robust
+  O(log n) WCC via min-label propagation + POINTER-JUMPING (the literal Kiveris large-star/small-star
+  was attempted first and was WRONG — caught by plan-review hand-trace; pointer-jumping is the
+  correct, hand-verified equivalent). Parity-green incl. a 30-node chain. (b) `pipeline.run_sail_pipeline`
+  end-to-end. (c) `bench-sail-100m.yml` scaffold (workflow_dispatch, SAIL_REMOTE secret, fail-fast).
+  The `sail` lane now has 6 green gates. Ray NOT retired.
+- **Remaining (needs a BYO cluster, not autonomously buildable):** the actual 100M multi-node run
+  (`SAIL_REMOTE` secret + 100M parquet) → the binding verdict + Ray retirement. Dispatch via
+  `gh workflow run bench-sail-100m.yml -f input=<parquet>` once `SAIL_REMOTE` is set.
+- **Split off / not done:** identity-on-Sail (its own stateful stage).
 
 ## Verification
 - CI smoke: a local Sail Spark Connect server (`pysail.spark.SparkConnectServer`) runs the same

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,14 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-04 — Sail tier S4 harness shipped (buildable tier COMPLETE)
+- S4 harness merged (PR #717): chain-robust O(log n) WCC via pointer-jumping (the blind
+  large-star/small-star attempt was wrong, caught by plan-review hand-trace + replaced),
+  `run_sail_pipeline` end-to-end, and the 100M bench scaffold. The `sail` lane has 6 green gates.
+  The BUILDABLE Sail tier is COMPLETE; only the real 100M cluster run + Ray retirement remain
+  (need a BYO Sail cluster). Updated [../architecture/sail-tier.md](../architecture/sail-tier.md) +
+  [../planning/roadmap.md](../planning/roadmap.md).
+
 ## 2026-06-03 — Sail tier Stage S3 (golden) shipped
 - S3 golden merged (PR #714): distributed survivorship on Sail (collect_list + merge_field UDF),
   content-parity green. SCOPE DECISION: S3 scoped to golden only; identity split to its own next

--- a/context-network/planning/roadmap.md
+++ b/context-network/planning/roadmap.md
@@ -30,9 +30,13 @@ Spec: `docs/superpowers/specs/2026-06-03-sail-tier-design.md`. Staged, each a ga
 - **S3 (golden) — SHIPPED (PR #714, 2026-06-03)** — distributed survivorship via
   `collect_list` + a scalar pandas UDF calling the one-box `merge_field`; content-parity green.
   Scoped to golden; identity split to its own stage.
-- **Identity on Sail — next** (split from S3; stateful entity store, not a relational op).
-- **S4 — binding 100M+ multi-node bench (REAL BYO cluster) + large-star/small-star WCC swap +
-  Ray retirement.** The only stage needing a real cluster.
+- **S4 harness — SHIPPED (PR #717, 2026-06-04)** — chain-robust O(log n) WCC (pointer-jumping;
+  the blind large-star attempt was wrong, caught by plan-review hand-trace), `run_sail_pipeline`
+  end-to-end, and the 100M bench scaffold. The `sail` lane has 6 green gates. The BUILDABLE Sail
+  tier is COMPLETE.
+- **Remaining (needs a BYO cluster):** the real 100M multi-node run (`SAIL_REMOTE` secret) → the
+  binding verdict + Ray retirement. The only thing left, and it needs real infrastructure.
+- **Identity on Sail** — split off; its own stateful stage, not yet done.
 - **S3** — golden (incl. custom rules) + identity on Sail.
 - **S4** — binding 100M+ multi-node bench + Ray retirement. Kill criterion: completes
   where one-box can't, per-node RSS bounded, wall scales with nodes.


### PR DESCRIPTION
Context network update: Sail tier S4 harness merged (PR #717) — the buildable Sail tier is complete; only the real 100M cluster run + Ray retirement remain. Architecture + roadmap + updates. Docs-only.