### PR TITLE
fix(golden): thread pair_scores into confidence_majority survivorship (#678)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -664,6 +664,7 @@ def build_golden_records_batch(
     rules: GoldenRulesConfig,
     quality_scores: dict[tuple[int, str], float] | None = None,
     provenance: bool = False,
+    cluster_pair_scores: dict[int, dict[tuple[int, int], float]] | None = None,
 ) -> list[dict]:
     """Vectorized batch builder for many golden records sharing a parent df.
 
@@ -691,6 +692,17 @@ def build_golden_records_batch(
             May also be a ray.data.Dataset (Phase 4 distributed path).
         rules: golden rules configuration.
         quality_scores: optional per-(row_id, col) quality weights.
+        cluster_pair_scores: optional ``{cluster_id: {(row_id_a, row_id_b):
+            score}}`` -- the per-cluster scored edges, keyed by the SAME
+            ``__row_id__`` values that appear in ``multi_df``. Required for
+            the ``confidence_majority`` strategy to actually weight by edge
+            confidence; ``None`` (the default) preserves today's behavior
+            where ``confidence_majority`` silently falls back to
+            count-majority (#678). Only consumed on the slow per-cluster
+            path; the polars-native fast path never uses confidence_majority.
+            The edge keys (row ids) are remapped per cluster to the positional
+            member indices that ``merge_field`` / ``_confidence_majority``
+            expect.
         provenance: when True, each field dict additionally carries
             ``source_row_id`` -- the ``__row_id__`` of the record whose value
             won survivorship for that field (``None`` when the field is
@@ -783,6 +795,25 @@ def build_golden_records_batch(
         per_cluster = (
             cluster_overrides.get(int(cid)) if cluster_overrides else None
         )
+        # #678: remap this cluster's pair_scores from row-id keys to the
+        # positional member indices merge_field/_confidence_majority use.
+        # The cluster dict keys edges by __row_id__ (e.g. (10, 11)); the
+        # merge functions key non_null by slice position (0..size-1). Build
+        # a row_id -> position map from this cluster's row-id slice and
+        # rewrite the edge keys. None (default) leaves pair_scores unset,
+        # preserving the count-majority fallback.
+        positional_pair_scores: dict[tuple[int, int], float] | None = None
+        if cluster_pair_scores is not None and row_id_array is not None:
+            cluster_scores = cluster_pair_scores.get(int(cid))
+            if cluster_scores:
+                row_slice = row_id_array[offset:offset + size]
+                rid_to_pos = {rid: pos for pos, rid in enumerate(row_slice)}
+                positional_pair_scores = {}
+                for (rid_a, rid_b), score in cluster_scores.items():
+                    pa = rid_to_pos.get(rid_a)
+                    pb = rid_to_pos.get(rid_b)
+                    if pa is not None and pb is not None:
+                        positional_pair_scores[(pa, pb)] = score
         for col in user_cols:
             values = col_arrays[col][offset:offset + size]
             if per_cluster and col in per_cluster:
@@ -809,6 +840,7 @@ def build_golden_records_batch(
 
             val, conf, idx = merge_field(
                 values, field_rule, sources=sources, dates=dates, quality_weights=weights,
+                pair_scores=positional_pair_scores,
             )
             field: dict = {"value": val, "confidence": conf}
             if provenance:

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1738,9 +1738,25 @@ def _run_dedupe_pipeline(
                     golden_records = []
                 else:
                     with stage("golden_build_records_batch_slow"):
+                        # #678: thread per-cluster pair_scores so the
+                        # confidence_majority strategy actually weights by
+                        # edge confidence instead of silently degrading to
+                        # count-majority. The legacy `clusters` dict (this
+                        # non-frames, non-columnar default path) carries real
+                        # per-cluster pair_scores keyed by __row_id__; the
+                        # builder remaps those to positional member indices.
+                        # The frames-out / columnar paths carry pair_scores={}
+                        # by design, so this lookup yields empty dicts there
+                        # (documented limitation; confidence_majority on those
+                        # paths still falls back to count-majority).
+                        cluster_pair_scores = {
+                            cid: info.get("pair_scores", {})
+                            for cid, info in clusters.items()
+                        }
                         golden_records = build_golden_records_batch(
                             multi_df, golden_rules,
                             provenance=_provenance_on,
+                            cluster_pair_scores=cluster_pair_scores,
                         )
 
     # Build golden DataFrame (slow path: walks the list[dict] returned by

--- a/packages/python/goldenmatch/tests/test_confidence_majority_678.py
+++ b/packages/python/goldenmatch/tests/test_confidence_majority_678.py
@@ -1,0 +1,74 @@
+"""Regression test for #678: confidence_majority silently degraded to
+count-majority because the pipeline never fed per-cluster pair_scores into
+``build_golden_records_batch``.
+
+These are UNIT tests on ``build_golden_records_batch``: they prove that when
+a cluster's pair_scores reach the builder, ``confidence_majority`` consumes
+the edge confidences (and diverges from count-majority), and that without
+them the builder falls back to count-majority (the documented fallback).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.config.schemas import GoldenRulesConfig
+from goldenmatch.core.golden import build_golden_records_batch
+
+
+def _multi_df_diverge() -> pl.DataFrame:
+    """One cluster (id 0), four members 10/11/12/13.
+
+    Field ``name``: rows 10, 11 -> "A" (2 votes); rows 12, 13 -> "B" (2 votes).
+    Count-majority is a 2-2 tie broken by first-occurrence -> "A".
+
+    Edges:
+      (10,11) "A"-"A" weak  -> 0.55  (A's only agreeing edge)
+      (12,13) "B"-"B" strong-> 0.99  (B's only agreeing edge)
+      cross edges 0.50 (disagree, contribute to neither value)
+
+    confidence_majority: A=0.55, B=0.99 -> "B" wins.
+    count-majority: 2-2 tie -> first occurrence "A".
+    """
+    return pl.DataFrame(
+        {
+            "__cluster_id__": [0, 0, 0, 0],
+            "__row_id__": [10, 11, 12, 13],
+            "name": ["A", "A", "B", "B"],
+        }
+    )
+
+
+_PAIR_SCORES_DIVERGE = {
+    (10, 11): 0.55,
+    (12, 13): 0.99,
+    (10, 12): 0.50,
+    (10, 13): 0.50,
+    (11, 12): 0.50,
+    (11, 13): 0.50,
+}
+
+
+def test_confidence_majority_consumes_pair_scores() -> None:
+    """With cluster_pair_scores, confidence_majority picks the high-confidence
+    value "B" even though count-majority would pick "A"."""
+    rules = GoldenRulesConfig(default_strategy="confidence_majority")
+    records = build_golden_records_batch(
+        _multi_df_diverge(),
+        rules,
+        cluster_pair_scores={0: dict(_PAIR_SCORES_DIVERGE)},
+    )
+    assert len(records) == 1
+    assert records[0]["name"]["value"] == "B"
+
+
+def test_confidence_majority_falls_back_without_pair_scores() -> None:
+    """Without cluster_pair_scores (None), the builder falls back to
+    count-majority -> "A" (first occurrence of the tied value)."""
+    rules = GoldenRulesConfig(default_strategy="confidence_majority")
+    records = build_golden_records_batch(
+        _multi_df_diverge(),
+        rules,
+        cluster_pair_scores=None,
+    )
+    assert len(records) == 1
+    assert records[0]["name"]["value"] == "A"

--- a/packages/python/goldenmatch/tests/test_confidence_majority_678.py
+++ b/packages/python/goldenmatch/tests/test_confidence_majority_678.py
@@ -11,7 +11,15 @@ them the builder falls back to count-majority (the documented fallback).
 from __future__ import annotations
 
 import polars as pl
-from goldenmatch.config.schemas import GoldenRulesConfig
+from goldenmatch import dedupe_df
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    GoldenRulesConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
 from goldenmatch.core.golden import build_golden_records_batch
 
 
@@ -72,3 +80,93 @@ def test_confidence_majority_falls_back_without_pair_scores() -> None:
     )
     assert len(records) == 1
     assert records[0]["name"]["value"] == "A"
+
+
+def test_pipeline_threads_pair_scores_into_confidence_majority() -> None:
+    """End-to-end pipeline-seam regression for #678.
+
+    The unit tests above prove ``build_golden_records_batch`` consumes
+    pair_scores *when handed them*. This test guards the wiring seam the
+    original bug lived in: ``_run_dedupe_pipeline`` building
+    ``cluster_pair_scores`` from the legacy ``clusters`` dict and passing it
+    into the builder. Reverting the ``cluster_pair_scores=`` kwarg in
+    ``pipeline.py`` makes this test fail (verified manually: golden ``name``
+    flips ``Bravo`` -> ``Alpha``), so the unit-only coverage that the fix
+    shipped with would NOT have caught a regression at the call site.
+
+    Fixture: one 4-member cluster. All four rows share the ``block`` value so
+    blocking lands them in a single block; the weighted ``link`` matchkey
+    (jaro_winkler, rerank disabled so no cross-encoder model loads) scores
+    every intra-block pair above the 0.80 threshold, so they cluster
+    transitively into one component with REAL, graded per-pair edge weights:
+
+        (Alpha-rows)   (0,1) = 0.868   <- the only Alpha-agreeing edge (weak)
+        (Bravo-rows)   (2,3) = 1.000   <- the only Bravo-agreeing edge (strong)
+        cross edges    0.858 .. 0.974  <- disagree on ``name``, ignored
+
+    Survivorship field ``name`` is independent of the link/scoring field and
+    is split 2-2 (Alpha, Alpha, Bravo, Bravo):
+
+      - count-majority: a 2-2 tie broken by first occurrence -> "Alpha".
+      - confidence_majority: Alpha edge-sum 0.868 vs Bravo edge-sum 1.000
+        -> "Bravo".
+
+    So a golden ``name`` of "Bravo" can ONLY come from confidence-weighted
+    survivorship actually receiving this cluster's pair_scores through the
+    pipeline. "Alpha" means the pipeline silently degraded to count-majority
+    (the #678 bug).
+
+    Uses an EXPLICIT GoldenMatchConfig (not zero-config ``dedupe_df(df)``)
+    with rerank=False so no Hugging Face cross-encoder loads -- per
+    CLAUDE.md, auto-config / rerank segfaults torch in this env.
+    """
+    df = pl.DataFrame(
+        {
+            # Constant block -> all four rows in one block.
+            "block": ["B", "B", "B", "B"],
+            # Scoring field: graded jaro_winkler similarity. Rows 0,1 (Alpha)
+            # link weakly (0.868); rows 2,3 (Bravo) link identically (1.0).
+            "link": [
+                "globex international",
+                "globex intl group",
+                "globex international co",
+                "globex international co",
+            ],
+            # Survivorship field: 2-2 split that makes count- and
+            # confidence-majority diverge.
+            "name": ["Alpha", "Alpha", "Bravo", "Bravo"],
+        }
+    )
+    matchkey = MatchkeyConfig(
+        name="link",
+        type="weighted",
+        fields=[MatchkeyField(field="link", scorer="jaro_winkler", weight=1.0)],
+        threshold=0.80,
+        rerank=False,  # do NOT load a cross-encoder (segfaults torch here).
+    )
+    config = GoldenMatchConfig(
+        matchkeys=[matchkey],
+        blocking=BlockingConfig(
+            keys=[BlockingKeyConfig(fields=["block"], transforms=[])],
+            strategy="static",
+        ),
+        golden_rules=GoldenRulesConfig(default_strategy="confidence_majority"),
+    )
+
+    result = dedupe_df(df, config=config, confidence_required=False)
+
+    # Sanity: the four rows collapsed into exactly one multi-member cluster
+    # carrying real per-pair scores (proves we're on the dict slow path that
+    # threads pair_scores, not the fast/frames/columnar paths).
+    assert result.clusters is not None
+    multi = [c for c in result.clusters.values() if len(c["members"]) > 1]
+    assert len(multi) == 1, f"expected one multi-member cluster, got {result.clusters}"
+    assert len(multi[0]["members"]) == 4
+    assert multi[0].get("pair_scores"), "cluster carried no per-pair scores"
+
+    # The seam assertion: golden ``name`` is the confidence-majority winner
+    # "Bravo", NOT the count-majority winner "Alpha". This is byte-for-byte
+    # the value that flips if the pipeline stops passing cluster_pair_scores.
+    assert result.golden is not None
+    assert result.golden.height == 1
+    assert result.golden["name"][0] == "Bravo"


### PR DESCRIPTION
Fixes #678.

## Bug
`confidence_majority` golden survivorship silently degraded to **count-majority** on every pipeline path: `build_golden_records_batch` never received per-cluster `pair_scores`, and `_confidence_majority` falls back to count-majority when they're None/empty. The data existed (the legacy `clusters` dict from `build_clusters` carries per-cluster `pair_scores`) — it just wasn't threaded.

## Fix
- `core/golden.py`: `build_golden_records_batch` gains `cluster_pair_scores`. The slow per-cluster loop **remaps** edge keys from `__row_id__` space to the positional index space `_confidence_majority` uses (0..size-1 within the cluster slice) before passing to `merge_field`. A raw pass would silently re-degrade (different key spaces) — the remap is the load-bearing detail.
- `core/pipeline.py`: the slow-path golden call now passes `{cid: info["pair_scores"] for cid, info in clusters.items()}`.
- Fast/uniform path untouched (it doesn't use confidence_majority). Frames-out/columnar paths carry `pair_scores={}` by design — confidence_majority there still falls back to count-majority (documented limitation; tracking separately).

## Tests
- `tests/test_confidence_majority_678.py`: unit test where count-majority and confidence-majority **diverge** (row-ids disjoint from positional range so a broken/identity remap is detectable) + None-fallback companion; **plus an e2e pipeline-seam test** through `dedupe_df` (explicit no-rerank config) — verified to flip Bravo→Alpha when the pipeline kwarg is removed, so it guards the actual wiring seam.
- `test_golden.py` green; ruff clean; no new pyright errors (the 12 are pre-existing import-resolution noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)