### PR TITLE
docs: headline 100M distributed scale + add configs/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 *GoldenCheck profiles → GoldenFlow standardizes → GoldenMatch deduplicates → GoldenPipe orchestrates. With InferMap for schema mapping and a Rust extension layer for Postgres / DuckDB.*
 
+**⚡ GoldenMatch scales from a CSV on your laptop to 100M+ rows on a Ray cluster — verified: 100,000,000 records deduped in 213 s with a 0.30 GB driver footprint.**
+
 <br>
 
 <!-- Headline package: goldenmatch -->
@@ -366,6 +368,8 @@ Published GoldenMatch numbers (DQbench composite 91.04, DBLP-ACM 0.9641 F1, Febr
 ## Scale envelope
 
 "How big can this handle?" is answered in [`docs/scale-envelope.md`](docs/scale-envelope.md): per-backend ranges (Polars in-memory < 500K, DuckDB out-of-core 500K - 50M, Ray distributed >= 50M), block-size failure modes, candidate-pair math, and a single-page decision tree for picking a backend.
+
+**Verified at the top end:** a full **100,000,000-row** GoldenMatch dedupe on a 4-worker Ray cluster (`e2-standard-16`, 64 worker CPU) in **213 s**, 20,000,000 golden records, driver process peak **0.30 GB RSS** — the distributed pipeline is driver-collect-free end to end. Recipe in [`packages/python/goldenmatch/configs/distributed-100m.yaml`](packages/python/goldenmatch/configs/distributed-100m.yaml).
 
 ---
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -7,6 +7,8 @@
 
 *Zero-config entity resolution for Python & TypeScript — with a self-verifying auto-config that tells you when it's unsure.*
 
+**⚡ Scales from a CSV on your laptop to 100M+ rows on a Ray cluster — verified: 100,000,000 records deduped in 213 s with a 0.30 GB driver footprint.** ([how →](#scaling-to-100m))
+
 <br>
 
 <!-- Packages -->
@@ -719,6 +721,10 @@ Files/DB → Ingest → Standardize → Block → Score → Cluster → Golden R
 
 ## Config Reference
 
+> 📁 **Copy-paste-ready configs live in [`configs/`](configs/)** — a robust
+> [`customers.yaml`](configs/customers.yaml), a [`distributed-100m.yaml`](configs/distributed-100m.yaml),
+> and a [walkthrough README](configs/README.md) explaining every knob.
+
 ```yaml
 matchkeys:
   - name: exact_email
@@ -1030,7 +1036,48 @@ goldenmatch watch --table customers --connection-string "$DATABASE_URL" --interv
 - Progressive embedding: computes 100K embeddings per run, ANN improves over time
 - Persistent clusters with golden record versioning
 
-**Scale:** Tested to 10M+ records in Postgres. For 100M+, use larger chunk sizes and dedicated Postgres infrastructure.
+**Scale:** Tested to 10M+ records in Postgres. For 100M+ on a cluster, use distributed mode below.
+
+## Scaling to 100M
+
+GoldenMatch runs the same matching policy from a CSV on your laptop up to 100M+
+rows on a [Ray](https://www.ray.io/) cluster. **Verified:** a full
+**100,000,000-row** dedupe in **213 s** on a 4-worker `e2-standard-16` cluster
+(64 worker CPU) producing **20,000,000 golden records**, with the driver process
+peaking at **0.30 GB RSS**.
+
+The distributed pipeline is **driver-collect-free** — every stage runs on the
+workers and nothing funnels back to a single node, which is what makes it scale:
+
+```
+score  ->  per-partition local connected-components  ->  distributed join
+       ->  distributed golden build  ->  distributed write
+```
+
+**Run it:**
+
+1. Stand up a Ray cluster. Run the **head as a pure driver** so shuffle data
+   never lands on it; the workers supply all the compute:
+   ```bash
+   # head node
+   ray start --head --num-cpus=0 --object-store-memory=20000000000
+   # each worker
+   ray start --address=<head-ip>:6379 --num-cpus=16 --object-store-memory=20000000000
+   ```
+2. Make sure your input carries a **global `__row_id__`** column (0..N-1, unique
+   across the whole dataset). Without it, partition-local ids collide and
+   unrelated clusters get merged.
+3. Drive it through the fully-distributed pipeline:
+   ```bash
+   export GOLDENMATCH_DISTRIBUTED_PIPELINE=2
+   export GOLDENMATCH_ENABLE_DISTRIBUTED_RAY=1
+   export RAY_ADDRESS=auto
+   ```
+
+- **Config:** [`configs/distributed-100m.yaml`](configs/distributed-100m.yaml) (matching policy + the full recipe).
+- **Runnable demo** (Ray local mode, no cluster): [`examples/distributed_pipeline.py`](examples/distributed_pipeline.py).
+- **The exact 100M assembly:** [`scripts/bench_phase5_explicit.py`](scripts/bench_phase5_explicit.py).
+- **Background:** [`docs/scale-100m-ray-vs-spark.md`](docs/scale-100m-ray-vs-spark.md).
 
 ## Interactive TUI
 

--- a/packages/python/goldenmatch/configs/README.md
+++ b/packages/python/goldenmatch/configs/README.md
@@ -1,0 +1,124 @@
+# GoldenMatch config folder
+
+Copy-paste-ready configs you can point at your own data. Start from the one
+closest to your job, change the column names, and run.
+
+| File | Use it when |
+| --- | --- |
+| [`customers.yaml`](customers.yaml) | Single-node dedupe of customers / contacts / accounts. The robust default starting point. |
+| [`distributed-100m.yaml`](distributed-100m.yaml) | 100M+ rows on a Ray cluster. The matching policy plus the env-var + cluster recipe. |
+
+> **You often need no config at all.** `goldenmatch dedupe data.csv` auto-tunes
+> blocking, matchkeys, and thresholds, and tells you when it is unsure. Reach
+> for a config when you want a *pinned, reviewable* matching policy, or to
+> override one auto-tuned decision.
+
+## Run it
+
+```bash
+# Single node
+goldenmatch dedupe customers.csv --config configs/customers.yaml
+
+# From Python
+from goldenmatch import dedupe
+result = dedupe("customers.csv", config="configs/customers.yaml")
+print(result.golden)        # canonical records
+print(result.clusters)      # who merged with whom
+```
+
+## Anatomy of a config
+
+Every section is optional. A config is a YAML mapping with these top-level keys:
+
+### `matchkeys` — the rules that declare two records "the same"
+
+Records merge if **any** matchkey fires. Order cheap+precise first.
+
+```yaml
+matchkeys:
+  - name: email_exact          # exact match on a normalized field
+    type: exact
+    fields:
+      - column: email
+        transforms: [lowercase, strip]
+
+  - name: name_fuzzy           # fuzzy match; weighted needs a threshold
+    type: weighted
+    threshold: 0.88            # pair merges when the weighted score >= this
+    fields:
+      - column: first_name
+        scorer: jaro_winkler   # see "Scorers" below
+        weight: 1.0
+      - column: last_name
+        scorer: jaro_winkler
+        weight: 1.5            # surname agreement counts more
+```
+
+- `type: exact` — binary equality on the (transformed) field. No scorer/weight.
+- `type: weighted` — per-field fuzzy scores combined by `weight`; merge when the
+  combined score crosses `threshold` (**required** for weighted).
+- `column` (or `field`) — the input column. `transforms` normalize it first.
+
+**Scorers** (common): `jaro_winkler` (names), `levenshtein` /
+`token_sort_ratio` (free text), `exact`, `jaccard` (sets/addresses),
+`embedding` (semantic). **Transforms** (common): `lowercase`, `strip`,
+`name_proper`, `email`, `phone`, `zip5`, `substring:start:end`.
+
+### `blocking` — who gets compared to whom (the scale knob)
+
+Without blocking, matching is O(n^2). A blocking key buckets records so only
+records sharing a key are scored. Tune for recall (bigger buckets) vs speed
+(smaller buckets).
+
+```yaml
+blocking:
+  max_block_size: 5000           # skip pathologically huge buckets
+  skip_oversized: true
+  keys:
+    - fields: [last_name]
+      transforms: [lowercase, "substring:0:3"]   # block on first 3 letters
+```
+
+### `standardization` — clean fields before matching
+
+```yaml
+standardization:
+  email: [email]
+  last_name: [strip, name_proper]
+  zip: [zip5]
+```
+
+### `golden_rules` — collapse a cluster into one canonical row
+
+```yaml
+golden_rules:
+  default_strategy: most_complete   # keep the most-populated/cleanest value per field
+```
+
+### `output`
+
+```yaml
+output:
+  format: csv          # csv | parquet
+  directory: ./goldenmatch_out
+  run_name: customers
+```
+
+## Tuning, in order of impact
+
+1. **Blocking selectivity.** This decides scale. Too-broad keys blow up pair
+   counts; too-narrow keys miss true duplicates. Block on the most selective
+   field that still co-locates duplicates.
+2. **Matchkey threshold.** Lower = more recall (more merges, more false
+   merges); higher = more precision. Names usually sit at 0.85-0.92.
+3. **Add a second matchkey** for an independent signal (e.g. exact phone) before
+   loosening a threshold.
+
+## Scaling to 100M+
+
+The matching policy is the same; the *invocation* changes. See
+[`distributed-100m.yaml`](distributed-100m.yaml) for the full recipe:
+`GOLDENMATCH_DISTRIBUTED_PIPELINE=2` over a Ray cluster (head as a pure driver,
+workers do all compute), with a global `__row_id__` on the input. Verified at
+100,000,000 rows in ~213 s with a 0.30 GB driver footprint. Runnable demo:
+[`examples/distributed_pipeline.py`](../examples/distributed_pipeline.py).

--- a/packages/python/goldenmatch/configs/customers.yaml
+++ b/packages/python/goldenmatch/configs/customers.yaml
@@ -1,0 +1,76 @@
+# =============================================================================
+# GoldenMatch config: customer / contact deduplication (single node)
+# =============================================================================
+# A robust, production-shaped starting point. Copy it, point it at your columns,
+# and run:
+#
+#     goldenmatch dedupe customers.csv --config configs/customers.yaml
+#
+# You usually do NOT need a config at all -- `goldenmatch dedupe customers.csv`
+# auto-tunes everything. Write a config when you want to PIN the behavior
+# (reproducible runs), override one decision the auto-tuner got wrong, or
+# document the matching policy for review. Every section below is optional;
+# delete what you don't need.
+# -----------------------------------------------------------------------------
+
+# --- Matchkeys: the rules that declare two records "the same" -----------------
+# Records match if ANY matchkey fires. List the cheapest, highest-precision
+# rule first (exact email), then fuzzier ones.
+matchkeys:
+  # 1) Exact match on normalized email. High precision, near-zero false merges.
+  - name: email_exact
+    type: exact
+    fields:
+      - column: email
+        transforms: [lowercase, strip]      # normalize before comparing
+
+  # 2) Fuzzy match on name. `weighted` needs a `threshold`, and every field
+  #    needs a `scorer` + `weight`. jaro_winkler is the workhorse for names;
+  #    it rewards shared prefixes and tolerates typos/transpositions.
+  - name: name_fuzzy
+    type: weighted
+    threshold: 0.88                          # 0.85-0.92 is the usual band for names
+    fields:
+      - column: first_name
+        scorer: jaro_winkler
+        weight: 1.0
+      - column: last_name
+        scorer: jaro_winkler
+        weight: 1.5                          # surname agreement matters more
+
+# --- Blocking: who gets compared to whom (the scale knob) ---------------------
+# Without blocking, matching is O(n^2). A blocking key buckets records so only
+# records sharing a key are scored. Pick a key that co-locates true duplicates
+# but is selective enough to keep buckets small.
+blocking:
+  max_block_size: 5000                       # guardrail: skip pathologically huge buckets
+  skip_oversized: true
+  keys:
+    # Block on the first 3 letters of the (normalized) last name. Tune the
+    # substring length: shorter = bigger buckets/higher recall, longer = faster.
+    - fields: [last_name]
+      transforms: [lowercase, "substring:0:3"]
+
+# --- Standardization: clean fields before matching ----------------------------
+# Applied once up front. Cuts false negatives from formatting noise.
+standardization:
+  email: [email]                             # lowercase + trim + canonicalize
+  phone: [phone]                             # strip to digits / E.164-ish
+  first_name: [strip, name_proper]
+  last_name: [strip, name_proper]
+  zip: [zip5]                                # keep first 5 digits
+
+# --- Validation: cheap autofix pass (typos, casing, stray whitespace) ---------
+validation:
+  auto_fix: true
+
+# --- Golden record: how to collapse a cluster into one canonical row ----------
+# most_complete = field-by-field, keep the most-populated/cleanest value.
+golden_rules:
+  default_strategy: most_complete
+
+# --- Output --------------------------------------------------------------------
+output:
+  format: csv                                # csv | parquet
+  directory: ./goldenmatch_out
+  run_name: customers

--- a/packages/python/goldenmatch/configs/distributed-100m.yaml
+++ b/packages/python/goldenmatch/configs/distributed-100m.yaml
@@ -1,0 +1,73 @@
+# =============================================================================
+# GoldenMatch config: distributed dedupe at 100M+ rows (Ray cluster)
+# =============================================================================
+# The *matching policy* below is an ordinary config -- identical in shape to
+# customers.yaml. What makes a run "distributed" is HOW you invoke it (env vars
+# + a Ray cluster), not the config file. This file documents both.
+#
+# Verified shape: a full 100,000,000-row dedupe ran in ~213 s on a 4-worker
+# `e2-standard-16` cluster (64 worker CPU), 20,000,000 golden records, with the
+# driver process peaking at 0.30 GB RSS. The pipeline is driver-collect-free:
+#   score -> per-partition local connected-components -> distributed join
+#   -> distributed golden build -> distributed write.
+#
+# --- How to run (the part that makes it distributed) --------------------------
+# 1. Stand up a Ray cluster. Run the HEAD as a pure driver so shuffle data
+#    never lands on it:
+#       ray start --head --num-cpus=0 --object-store-memory=20000000000
+#    Workers join and supply ALL the compute:
+#       ray start --address=<head-ip>:6379 --num-cpus=16 --object-store-memory=20000000000
+#    On cloud, give workers WRITE access to object storage (the distributed
+#    parquet write runs ON the workers), e.g. GCP `--scopes=cloud-platform`.
+#
+# 2. Your input must carry a GLOBAL row id column named `__row_id__`
+#    (0..N-1, unique across the whole dataset). This is load-bearing: without
+#    it, each partition mints local ids that collide across partitions and
+#    connected-components merges unrelated clusters. The bench generator
+#    (`scripts/generate_phase5_dataset.py`) writes it; for your own data add a
+#    monotonic id column before partitioning.
+#
+# 3. Drive it through the fully-distributed pipeline:
+#       export GOLDENMATCH_DISTRIBUTED_PIPELINE=2
+#       export GOLDENMATCH_ENABLE_DISTRIBUTED_RAY=1
+#       export RAY_ADDRESS=auto
+#    Then read the input partitioned and run it. See
+#    `scripts/bench_phase5_explicit.py` for the exact 100M assembly, and
+#    `examples/distributed_pipeline.py` for a runnable Ray-local-mode demo.
+# -----------------------------------------------------------------------------
+
+# --- Matchkeys ----------------------------------------------------------------
+# Keep matchkeys cheap at scale: prefer exact/blocked-fuzzy over many fuzzy
+# fields. Each fuzzy field is scored per candidate pair on every worker.
+matchkeys:
+  - name: name_fuzzy
+    type: weighted
+    threshold: 0.85
+    fields:
+      - column: first_name
+        scorer: jaro_winkler
+        weight: 1.0
+
+# --- Blocking (THE scale lever) ------------------------------------------------
+# At 100M, blocking selectivity decides whether you finish in minutes or never.
+# Block on a high-cardinality key so buckets stay small (here: a unique-ish
+# last_name). Each scoring partition only compares within its own rows, so a
+# selective key keeps per-partition pair counts bounded.
+blocking:
+  strategy: static
+  max_block_size: 5000
+  skip_oversized: true
+  keys:
+    - fields: [last_name]
+
+# --- Golden record ------------------------------------------------------------
+golden_rules:
+  default_strategy: most_complete
+
+# --- Output -------------------------------------------------------------------
+# At scale the pipeline writes a DIRECTORY of parquet part files (one per
+# partition), straight from the workers -- never materialized on the driver.
+output:
+  format: parquet
+  directory: ./goldenmatch_out_100m
+  run_name: distributed_100m


### PR DESCRIPTION
Makes the verified 100M distributed result a **headline** and gives users a real config folder to copy.

## README
- **Hero headline** (root + package README): scales from a CSV to 100M+ rows on a Ray cluster, verified 213 s / 0.30 GB driver.
- New **`## Scaling to 100M`** section: the driver-collect-free pipeline shape + the cluster recipe (head `--num-cpus=0`, global `__row_id__`, the env vars).
- Root **scale-envelope** updated with the verified top-end number.

## New `configs/` folder (copy-paste-ready)
- [`customers.yaml`](packages/python/goldenmatch/configs/customers.yaml) — robust, heavily-commented single-node config (exact + fuzzy matchkeys, blocking, standardization, golden rules, output).
- [`distributed-100m.yaml`](packages/python/goldenmatch/configs/distributed-100m.yaml) — the at-scale matching policy + full run recipe.
- [`README.md`](packages/python/goldenmatch/configs/README.md) — a walkthrough of every section + tuning guidance.
- Both YAMLs validated through `load_config` (parse into a real `GoldenMatchConfig`).

Docs/config only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)