### PR TITLE
fix(autoconfig): bound blocking cost + refuse RED by default (#715 reopened)

### DIFF
--- a/.github/workflows/repro-issue-715.yml
+++ b/.github/workflows/repro-issue-715.yml
@@ -81,3 +81,63 @@ jobs:
           name: issue-715-repro-log
           path: packages/python/goldenmatch/repro715.log
           retention-days: 30
+
+  # #715 REOPENED guard: assert the FIXED build_blocking yields a BOUNDED
+  # blocking config on the sparse-zip + realistic-surname healthcare shape at
+  # scale (>=500K). A sample-sized unit test cannot catch the at-scale blocking
+  # blow-up -- the gap that let #715 reopen. Runs build_blocking on the FULL df
+  # (the v0 committed-config path) so we reproduce the committed blocking choice
+  # WITHOUT the full controller (avoids a rerank/torch segfault risk in CI).
+  blocking-scale:
+    runs-on: large-new-64GB
+    timeout-minutes: 30
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+      POLARS_SKIP_CPU_CHECK: "1"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Run #715 blocking-scale assertion
+        working-directory: packages/python/goldenmatch
+        run: |
+          uv run python scripts/repro_issue_715.py --mode blocking-scale --rows 500000 \
+            | tee repro715-blocking-scale.log
+          {
+            echo "## issue #715 blocking-scale (rows=\`500000\`, runner=\`large-new-64GB\`)"
+            echo ""
+            echo '```'
+            cat repro715-blocking-scale.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Assert blocking bounded
+        working-directory: packages/python/goldenmatch
+        run: |
+          if grep -q "BLOCKING UNBOUNDED" repro715-blocking-scale.log; then
+            echo "::error::#715 blocking UNBOUNDED at scale -- build_blocking emitted an oversized key/pass"
+            exit 1
+          fi
+          if grep -qE "BLOCKING BOUNDED|BLOCKING REFUSED \(degenerate\)" repro715-blocking-scale.log; then
+            echo "blocking bounded (or degenerate-refused) at scale"
+          else
+            echo "::error::no blocking-scale verdict found in log"
+            exit 1
+          fi
+
+      - name: Upload blocking-scale log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: issue-715-blocking-scale-log
+          path: packages/python/goldenmatch/repro715-blocking-scale.log
+          retention-days: 30

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -322,6 +322,7 @@ def dedupe_df(
     backend: str | None = None,
     source_name: str = "dataframe",
     confidence_required: bool = True,
+    allow_red_config: bool = False,
     exclude_columns: list[str] | None = None,
 ) -> DedupeResult:
     """Deduplicate a Polars DataFrame directly (no file I/O).
@@ -389,6 +390,7 @@ def dedupe_df(
                         llm_auto=llm_auto,
                         _skip_finalize=True,
                         confidence_required=confidence_required,
+                        allow_red_config=allow_red_config,
                     )
                 _used_controller = True
 
@@ -491,6 +493,7 @@ def match_df(
     threshold: float | None = None,
     backend: str | None = None,
     confidence_required: bool = True,
+    allow_red_config: bool = False,
     exclude_columns: list[str] | None = None,
 ) -> MatchResult:
     """Match a target DataFrame against a reference DataFrame (no file I/O).
@@ -546,6 +549,7 @@ def match_df(
                 config = _self_api.auto_configure_df(
                     target, reference=reference, _skip_finalize=True,
                     confidence_required=confidence_required,
+                    allow_red_config=allow_red_config,
                 )
                 _used_controller = True
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -901,13 +901,59 @@ def _build_compound_blocking(
     def _null_rate(col_name: str) -> float:
         return df[col_name].null_count() / df.height if df.height > 0 else 0.0
 
-    # Build unified candidate pool (excludes numeric, date, identifier)
-    candidates = [
-        p for p in profiles
-        if p.col_type not in ("numeric", "date", "identifier")
-        and _null_rate(p.name) <= max_null_rate
-        and _check_source_overlap(df, p.name) > 0.0
-    ]
+    def _max_block_size(col_name: str) -> int:
+        """Largest group size when blocking on this column."""
+        return int(df.group_by(col_name).len().get_column("len").max() or 0)  # pyright: ignore[reportArgumentType]  # polars max() typed as PythonLiteral; "len" column is int64 at runtime
+
+    def _nonnull_ratio(col_name: str) -> float:
+        """Distinct/non-null ratio -- the TRUE per-record uniqueness, not the
+        null-deflated ColumnProfile.cardinality_ratio. A near-1.0 value means a
+        surrogate-key-like column (npi/phone/email) whose only big "block" is
+        its null bucket -- useless as a blocking component."""
+        nn = df[col_name].drop_nulls()
+        n = nn.len()
+        return (nn.n_unique() / n) if n > 0 else 1.0
+
+    # #715: judge compound COMPONENTS by whether they BOUND block size (i.e.
+    # actually group records) and aren't surrogate keys -- NOT by col_type.
+    # A sparse zip5 reclassifies `numeric -> identifier` and (at ~50% null)
+    # exceeds the single-key null ceiling, so the old col_type/null filters
+    # doubly excluded it, leaving only oversized name columns. As a compound
+    # COMPONENT, a high-null column is fine: the multi_pass config's other
+    # passes cover the null rows. So:
+    #   - keep `numeric`/`date` excluded;
+    #   - admit `identifier` (and the high-cardinality `email`/`phone` types)
+    #     ONLY when the column genuinely GROUPS records: non-singleton blocks
+    #     (`_max_block_size > 1`), `cardinality_ratio < 1.0`, and a non-null
+    #     distinct ratio below the blocking gate (rejects surrogate keys like
+    #     npi/phone/email whose non-null values are ~unique per record and
+    #     whose only large block is the null bucket);
+    #   - relax the single-key null ceiling to 0.6 for the component role so a
+    #     ~50%-null zip5 qualifies.
+    from goldenmatch.core.blocking_candidates import _blocking_max_ratio
+    _grouping_ratio_max = _blocking_max_ratio()
+    _component_null_ceiling = max(max_null_rate, 0.6)
+    _high_card_types = ("identifier", "email", "phone")
+
+    def _is_admissible(p: ColumnProfile) -> bool:
+        if p.col_type in ("numeric", "date"):
+            return False
+        if _check_source_overlap(df, p.name) <= 0.0:
+            return False
+        if p.col_type in _high_card_types:
+            # Surrogate-key / near-unique guard: must actually group records.
+            if not (
+                _max_block_size(p.name) > 1
+                and p.cardinality_ratio < 1.0
+                and _nonnull_ratio(p.name) < _grouping_ratio_max
+            ):
+                return False
+            # High-null is OK for a compound component (other passes cover nulls).
+            return _null_rate(p.name) <= _component_null_ceiling
+        # Low-cardinality types (name/string/geo/...): keep the stricter ceiling.
+        return _null_rate(p.name) <= max_null_rate
+
+    candidates = [p for p in profiles if _is_admissible(p)]
     if len(candidates) < 2:
         return None
 
@@ -1457,14 +1503,28 @@ def build_blocking(
         )
 
     # ── Check if name-based fallback would also be oversized ──
+    # #715: the name path picks ONE primary name column (pattern_names[0], else
+    # name_cols[0]) and blocks on it. If THAT primary is oversized, single-name
+    # blocking is degraded (it gets demoted to soundex/secondary or dropped) --
+    # so we should try a bounded compound first, even if some OTHER name column
+    # happens to be bounded on its own. Gating on "is the name path's primary
+    # oversized" (by the projected full-N size, consistent with _gate_passes)
+    # rather than "is EVERY name col oversized" lets the sparse-zip shape reach
+    # zip5+last_name instead of degrading to a bare last_name block.
+    def _name_path_primary() -> str | None:
+        if not name_cols:
+            return None
+        pattern_names = [p for p in name_cols if _classify_by_name(p.name) == "name"]
+        return (pattern_names[0] if pattern_names else name_cols[0]).name
+
+    _primary_name = _name_path_primary()
     _all_single_oversized = True
-    for p in name_cols:
+    if _primary_name is not None:
         try:
-            if _max_block_size(p.name) <= max_safe_block:
+            if _projected_block([_primary_name]) <= max_safe_block:
                 _all_single_oversized = False
-                break
         except Exception:
-            continue
+            pass
 
     if _all_single_oversized and (name_cols or text_cols):
         # All single columns produce oversized blocks — try compound blocking
@@ -1477,9 +1537,32 @@ def build_blocking(
 
         compound_config = _build_compound_blocking(profiles, df, max_safe_block, max_null_rate)
         if compound_config is not None:
-            return compound_config
-
-        logger.info("Compound blocking failed — falling through to single-column fallbacks")
+            # #715: project the compound's keys/passes to full N before emitting.
+            # _build_compound_blocking selects on SAMPLE block size, but a
+            # high-null component (e.g. a ~50%-null zip5) hides a large null
+            # bucket that scales linearly: zip5+last_name is ~323/block on a
+            # 30K sample but projects to ~10K at 1M. Gate it through the same
+            # projected guard as the name path; if nothing survives, fall
+            # through to single-column fallbacks rather than ship a bomb.
+            c_primary = (compound_config.keys or [None])[0]
+            c_passes = compound_config.passes or list(compound_config.keys or [])
+            if c_primary is not None:
+                gated_primary, gated_passes = _gate_passes(c_primary, c_passes)
+                if gated_primary is not None:
+                    return BlockingConfig(
+                        keys=[gated_primary],
+                        strategy="multi_pass",
+                        passes=gated_passes,
+                        max_block_size=max_safe_block,
+                        skip_oversized=True,
+                    )
+            logger.info(
+                "Compound blocking config projects oversized at full_n=%d -- "
+                "falling through to single-column fallbacks. See #715.",
+                effective_n_full,
+            )
+        else:
+            logger.info("Compound blocking failed — falling through to single-column fallbacks")
 
     # Name columns: use multi-pass with soundex + substring
     # Prefer columns matched by name pattern (person names) over data-profiled names

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1229,6 +1229,25 @@ def _pick_date_blocking_col(
     return None
 
 
+def _degenerate_blocking_config(max_safe_block: int) -> BlockingConfig:
+    """Empty-keys blocking config: the #715 degenerate signal.
+
+    Emitted when every candidate blocking key/pass projects oversized at
+    full N. Empty ``keys`` is exactly what the controller's #417 degenerate
+    guard inspects (``not blocking.keys`` at ``>= REFUSE_AT_N``), so it
+    refuses loudly rather than shipping a candidate-pair bomb. ``auto_suggest``
+    keeps the model valid (the validator bypasses the keys-required check for
+    auto_suggest) and matches the established empty-keys pattern used by the
+    CLI / preview paths.
+    """
+    return BlockingConfig(
+        keys=[],
+        auto_suggest=True,
+        max_block_size=max_safe_block,
+        skip_oversized=True,
+    )
+
+
 def build_blocking(
     profiles: list[ColumnProfile],
     df: pl.DataFrame,
@@ -1354,6 +1373,66 @@ def build_blocking(
     # practical OOM ceiling on a 16 GB runner.
     max_safe_block = max(1000, min(10_000, int(df.height) // 200))
 
+    # #715: gate every emitted blocking key/pass by its PROJECTED full-N max
+    # block size. build_blocking runs on a sample (or, in the v0 path, the
+    # full df) and the emitted single-column soundex(name) passes had no
+    # block-size guard. On a sparse-zip5 healthcare shape, zip5 reclassifies
+    # to `identifier` and drops out of the compound, leaving single-name
+    # passes whose max block projects to ~50K rows at 1M -> ~39.6M candidate
+    # pairs -> an 18-min run. project_max_block_size with full_n == df.height
+    # is the identity (v0 path uses exact block sizes -> correct).
+    from goldenmatch.core.blocking_candidates import project_max_block_size
+
+    def _projected_block(fields: list[str]) -> int:
+        try:
+            sample_mb = int(
+                df.group_by(fields).len().get_column("len").max() or 0
+            )  # pyright: ignore[reportArgumentType]  # polars max() typed as PythonLiteral; "len" is int64 at runtime
+        except Exception:  # pragma: no cover -- defensive
+            return 0
+        return project_max_block_size(sample_mb, df.height, effective_n_full)
+
+    def _pass_is_bounded(key: BlockingKeyConfig) -> bool:
+        return _projected_block(key.fields) <= max_safe_block
+
+    def _gate_passes(
+        primary: BlockingKeyConfig,
+        passes: list[BlockingKeyConfig],
+    ) -> tuple[BlockingKeyConfig | None, list[BlockingKeyConfig]]:
+        """Drop oversized passes; pick a bounded primary key (#715).
+
+        Returns ``(primary_or_None, surviving_passes)``. The chosen primary is
+        the original primary if it is bounded, else the first bounded pass.
+        When NOTHING is bounded, the primary is ``None`` (caller emits an
+        empty/degenerate config so the controller refuses rather than
+        shipping a candidate-pair bomb).
+        """
+        bounded = [p for p in passes if _pass_is_bounded(p)]
+        dropped = [p for p in passes if not _pass_is_bounded(p)]
+        if dropped:
+            logger.info(
+                "Dropping %d oversized blocking pass(es) by projected full-N "
+                "block size (> %d, full_n=%d): %s. See #715.",
+                len(dropped), max_safe_block, effective_n_full,
+                [(p.fields, p.transforms) for p in dropped],
+            )
+        if _pass_is_bounded(primary):
+            return primary, bounded
+        if bounded:
+            logger.info(
+                "Primary blocking key %s projects oversized (> %d); promoting "
+                "first bounded pass %s to primary. See #715.",
+                primary.fields, max_safe_block, bounded[0].fields,
+            )
+            return bounded[0], bounded
+        logger.warning(
+            "All name-fallback blocking keys/passes project oversized at "
+            "full_n=%d (> %d max_safe_block); emitting empty (degenerate) "
+            "blocking config so the controller refuses. See #715.",
+            effective_n_full, max_safe_block,
+        )
+        return None, []
+
     # Best case: block on highest-cardinality exact column (with low null rate + safe block size)
     if exact_cols:
         # Pre-filter: only evaluate top 5 by cardinality to avoid expensive group_by on all columns
@@ -1476,15 +1555,22 @@ def build_blocking(
                     fields=[date_block_col],
                     transforms=["lowercase", "strip"],
                 ))
+            geo_primary = BlockingKeyConfig(
+                fields=[best_geo, best_name], transforms=["lowercase", "strip"]
+            )
+            geo_passes = [
+                BlockingKeyConfig(fields=[best_geo, best_name], transforms=["lowercase", "strip"]),
+                BlockingKeyConfig(fields=[best_geo, best_name], transforms=["lowercase", "substring:0:5"]),
+                BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "soundex"]),
+                *extra_passes,
+            ]
+            primary, gated_passes = _gate_passes(geo_primary, geo_passes)
+            if primary is None:
+                return _degenerate_blocking_config(max_safe_block)
             return BlockingConfig(
-                keys=[BlockingKeyConfig(fields=[best_geo, best_name], transforms=["lowercase", "strip"])],
+                keys=[primary],
                 strategy="multi_pass",
-                passes=[
-                    BlockingKeyConfig(fields=[best_geo, best_name], transforms=["lowercase", "strip"]),
-                    BlockingKeyConfig(fields=[best_geo, best_name], transforms=["lowercase", "substring:0:5"]),
-                    BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "soundex"]),
-                    *extra_passes,
-                ],
+                passes=gated_passes,
                 max_block_size=max_safe_block,
                 skip_oversized=True,
             )
@@ -1504,15 +1590,22 @@ def build_blocking(
                 fields=[date_block_col],
                 transforms=["lowercase", "strip"],
             ))
+        name_primary = BlockingKeyConfig(
+            fields=[best_name], transforms=["lowercase", "soundex"]
+        )
+        name_passes = [
+            BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "substring:0:5"]),
+            BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "soundex"]),
+            BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "token_sort", "substring:0:8"]),
+            *extra_passes,
+        ]
+        primary, gated_passes = _gate_passes(name_primary, name_passes)
+        if primary is None:
+            return _degenerate_blocking_config(max_safe_block)
         return BlockingConfig(
-            keys=[BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "soundex"])],
+            keys=[primary],
             strategy="multi_pass",
-            passes=[
-                BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "substring:0:5"]),
-                BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "soundex"]),
-                BlockingKeyConfig(fields=[best_name], transforms=["lowercase", "token_sort", "substring:0:8"]),
-                *extra_passes,
-            ],
+            passes=gated_passes,
             max_block_size=max_safe_block,
             skip_oversized=True,
         )

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -930,6 +930,13 @@ def _build_compound_blocking(
     #     whose only large block is the null bucket);
     #   - relax the single-key null ceiling to 0.6 for the component role so a
     #     ~50%-null zip5 qualifies.
+    # NOTE: `_nonnull_ratio` / `_max_block_size` are computed on `df` directly.
+    # On the v0 non-distributed path `df` IS the full dataset (controller passes
+    # the full frame to `_initial_config`), so these are exact. If a SAMPLED df
+    # is ever fed here (distributed path), the unprojected non-null ratio is
+    # sample-inflated and would wrongly reject a mid-cardinality column -- such a
+    # caller must Chao1-project the ratio (see scale_cardinality_ratio_to_full_population).
+    # Tracked as a distributed-path follow-up; out of scope for #715 (single-node).
     from goldenmatch.core.blocking_candidates import _blocking_max_ratio
     _grouping_ratio_max = _blocking_max_ratio()
     _component_null_ceiling = max(max_null_rate, 0.6)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -2014,6 +2014,7 @@ def auto_configure_df(
     reference: pl.DataFrame | pl.LazyFrame | None = None,
     _skip_finalize: bool = False,
     confidence_required: bool = True,
+    allow_red_config: bool = False,
 ) -> GoldenMatchConfig:
     """Public auto-configuration entry point (controller-backed).
 
@@ -2149,6 +2150,7 @@ def auto_configure_df(
         v0_kwargs=v0_kw,
         skip_finalize=_skip_finalize,
         confidence_required=confidence_required,
+        allow_red_config=allow_red_config,
     )
 
     # Backend selection is now driven by the controller v3 planner inside

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1239,6 +1239,11 @@ def _degenerate_blocking_config(max_safe_block: int) -> BlockingConfig:
     keeps the model valid (the validator bypasses the keys-required check for
     auto_suggest) and matches the established empty-keys pattern used by the
     CLI / preview paths.
+
+    Note: the #417 guard refuses on empty keys only when the committed profile
+    is RED (``_no_blocking_keys AND _profile_red``); a GREEN/YELLOW profile
+    with empty keys would not refuse on that branch (unconditional RED refusal
+    is handled separately by the ``allow_red_config`` work).
     """
     return BlockingConfig(
         keys=[],
@@ -1385,11 +1390,9 @@ def build_blocking(
 
     def _projected_block(fields: list[str]) -> int:
         try:
-            sample_mb = int(
-                df.group_by(fields).len().get_column("len").max() or 0
-            )  # pyright: ignore[reportArgumentType]  # polars max() typed as PythonLiteral; "len" is int64 at runtime
+            sample_mb = int(df.group_by(fields).len().get_column("len").max() or 0)  # pyright: ignore[reportArgumentType]  # polars max() typed as PythonLiteral; "len" is int64 at runtime
         except Exception:  # pragma: no cover -- defensive
-            return 0
+            return effective_n_full  # fail-safe: treat unprojectable key as maximally oversized -> dropped
         return project_max_block_size(sample_mb, df.height, effective_n_full)
 
     def _pass_is_bounded(key: BlockingKeyConfig) -> bool:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -844,12 +844,13 @@ class AutoConfigController:
             # the all-iterations-errored path is the same user-facing
             # pathology as a RED committed entry -- caller would run the
             # full pipeline on the _RED_PROFILE sentinel and produce
-            # degenerate output. Refuse loudly.
+            # degenerate output. Refuse loudly at scale.
             #
             # #715 reopened: the _RED_PROFILE sentinel is a genuine give-up,
-            # so refuse by DEFAULT (independent of confidence_required AND
-            # REFUSE_AT_N) unless allow_red_config=True restores warn-and-run.
-            if not allow_red_config:
+            # so refuse unless allow_red_config=True restores warn-and-run.
+            # The refuse keeps the REFUSE_AT_N threshold -- below it, small-N
+            # runs are cheap and stay warn-and-run (the deliberate design).
+            if n_rows >= REFUSE_AT_N and not allow_red_config:
                 raise ControllerNotConfidentError(
                     n_rows=n_rows,
                     failing_sub_profile="data",  # n_errored=all means data path itself failed
@@ -863,29 +864,30 @@ class AutoConfigController:
         # + #417 degenerate-blocking guard into a SINGLE raise site).
         #
         # Invariant: a committed RED config raises ControllerNotConfidentError
-        # unless allow_red_config=True. A non-RED config never raises here.
+        # when ``n_rows >= REFUSE_AT_N and not allow_red_config``. A non-RED
+        # config never raises here. Below REFUSE_AT_N a committed RED entry
+        # warn-and-runs (cheap; the existing deliberate design).
         #
-        # #715 reopened: the RED-refuse fires by DEFAULT -- independent of
-        # confidence_required AND REFUSE_AT_N (so a small-N RED also raises).
-        # The legacy ``confidence_required and n_rows >= REFUSE_AT_N`` gate is
-        # a strict SUBSET of ``not allow_red_config``-default-True, so its
-        # callers keep raising. allow_red_config=True restores warn-and-run.
+        # #715 reopened: the RED-refuse keeps the REFUSE_AT_N threshold but
+        # drops confidence_required from the gate. confidence_required=False
+        # NO LONGER bypasses the RED-refuse (that was the reporter's bug);
+        # allow_red_config=True is now the SINGLE escape hatch that restores
+        # warn-and-run at scale. The legacy
+        # ``confidence_required and n_rows >= REFUSE_AT_N`` gate is replaced
+        # by ``n_rows >= REFUSE_AT_N and not allow_red_config``.
         #
         # This site supersedes the old Phase-3 RED-health raise here AND the
         # RED-keyed branches of the #417 guard below: it runs FIRST, so any
-        # committed-RED entry is refused here with the most-specific
+        # committed-RED entry at scale is refused here with the most-specific
         # failing_sub_profile. The #417 guard below stays for its NON-RED
         # blocking-degenerate estimator role (gated, as before, on
         # confidence_required + REFUSE_AT_N).
         #
-        # The gate is simply ``_committed_red and not allow_red_config``:
-        # allow_red_config=True is the SINGLE escape hatch (restores
-        # warn-and-run). confidence_required no longer gates the RED-refuse
-        # (the spec makes the refuse independent of it) -- a caller that
-        # previously used confidence_required=False to keep warn-and-run on a
-        # RED commit must now pass allow_red_config=True instead.
+        # confidence_required still gates the #417 NON-RED degenerate-blocking
+        # guard below -- a caller passes confidence_required=False to keep
+        # warn-and-run on NON-RED degenerate blocking.
         _committed_red = best_entry.profile.health() == HealthVerdict.RED
-        if _committed_red and not allow_red_config:
+        if _committed_red and n_rows >= REFUSE_AT_N and not allow_red_config:
             # Pick the most-specific failing sub-profile. When the committed
             # config has no blocking keys, the downstream sync degenerates to
             # a single mega-block -- surface that as the blocking-degenerate

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -424,11 +424,11 @@ class ControllerBudget:
         order of magnitude as N grows from 100K -> 1M. Cap at 20K so
         sample-iteration cost stays bounded above 1M.
 
-        Tiers (n_rows -> max_seconds, sample_size_default):
-          - <5K        -> 15s, 2K (sample_skip_below bypasses sampling)
-          - 5K-100K    -> 30s, 2K (historical defaults; preserves 100K bench)
-          - 100K-1M    -> 60s, int(sqrt(n) * 20) capped at 20K
-          - >=1M       -> 120s, 20K (capped)
+        Tiers (n_rows -> max_seconds, sample_size_default, max_iterations):
+          - <5K        -> 15s, 2K, 3  (sample_skip_below bypasses sampling)
+          - 5K-100K    -> 30s, 2K, 3  (historical defaults; preserves 100K bench)
+          - 100K-1M    -> 60s, int(sqrt(n) * 20) capped at 20K, 4
+          - >=1M       -> 120s, 20K, 5
         """
         if n_rows < 5_000:
             return cls(max_seconds=15.0)
@@ -436,8 +436,11 @@ class ControllerBudget:
             return cls()  # historical defaults
         if n_rows < 1_000_000:
             sample = min(int((n_rows**0.5) * 20), 20_000)
-            return cls(sample_size_default=sample, max_seconds=60.0)
-        return cls(sample_size_default=20_000, max_seconds=120.0)
+            # max_iterations=4: non-load-bearing for #715 (iteration sample masks
+            # the at-scale blocking blow-up) but a correct-direction budget scale.
+            return cls(sample_size_default=sample, max_seconds=60.0, max_iterations=4)
+        # max_iterations=5: same rationale as 100K-1M tier above.
+        return cls(sample_size_default=20_000, max_seconds=120.0, max_iterations=5)
 
 
 def _zero_label_commit_enabled() -> bool:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -888,20 +888,20 @@ class AutoConfigController:
         # warn-and-run on NON-RED degenerate blocking.
         _committed_red = best_entry.profile.health() == HealthVerdict.RED
         if _committed_red and n_rows >= REFUSE_AT_N and not allow_red_config:
-            # Pick the most-specific failing sub-profile. When the committed
-            # config has no blocking keys, the downstream sync degenerates to
-            # a single mega-block -- surface that as the blocking-degenerate
-            # stop_reason (#417). Otherwise fall back to the generic
-            # priority-ordered failing sub-profile.
+            # Report the ACTUAL failing sub-profile (priority-ordered). Only
+            # when blocking is genuinely the failing cause AND the committed
+            # config has no blocking keys does the downstream sync degenerate
+            # to a single mega-block -- surface THAT as the blocking-degenerate
+            # stop_reason (#417). A data-RED config with empty default keys is
+            # a data failure, not a blocking one.
+            failing = _identify_failing_subprofile(best_entry.profile)
             _blocking = best_entry.config.blocking
             _no_blocking_keys = (
                 _blocking is None or not getattr(_blocking, "keys", None)
             )
-            if _no_blocking_keys:
-                failing = "blocking"
+            if failing == "blocking" and _no_blocking_keys:
                 _stop_reason = StopReason.BLOCKING_DEGENERATE.name
             else:
-                failing = _identify_failing_subprofile(best_entry.profile)
                 _stop_reason = (
                     history.stop_reason.name if history.stop_reason else "unset"
                 )

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -288,7 +288,8 @@ class ControllerNotConfidentError(Exception):
             f"stop_reason: {stop_reason}). Running this config would produce "
             f"degenerate dedupe; passing it back instead of running. "
             f"Options: pass an explicit GoldenMatchConfig, lower the matchkey "
-            f"threshold, or re-call with confidence_required=False. See "
+            f"threshold, or re-call with allow_red_config=True (runs the "
+            f"degenerate config anyway) / confidence_required=False. See "
             f"{self.DOCS_URL}."
         )
 
@@ -478,6 +479,7 @@ class AutoConfigController:
         v0_kwargs: dict | None = None,
         skip_finalize: bool = False,
         confidence_required: bool = True,
+        allow_red_config: bool = False,
     ) -> tuple[GoldenMatchConfig, ComplexityProfile, RunHistory]:
         """Run iterative auto-config.
 
@@ -842,8 +844,12 @@ class AutoConfigController:
             # the all-iterations-errored path is the same user-facing
             # pathology as a RED committed entry -- caller would run the
             # full pipeline on the _RED_PROFILE sentinel and produce
-            # degenerate output. Refuse loudly at scale.
-            if confidence_required and n_rows >= REFUSE_AT_N:
+            # degenerate output. Refuse loudly.
+            #
+            # #715 reopened: the _RED_PROFILE sentinel is a genuine give-up,
+            # so refuse by DEFAULT (independent of confidence_required AND
+            # REFUSE_AT_N) unless allow_red_config=True restores warn-and-run.
+            if not allow_red_config:
                 raise ControllerNotConfidentError(
                     n_rows=n_rows,
                     failing_sub_profile="data",  # n_errored=all means data path itself failed
@@ -853,16 +859,50 @@ class AutoConfigController:
                 )
             return config_v0, _RED_PROFILE, history
 
-        # Confidence gate (Phase 3 of controller-budget pathology spec).
-        # When the controller committed a RED entry on a large input,
-        # running the full pipeline would produce ~26-min degenerate
-        # dedupe. Refuse loudly instead. Spec §Design / Confidence gate.
-        if (
-            confidence_required
-            and n_rows >= REFUSE_AT_N
-            and best_entry.profile.health() == HealthVerdict.RED
-        ):
-            failing = _identify_failing_subprofile(best_entry.profile)
+        # RED-refuse gate (reconciled #715-reopened + Phase 3 confidence gate
+        # + #417 degenerate-blocking guard into a SINGLE raise site).
+        #
+        # Invariant: a committed RED config raises ControllerNotConfidentError
+        # unless allow_red_config=True. A non-RED config never raises here.
+        #
+        # #715 reopened: the RED-refuse fires by DEFAULT -- independent of
+        # confidence_required AND REFUSE_AT_N (so a small-N RED also raises).
+        # The legacy ``confidence_required and n_rows >= REFUSE_AT_N`` gate is
+        # a strict SUBSET of ``not allow_red_config``-default-True, so its
+        # callers keep raising. allow_red_config=True restores warn-and-run.
+        #
+        # This site supersedes the old Phase-3 RED-health raise here AND the
+        # RED-keyed branches of the #417 guard below: it runs FIRST, so any
+        # committed-RED entry is refused here with the most-specific
+        # failing_sub_profile. The #417 guard below stays for its NON-RED
+        # blocking-degenerate estimator role (gated, as before, on
+        # confidence_required + REFUSE_AT_N).
+        #
+        # The gate is simply ``_committed_red and not allow_red_config``:
+        # allow_red_config=True is the SINGLE escape hatch (restores
+        # warn-and-run). confidence_required no longer gates the RED-refuse
+        # (the spec makes the refuse independent of it) -- a caller that
+        # previously used confidence_required=False to keep warn-and-run on a
+        # RED commit must now pass allow_red_config=True instead.
+        _committed_red = best_entry.profile.health() == HealthVerdict.RED
+        if _committed_red and not allow_red_config:
+            # Pick the most-specific failing sub-profile. When the committed
+            # config has no blocking keys, the downstream sync degenerates to
+            # a single mega-block -- surface that as the blocking-degenerate
+            # stop_reason (#417). Otherwise fall back to the generic
+            # priority-ordered failing sub-profile.
+            _blocking = best_entry.config.blocking
+            _no_blocking_keys = (
+                _blocking is None or not getattr(_blocking, "keys", None)
+            )
+            if _no_blocking_keys:
+                failing = "blocking"
+                _stop_reason = StopReason.BLOCKING_DEGENERATE.name
+            else:
+                failing = _identify_failing_subprofile(best_entry.profile)
+                _stop_reason = (
+                    history.stop_reason.name if history.stop_reason else "unset"
+                )
             # ``_LAST_CONTROLLER_RUN`` here is the CONTROLLER-LOCAL ContextVar
             # defined at the top of this file (line ~45), NOT the
             # ``(profile, history)`` tuple ContextVar in ``autoconfig.py``.
@@ -872,11 +912,7 @@ class AutoConfigController:
             raise ControllerNotConfidentError(
                 n_rows=n_rows,
                 failing_sub_profile=failing,
-                stop_reason=(
-                    history.stop_reason.name
-                    if history.stop_reason
-                    else "unset"
-                ),
+                stop_reason=_stop_reason,
             )
 
         # #408: blocking-degenerate gate. Independent of the RED-health
@@ -897,7 +933,16 @@ class AutoConfigController:
         # Trigger only when confidence_required (default True) -- caller
         # opts out via confidence_required=False to keep today's
         # "warn-and-run" behavior on degenerate blocking.
-        if confidence_required and n_rows >= REFUSE_AT_N:
+        #
+        # #715 reopened: this guard now handles ONLY the NON-RED
+        # degenerate-blocking case. Every committed-RED entry (including
+        # RED + no-blocking-keys) is already decided by the reconciled
+        # RED-refuse gate ABOVE -- which either raised (default) or, when
+        # allow_red_config=True, deliberately let the RED config through to
+        # warn-and-run. Re-raising here on a RED entry would (a) double-gate
+        # and (b) ignore allow_red_config. So skip this block entirely when
+        # the committed profile is RED.
+        if confidence_required and n_rows >= REFUSE_AT_N and not _committed_red:
             from goldenmatch.core.blocking_candidates import (
                 degenerate_guard_max_avg_block_size,
                 degenerate_guard_threshold,

--- a/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
@@ -120,6 +120,34 @@ def scale_cardinality_ratio_to_full_population(
     return min(scaled_distinct / full_n_rows, 1.0)
 
 
+def project_max_block_size(
+    sample_max_block: int,
+    sample_n: int,
+    full_n: int,
+) -> int:
+    """Project a sample's max block size to the full population.
+
+    Block size for a fixed-cardinality blocking key scales ~LINEARLY with N:
+    a key's largest block holds a roughly fixed FRACTION of all rows, so at
+    full scale the block grows by full_n / sample_n. (Contrast
+    ``scale_cardinality_ratio_to_full_population``, which uses sqrt because
+    DISTINCT-count growth is sublinear; block size is the opposite.)
+
+    Returns ``sample_max_block`` when the sample IS the full data
+    (``full_n <= sample_n``) or on degenerate inputs. Clamped to
+    ``full_n``.
+
+    Used by ``build_blocking`` to reject blocking keys/passes whose projected
+    full-N max block size would exceed ``max_safe_block`` (#715).
+    """
+    if sample_n <= 0 or sample_max_block <= 0:
+        return max(0, sample_max_block)
+    if full_n <= sample_n:
+        return sample_max_block
+    projected = int(round(sample_max_block * (full_n / sample_n)))
+    return min(projected, full_n)
+
+
 @dataclass(frozen=True)
 class ColumnRole:
     """Per-column role classification.

--- a/packages/python/goldenmatch/scripts/repro_issue_715.py
+++ b/packages/python/goldenmatch/scripts/repro_issue_715.py
@@ -49,7 +49,9 @@ LAST_NAMES = [
 ]
 
 
-def make_healthcare_df(n: int, seed: int = 715) -> pl.DataFrame:
+def make_healthcare_df(
+    n: int, seed: int = 715, zip_present: float = 0.95
+) -> pl.DataFrame:
     """Synthetic healthcare-provider shape, mirroring the #715 description:
 
     - source: categorical, 15 values
@@ -82,7 +84,7 @@ def make_healthcare_df(n: int, seed: int = 715) -> pl.DataFrame:
                 "phone_number": maybe(phone, 0.50),
                 "first_name": maybe(fn, 0.98),
                 "last_name": maybe(ln, 0.98),
-                "zip5": maybe(zip5, 0.95),
+                "zip5": maybe(zip5, zip_present),
                 "matching_id": f"rec_{i}",
             }
         )

--- a/packages/python/goldenmatch/scripts/repro_issue_715.py
+++ b/packages/python/goldenmatch/scripts/repro_issue_715.py
@@ -9,12 +9,25 @@ determined by these three calls, and Guard 1 trips at any df.height > 10_000,
 so ~20K synthetic rows reproduce the exact mechanism in a couple of seconds.
 
 Run:
+    # default (pincer) mode -- positional N_ROWS (back-compat with the workflow)
     python scripts/repro_issue_715.py [N_ROWS]
 
-Expected output: email hits the O(N^2) exact-matchkey guard, npi/phone are
-classified as `identifier` (skipped from matchkeys outright), and all three are
-rejected from blocking by the #408 cardinality gate -> matchkeys are fuzzy-only
-on name, blocking is empty. That is the unusable config reported in #715.
+    # at-scale blocking-bound assertion (#715 reopened)
+    python scripts/repro_issue_715.py --mode blocking-scale --rows 500000
+
+Expected output (pincer mode): email hits the O(N^2) exact-matchkey guard,
+npi/phone are classified as `identifier` (skipped from matchkeys outright), and
+all three are rejected from blocking by the #408 cardinality gate -> matchkeys
+are fuzzy-only on name, blocking is empty. That is the unusable config reported
+in #715.
+
+The blocking-scale mode is the #715-REOPENED guard: a sample-sized unit test
+cannot catch the at-scale blocking blow-up (the gap that let #715 reopen). It
+builds a sparse-zip, realistic-surname df at full N, runs build_blocking on the
+FULL df (the v0 committed-config path), and asserts every emitted key/pass has a
+max block size <= the autoconfig cap. Prints `BLOCKING BOUNDED`,
+`BLOCKING REFUSED (degenerate)` (acceptable -- the fix refused a bomb), or
+`BLOCKING UNBOUNDED: <fields>=<size> > <cap>` (a real fix gap).
 """
 from __future__ import annotations
 
@@ -50,7 +63,10 @@ LAST_NAMES = [
 
 
 def make_healthcare_df(
-    n: int, seed: int = 715, zip_present: float = 0.95
+    n: int,
+    seed: int = 715,
+    zip_present: float = 0.95,
+    rich_surnames: int = 0,
 ) -> pl.DataFrame:
     """Synthetic healthcare-provider shape, mirroring the #715 description:
 
@@ -61,6 +77,12 @@ def make_healthcare_df(
     - first_name / last_name: mostly non-null, moderate cardinality
     - zip5: mostly non-null, moderate cardinality (~5k distinct)
     - matching_id: stable per-record id (not used for config)
+
+    When ``rich_surnames > 0``, ``last_name`` is drawn from a synthetic pool
+    of that many distinct surnames (``f"sur{k}"``) instead of the 50-name
+    LAST_NAMES list. This gives realistic surname cardinality so a bounded
+    last_name-based compound exists at scale (the realistic scenario in the
+    #715-reopened at-scale blocking assertion).
     """
     rng = random.Random(seed)
 
@@ -70,7 +92,10 @@ def make_healthcare_df(
     rows = []
     for i in range(n):
         fn = rng.choice(FIRST_NAMES)
-        ln = rng.choice(LAST_NAMES)
+        if rich_surnames > 0:
+            ln = f"sur{rng.randint(0, rich_surnames - 1)}"
+        else:
+            ln = rng.choice(LAST_NAMES)
         # High-cardinality identifiers: unique-ish per record among non-nulls.
         npi = f"{rng.randint(1_000_000_000, 1_999_999_999)}"
         email = f"{fn}.{ln}{rng.randint(0, 9_999_999)}@example.org"
@@ -91,8 +116,7 @@ def make_healthcare_df(
     return pl.DataFrame(rows)
 
 
-def main() -> None:
-    n = int(sys.argv[1]) if len(sys.argv) > 1 else 20_000
+def _run_pincer_mode(n: int) -> None:
     df = make_healthcare_df(n)
     print(f"=== Synthetic healthcare df: {df.height:,} rows x {df.width} cols ===")
     print(df.head(5))
@@ -154,6 +178,135 @@ def main() -> None:
         print(f"  >>> Exact matchkey fields: {sorted(exact_fields)}")
     else:
         print("  >>> inconclusive: no identifier-eligible columns found at this shape/scale.")
+
+
+def _max_block_full(df: pl.DataFrame, key) -> int:
+    """True max block size for one emitted blocking key/pass on the FULL df.
+
+    Mirrors exactly what the static blocker does: build the production block-key
+    expression (so transforms AND the ``concat_str`` null-propagation for
+    compound keys are honored), filter the null / ``nan`` / ``null`` / ``none``
+    sentinel keys the pipeline discards, then take the max surviving group size.
+    Counting the filtered null bucket would over-report (e.g. a sparse-zip null
+    collision the pipeline never scores). Returns -1 if the key references
+    columns absent from df or the expr build fails.
+    """
+    from goldenmatch.core.blocker import _build_block_key_expr
+
+    if not all(f in df.columns for f in key.fields):
+        return -1
+    try:
+        expr = _build_block_key_expr(key)
+        sizes = (
+            df.with_columns(expr)
+            .filter(
+                pl.col("__block_key__").is_not_null()
+                & ~pl.col("__block_key__")
+                .str.strip_chars()
+                .str.to_lowercase()
+                .is_in(["nan", "null", "none"])
+            )
+            .group_by("__block_key__")
+            .len()
+            .get_column("len")
+        )
+    except Exception:
+        return -1
+    return int(sizes.max() or 0)
+
+
+def _run_blocking_scale_mode(n: int) -> None:
+    """At-scale blocking-bound assertion for #715 (reopened).
+
+    Builds a sparse-zip, realistic-surname healthcare-shape df at full N,
+    runs the real build_blocking on the FULL df (the v0 committed-config path),
+    and asserts every emitted blocking key/pass has a max block size <= the
+    autoconfig cap. A sample-sized unit test cannot catch the at-scale
+    blocking blow-up -- the gap that let #715 reopen.
+    """
+    df = make_healthcare_df(n, zip_present=0.5, rich_surnames=5000)
+    df = df.drop("matching_id")
+    print(
+        f"=== blocking-scale: {df.height:,} rows x {df.width} cols "
+        f"(sparse zip ~0.5, rich surnames ~5000) ==="
+    )
+    print()
+
+    profiles = profile_columns(df)
+    print("=== Column profiles (classification + cardinality) ===")
+    for p in profiles:
+        print(
+            f"  {p.name:<14} col_type={p.col_type:<11} "
+            f"card_ratio={p.cardinality_ratio:.4f} null_rate={p.null_rate:.3f}"
+        )
+    print()
+
+    blk = build_blocking(profiles, df, n_rows_full=df.height)
+
+    # Same cap build_blocking gates on internally.
+    cap = max(1000, min(10_000, n // 200))
+
+    keys = list(blk.keys or [])
+    passes = list(blk.passes or [])
+    print("=== build_blocking output ===")
+    print(f"  strategy={blk.strategy}")
+    print(f"  keys=  {[k.fields for k in keys]}")
+    print(f"  passes={[k.fields for k in passes]}")
+    print(f"  max_safe_block (cap) = {cap:,}")
+    print()
+
+    emitted = keys + passes
+    print("=== per key/pass max block size vs cap ===")
+    oversized: list[str] = []
+    if not emitted:
+        print("  (no keys or passes emitted)")
+    for key in emitted:
+        size = _max_block_full(df, key)
+        flag = "OK" if 0 <= size <= cap else "OVERSIZED"
+        print(f"  {'+'.join(key.fields):<28} max_block={size:<10,} cap={cap:,}  [{flag}]")
+        if size > cap:
+            oversized.append(f"{'+'.join(key.fields)}={size}")
+    print()
+
+    print("=== BLOCKING-SCALE VERDICT ===")
+    if oversized:
+        worst = oversized[0]
+        fields, _, size = worst.partition("=")
+        print(f"  BLOCKING UNBOUNDED: {fields}={size} > {cap}")
+    elif not emitted:
+        # Empty/degenerate config: the fix refused rather than shipping a
+        # candidate-pair bomb. Acceptable.
+        print("  BLOCKING REFUSED (degenerate)")
+    else:
+        print("  BLOCKING BOUNDED")
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    mode = "pincer"
+    rows: int | None = None
+
+    # Parse a tiny CLI by hand so the existing positional `rows` invocation
+    # (repro-issue-715.yml: `repro_issue_715.py "$ROWS"`) keeps working.
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--mode":
+            mode = args[i + 1]
+            i += 2
+        elif a == "--rows":
+            rows = int(args[i + 1])
+            i += 2
+        elif not a.startswith("--"):
+            rows = int(a)  # positional rows (default-mode back-compat)
+            i += 1
+        else:
+            i += 1
+
+    if mode == "blocking-scale":
+        _run_blocking_scale_mode(rows if rows is not None else 500_000)
+    else:
+        _run_pincer_mode(rows if rows is not None else 20_000)
 
 
 if __name__ == "__main__":

--- a/packages/python/goldenmatch/tests/test_allow_red_config.py
+++ b/packages/python/goldenmatch/tests/test_allow_red_config.py
@@ -1,9 +1,11 @@
 """End-to-end API tests for the allow_red_config kwarg (#715 reopened).
 
-A committed RED config now raises ControllerNotConfidentError by DEFAULT —
-independent of confidence_required AND independent of REFUSE_AT_N (so a
-small-N RED also raises). allow_red_config=True restores today's
-warn-and-run behavior. See #715 reopened, Task 5.
+A committed RED config raises ControllerNotConfidentError when
+``n_rows >= REFUSE_AT_N and not allow_red_config``. Below REFUSE_AT_N a RED
+commit warn-and-runs (cheap; the existing deliberate design).
+allow_red_config=True restores warn-and-run at scale. confidence_required is
+NOT part of the RED gate -- confidence_required=False no longer bypasses the
+RED-refuse (that was the reporter's bug). See #715 reopened, Task 5.
 
 Mirrors tests/test_api_confidence_required_kwarg.py's monkeypatch-forced-RED
 helper."""
@@ -61,65 +63,32 @@ def _df(n_rows: int) -> pl.DataFrame:
     })
 
 
-# --- default: RED commit raises (allow_red_config defaults False), even
-#     below REFUSE_AT_N --------------------------------------------------
+# --- small-N (< REFUSE_AT_N): RED commit does NOT raise (warn-and-run
+#     preserved -- the deliberate design) ----------------------------------
 
-def test_dedupe_df_raises_on_red_by_default_small_n(monkeypatch):
-    # SMALL n (< REFUSE_AT_N): old confidence gate would let this run; the
-    # new allow_red_config default refuses regardless.
+def test_dedupe_df_small_n_red_does_not_raise(monkeypatch):
+    # Below REFUSE_AT_N a RED commit is cheap -- warn-and-run, no raise.
     _force_red_history(monkeypatch, n_rows_in_df=50)
-    with pytest.raises(ControllerNotConfidentError):
-        gm.dedupe_df(_df(50))  # allow_red_config defaults False
-
-
-def test_dedupe_df_allow_red_config_true_runs(monkeypatch):
-    _force_red_history(monkeypatch, n_rows_in_df=50)
-    result = gm.dedupe_df(_df(50), allow_red_config=True)
+    result = gm.dedupe_df(_df(50))  # allow_red_config defaults False
     assert result is not None
 
 
-def test_auto_configure_df_raises_on_red_by_default(monkeypatch):
+def test_auto_configure_df_small_n_red_does_not_raise(monkeypatch):
     from goldenmatch.core.autoconfig import auto_configure_df
 
     _force_red_history(monkeypatch, n_rows_in_df=50)
-    with pytest.raises(ControllerNotConfidentError):
-        auto_configure_df(_df(50))
-
-
-def test_auto_configure_df_allow_red_config_true_returns_config(monkeypatch):
-    from goldenmatch.core.autoconfig import auto_configure_df
-
-    _force_red_history(monkeypatch, n_rows_in_df=50)
-    cfg = auto_configure_df(_df(50), allow_red_config=True)
+    cfg = auto_configure_df(_df(50))
     assert cfg is not None
 
 
-def test_match_df_raises_on_red_by_default_small_n(monkeypatch):
+def test_match_df_small_n_red_does_not_raise(monkeypatch):
     _force_red_history(monkeypatch, n_rows_in_df=50)
-    with pytest.raises(ControllerNotConfidentError):
-        gm.match_df(_df(50), _df(20))
-
-
-def test_match_df_allow_red_config_true_runs(monkeypatch):
-    _force_red_history(monkeypatch, n_rows_in_df=50)
-    result = gm.match_df(_df(50), _df(20), allow_red_config=True)
+    result = gm.match_df(_df(50), _df(20))
     assert result is not None
 
 
-def test_error_message_mentions_allow_red_config(monkeypatch):
-    from goldenmatch.core.autoconfig import auto_configure_df
-
-    _force_red_history(monkeypatch, n_rows_in_df=50)
-    try:
-        auto_configure_df(_df(50))
-    except ControllerNotConfidentError as e:
-        assert "allow_red_config" in str(e)
-    else:  # pragma: no cover
-        pytest.fail("expected ControllerNotConfidentError")
-
-
-# --- at-scale RED still raises by default (covers the old confidence-gate
-#     callers too) -------------------------------------------------------
+# --- at-scale RED (>= REFUSE_AT_N) raises by default; allow_red_config=True
+#     restores warn-and-run -------------------------------------------------
 
 def test_dedupe_df_raises_on_red_at_scale_by_default(monkeypatch):
     _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
@@ -131,3 +100,57 @@ def test_dedupe_df_allow_red_config_true_runs_at_scale(monkeypatch):
     _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
     result = gm.dedupe_df(_df(REFUSE_AT_N), allow_red_config=True)
     assert result is not None
+
+
+def test_auto_configure_df_raises_on_red_at_scale_by_default(monkeypatch):
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
+    with pytest.raises(ControllerNotConfidentError):
+        auto_configure_df(_df(REFUSE_AT_N))
+
+
+def test_auto_configure_df_allow_red_config_true_returns_config(monkeypatch):
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
+    cfg = auto_configure_df(_df(REFUSE_AT_N), allow_red_config=True)
+    assert cfg is not None
+
+
+def test_match_df_raises_on_red_at_scale_by_default(monkeypatch):
+    _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
+    with pytest.raises(ControllerNotConfidentError):
+        gm.match_df(_df(REFUSE_AT_N), _df(20))
+
+
+def test_match_df_allow_red_config_true_runs_at_scale(monkeypatch):
+    _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
+    result = gm.match_df(_df(REFUSE_AT_N), _df(20), allow_red_config=True)
+    assert result is not None
+
+
+# --- confidence_required=False NO LONGER bypasses RED-refuse at scale (the
+#     reporter's bug -- behavior change) -------------------------------------
+
+def test_confidence_required_false_still_raises_on_red_at_scale(monkeypatch):
+    # Pre-#715-reopened, confidence_required=False kept warn-and-run on a RED
+    # commit. Now allow_red_config is the only escape; confidence_required is
+    # out of the RED gate, so this still raises.
+    _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
+    with pytest.raises(ControllerNotConfidentError):
+        gm.dedupe_df(_df(REFUSE_AT_N), confidence_required=False)
+
+
+# --- error message surfaces the escape hatch -------------------------------
+
+def test_error_message_mentions_allow_red_config(monkeypatch):
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
+    try:
+        auto_configure_df(_df(REFUSE_AT_N))
+    except ControllerNotConfidentError as e:
+        assert "allow_red_config" in str(e)
+    else:  # pragma: no cover
+        pytest.fail("expected ControllerNotConfidentError")

--- a/packages/python/goldenmatch/tests/test_allow_red_config.py
+++ b/packages/python/goldenmatch/tests/test_allow_red_config.py
@@ -1,0 +1,133 @@
+"""End-to-end API tests for the allow_red_config kwarg (#715 reopened).
+
+A committed RED config now raises ControllerNotConfidentError by DEFAULT —
+independent of confidence_required AND independent of REFUSE_AT_N (so a
+small-N RED also raises). allow_red_config=True restores today's
+warn-and-run behavior. See #715 reopened, Task 5.
+
+Mirrors tests/test_api_confidence_required_kwarg.py's monkeypatch-forced-RED
+helper."""
+from __future__ import annotations
+
+import goldenmatch as gm
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import GoldenMatchConfig
+from goldenmatch.core.autoconfig_controller import (
+    REFUSE_AT_N,
+    ControllerNotConfidentError,
+)
+
+
+@pytest.fixture(autouse=True)
+def _disable_autoconfig_memory(monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+
+
+def _force_red_history(monkeypatch, n_rows_in_df: int):
+    """Force pick_committed to return a RED HistoryEntry."""
+    from goldenmatch.core.autoconfig_history import HistoryEntry, RunHistory
+    from goldenmatch.core.complexity_profile import (
+        BlockingProfile,
+        ComplexityProfile,
+        DataProfile,
+        ProfileMeta,
+        ScoringProfile,
+    )
+
+    red_profile = ComplexityProfile(
+        data=DataProfile(n_rows=0),
+        blocking=BlockingProfile(),
+        scoring=ScoringProfile(),
+        meta=ProfileMeta(
+            iteration=0, is_sample=False, sample_size=n_rows_in_df,
+            n_rows_full=n_rows_in_df, wall_clock_ms=0, seed=0,
+        ),
+    )
+
+    def _picker(self, *args, **kwargs):
+        return HistoryEntry(
+            iteration=0, config=GoldenMatchConfig(), profile=red_profile,
+            decision=None, error=None, wall_clock_ms=0,
+        )
+
+    monkeypatch.setattr(RunHistory, "pick_committed", _picker)
+
+
+def _df(n_rows: int) -> pl.DataFrame:
+    return pl.DataFrame({
+        "name": ["alice"] * n_rows,
+        "email": [f"u{i}@x.com" for i in range(n_rows)],
+    })
+
+
+# --- default: RED commit raises (allow_red_config defaults False), even
+#     below REFUSE_AT_N --------------------------------------------------
+
+def test_dedupe_df_raises_on_red_by_default_small_n(monkeypatch):
+    # SMALL n (< REFUSE_AT_N): old confidence gate would let this run; the
+    # new allow_red_config default refuses regardless.
+    _force_red_history(monkeypatch, n_rows_in_df=50)
+    with pytest.raises(ControllerNotConfidentError):
+        gm.dedupe_df(_df(50))  # allow_red_config defaults False
+
+
+def test_dedupe_df_allow_red_config_true_runs(monkeypatch):
+    _force_red_history(monkeypatch, n_rows_in_df=50)
+    result = gm.dedupe_df(_df(50), allow_red_config=True)
+    assert result is not None
+
+
+def test_auto_configure_df_raises_on_red_by_default(monkeypatch):
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    _force_red_history(monkeypatch, n_rows_in_df=50)
+    with pytest.raises(ControllerNotConfidentError):
+        auto_configure_df(_df(50))
+
+
+def test_auto_configure_df_allow_red_config_true_returns_config(monkeypatch):
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    _force_red_history(monkeypatch, n_rows_in_df=50)
+    cfg = auto_configure_df(_df(50), allow_red_config=True)
+    assert cfg is not None
+
+
+def test_match_df_raises_on_red_by_default_small_n(monkeypatch):
+    _force_red_history(monkeypatch, n_rows_in_df=50)
+    with pytest.raises(ControllerNotConfidentError):
+        gm.match_df(_df(50), _df(20))
+
+
+def test_match_df_allow_red_config_true_runs(monkeypatch):
+    _force_red_history(monkeypatch, n_rows_in_df=50)
+    result = gm.match_df(_df(50), _df(20), allow_red_config=True)
+    assert result is not None
+
+
+def test_error_message_mentions_allow_red_config(monkeypatch):
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    _force_red_history(monkeypatch, n_rows_in_df=50)
+    try:
+        auto_configure_df(_df(50))
+    except ControllerNotConfidentError as e:
+        assert "allow_red_config" in str(e)
+    else:  # pragma: no cover
+        pytest.fail("expected ControllerNotConfidentError")
+
+
+# --- at-scale RED still raises by default (covers the old confidence-gate
+#     callers too) -------------------------------------------------------
+
+def test_dedupe_df_raises_on_red_at_scale_by_default(monkeypatch):
+    _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
+    with pytest.raises(ControllerNotConfidentError):
+        gm.dedupe_df(_df(REFUSE_AT_N))
+
+
+def test_dedupe_df_allow_red_config_true_runs_at_scale(monkeypatch):
+    _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
+    result = gm.dedupe_df(_df(REFUSE_AT_N), allow_red_config=True)
+    assert result is not None

--- a/packages/python/goldenmatch/tests/test_api_confidence_required_kwarg.py
+++ b/packages/python/goldenmatch/tests/test_api_confidence_required_kwarg.py
@@ -62,9 +62,14 @@ def test_dedupe_df_default_raises_at_scale_on_red(monkeypatch):
         gm.dedupe_df(_df(REFUSE_AT_N))
 
 
-def test_dedupe_df_confidence_required_false_short_circuits(monkeypatch):
+def test_dedupe_df_allow_red_config_short_circuits(monkeypatch):
+    # #715 reopened: a RED commit now raises by default regardless of
+    # confidence_required; allow_red_config=True is the escape hatch that
+    # restores today's warn-and-run.
     _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
-    result = gm.dedupe_df(_df(REFUSE_AT_N), confidence_required=False)
+    result = gm.dedupe_df(
+        _df(REFUSE_AT_N), confidence_required=False, allow_red_config=True
+    )
     assert result is not None
 
 
@@ -76,11 +81,13 @@ def test_auto_configure_df_default_raises_at_scale_on_red(monkeypatch):
         auto_configure_df(_df(REFUSE_AT_N))
 
 
-def test_auto_configure_df_confidence_required_false_returns_v0(monkeypatch):
+def test_auto_configure_df_allow_red_config_returns_v0(monkeypatch):
     from goldenmatch.core.autoconfig import auto_configure_df
 
     _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
-    cfg = auto_configure_df(_df(REFUSE_AT_N), confidence_required=False)
+    cfg = auto_configure_df(
+        _df(REFUSE_AT_N), confidence_required=False, allow_red_config=True
+    )
     assert cfg is not None
 
 
@@ -92,9 +99,11 @@ def test_match_df_default_raises_at_scale_on_red(monkeypatch):
         gm.match_df(target, reference)
 
 
-def test_match_df_confidence_required_false_short_circuits(monkeypatch):
+def test_match_df_allow_red_config_short_circuits(monkeypatch):
     _force_red_history(monkeypatch, n_rows_in_df=REFUSE_AT_N)
     target = _df(REFUSE_AT_N)
     reference = _df(100)
-    result = gm.match_df(target, reference, confidence_required=False)
+    result = gm.match_df(
+        target, reference, confidence_required=False, allow_red_config=True
+    )
     assert result is not None

--- a/packages/python/goldenmatch/tests/test_autoconfig_blocking_cost_715.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_blocking_cost_715.py
@@ -23,3 +23,43 @@ def test_project_max_block_size_clamped_to_full_n():
 def test_project_max_block_size_degenerate_inputs():
     assert project_max_block_size(0, 0, 100) == 0
     assert project_max_block_size(10, 100, 0) == 10  # full_n <= sample_n -> identity
+
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+
+def _proj_block(df, cols, full_n):
+    from goldenmatch.core.blocking_candidates import project_max_block_size
+    mb = int(df.group_by(cols).len().get_column("len").max() or 0)
+    return project_max_block_size(mb, df.height, full_n)
+
+
+def test_no_emitted_blocking_pass_exceeds_cap_sparse_zip():
+    from goldenmatch.core.autoconfig import build_blocking, profile_columns
+    from repro_issue_715 import make_healthcare_df
+
+    # matching_id is the ground-truth record id (`not used for config`), so the
+    # real pipeline never feeds it to build_blocking; drop it here too.
+    df = make_healthcare_df(30_000, zip_present=0.5).drop("matching_id")  # sparse zip5
+    profiles = profile_columns(df)
+    full_n = 1_000_000  # simulate scale; v0 path uses full df but we assert projected
+    blk = build_blocking(profiles, df, n_rows_full=full_n)
+    cap = blk.max_block_size or 5000
+    for k in (blk.keys or []):
+        assert _proj_block(df, k.fields, full_n) <= cap, f"key {k.fields} oversized"
+    for p in (blk.passes or []):
+        assert _proj_block(df, p.fields, full_n) <= cap, f"pass {p.fields} oversized"
+
+
+def test_dense_zip_still_picks_bounded_compound():
+    # regression: the good (dense-zip) shape must still get a bounded compound.
+    from goldenmatch.core.autoconfig import build_blocking, profile_columns
+    from repro_issue_715 import make_healthcare_df
+
+    df = make_healthcare_df(30_000, zip_present=0.95).drop("matching_id")
+    profiles = profile_columns(df)
+    blk = build_blocking(profiles, df, n_rows_full=df.height)
+    assert blk.keys, "expected a blocking key on the dense-zip shape"

--- a/packages/python/goldenmatch/tests/test_autoconfig_blocking_cost_715.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_blocking_cost_715.py
@@ -85,3 +85,12 @@ def test_sparse_zip_gets_bounded_compound_not_degenerate():
     for p in (blk.passes or []):
         all_fields.update(p.fields)
     assert "zip5" in all_fields, f"expected zip5 to bound the compound, got {all_fields}"
+
+
+def test_max_iterations_scales_with_dataset_size():
+    from goldenmatch.core.autoconfig_controller import ControllerBudget
+    small = ControllerBudget.for_dataset(10_000).max_iterations
+    large = ControllerBudget.for_dataset(2_000_000).max_iterations
+    assert large > small, f"expected more iterations at scale, got small={small} large={large}"
+    # base/default unchanged for small data
+    assert ControllerBudget.for_dataset(10_000).max_iterations == 3

--- a/packages/python/goldenmatch/tests/test_autoconfig_blocking_cost_715.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_blocking_cost_715.py
@@ -1,0 +1,25 @@
+"""Tests for project_max_block_size (#715 reopened — full-N block-cost guard)."""
+
+from goldenmatch.core.blocking_candidates import project_max_block_size
+
+
+def test_project_max_block_size_scales_linearly_with_full_n():
+    # A key with max block 250 in a 5K sample projects up toward full N (linear).
+    proj = project_max_block_size(sample_max_block=250, sample_n=5_000, full_n=1_000_000)
+    assert proj > 250
+    # ~linear: 250 * (1_000_000 / 5_000) = 50_000
+    assert 40_000 <= proj <= 60_000
+
+
+def test_project_max_block_size_identity_when_sample_is_full():
+    assert project_max_block_size(4055, 200_000, 200_000) == 4055
+
+
+def test_project_max_block_size_clamped_to_full_n():
+    # cannot exceed full_n
+    assert project_max_block_size(sample_max_block=900, sample_n=1_000, full_n=10_000) <= 10_000
+
+
+def test_project_max_block_size_degenerate_inputs():
+    assert project_max_block_size(0, 0, 100) == 0
+    assert project_max_block_size(10, 100, 0) == 10  # full_n <= sample_n -> identity

--- a/packages/python/goldenmatch/tests/test_autoconfig_blocking_cost_715.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_blocking_cost_715.py
@@ -63,3 +63,25 @@ def test_dense_zip_still_picks_bounded_compound():
     profiles = profile_columns(df)
     blk = build_blocking(profiles, df, n_rows_full=df.height)
     assert blk.keys, "expected a blocking key on the dense-zip shape"
+
+
+def test_sparse_zip_gets_bounded_compound_not_degenerate():
+    """B2: with sparse zip5 (reclassified identifier, ~45% null), the compound
+    search must still reach a BOUNDED compound (e.g. zip5+last_name) so blocking
+    is non-empty -- not degenerate. zip5 must be usable as a compound component
+    despite high null + identifier type."""
+    from goldenmatch.core.autoconfig import build_blocking, profile_columns
+    from repro_issue_715 import make_healthcare_df
+
+    df = make_healthcare_df(30_000, zip_present=0.5).drop("matching_id")
+    profiles = profile_columns(df)
+    blk = build_blocking(profiles, df, n_rows_full=df.height)
+    # Non-degenerate: has at least one real blocking key.
+    assert blk.keys, "expected a bounded compound key, got degenerate/empty blocking"
+    # The bounding column (zip5) should appear in the chosen key/passes.
+    all_fields = set()
+    for k in (blk.keys or []):
+        all_fields.update(k.fields)
+    for p in (blk.passes or []):
+        all_fields.update(p.fields)
+    assert "zip5" in all_fields, f"expected zip5 to bound the compound, got {all_fields}"

--- a/packages/python/goldenmatch/tests/test_controller_budget_for_dataset.py
+++ b/packages/python/goldenmatch/tests/test_controller_budget_for_dataset.py
@@ -65,11 +65,12 @@ def test_for_dataset_returns_new_instance_each_call():
 
 
 def test_for_dataset_preserves_other_budget_fields():
-    """Only sample_size_default and max_seconds vary by tier; the rest
-    (max_iterations, sample_skip_below, converge_epsilon, drift_threshold)
-    keep their defaults so the iteration loop's other tuning stays stable."""
+    """sample_size_default, max_seconds, AND max_iterations vary by tier
+    (#715: max_iterations now scales 3 -> 4 -> 5 across tiers). The rest
+    (sample_skip_below, converge_epsilon, drift_threshold) keep their
+    defaults so the iteration loop's other tuning stays stable."""
     b = ControllerBudget.for_dataset(500_000)
-    assert b.max_iterations == 3
+    assert b.max_iterations == 4  # 100K-1M tier scales to 4 (#715)
     assert b.sample_skip_below == 5000
     assert b.converge_epsilon == 0.05
     assert b.drift_threshold == 0.30

--- a/packages/python/goldenmatch/tests/test_controller_confidence_gate.py
+++ b/packages/python/goldenmatch/tests/test_controller_confidence_gate.py
@@ -193,10 +193,20 @@ def test_gate_does_not_fire_on_yellow_or_green(monkeypatch):
     assert result is not None
 
 
-def test_gate_short_circuits_with_confidence_required_false(monkeypatch):
-    """Spec §Backward compatibility: kwarg opt-out preserves today's
-    warn-and-run behavior. Un-skipped in Phase 4."""
+def test_confidence_required_false_no_longer_bypasses_red_refuse(monkeypatch):
+    """#715 reopened: confidence_required=False NO LONGER bypasses the
+    RED-refuse (that was the reporter's bug). A committed-RED entry at
+    >= REFUSE_AT_N raises regardless of confidence_required."""
     _force_red_history_entry(monkeypatch, n_rows_in_df=SMALL_N)
     df = _df(SMALL_N)
-    result = gm.dedupe_df(df, confidence_required=False)
+    with pytest.raises(ControllerNotConfidentError):
+        gm.dedupe_df(df, confidence_required=False)
+
+
+def test_allow_red_config_is_the_red_refuse_escape_hatch(monkeypatch):
+    """#715 reopened: allow_red_config=True is now the SINGLE escape hatch
+    that restores warn-and-run on a committed-RED entry at >= REFUSE_AT_N."""
+    _force_red_history_entry(monkeypatch, n_rows_in_df=SMALL_N)
+    df = _df(SMALL_N)
+    result = gm.dedupe_df(df, allow_red_config=True)
     assert result is not None


### PR DESCRIPTION
Reopens-fix for #715. PR #720 fixed the matchkey half; the reporter verified that and reopened because (a) auto-config still committed a RED config and **ran anyway**, and (b) a new failure mode appeared: an unbounded `soundex(name)` blocking pass producing ~30K-row blocks at 1M → 39.6M candidate edges → 18-min run → cancelled.

## Root cause (reproduced, not reasoned)
Ran `profile_columns` + `build_blocking` on the synthetic healthcare shape at 50K/200K:
- **B1:** `build_blocking` emitted single-column `soundex(name)` passes with **no per-pass block-size gate**. v0 builds blocking on the full df, so block sizes are exact — the code just never checked them.
- **B2:** a **sparse `zip5`** (~45% null) reclassifies `zip→identifier` and was dropped from `_build_compound_blocking`, removing the one column that would bound block size (`zip5+last_name`).
- **A:** the committed RED config ran anyway; the existing raise was gated on `confidence_required` (which the reporter set `False`).
- **Iteration budget:** `ControllerBudget.max_iterations` was hardcoded at 3 for all sizes (the reporter's hypothesis — confirmed, though not load-bearing: the controller iterates on a sample that masks the at-scale blow-up).

## Fix (four parts)
1. **B1** — `project_max_block_size` (linear full-N projection) gates every emitted blocking key/pass; oversized passes dropped; degenerate (empty) config when nothing bounds, so the controller refuses rather than shipping a bomb.
2. **B2** — `_build_compound_blocking` judges candidates by block size (non-singleton, `card<1.0`, non-null distinct ratio under the gate) not col_type, and relaxes the null ceiling for the multi_pass component role → `zip5+last_name` reachable.
3. **Iteration budget** — `for_dataset` scales `max_iterations` 3→4→5 across the 100K/1M tiers.
4. **A** — new `allow_red_config` flag: a committed RED config at `n_rows >= REFUSE_AT_N` now **raises by default** (independent of `confidence_required`; `confidence_required=False` no longer bypasses it). `allow_red_config=True` restores warn-and-run. Reconciled with the existing #417 degenerate-blocking guard to raise once. Small-N (<100K) keeps warn-and-run (cheap; deliberate existing design).

## Tests
- New `tests/test_autoconfig_blocking_cost_715.py` (B1 cap invariant, B2 bounded compound, dense-zip no-regression, iteration scaling) + `tests/test_allow_red_config.py` (default-raise at scale, escape hatch, small-N warn-and-run, `confidence_required=False` now raises).
- Regression: `test_autoconfig.py` + `test_autoconfig_regressions.py` + `test_api.py` = 186 passed, 3 skipped. pyright 0, ruff clean.
- **At-scale CI** (`repro-issue-715.yml` new `blocking-scale` job, ≥500K): asserts the committed blocking is bounded (`BLOCKING BOUNDED`) — the gap a sample-sized unit test can't catch, which is what let #715 reopen. Local 100K: `last_name+first_name` max block 8 vs cap 1000.

## Validation
- In-house #528 quality gate runs in this PR's CI (recall backstop for the changed blocking selection).
- DQbench T1/T2/T3: to be confirmed before merge (recall risk from dropping oversized recall passes / changed blocking selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)