### PR TITLE
feat(autoconfig): #491 lever coverage — qgram scorer + probabilistic selection + ANN blocking

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -21,7 +21,7 @@ VALID_SIMPLE_TRANSFORMS = frozenset({
 VALID_SCORERS = frozenset({
     "exact", "jaro_winkler", "levenshtein", "token_sort", "soundex_match",
     "embedding", "record_embedding", "ensemble",
-    "dice", "jaccard",
+    "dice", "jaccard", "qgram",
 })
 
 VALID_STRATEGIES = frozenset({

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1402,14 +1402,19 @@ def build_blocking(
     effective_n_full = n_rows_full if n_rows_full is not None else df.height
     sample_n = max(df.height, 1)
 
-    # #491: auto-select ANN blocking when embeddings are present AND the
-    # dataset is at scale. STRICT conjunctive gate — ANN is emitted ONLY when
-    # an embedding-bearing column exists (ANNBlocker needs a vector column;
-    # blocker.py raises ValueError if ``ann_column`` is unset). The embedding
-    # signal is a profile with ``col_type == "description"`` — those columns
-    # become ``record_embedding`` scorers in build_matchkeys (line ~852) and
-    # carry the vectors ANN embeds. No embedding column => fall through to the
-    # existing exact/name/compound logic (never ann).
+    # #491: ANN blocking is a FALLBACK, not a preempt. ANN is emitted ONLY
+    # when an embedding-bearing column exists, the dataset is at scale, AND no
+    # bounded exact blocking key is available. A strong exact identifier still
+    # wins over ANN when present — we evaluate the exact/safe-exact path first
+    # (below) and only fall through to ANN when that path produced no usable
+    # key, before the name/compound fallback.
+    #
+    # STRICT invariant preserved: ANN is never emitted without an embedding-
+    # bearing column. ANNBlocker needs a vector column (blocker.py raises
+    # ValueError if ``ann_column`` is unset). The embedding signal is a profile
+    # with ``col_type == "description"`` — those columns become
+    # ``record_embedding`` scorers in build_matchkeys (line ~852) and carry the
+    # vectors ANN embeds. No embedding column => never ann.
     #
     # ANN_MIN_ROWS default 100_000; env-overridable via
     # GOLDENMATCH_ANN_MIN_ROWS (mirrors the env-threshold pattern used by
@@ -1429,15 +1434,7 @@ def build_blocking(
         ann_min_rows = _ANN_MIN_ROWS_DEFAULT
 
     _embedding_cols = [p for p in profiles if p.col_type == "description"]
-    _ann_rows = effective_n_full
-    if _embedding_cols and _ann_rows >= ann_min_rows:
-        ann_col = _embedding_cols[0].name
-        logger.info(
-            "Auto-selecting ANN blocking: embedding column %r present and "
-            "n_rows=%d >= ANN_MIN_ROWS=%d. See #491.",
-            ann_col, _ann_rows, ann_min_rows,
-        )
-        return BlockingConfig(strategy="ann", ann_column=ann_col)
+    _ann_eligible = bool(_embedding_cols) and effective_n_full >= ann_min_rows
 
     def _projected_ratio(p: ColumnProfile) -> float:
         """Sample-corrected cardinality_ratio for the gate."""
@@ -1590,6 +1587,20 @@ def build_blocking(
             "falling through to name-based blocking",
             max_safe_block,
         )
+
+    # #491: ANN fallback. We only reach here when no bounded exact blocking
+    # key was found (the exact path above returns whenever it had a usable
+    # safe_exact key). If embeddings are present at scale, prefer ANN over the
+    # name/compound fallback below.
+    if _ann_eligible:
+        ann_col = _embedding_cols[0].name
+        logger.info(
+            "Auto-selecting ANN blocking (fallback): no bounded exact "
+            "blocking key available, embedding column %r present and "
+            "n_rows=%d >= ANN_MIN_ROWS=%d. See #491.",
+            ann_col, effective_n_full, ann_min_rows,
+        )
+        return BlockingConfig(strategy="ann", ann_column=ann_col)
 
     # ── Check if name-based fallback would also be oversized ──
     # #715: the name path picks ONE primary name column (pattern_names[0], else

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -531,6 +531,43 @@ _DOMAIN_SCORER_MAP = {
 }
 
 
+def _is_short_code(p: ColumnProfile) -> bool:
+    """#491: detect short alphanumeric *code* columns (SKU, part-no, plan-code).
+
+    These collapse under the generic string scorers (``token_sort`` token-bag
+    similarity is meaningless on a 6-char opaque code), so they get routed to
+    the char-n-gram ``qgram`` scorer instead. Deliberately conservative — a
+    real name/word column must NOT match, or we'd silently swap proven name
+    scoring for qgram. The letter+digit-mix requirement is the main guard:
+    English names/words are letters-only, so they fail it.
+    """
+    if not (3 <= p.avg_len <= 12):
+        return False
+    if p.cardinality_ratio < 0.3:
+        return False
+    # Only generic string-ish columns are candidates; named identity types
+    # (name/email/phone/zip/geo/date/numeric) keep their tuned scorers.
+    if p.col_type not in ("string", "identifier"):
+        return False
+
+    samples = [s for s in (p.sample_values or []) if s]
+    if not samples:
+        return False
+
+    # Code-like signal: the value carries BOTH a letter and a digit
+    # (e.g. ``A1B2C3``, ``SKU-9921``). This is the discriminating test that
+    # excludes pure-alpha names/words and pure-numeric IDs (already handled
+    # as identifiers/numeric upstream). Require a clear majority to look
+    # code-like before overriding.
+    def _is_code_like(s: str) -> bool:
+        has_alpha = any(c.isalpha() for c in s)
+        has_digit = any(c.isdigit() for c in s)
+        return has_alpha and has_digit
+
+    code_like = sum(1 for s in samples if _is_code_like(s))
+    return code_like >= max(1, (len(samples) + 1) // 2)
+
+
 def _adaptive_threshold(fields: list[MatchkeyField]) -> float:
     """Compute threshold based on field types in the matchkey."""
     exact_scorers = {"exact"}
@@ -607,6 +644,14 @@ def build_matchkeys(
         scorer, transforms = _refdata_refine_matchkey_field(
             p.name, scorer, transforms, p.col_type,
         )
+
+        # #491: short opaque codes (SKU, part-no) score badly under the
+        # generic string scorers — token_sort/ensemble assume word-ish text.
+        # Route them to the char-n-gram qgram scorer instead. Gated on
+        # _is_short_code (letter+digit mix, short, high-cardinality) so real
+        # names/words/identifiers keep their tuned scorers untouched.
+        if scorer in ("token_sort", "ensemble") and _is_short_code(p):
+            scorer = "qgram"
 
         # Geo and zip are blocking signals, NOT identity claims. An exact
         # matchkey on a city column asserts "two records sharing a city are

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1402,6 +1402,43 @@ def build_blocking(
     effective_n_full = n_rows_full if n_rows_full is not None else df.height
     sample_n = max(df.height, 1)
 
+    # #491: auto-select ANN blocking when embeddings are present AND the
+    # dataset is at scale. STRICT conjunctive gate — ANN is emitted ONLY when
+    # an embedding-bearing column exists (ANNBlocker needs a vector column;
+    # blocker.py raises ValueError if ``ann_column`` is unset). The embedding
+    # signal is a profile with ``col_type == "description"`` — those columns
+    # become ``record_embedding`` scorers in build_matchkeys (line ~852) and
+    # carry the vectors ANN embeds. No embedding column => fall through to the
+    # existing exact/name/compound logic (never ann).
+    #
+    # ANN_MIN_ROWS default 100_000; env-overridable via
+    # GOLDENMATCH_ANN_MIN_ROWS (mirrors the env-threshold pattern used by
+    # GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD below).
+    _ANN_MIN_ROWS_DEFAULT = 100_000
+    _ann_raw = os.environ.get("GOLDENMATCH_ANN_MIN_ROWS")
+    if _ann_raw is not None:
+        try:
+            ann_min_rows = int(_ann_raw)
+        except ValueError:
+            logger.warning(
+                "GOLDENMATCH_ANN_MIN_ROWS=%r is not an int; ignoring and "
+                "using default %d.", _ann_raw, _ANN_MIN_ROWS_DEFAULT,
+            )
+            ann_min_rows = _ANN_MIN_ROWS_DEFAULT
+    else:
+        ann_min_rows = _ANN_MIN_ROWS_DEFAULT
+
+    _embedding_cols = [p for p in profiles if p.col_type == "description"]
+    _ann_rows = effective_n_full
+    if _embedding_cols and _ann_rows >= ann_min_rows:
+        ann_col = _embedding_cols[0].name
+        logger.info(
+            "Auto-selecting ANN blocking: embedding column %r present and "
+            "n_rows=%d >= ANN_MIN_ROWS=%d. See #491.",
+            ann_col, _ann_rows, ann_min_rows,
+        )
+        return BlockingConfig(strategy="ann", ann_column=ann_col)
+
     def _projected_ratio(p: ColumnProfile) -> float:
         """Sample-corrected cardinality_ratio for the gate."""
         if effective_n_full <= sample_n:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -653,6 +653,94 @@ def rule_blocking_field_null_heavy(
     return new_cfg, decision
 
 
+_FUZZY_GRADED_SCORERS = frozenset({
+    "jaro_winkler", "levenshtein", "token_sort", "soundex_match",
+    "embedding", "record_embedding", "ensemble", "dice", "jaccard", "qgram",
+})
+
+
+def rule_select_probabilistic_matchkey(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
+) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
+    """#491: let the iterative controller select a *probabilistic* matchkey on
+    the data shape where it actually helps — a wide fuzzy-only weighted matchkey
+    whose linear weighting can't separate matches from non-matches.
+
+    CONSERVATIVE trigger. Over-firing regresses NCVR / Febrl3 / DQbench, so all
+    of the following must hold:
+
+    (a) ``current`` has a ``weighted`` matchkey with >= 3 fields whose scorers
+        are graded/fuzzy (anything in VALID_SCORERS except ``exact``). A small
+        (1-2 field) matchkey doesn't have enough evidence channels for the EM
+        weighting to beat a hand-tuned weighted sum.
+    (b) Scoring is recall-limited: very little mass reaches the threshold AND
+        the score distribution is near-unimodal (poor match/non-match
+        separation). This reuses the same ``mass_above_threshold`` /
+        ``dip_statistic`` signals ``rule_unimodal_scoring`` and
+        ``rule_recall_gap_suspected`` read — a low dip is the "scores don't
+        separate" signal; low above-threshold mass is the "recall is being
+        left on the table" signal.
+    (c) ``current`` has NO ``exact`` matchkey. An exact anchor already provides
+        a high-precision recall path; flipping the fuzzy key to probabilistic
+        on top of it is the over-firing case the benchmark gate guards against.
+
+    Action: swap that weighted matchkey to ``probabilistic`` via
+    ``MatchkeyTypeSwap`` (EM-weighted log-likelihood comparison) so the field
+    agreement weights are learned rather than fixed.
+    """
+    from goldenmatch.core.config_edits import MatchkeyTypeSwap
+
+    # (c) No exact matchkey anywhere.
+    if any(mk.type == "exact" for mk in (current.matchkeys or [])):
+        return None
+
+    # (a) A weighted matchkey with >= 3 graded fuzzy (non-exact) fields.
+    target_mk = None
+    for mk in (current.matchkeys or []):
+        if mk.type != "weighted":
+            continue
+        fuzzy_fields = [
+            f for f in (mk.fields or [])
+            if f.scorer is not None and f.scorer in _FUZZY_GRADED_SCORERS
+        ]
+        if len(fuzzy_fields) >= 3:
+            target_mk = mk
+            break
+    if target_mk is None:
+        return None
+
+    # (b) Recall-limited scoring: poor separation (low dip) AND little mass above
+    # threshold, with pairs actually scored (so the signal is real).
+    sp = profile.scoring
+    recall_limited = (
+        sp.n_pairs_scored > 0
+        and sp.dip_statistic < 0.02
+        and sp.mass_above_threshold < 0.15
+    )
+    if not recall_limited:
+        return None
+
+    new_cfg = MatchkeyTypeSwap(
+        matchkey=target_mk.name, target_type="probabilistic"
+    ).apply(current)
+    if new_cfg is None:
+        return None
+
+    decision = PolicyDecision(
+        rule_name="select_probabilistic_matchkey",
+        rationale=(
+            f"weighted matchkey {target_mk.name!r} has "
+            f"{len([f for f in (target_mk.fields or []) if f.scorer in _FUZZY_GRADED_SCORERS])} "
+            f"graded fuzzy fields, no exact anchor, and scoring is recall-limited "
+            f"(dip_statistic={sp.dip_statistic:.4f} < 0.02, "
+            f"mass_above_threshold={sp.mass_above_threshold:.3f} < 0.15); "
+            f"swapping to probabilistic (EM-learned field weights)"
+        ),
+        config_diff={f"matchkeys[{target_mk.name}].type": "probabilistic"},
+    )
+    return new_cfg, decision
+
+
 def rule_recall_gap_suspected(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -1097,6 +1185,7 @@ DEFAULT_RULES = [
     rule_low_transitivity,                 # 12 tuning: transitivity low
     rule_no_matches,                       # 13 tuning: nothing matches
     rule_matchkey_demote_high_cardinality_field,  # 14 NEW 2026-05-29: matchkey YELLOW from uniquely-identifying field
+    rule_select_probabilistic_matchkey,    # NEW #491: wide fuzzy-only weighted mk + recall-limited + no exact anchor -> probabilistic
     rule_recall_gap_suspected,             # 15 tuning: random pair probe high OR over-tight signature (kept second-to-last)
     rule_sparse_match_expand,              # 16 NEW v1.10: lower threshold proxy for sparse datasets (kept last)
     # NOTE: rule_enable_llm_scorer is intentionally NOT in DEFAULT_RULES.

--- a/packages/python/goldenmatch/goldenmatch/core/config_optimizer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_optimizer.py
@@ -39,6 +39,7 @@ from goldenmatch.core.config_edits import (
     BlockingKeyEdit,
     BlockingStrategyEdit,
     ConfigEdit,
+    MatchkeyTypeSwap,
     ScorerSwap,
     ThresholdShift,
     WeightShift,
@@ -319,7 +320,7 @@ class CoordinateDescentProposer:
     """
 
     single_round = False
-    _FAMILIES = ("threshold", "scorer", "weight", "blocking", "blocking_key")
+    _FAMILIES = ("threshold", "scorer", "weight", "mktype", "blocking", "blocking_key")
 
     def __init__(
         self,
@@ -368,6 +369,17 @@ class CoordinateDescentProposer:
                     for d in self._weight_deltas:
                         weight_edits.append(WeightShift(mk.name, f.field, d))
             return weight_edits
+        if family == "mktype":
+            # #491: weighted -> probabilistic was unreachable from the
+            # deterministic search. Offer a type swap for each weighted matchkey
+            # so the optimizer can pick probabilistic empirically.
+            mktype_edits: list[ConfigEdit] = []
+            for mk in base.get_matchkeys():
+                if getattr(mk, "type", None) == "weighted":
+                    mktype_edits.append(
+                        MatchkeyTypeSwap(matchkey=mk.name, target_type="probabilistic")
+                    )
+            return mktype_edits
         if family == "blocking":
             return [BlockingStrategyEdit(s) for s in self._blocking_strategies]
         if family == "blocking_key":

--- a/packages/python/goldenmatch/goldenmatch/core/config_optimizer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_optimizer.py
@@ -331,7 +331,8 @@ class CoordinateDescentProposer:
             # the data-dependent string-similarity choice. (dice/jaccard are
             # bloom-filter/PPRL scorers — they expect hex CLKs, not plain text —
             # so they are NOT in the general candidate set.)
-            "token_sort", "ensemble", "levenshtein", "soundex_match",
+            # #491 Task 2: qgram (char-n-gram Jaccard) added for short-code columns.
+            "token_sort", "ensemble", "levenshtein", "soundex_match", "qgram",
         ),
         weight_deltas: tuple[float, ...] = (-0.5, 0.5),
         blocking_strategies: tuple[str, ...] = ("multi_pass",),

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -90,6 +90,8 @@ def score_field(val_a: str | None, val_b: str | None, scorer: str) -> float | No
         return _dice_score_single(val_a, val_b)
     elif scorer == "jaccard":
         return _jaccard_score_single(val_a, val_b)
+    elif scorer == "qgram":
+        return _qgram_score_single(val_a, val_b)
     else:
         # Check plugin registry
         from goldenmatch.plugins.registry import PluginRegistry
@@ -420,6 +422,8 @@ def _fuzzy_score_matrix(
         return _dice_score_matrix(values)
     elif scorer_name == "jaccard":
         return _jaccard_score_matrix(values)
+    elif scorer_name == "qgram":
+        return _qgram_score_matrix(values)
     else:
         # Plugin scorer fallback. Two contracts:
         # 1. Plugin exposes ``score_matrix(values) -> np.ndarray`` — vectorized
@@ -607,6 +611,68 @@ def _jaccard_score_matrix(values: list) -> np.ndarray:
         jaccard = np.where(union > 0, intersection / union, 0.0)
 
     return jaccard.astype(np.float64)
+
+
+def _qgram_set(s: str, n: int = 3) -> set[str]:
+    """Padded character-n-gram set of a raw string.
+
+    Lowercases and pads with ``n-1`` ``#`` sentinels on each side (so a
+    3-gram view of ``"abc"`` is ``{"##a", "#ab", "abc", "bc#", "c##"}``)
+    then returns the FULL set of length-``n`` substrings -- no truncation
+    (unlike the lossy ``qgram:N`` *transform*, which keeps only ``[:5]``).
+    """
+    s = s.lower()
+    pad = "#" * (n - 1)
+    padded = pad + s + pad
+    return {padded[i : i + n] for i in range(len(padded) - n + 1)}
+
+
+def _qgram_score_single(val_a: str, val_b: str, n: int = 3) -> float:
+    """Character-n-gram Jaccard similarity on two raw strings.
+
+    Returns 1.0 when the strings are identical (incl. both empty), 0.0 when
+    the q-gram union is empty (one side empty, the other not), else the
+    Jaccard ratio ``|A & B| / |A | B|`` over their padded q-gram sets.
+    """
+    if val_a == val_b:
+        return 1.0
+    set_a = _qgram_set(val_a, n)
+    set_b = _qgram_set(val_b, n)
+    union = set_a | set_b
+    if not union:
+        return 0.0
+    return len(set_a & set_b) / len(union)
+
+
+def _qgram_score_matrix(values: list, n: int = 3) -> np.ndarray:
+    """NxN character-n-gram Jaccard matrix on raw strings.
+
+    Clear O(N^2) loop -- qgram is a short-code scorer, blocks are small and
+    it stays on the Python path (no native dispatch). None values score 0.0
+    against everything (including the diagonal), mirroring how the bloom
+    matrices treat missing values.
+    """
+    size = len(values)
+    out = np.zeros((size, size), dtype=np.float64)
+    grams: list[set[str] | None] = [
+        _qgram_set(v, n) if v is not None else None for v in values
+    ]
+    for i in range(size):
+        gi = grams[i]
+        if gi is None:
+            continue
+        out[i, i] = 1.0
+        for j in range(i + 1, size):
+            gj = grams[j]
+            if gj is None:
+                continue
+            if values[i] == values[j]:
+                s = 1.0
+            else:
+                union = gi | gj
+                s = len(gi & gj) / len(union) if union else 0.0
+            out[i, j] = out[j, i] = s
+    return out
 
 
 def _build_null_mask(values: list) -> np.ndarray:

--- a/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
@@ -1,0 +1,43 @@
+"""#491 lever-coverage: real qgram char-n-gram similarity scorer.
+
+Task 0: qgram was only a lossy ``qgram:N`` transform; a genuine
+character-n-gram Jaccard *scorer* is needed for short-code routing.
+"""
+
+from __future__ import annotations
+
+from goldenmatch.core.scorer import score_field
+
+
+def test_qgram_scorer_similarity():
+    assert score_field("ABC123", "ABC123", "qgram") == 1.0  # identical
+    disjoint = score_field("ABC123", "XYZ789", "qgram")
+    assert disjoint is not None and disjoint < 0.2  # disjoint
+    s = score_field("ABC123", "ABC132", "qgram")
+    assert s is not None and 0.3 < s < 1.0  # transposition-ish
+
+
+def test_qgram_scorer_empty_handling():
+    # Both empty -> identical -> 1.0
+    assert score_field("", "", "qgram") == 1.0
+    # One empty, one not -> no shared grams -> 0.0
+    assert score_field("", "ABC123", "qgram") == 0.0
+
+
+def test_qgram_scorer_matrix_matches_single():
+    from goldenmatch.core.scorer import _fuzzy_score_matrix
+
+    vals = ["ABC123", "ABC132", "XYZ789"]
+    m = _fuzzy_score_matrix(vals, "qgram")
+    n = len(vals)
+    assert m.shape == (n, n)
+    # Diagonal is self-similarity == 1.0
+    for i in range(n):
+        assert m[i, i] == 1.0
+    # Off-diagonal matches the single-pair scorer
+    for i in range(n):
+        for j in range(n):
+            if i != j:
+                single = score_field(vals[i], vals[j], "qgram")
+                assert single is not None
+                assert abs(m[i, j] - single) < 1e-9

--- a/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
@@ -257,7 +257,9 @@ def test_rule_skips_small_or_healthy():
 def _profiles_with_embeddings():
     """Profiles that carry an embedding signal: a ``description`` column
     (becomes a ``record_embedding`` scorer / ANN-eligible vector column),
-    plus an ordinary name column."""
+    plus an ordinary name column. Crucially there is NO bounded exact
+    blocking column here, so ANN is genuinely the best blocking option and
+    the fallback gate (#491) lets it fire."""
     from goldenmatch.core.autoconfig import ColumnProfile
 
     return [
@@ -269,6 +271,37 @@ def _profiles_with_embeddings():
                 "radiology technician regional medical center",
             ],
             null_rate=0.0, cardinality_ratio=0.95, avg_len=42.0,
+        ),
+        ColumnProfile(
+            "last_name", "Utf8", "name", 0.9,
+            sample_values=["smith", "jones", "garcia"],
+            null_rate=0.0, cardinality_ratio=0.3, avg_len=5.0,
+        ),
+    ]
+
+
+def _profiles_with_embeddings_and_exact():
+    """Profiles that carry BOTH an embedding signal (a ``description``
+    column) AND a strong, bounded exact blocking column (a moderate-
+    cardinality ``identifier``). Under the #491 fallback gate the exact
+    blocking key must win — ANN only fires when no bounded exact key
+    exists."""
+    from goldenmatch.core.autoconfig import ColumnProfile
+
+    return [
+        ColumnProfile(
+            "bio", "Utf8", "description", 0.9,
+            sample_values=[
+                "senior cardiologist at mercy hospital",
+                "pediatric nurse practitioner downtown clinic",
+                "radiology technician regional medical center",
+            ],
+            null_rate=0.0, cardinality_ratio=0.95, avg_len=42.0,
+        ),
+        ColumnProfile(
+            "member_id", "Utf8", "identifier", 0.9,
+            sample_values=["m-100", "m-101", "m-102"],
+            null_rate=0.0, cardinality_ratio=0.5, avg_len=5.0,
         ),
         ColumnProfile(
             "last_name", "Utf8", "name", 0.9,
@@ -331,3 +364,26 @@ def test_no_ann_below_scale():
     df = _ann_df(["bio", "last_name"])
     blk = build_blocking(profiles, df, n_rows_full=1_000)
     assert blk.strategy != "ann"
+
+
+def test_exact_blocking_wins_over_ann_when_available():
+    # #491 fallback gate: a strong, bounded exact blocking column wins over
+    # ANN even when an embedding column is present and the dataset is at
+    # scale. ANN is a FALLBACK, not a preempt.
+    import polars as pl
+    from goldenmatch.core.autoconfig import build_blocking
+
+    profiles = _profiles_with_embeddings_and_exact()
+    # Distinct member_id per row -> singleton (bounded) exact blocks.
+    df = pl.DataFrame(
+        {
+            "bio": ["a", "b", "c", "d"],
+            "member_id": ["m-100", "m-101", "m-102", "m-103"],
+            "last_name": ["smith", "jones", "garcia", "lee"],
+        }
+    )
+    blk = build_blocking(profiles, df, n_rows_full=200_000)
+    assert blk.strategy != "ann"
+    # The exact key on member_id should be the chosen primary.
+    fields = [f for k in (blk.keys or []) for f in k.fields]
+    assert "member_id" in fields

--- a/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
@@ -67,3 +67,12 @@ def test_short_code_column_gets_qgram():
     scorers = {f.field: f.scorer for mk in mks for f in mk.fields}
     assert scorers.get("sku") == "qgram"
     assert scorers.get("first_name") != "qgram"
+
+
+# ── Task 2: optimizer scorer-family includes qgram ───────────────────────────
+
+
+def test_optimizer_scorer_family_includes_qgram():
+    from goldenmatch.core.config_optimizer import CoordinateDescentProposer
+
+    assert "qgram" in CoordinateDescentProposer()._scorers

--- a/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
@@ -118,3 +118,134 @@ def test_optimizer_proposes_probabilistic_candidate():
                     types.add(mk.type)
 
     assert "probabilistic" in types
+
+
+# ── Task 4: conservative controller refit rule -> probabilistic matchkey ──────
+
+
+def _491_cfg(*, exact_anchor: bool, n_fuzzy_fields: int):
+    """Build a config with one weighted matchkey of ``n_fuzzy_fields`` graded
+    fuzzy fields (plus optionally a separate exact matchkey)."""
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    fuzzy_scorers = ["jaro_winkler", "levenshtein", "token_sort", "qgram"]
+    fuzzy_fields = [
+        MatchkeyField(
+            field=f"f{i}", scorer=fuzzy_scorers[i % len(fuzzy_scorers)],
+            weight=1.0, transforms=["lowercase"],
+        )
+        for i in range(n_fuzzy_fields)
+    ]
+    matchkeys = [
+        MatchkeyConfig(
+            name="weighted_mk", type="weighted", threshold=0.8,
+            fields=fuzzy_fields,
+        )
+    ]
+    if exact_anchor:
+        matchkeys.append(
+            MatchkeyConfig(
+                name="exact_mk", type="exact",
+                fields=[MatchkeyField(field="email", transforms=["lowercase"])],
+            )
+        )
+    return GoldenMatchConfig(
+        matchkeys=matchkeys,
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["last_name"], transforms=["lowercase"])],
+        ),
+    )
+
+
+def _491_profile(*, recall_limited: bool):
+    """ComplexityProfile whose scoring is recall-limited (low mass above
+    threshold + poor separation) or healthy."""
+    from goldenmatch.core.complexity_profile import (
+        BlockingProfile,
+        ClusterProfile,
+        ComplexityProfile,
+        DataProfile,
+        FieldStats,
+        MatchkeyProfile,
+        ScoringProfile,
+    )
+
+    if recall_limited:
+        scoring = ScoringProfile(
+            n_pairs_scored=800, candidates_compared=900,
+            mass_above_threshold=0.04,   # very few pairs reach threshold
+            mass_in_borderline=0.05,
+            dip_statistic=0.008,         # poor separation (near-unimodal)
+        )
+    else:
+        scoring = ScoringProfile(
+            n_pairs_scored=800, candidates_compared=900,
+            mass_above_threshold=0.6,    # healthy: clear above-threshold mass
+            mass_in_borderline=0.05,
+            dip_statistic=0.08,          # clear bimodal separation
+        )
+    return ComplexityProfile(
+        data=DataProfile(
+            n_rows=2000, n_cols=5,
+            column_types={"f0": "name", "f1": "text", "f2": "geo",
+                          "f3": "text", "email": "id-like"},
+        ),
+        blocking=BlockingProfile(
+            keys_used=[["last_name"]], n_blocks=400, total_comparisons=900,
+            reduction_ratio=0.9, block_sizes_p99=10,
+        ),
+        scoring=scoring,
+        cluster=ClusterProfile(transitivity_rate=0.9),
+        matchkey=MatchkeyProfile(per_field={"f0": FieldStats(0.5, 0.0, 8)}),
+    )
+
+
+def test_rule_selects_probabilistic_on_target_shape():
+    from goldenmatch.core.autoconfig_history import RunHistory
+    from goldenmatch.core.autoconfig_rules import (
+        rule_select_probabilistic_matchkey,
+    )
+
+    cfg = _491_cfg(exact_anchor=False, n_fuzzy_fields=3)
+    profile = _491_profile(recall_limited=True)
+    out = rule_select_probabilistic_matchkey(profile, cfg, RunHistory())
+    assert out is not None
+    new_cfg, decision = out
+    swapped = next(mk for mk in new_cfg.get_matchkeys() if mk.name == "weighted_mk")
+    assert swapped.type == "probabilistic"
+    assert decision.rule_name == "select_probabilistic_matchkey"
+
+
+def test_rule_skips_when_exact_anchor_present():
+    from goldenmatch.core.autoconfig_history import RunHistory
+    from goldenmatch.core.autoconfig_rules import (
+        rule_select_probabilistic_matchkey,
+    )
+
+    cfg = _491_cfg(exact_anchor=True, n_fuzzy_fields=3)
+    profile = _491_profile(recall_limited=True)
+    assert rule_select_probabilistic_matchkey(profile, cfg, RunHistory()) is None
+
+
+def test_rule_skips_small_or_healthy():
+    from goldenmatch.core.autoconfig_history import RunHistory
+    from goldenmatch.core.autoconfig_rules import (
+        rule_select_probabilistic_matchkey,
+    )
+
+    # Too few graded fuzzy fields (2 < 3) — should not fire even when recall-limited.
+    small_cfg = _491_cfg(exact_anchor=False, n_fuzzy_fields=2)
+    recall_limited = _491_profile(recall_limited=True)
+    assert rule_select_probabilistic_matchkey(recall_limited, small_cfg, RunHistory()) is None
+
+    # Target field count but healthy scoring — should not fire.
+    target_cfg = _491_cfg(exact_anchor=False, n_fuzzy_fields=3)
+    healthy = _491_profile(recall_limited=False)
+    assert rule_select_probabilistic_matchkey(healthy, target_cfg, RunHistory()) is None

--- a/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
@@ -76,3 +76,45 @@ def test_optimizer_scorer_family_includes_qgram():
     from goldenmatch.core.config_optimizer import CoordinateDescentProposer
 
     assert "qgram" in CoordinateDescentProposer()._scorers
+
+
+# ── Task 3: optimizer proposes weighted->probabilistic matchkey-type swaps ────
+
+
+def test_optimizer_proposes_probabilistic_candidate():
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+    from goldenmatch.core.config_optimizer import (
+        CoordinateDescentProposer,
+        SearchState,
+    )
+
+    config = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="mk", type="weighted", threshold=0.8, rerank=False,
+            fields=[MatchkeyField(field="first_name", scorer="jaro_winkler", weight=1.0, transforms=[])],
+        )],
+        blocking=BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["last_name"], transforms=[])],
+        ),
+    )
+    state = SearchState(base_config=config, objective="confidence")
+
+    proposer = CoordinateDescentProposer()
+    types: set[str] = set()
+    # Drain every family (propose returns one family per call).
+    while True:
+        cands = proposer.propose(state)
+        if not cands:
+            break
+        for _label, cfg in cands:
+            for mk in cfg.get_matchkeys():
+                if mk.type is not None:
+                    types.add(mk.type)
+
+    assert "probabilistic" in types

--- a/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
@@ -249,3 +249,85 @@ def test_rule_skips_small_or_healthy():
     target_cfg = _491_cfg(exact_anchor=False, n_fuzzy_fields=3)
     healthy = _491_profile(recall_limited=False)
     assert rule_select_probabilistic_matchkey(healthy, target_cfg, RunHistory()) is None
+
+
+# ── Task 5: ANN blocking auto-selected with embeddings at scale (#491) ────────
+
+
+def _profiles_with_embeddings():
+    """Profiles that carry an embedding signal: a ``description`` column
+    (becomes a ``record_embedding`` scorer / ANN-eligible vector column),
+    plus an ordinary name column."""
+    from goldenmatch.core.autoconfig import ColumnProfile
+
+    return [
+        ColumnProfile(
+            "bio", "Utf8", "description", 0.9,
+            sample_values=[
+                "senior cardiologist at mercy hospital",
+                "pediatric nurse practitioner downtown clinic",
+                "radiology technician regional medical center",
+            ],
+            null_rate=0.0, cardinality_ratio=0.95, avg_len=42.0,
+        ),
+        ColumnProfile(
+            "last_name", "Utf8", "name", 0.9,
+            sample_values=["smith", "jones", "garcia"],
+            null_rate=0.0, cardinality_ratio=0.3, avg_len=5.0,
+        ),
+    ]
+
+
+def _profiles_no_embeddings():
+    """Profiles with NO embedding-bearing column — must never yield ANN."""
+    from goldenmatch.core.autoconfig import ColumnProfile
+
+    return [
+        ColumnProfile(
+            "last_name", "Utf8", "name", 0.9,
+            sample_values=["smith", "jones", "garcia"],
+            null_rate=0.0, cardinality_ratio=0.3, avg_len=5.0,
+        ),
+        ColumnProfile(
+            "city", "Utf8", "geo", 0.9,
+            sample_values=["austin", "dallas", "houston"],
+            null_rate=0.0, cardinality_ratio=0.2, avg_len=6.0,
+        ),
+    ]
+
+
+def _ann_df(cols: list[str]):
+    import polars as pl
+
+    return pl.DataFrame({c: ["a", "b", "c", "d"] for c in cols})
+
+
+def test_ann_blocking_when_embeddings_and_scale():
+    from goldenmatch.core.autoconfig import build_blocking
+
+    profiles = _profiles_with_embeddings()
+    df = _ann_df(["bio", "last_name"])
+    blk = build_blocking(profiles, df, n_rows_full=200_000)
+    assert blk.strategy == "ann"
+    assert blk.ann_column  # set to the embedding column name
+    assert blk.ann_column == "bio"
+
+
+def test_no_ann_without_embeddings():
+    # Safety invariant: no embedding column -> must NOT be ann (ANNBlocker
+    # would raise ValueError without an ann_column / vectors).
+    from goldenmatch.core.autoconfig import build_blocking
+
+    profiles = _profiles_no_embeddings()
+    df = _ann_df(["last_name", "city"])
+    blk = build_blocking(profiles, df, n_rows_full=200_000)
+    assert blk.strategy != "ann"
+
+
+def test_no_ann_below_scale():
+    from goldenmatch.core.autoconfig import build_blocking
+
+    profiles = _profiles_with_embeddings()
+    df = _ann_df(["bio", "last_name"])
+    blk = build_blocking(profiles, df, n_rows_full=1_000)
+    assert blk.strategy != "ann"

--- a/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_491_levers.py
@@ -41,3 +41,29 @@ def test_qgram_scorer_matrix_matches_single():
                 single = score_field(vals[i], vals[j], "qgram")
                 assert single is not None
                 assert abs(m[i, j] - single) < 1e-9
+
+
+# ── Task 1: short-code columns route to qgram in build_matchkeys ────────────
+
+
+def _df_with(cols: list[str]):
+    import polars as pl
+
+    return pl.DataFrame({c: ["x", "y", "z"] for c in cols})
+
+
+def test_short_code_column_gets_qgram():
+    from goldenmatch.core.autoconfig import ColumnProfile, build_matchkeys
+
+    profiles = [
+        ColumnProfile("sku", "Utf8", "string", 0.9,
+                      sample_values=["A1B2C3", "X9Y8Z7", "Q2W3E4"],
+                      null_rate=0.0, cardinality_ratio=0.7, avg_len=6.0),
+        ColumnProfile("first_name", "Utf8", "name", 0.9,
+                      sample_values=["james", "mary", "john"],
+                      null_rate=0.0, cardinality_ratio=0.02, avg_len=5.0),
+    ]
+    mks = build_matchkeys(profiles, df=_df_with(["sku", "first_name"]))
+    scorers = {f.field: f.scorer for mk in mks for f in mk.fields}
+    assert scorers.get("sku") == "qgram"
+    assert scorers.get("first_name") != "qgram"

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -436,7 +436,7 @@ def test_default_rules_list_has_five_entries():
     # Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1)
     # Updated to 13: Phase 5 added rule_corruption_normalize, rule_cross_blocking_disagreement,
     # rule_sparse_match_expand (v1.10)
-    assert len(DEFAULT_RULES) == 15  # v1.20.x #124/#458: demote_clustered_identity removed from rotation
+    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
 
 
 def test_heuristic_policy_with_default_rules_fires_on_red_blocking():
@@ -619,7 +619,7 @@ def test_default_rules_now_has_six_entries():
     Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 15  # v1.20.x #124/#458: demote_clustered_identity removed from rotation
+    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
 
 
 def test_singleton_trap_runs_before_blocking_too_coarse():
@@ -835,7 +835,7 @@ def test_default_rules_now_has_seven_entries():
     Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 15  # v1.20.x #124/#458: demote_clustered_identity removed from rotation
+    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
 
 
 def test_rule_key_swap_is_before_rule_no_matches():
@@ -1159,7 +1159,7 @@ def test_default_rules_now_has_nine_entries():
     AutoConfigController._maybe_decorate_with_llm_scorer post-iteration decoration.)
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 15  # v1.20.x #124/#458: demote_clustered_identity removed from rotation
+    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
 
 
 def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_last():
@@ -1300,7 +1300,7 @@ def test_default_rules_now_has_ten_entries():
     Updated to 13: Phase 5 added rule_corruption_normalize, rule_cross_blocking_disagreement,
     rule_sparse_match_expand (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 15  # v1.20.x #124/#458: demote_clustered_identity removed from rotation
+    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
 
 
 def test_rule_enable_llm_scorer_not_in_default_rules():
@@ -1548,7 +1548,7 @@ def test_default_rules_now_has_ten_entries_final():
     """Fix 1 (reorder) + Fix 2 (new rule) → 10 rules total.
     Updated to 13: Phase 5 added 3 new indicator-aware rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 15  # v1.20.x #124/#458: demote_clustered_identity removed from rotation
+    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
 
 
 # ============================================================


### PR DESCRIPTION
Addresses #491 (auto-config lever-coverage gap). Audit found levenshtein/soundex already reachable and dice/jaccard are PPRL-only (struck), so this covers the genuine remainder.

## Levers
**qgram** (was a misnomer in the issue — `qgram` is a lossy transform, not a scorer; dice/jaccard are bloom-only):
- New real `qgram` char-n-gram Jaccard scorer (`scorer.py` single + NxN dispatch, added to `VALID_SCORERS`).
- `build_matchkeys` routes short-code columns (conservative letter+digit detector) to it.
- Added to the `CoordinateDescentProposer` scorer family.

**probabilistic** (both homes, per the design):
- A1 optimizer: wired the existing `MatchkeyTypeSwap` edit into `CoordinateDescentProposer` as a `mktype` family → deterministic search can pick weighted↔probabilistic.
- A2 controller: `rule_select_probabilistic_matchkey` — conservative trigger (weighted matchkey with ≥3 graded-fuzzy fields AND recall-limited scoring `dip<0.02 & mass<0.15` AND no exact anchor). Inserted before `rule_recall_gap_suspected` (ordering invariant preserved; 6 count-assertions bumped).

**ANN blocking**:
- `build_blocking` emits `strategy="ann"` (flat `ann_*` fields) as a **fallback** — only when an embedding/description column is present AND `n_rows >= ANN_MIN_ROWS` (env `GOLDENMATCH_ANN_MIN_ROWS`, default 100K) AND no bounded exact key exists (exact-id blocking still wins when available). Strict invariant: never `ann` without vectors.

## Tests
`tests/test_autoconfig_491_levers.py` (13): qgram scorer similarity + dispatch; short-code routing (+ no name/address regression); optimizer qgram family + probabilistic candidate; controller rule fires-on-shape / skips-on-exact-anchor / skips-small-healthy; ANN fires-with-embeddings+scale, never-without-embeddings, below-scale, exact-wins-over-ann. ruff clean, no new pyright errors. Regression: `test_autoconfig.py`/`test_refdata_autoconfig.py`/`test_config_optimizer.py`/`test_autoconfig_policy.py`/`test_autoconfig_rules.py` all green.

## Risk / ship-or-defer (A2)
A2 changes default-path selection. It's inert when an exact anchor exists (guard c) — so DQbench T3 / NCVR-composite shapes can't trip it. The #528 in-house quality gate runs in this PR's CI. **If NCVR/Febrl3/DQbench regress, A2 (the controller rule) is reverted, leaving probabilistic reachable via the optimizer (A1)** — still satisfies #491. qgram routing + ANN are gated/fallback so their default-path risk is bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)