### PR TITLE
Cluster split: single-MST batch split + scaled edge budget + loud-keep failure mode (#661, #726)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -444,6 +444,12 @@ class GoldenRulesConfig(BaseModel):
     auto_split: bool = True
     quality_weighting: bool = True
     weak_cluster_threshold: float = 0.3
+    # #726: cap on cumulative auto-split edge-work. None => auto-scaled
+    # max(5_000_000, n_rows * 5). Raise this (or env
+    # GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET) if a loud "clusters left oversized"
+    # warning fires on a legitimately dense dataset. Precedence: this field >
+    # env > auto-scaled.
+    split_edge_budget: int | None = None
     # v1.18: post-cluster golden-rules refinement. When True, after
     # clustering the pipeline runs `refine_golden_rules` against the
     # cluster output + column profiles to pick per-field strategies

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -668,55 +668,33 @@ def build_cluster_frames(
         # budget + no-progress guards, deterministic sub.sort, re-enqueue still-
         # oversized). split rows carry quality="split" so the Step-3 vectorized
         # weak/quality block's when(quality=="split") short-circuit preserves them.
-        oversized = metadata.filter(_pl.col("oversized"))["cluster_id"].to_list()
+        oversized = sorted(metadata.filter(_pl.col("oversized"))["cluster_id"].to_list())
         if oversized:
             members_by_cid = {
                 int(cid): assignments.filter(_pl.col("cluster_id") == cid)["member_id"].to_list()
                 for cid in oversized
             }
-            # Mirror _finalize_clusters's SINGLE `result` dict for split clusters.
-            # split_result holds sub-clusters by cid; an intermediate sub that
-            # re-splits is POPPED (del split_result[cid]) so it can't be emitted
-            # twice. Rows are materialized ONLY at the end, from the FINAL entries.
-            # (Eagerly appending rows + relying on drop_cids -- which only filters
-            # the ORIGINAL bulk frame -- duplicated re-split intermediates: an
-            # invalid overlapping partition.)
-            # live_cids mirrors result.keys() (cids 1..n pre-split + split cids);
-            # next_cid = max(live)+1 AFTER discarding the split cid REUSES a freed
-            # max slot, exactly as _finalize's `result.pop(cid); max(result.keys())+1`.
             live_cids = set(range(1, metadata.height + 1))
             split_result: dict[int, dict] = {}
             drop_cids = set()                      # ORIGINAL cids that split
-            to_split = list(oversized)
             edge_work, edge_budget, budget_tripped = 0, _split_edge_work_budget(), False
-            while to_split:
-                cid = to_split.pop()
-                members = members_by_cid.pop(cid)
+            for cid in oversized:
+                members = members_by_cid[int(cid)]
                 ms = set(members)
                 ps = {(a, b): s for a, b, s in pairs_list if a in ms and b in ms}
                 edge_work += len(ps)
                 if edge_work > edge_budget:
                     budget_tripped = True
-                    break  # leave cid (+ queued) oversized: don't drop / don't pop
-                subs = split_oversized_cluster(members, ps)
+                    break  # leave cid (+ remaining) oversized: original rows stay
+                subs = split_oversized_cluster_to_size(members, ps, max_cluster_size)
                 if len(subs) <= 1:
-                    continue  # unsplittable: original row / split_result entry stays
-                subs.sort(key=lambda sc: min(sc["members"]))
-                # Remove the cid being split (post-pop, like _finalize's result.pop):
-                # an intermediate split sub leaves split_result; an original cid is
-                # filtered from the bulk frame via drop_cids.
-                if cid in split_result:
-                    del split_result[cid]
-                else:
-                    drop_cids.add(cid)
-                live_cids.discard(cid)
-                next_cid = max(live_cids, default=0) + 1   # mirror _finalize (post-pop)
+                    continue  # unsplittable: original row stays
+                drop_cids.add(int(cid))
+                live_cids.discard(int(cid))
+                next_cid = max(live_cids, default=0) + 1
                 for sc in subs:
                     split_result[next_cid] = sc
                     live_cids.add(next_cid)
-                    if sc["size"] > max_cluster_size:
-                        members_by_cid[next_cid] = sc["members"]
-                        to_split.append(next_cid)
                     next_cid += 1
             if budget_tripped:
                 _clog.warning("build_cluster_frames: auto-split edge-work budget (%d) "
@@ -953,16 +931,14 @@ def _finalize_clusters(
     # Oversized clusters left un-split are excluded from golden downstream, the
     # same as auto_split=False -- a giant cohesive blob of near-identical records
     # is legitimately one quarantined cluster, not N arbitrary cuts.
-    to_split = [cid for cid, c in result.items() if c["oversized"]] if auto_split else []
+    oversized_cids = sorted(cid for cid, c in result.items() if c["oversized"]) if auto_split else []
     edge_work = 0
     edge_budget = _split_edge_work_budget()
     budget_tripped = False
-    while to_split:
-        cid = to_split.pop()
-        cinfo = result.pop(cid)
+    for cid in oversized_cids:
+        cinfo = result[cid]
         # Columnar path: materialize this oversized cluster's pair_scores on demand
-        # from the raw input pairs (input order, last-wins == the dict path's fill)
-        # so the MST split + edge-budget meter behave identically. Rare (oversized).
+        # from the raw input pairs (input order, last-wins == the dict path's fill).
         if raw_pairs is not None and not cinfo["pair_scores"]:
             _ms = set(cinfo["members"])
             cinfo["pair_scores"] = {
@@ -971,30 +947,20 @@ def _finalize_clusters(
         edge_work += len(cinfo["pair_scores"])
         if edge_work > edge_budget:
             cinfo["oversized"] = True
-            result[cid] = cinfo  # leave oversized; queued cids stay in result too
             budget_tripped = True
-            break
-        sub_clusters = split_oversized_cluster(cinfo["members"], cinfo["pair_scores"])
-        if len(sub_clusters) <= 1:
-            # Couldn't split (no edges / no MST): leave it as-is, don't re-enqueue.
+            break  # leave this + remaining oversized cids in result, flagged
+        subs = split_oversized_cluster_to_size(
+            cinfo["members"], cinfo["pair_scores"], max_cluster_size
+        )
+        if len(subs) <= 1:
+            # Unsplittable (no edges / single blob): leave as-is, flagged by size.
             cinfo["oversized"] = cinfo["size"] > max_cluster_size
-            result[cid] = cinfo
             continue
-        # Deterministic cluster-id assignment. The native mst_split_components
-        # kernel returns sub-clusters in Rust HashMap iteration order
-        # (nondeterministic per call), which made split-cluster ids vary
-        # run-to-run -- and diverge between the dict and columnar build paths,
-        # which call this independently. Sort by min member so next_cid below is
-        # assigned stably. The partition content is already deterministic; this
-        # only pins the labels, the durability invariant identity ids depend on.
-        sub_clusters.sort(key=lambda sc: min(sc["members"]))
+        del result[cid]
         next_cid = max(result.keys(), default=0) + 1
-        for sc in sub_clusters:
-            sc["oversized"] = sc["size"] > max_cluster_size
-            sc["_was_split"] = True
+        for sc in subs:
+            sc["_was_split"] = True            # batch fn already set sc["oversized"]
             result[next_cid] = sc
-            if sc["oversized"]:
-                to_split.append(next_cid)
             next_cid += 1
     if budget_tripped:
         n_oversized = sum(1 for c in result.values() if c.get("oversized"))

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -223,6 +223,89 @@ def split_oversized_cluster(
     return result
 
 
+def split_oversized_cluster_to_size(
+    members: list[int],
+    pair_scores: dict[tuple[int, int], float],
+    max_size: int,
+) -> list[dict]:
+    """Split a cluster down to ``max_size`` from a SINGLE MST build (#661).
+
+    Repeatedly cuts the weakest tree edge of any component still larger than
+    ``max_size``. A sub-tree of a maximum spanning tree IS the maximum spanning
+    tree of its induced sub-graph (cycle property), so cutting original tree
+    edges reproduces the old per-component re-MST cut decisions (same membership
+    partition, same first-minimum tie-break). Returns final sub-clusters in a
+    DETERMINISTIC order (sort-by-min-member at each cut, oversized components
+    re-enqueued LIFO).
+
+    Components that cannot be cut further (no remaining cuttable tree edge) are
+    returned still oversized (``oversized=True``)."""
+    if len(members) <= max_size or len(members) <= 1 or not pair_scores:
+        size = len(members)
+        return [{"members": sorted(members), "size": size,
+                 "oversized": size > max_size, "pair_scores": pair_scores,
+                 **_confidence_fields(pair_scores, size)}]
+
+    tree_edges = _build_mst(members, pair_scores)
+    if not tree_edges:
+        size = len(members)
+        return [{"members": sorted(members), "size": size,
+                 "oversized": size > max_size, "pair_scores": pair_scores,
+                 **_confidence_fields(pair_scores, size)}]
+
+    out_order: list[frozenset[int]] = []
+    work: list[tuple[set[int], list]] = [(set(members), list(tree_edges))]
+    while work:
+        node_set, edges = work.pop()
+        if len(node_set) <= max_size or not edges:
+            out_order.append(frozenset(node_set))
+            continue
+        weakest = min(edges, key=lambda e: e[2])   # first-minimum, same as today
+        remaining = [e for e in edges if e is not weakest]
+        uf = UnionFind()
+        uf.add_many(list(node_set))
+        for a, b, _s in remaining:
+            uf.union(a, b)
+        comps = uf.get_clusters()                   # 2 components
+        node_to_rep = {n: uf.find(n) for n in node_set}
+        rep_to_edges: dict[int, list] = {}
+        for e in remaining:
+            rep_to_edges.setdefault(node_to_rep[e[0]], []).append(e)
+        sub_items = [(c, rep_to_edges.get(uf.find(next(iter(c))), [])) for c in comps]
+        sub_items.sort(key=lambda ci: min(ci[0]))
+        for c, ce in sub_items:
+            if len(c) > max_size:
+                work.append((set(c), ce))
+            else:
+                out_order.append(frozenset(c))
+
+    member_to_idx: dict[int, int] = {}
+    for idx, s in enumerate(out_order):
+        for m in s:
+            member_to_idx[m] = idx
+    sub_pairs: list[dict] = [{} for _ in out_order]
+    for (a, b), sc in pair_scores.items():
+        ia = member_to_idx.get(a)
+        if ia is not None and ia == member_to_idx.get(b):
+            sub_pairs[ia][(a, b)] = sc
+
+    result = []
+    for idx, s in enumerate(out_order):
+        sc_list = sorted(s)
+        size = len(sc_list)
+        result.append({
+            "members": sc_list, "size": size, "oversized": size > max_size,
+            "pair_scores": sub_pairs[idx],
+            **_confidence_fields(sub_pairs[idx], size),
+        })
+    return result
+
+
+def _confidence_fields(pair_scores: dict, size: int) -> dict:
+    conf = compute_cluster_confidence(pair_scores, size)
+    return {"confidence": conf["confidence"], "bottleneck_pair": conf["bottleneck_pair"]}
+
+
 # Bridge detection is O(E*(V+E)) per cluster; only run on clusters at or below
 # this size so the sample path stays cheap (clusters there are small).
 _BRIDGE_MAX_CLUSTER_SIZE = 100

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -34,15 +34,25 @@ _clog = logging.getLogger("goldenmatch.cluster")
 _DEFAULT_SPLIT_EDGE_WORK_BUDGET = 5_000_000
 
 
-def _split_edge_work_budget() -> int:
-    """Cumulative-edge-work cap for the auto-split loop (env-overridable)."""
+_SPLIT_EDGE_BUDGET_PER_ROW = 5  # C: linear edge-work allowance per input row
+
+
+def _split_edge_work_budget(n_rows: int, override: int | None = None) -> int:
+    """Cumulative-edge-work cap for the auto-split loop.
+
+    Precedence: explicit ``override`` (GoldenRulesConfig.split_edge_budget) >
+    GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET env > max(5M, n_rows * C). With the
+    single-MST batch split (#661) exhaustion is rare; this makes the rare case
+    scale-appropriate and tunable."""
+    if override is not None:
+        return max(1, int(override))
     raw = os.environ.get("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET")
-    if raw is None:
-        return _DEFAULT_SPLIT_EDGE_WORK_BUDGET
-    try:
-        return max(1, int(raw))
-    except ValueError:
-        return _DEFAULT_SPLIT_EDGE_WORK_BUDGET
+    if raw is not None:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            pass
+    return max(_DEFAULT_SPLIT_EDGE_WORK_BUDGET, int(n_rows) * _SPLIT_EDGE_BUDGET_PER_ROW)
 
 
 def _record_unmerge_corrections(
@@ -447,6 +457,7 @@ def build_clusters(
     max_cluster_size: int = 100,
     weak_cluster_threshold: float = 0.3,
     auto_split: bool = True,
+    split_edge_budget: int | None = None,
 ) -> dict[int, dict]:
     """Build clusters from scored pairs using Union-Find.
 
@@ -509,10 +520,12 @@ def build_clusters(
     if _columnar_cluster_build_enabled():
         return _build_clusters_via_frames(
             pairs, all_ids, max_cluster_size, weak_cluster_threshold, auto_split,
+            split_edge_budget,
         )
 
     return _build_clusters_dict_path(
         pairs, all_ids, max_cluster_size, weak_cluster_threshold, auto_split,
+        split_edge_budget=split_edge_budget,
     )
 
 
@@ -550,6 +563,7 @@ def build_cluster_frames(
     max_cluster_size: int,
     weak_cluster_threshold: float,
     auto_split: bool,
+    split_edge_budget: int | None = None,
 ) -> ClusterFrames:
     """SP-A frames-out entry point (gated ``GOLDENMATCH_CLUSTER_FRAMES_OUT``).
 
@@ -679,7 +693,7 @@ def build_cluster_frames(
             live_cids = set(range(1, metadata.height + 1))
             split_result: dict[int, dict] = {}
             drop_cids = set()                      # ORIGINAL cids that split
-            edge_work, edge_budget, budget_tripped = 0, _split_edge_work_budget(), False
+            edge_work, edge_budget, budget_tripped = 0, _split_edge_work_budget(len(all_ids), split_edge_budget), False
             for cid in oversized:
                 members = members_by_cid[int(cid)]
                 ms = set(members)
@@ -822,6 +836,7 @@ def _build_clusters_dict_path(
     max_cluster_size: int,
     weak_cluster_threshold: float,
     auto_split: bool,
+    split_edge_budget: int | None = None,
 ) -> dict[int, dict]:
     """Legacy list/dict Union-Find cluster build. Verbatim extraction of the
     original ``build_clusters`` body (UF stage -> emit); behavior is unchanged.
@@ -893,6 +908,7 @@ def _build_clusters_dict_path(
 
     return _finalize_clusters(
         result, max_cluster_size, weak_cluster_threshold, auto_split,
+        n_rows=len(all_ids), split_edge_budget=split_edge_budget,
     )
 
 
@@ -904,6 +920,8 @@ def _finalize_clusters(
     *,
     raw_pairs: list[tuple[int, int, float]] | None = None,
     weak_stats: dict[int, tuple[float, float]] | None = None,
+    n_rows: int = 0,
+    split_edge_budget: int | None = None,
 ) -> dict[int, dict]:
     """Shared cluster-build tail: auto-split oversized clusters, assign
     ``cluster_quality`` (+ weak confidence downgrade), then emit the profile.
@@ -935,7 +953,7 @@ def _finalize_clusters(
     # is legitimately one quarantined cluster, not N arbitrary cuts.
     oversized_cids = sorted(cid for cid, c in result.items() if c["oversized"]) if auto_split else []
     edge_work = 0
-    edge_budget = _split_edge_work_budget()
+    edge_budget = _split_edge_work_budget(n_rows, split_edge_budget)
     budget_tripped = False
     for cid in oversized_cids:
         cinfo = result[cid]
@@ -1021,6 +1039,7 @@ def _build_clusters_via_frames(
     max_cluster_size: int,
     weak_cluster_threshold: float,
     auto_split: bool,
+    split_edge_budget: int | None = None,
 ) -> dict[int, dict]:
     """Columnar cluster-build core. Returns the dict path's shape EXCEPT
     ``pair_scores`` is ``{}`` on every cluster (SP4: the eager per-cluster dict --
@@ -1095,6 +1114,7 @@ def _build_clusters_via_frames(
     return _finalize_clusters(
         result, max_cluster_size, weak_cluster_threshold, auto_split,
         raw_pairs=pairs_list, weak_stats=weak_stats,
+        n_rows=len(all_ids), split_edge_budget=split_edge_budget,
     )
 
 
@@ -1622,6 +1642,7 @@ def build_clusters_columnar(
     max_cluster_size: int = 100,
     weak_cluster_threshold: float = 0.3,
     auto_split: bool = True,
+    split_edge_budget: int | None = None,
 ) -> dict[int, dict]:
     """Columnar wrapper around :func:`build_clusters`.
 
@@ -1671,6 +1692,7 @@ def build_clusters_columnar(
         max_cluster_size=max_cluster_size,
         weak_cluster_threshold=weak_cluster_threshold,
         auto_split=auto_split,
+        split_edge_budget=split_edge_budget,
     )
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -575,8 +575,8 @@ def build_cluster_frames(
     The BULK path (non-oversized clusters) is the shared pre-split Union-Find
     (via ``_columnar_presplit``) + vectorized weak/quality + emit. Oversized
     clusters are auto-split frames-natively (the dict is materialized ONLY for
-    that rare minority), reusing ``split_oversized_cluster`` and mirroring
-    ``_finalize_clusters``.
+    that rare minority), reusing ``split_oversized_cluster_to_size`` (one batch
+    split per top-level oversized cluster) and mirroring ``_finalize_clusters``.
 
     ``cluster_frames_to_dict(build_cluster_frames(...))`` round-trips to
     ``build_clusters(...)`` gate-ON (the score-free dict): members-as-set,

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -664,10 +664,12 @@ def build_cluster_frames(
     if auto_split:
         # Frames-native auto-split: the per-cluster dict (the SP1 bench loss) is
         # confined to the rare oversized MINORITY. Mirrors _finalize_clusters's
-        # split loop EXACTLY (next_cid from max-existing +1 before use, edge-work
-        # budget + no-progress guards, deterministic sub.sort, re-enqueue still-
-        # oversized). split rows carry quality="split" so the Step-3 vectorized
-        # weak/quality block's when(quality=="split") short-circuit preserves them.
+        # split loop EXACTLY: iterate sorted(oversized), call
+        # split_oversized_cluster_to_size ONCE per top-level cluster (the batch fn
+        # owns the full recursive split + sub ordering -- no re-enqueue here), and
+        # label subs contiguously from max(live_cids)+1. split rows carry
+        # quality="split" so the Step-3 vectorized weak/quality block's
+        # when(quality=="split") short-circuit preserves them.
         oversized = sorted(metadata.filter(_pl.col("oversized"))["cluster_id"].to_list())
         if oversized:
             members_by_cid = {

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -713,8 +713,15 @@ def build_cluster_frames(
                     live_cids.add(next_cid)
                     next_cid += 1
             if budget_tripped:
-                _clog.warning("build_cluster_frames: auto-split edge-work budget (%d) "
-                              "exhausted; clusters left oversized.", edge_budget)
+                n_oversized = sum(1 for c in oversized if int(c) not in drop_cids)
+                _clog.warning(
+                    "build_cluster_frames: auto-split edge-work budget (%d) "
+                    "exhausted; %d cluster(s) left OVERSIZED and flagged (kept in "
+                    "output, excluded from golden downstream). Raise "
+                    "GoldenRulesConfig.split_edge_budget or env "
+                    "GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET to split them.",
+                    edge_budget, n_oversized,
+                )
             # Materialize the FINAL split sub-clusters into frame rows. split rows
             # carry quality="split" so the Step-3 when(quality=="split") short-circuit
             # preserves them. min/avg are schema-fill (unused: split skips the weak test).
@@ -986,8 +993,9 @@ def _finalize_clusters(
         n_oversized = sum(1 for c in result.values() if c.get("oversized"))
         _clog.warning(
             "build_clusters: auto-split edge-work budget (%d) exhausted; %d "
-            "cluster(s) left oversized (dense, no clean weak-bridge split). "
-            "Oversized clusters are excluded from golden downstream.",
+            "cluster(s) left OVERSIZED and flagged (kept in output, excluded "
+            "from golden downstream). Raise GoldenRulesConfig.split_edge_budget "
+            "or env GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET to split them.",
             edge_budget, n_oversized,
         )
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1452,6 +1452,7 @@ def _run_dedupe_pipeline(
     max_cluster_size = 100
     weak_threshold = 0.3
     auto_split = True
+    split_edge_budget = None
     if config.golden_rules:
         if hasattr(config.golden_rules, "max_cluster_size"):
             max_cluster_size = config.golden_rules.max_cluster_size
@@ -1459,6 +1460,7 @@ def _run_dedupe_pipeline(
             weak_threshold = config.golden_rules.weak_cluster_threshold
         if hasattr(config.golden_rules, "auto_split"):
             auto_split = config.golden_rules.auto_split
+        split_edge_budget = getattr(config.golden_rules, "split_edge_budget", None)
 
     record_metric(
         "scored_pair_count",
@@ -1499,6 +1501,7 @@ def _run_dedupe_pipeline(
                 max_cluster_size=max_cluster_size,
                 weak_cluster_threshold=weak_threshold,
                 auto_split=auto_split,
+                split_edge_budget=split_edge_budget,
             )
         elif _cluster_frames_out_enabled():
             cluster_frames = build_cluster_frames(
@@ -1506,6 +1509,7 @@ def _run_dedupe_pipeline(
                 max_cluster_size=max_cluster_size,
                 weak_cluster_threshold=weak_threshold,
                 auto_split=auto_split,
+                split_edge_budget=split_edge_budget,
             )
             # SP-B: do NOT rebuild the dict eagerly. stats + dupes (always-run
             # hot path) are computed directly from the frame aggregates below;
@@ -1521,6 +1525,7 @@ def _run_dedupe_pipeline(
                 max_cluster_size=max_cluster_size,
                 weak_cluster_threshold=weak_threshold,
                 auto_split=auto_split,
+                split_edge_budget=split_edge_budget,
             )
     # SP-B lazy dict rebuild. On the frames-out branch `clusters` is unbound;
     # the remaining dict consumers (adaptive refiner, lineage, identity,

--- a/packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_cluster_frames_out_parity.py
@@ -65,8 +65,22 @@ def _adversarial_pairs():
         (32, 34, 0.99), (32, 35, 0.99), (32, 36, 0.99), (33, 34, 0.99),
         (33, 35, 0.99), (33, 36, 0.99), (34, 35, 0.99), (34, 36, 0.99),
         (35, 36, 0.99),
+        # Group A (40-48): three triangles + two weak bridges -> splits into 3
+        # components at max_cluster_size=5 (exercises the batch fn's repeated cuts
+        # on the hand-written frames-out split loop).
+        (40, 41, 0.99), (40, 42, 0.99), (41, 42, 0.99),
+        (43, 44, 0.99), (43, 45, 0.99), (44, 45, 0.99),
+        (46, 47, 0.99), (46, 48, 0.99), (47, 48, 0.99),
+        (42, 43, 0.30), (45, 46, 0.25),
+        # Group B (50-57): two 4-cliques + one weak bridge -> a SECOND splittable
+        # oversized top-level cluster (exercises multi-cluster labeling order).
+        (50, 51, 0.99), (50, 52, 0.99), (50, 53, 0.99),
+        (51, 52, 0.99), (51, 53, 0.99), (52, 53, 0.99),
+        (54, 55, 0.99), (54, 56, 0.99), (54, 57, 0.99),
+        (55, 56, 0.99), (55, 57, 0.99), (56, 57, 0.99),
+        (53, 54, 0.28),
     ]
-    all_ids = list(range(0, 23)) + list(range(30, 37))
+    all_ids = list(range(0, 23)) + list(range(30, 37)) + list(range(40, 49)) + list(range(50, 58))
     return pairs, all_ids
 
 
@@ -109,6 +123,29 @@ def test_frames_out_roundtrips_to_dict_full(monkeypatch, native):
     assert got.keys() == ref.keys()
     for cid in ref:
         assert _norm(got[cid]) == _norm(ref[cid]), f"cid {cid}: {got[cid]} vs {ref[cid]}"
+
+
+def test_budget_break_frames_out_matches_dict(monkeypatch):
+    """#726: under budget exhaustion, the frames-out split loop and the dict path
+    leave the SAME clusters oversized + conserve total membership. Locks the two
+    `break` paths (the hand-written frames loop vs `_finalize_clusters`) against
+    each other -- the cross-path parity the per-task review flagged as untested."""
+    pairs, all_ids = _adversarial_pairs()
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET", "1")  # exhaust immediately
+    kw = dict(all_ids=all_ids, max_cluster_size=5,
+              weak_cluster_threshold=0.3, auto_split=True)
+    monkeypatch.setenv("GOLDENMATCH_COLUMNAR_CLUSTER_BUILD", "1")
+    monkeypatch.delenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", raising=False)
+    ref = build_clusters(pairs, **kw)
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
+    got = cluster_frames_to_dict(build_cluster_frames(pairs, **kw))
+    assert got.keys() == ref.keys()
+    for cid in ref:
+        assert _norm(got[cid]) == _norm(ref[cid]), f"cid {cid}: {got[cid]} vs {ref[cid]}"
+    # Membership conserved + something left oversized (budget=1 trips immediately).
+    assert sum(c["size"] for c in got.values()) == len(all_ids)
+    assert any(c["oversized"] for c in got.values())
 
 
 def test_step3_quality_matches_dict_loop(monkeypatch):

--- a/packages/python/goldenmatch/tests/test_cluster_split_to_size.py
+++ b/packages/python/goldenmatch/tests/test_cluster_split_to_size.py
@@ -90,3 +90,34 @@ def test_caller_invokes_batch_once_per_top_level_cluster(monkeypatch):
     pairs = [(a, b, 0.99) for i, a in enumerate(members) for b in members[i + 1:]]
     cl.build_clusters(pairs, all_ids=members, max_cluster_size=5)
     assert calls["n"] == 1
+
+
+def test_budget_autoscales_with_n_rows():
+    from goldenmatch.core.cluster import _split_edge_work_budget
+    assert _split_edge_work_budget(1000) == 5_000_000           # floor
+    assert _split_edge_work_budget(2_000_000) == 10_000_000     # n_rows * 5
+
+
+def test_budget_env_overrides_autoscale(monkeypatch):
+    from goldenmatch.core.cluster import _split_edge_work_budget
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET", "777")
+    assert _split_edge_work_budget(2_000_000) == 777
+
+
+def test_budget_config_override_beats_env(monkeypatch):
+    from goldenmatch.core.cluster import _split_edge_work_budget
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET", "777")
+    assert _split_edge_work_budget(2_000_000, override=12345) == 12345
+
+
+def test_golden_rules_config_has_split_edge_budget():
+    # GoldenRulesConfig has a model-validator requiring default_strategy; pass a
+    # valid one so we can exercise the new split_edge_budget field (the field is
+    # the unit under test, not the validator).
+    from goldenmatch.config.schemas import GoldenRulesConfig
+    assert GoldenRulesConfig(default_strategy="most_recent").split_edge_budget is None
+    assert (
+        GoldenRulesConfig(default_strategy="most_recent", split_edge_budget=999)
+        .split_edge_budget
+        == 999
+    )

--- a/packages/python/goldenmatch/tests/test_cluster_split_to_size.py
+++ b/packages/python/goldenmatch/tests/test_cluster_split_to_size.py
@@ -121,3 +121,32 @@ def test_golden_rules_config_has_split_edge_budget():
         .split_edge_budget
         == 999
     )
+
+
+def test_budget_exhaustion_warns_and_keeps_clusters(monkeypatch, caplog):
+    """#726: tiny budget + a dense cluster -> WARNING names the knob AND the
+    oversized clusters stay in the output, flagged (NOT dropped)."""
+    import logging
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET", "1")  # exhaust immediately
+    from goldenmatch.core.cluster import build_clusters
+    members = list(range(200, 215))
+    pairs = [(a, b, 0.99) for i, a in enumerate(members) for b in members[i + 1:]]
+    with caplog.at_level(logging.WARNING, logger="goldenmatch.cluster"):
+        clusters = build_clusters(pairs, all_ids=members, max_cluster_size=5)
+    assert any(c["oversized"] for c in clusters.values())
+    assert sum(c["size"] for c in clusters.values()) == len(members)
+    msg = " ".join(r.message for r in caplog.records)
+    assert "split_edge_budget" in msg and "GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET" in msg
+
+
+def test_budget_invalid_env_falls_through_to_autoscale(monkeypatch):
+    from goldenmatch.core.cluster import _split_edge_work_budget
+    monkeypatch.setenv("GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET", "not-an-int")
+    assert _split_edge_work_budget(2_000_000) == 10_000_000  # autoscale, no crash
+
+
+def test_budget_override_zero_or_negative_clamps_to_one():
+    from goldenmatch.core.cluster import _split_edge_work_budget
+    assert _split_edge_work_budget(1000, override=0) == 1
+    assert _split_edge_work_budget(1000, override=-5) == 1

--- a/packages/python/goldenmatch/tests/test_cluster_split_to_size.py
+++ b/packages/python/goldenmatch/tests/test_cluster_split_to_size.py
@@ -1,0 +1,76 @@
+"""#661: split_oversized_cluster_to_size builds the MST once and splits all the
+way to max_size, producing the SAME membership partition (and per-component
+confidence/bottleneck) as the old repeated single-weakest-edge loop. The
+reference below drives the UNCHANGED single-edge split_oversized_cluster, so it
+is a genuinely different code path from the batch loop (not tautological)."""
+from __future__ import annotations
+
+import pytest
+from goldenmatch.core.cluster import (
+    split_oversized_cluster,
+    split_oversized_cluster_to_size,
+)
+
+
+def _old_partition(members, pair_scores, max_size):
+    """Reference: the pre-#661 algorithm. Repeatedly call the unchanged
+    single-edge split_oversized_cluster on any still-oversized component,
+    re-filtering that component's induced pairs each pass. Returns the FINAL
+    list of member-lists. Locks the PARTITION, not labels."""
+    work = [list(members)]
+    final = []
+    while work:
+        comp = work.pop()
+        if len(comp) <= max_size:
+            final.append(comp)
+            continue
+        ms = set(comp)
+        ps = {(a, b): s for (a, b), s in pair_scores.items() if a in ms and b in ms}
+        subs = split_oversized_cluster(comp, ps)
+        if len(subs) <= 1:
+            final.append(comp)        # unsplittable: stays as-is, oversized
+            continue
+        for sc in subs:
+            work.append(sc["members"])
+    return final
+
+
+def _dense_clique(nodes, score=0.99):
+    return {(a, b): score for i, a in enumerate(nodes) for b in nodes[i + 1:]}
+
+
+@pytest.mark.parametrize("native", ["0", "1"])
+def test_batch_split_membership_matches_old(monkeypatch, native):
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", native)
+    members = list(range(10, 19))
+    ps = {}
+    ps.update(_dense_clique([10, 11, 12]))
+    ps.update(_dense_clique([13, 14, 15]))
+    ps.update(_dense_clique([16, 17, 18]))
+    ps[(12, 13)] = 0.30   # weak bridge 1
+    ps[(15, 16)] = 0.25   # weak bridge 2
+    got = split_oversized_cluster_to_size(members, ps, max_size=2)
+    want = _old_partition(members, ps, max_size=2)
+    assert {frozenset(s["members"]) for s in got} == {frozenset(c) for c in want}
+    from goldenmatch.core.cluster import compute_cluster_confidence
+    for s in got:
+        ms = set(s["members"])
+        induced = {(a, b): v for (a, b), v in ps.items() if a in ms and b in ms}
+        ref = compute_cluster_confidence(induced, len(ms))
+        assert round(s["confidence"], 12) == round(ref["confidence"], 12)
+        assert s["bottleneck_pair"] == ref["bottleneck_pair"]
+
+
+def test_single_mst_build_per_top_level_cluster(monkeypatch):
+    """#661: a dense cluster peeling into k components builds the MST ONCE."""
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    import goldenmatch.core.cluster as cl
+    calls = {"n": 0}
+    orig = cl._build_mst
+    monkeypatch.setattr(cl, "_build_mst",
+                        lambda m, ps: (calls.__setitem__("n", calls["n"] + 1), orig(m, ps))[1])
+    members = list(range(100, 130))
+    ps = {(a, b): 0.99 for i, a in enumerate(members) for b in members[i + 1:]}
+    subs = cl.split_oversized_cluster_to_size(members, ps, max_size=5)
+    assert calls["n"] == 1
+    assert all(s["size"] <= 5 or s["oversized"] for s in subs)

--- a/packages/python/goldenmatch/tests/test_cluster_split_to_size.py
+++ b/packages/python/goldenmatch/tests/test_cluster_split_to_size.py
@@ -74,3 +74,19 @@ def test_single_mst_build_per_top_level_cluster(monkeypatch):
     subs = cl.split_oversized_cluster_to_size(members, ps, max_size=5)
     assert calls["n"] == 1
     assert all(s["size"] <= 5 or s["oversized"] for s in subs)
+
+
+def test_caller_invokes_batch_once_per_top_level_cluster(monkeypatch):
+    """#661: the build path calls split_oversized_cluster_to_size exactly once
+    per oversized TOP-LEVEL cluster (no per-pass re-call)."""
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    import goldenmatch.core.cluster as cl
+    calls = {"n": 0}
+    orig = cl.split_oversized_cluster_to_size
+    monkeypatch.setattr(cl, "split_oversized_cluster_to_size",
+                        lambda *a, **k: (calls.__setitem__("n", calls["n"] + 1), orig(*a, **k))[1])
+    # ONE oversized top-level cluster (15-node clique) -> exactly ONE batch call.
+    members = list(range(100, 115))
+    pairs = [(a, b, 0.99) for i, a in enumerate(members) for b in members[i + 1:]]
+    cl.build_clusters(pairs, all_ids=members, max_cluster_size=5)
+    assert calls["n"] == 1

--- a/packages/python/goldenmatch/tests/test_columnar_drop_pairscores_parity.py
+++ b/packages/python/goldenmatch/tests/test_columnar_drop_pairscores_parity.py
@@ -21,6 +21,10 @@ def _adversarial_pairs():
     # oversized that splits (10..16 minus 13), score-tied (20,21,22), dup pair,
     # dense clique that can't cleanly split (30..36). PLUS a different-score
     # duplicate canonical pair (3,4) to exercise the kernel last-wins dedup.
+    # Group A (40..48): three triangles + two weak bridges -> splits into 3
+    # components (exercises a cluster that cuts into >=3 pieces). Group B (50..57):
+    # two 4-cliques + one weak bridge -> a SECOND splittable oversized top-level
+    # cluster (exercises top-level iteration/labeling order across multiple splits).
     pairs = [
         (1, 2, 0.95),
         (3, 4, 0.9), (4, 5, 0.92), (3, 5, 0.88),
@@ -37,8 +41,21 @@ def _adversarial_pairs():
         (32, 34, 0.99), (32, 35, 0.99), (32, 36, 0.99), (33, 34, 0.99),
         (33, 35, 0.99), (33, 36, 0.99), (34, 35, 0.99), (34, 36, 0.99),
         (35, 36, 0.99),
+        # Group A (40-48): three triangles joined by two weak bridges -> splits
+        # into 3 components at max_cluster_size=5 (exercises repeated cuts).
+        (40, 41, 0.99), (40, 42, 0.99), (41, 42, 0.99),
+        (43, 44, 0.99), (43, 45, 0.99), (44, 45, 0.99),
+        (46, 47, 0.99), (46, 48, 0.99), (47, 48, 0.99),
+        (42, 43, 0.30), (45, 46, 0.25),
+        # Group B (50-57): two 4-cliques joined by one weak bridge -> a SECOND
+        # splittable oversized top-level cluster (splits into 2).
+        (50, 51, 0.99), (50, 52, 0.99), (50, 53, 0.99),
+        (51, 52, 0.99), (51, 53, 0.99), (52, 53, 0.99),
+        (54, 55, 0.99), (54, 56, 0.99), (54, 57, 0.99),
+        (55, 56, 0.99), (55, 57, 0.99), (56, 57, 0.99),
+        (53, 54, 0.28),
     ]
-    all_ids = list(range(0, 23)) + list(range(30, 37))
+    all_ids = list(range(0, 23)) + list(range(30, 37)) + list(range(40, 49)) + list(range(50, 58))
     return pairs, all_ids
 
 


### PR DESCRIPTION
Closes #661, closes #726.

## What

Replaces the O(E*k) per-pass re-MST auto-split with a single-MST batch split, scales the auto-split edge-work budget to dataset size (config-tunable), and turns budget exhaustion into a loud warning that keeps oversized clusters flagged rather than silently dropping them.

### #661 (root cause): redundant MST rebuilds
`split_oversized_cluster` removed one weakest MST edge per call; the callers re-enqueued still-oversized subs and re-called it, rebuilding the MST over O(E) edges every pass (O(E*k) for k cuts). On a dense cluster with no clean weak bridge this peeled ~1 node per pass and effectively hung.

- New `split_oversized_cluster_to_size(members, pair_scores, max_size)`: builds the MST **once**, then cuts the weakest **tree edge** of any still-oversized component. A sub-tree of a maximum spanning tree is the max spanning tree of its induced sub-graph (cycle property), so cutting original tree edges reproduces the old per-component re-MST cut decisions, same first-minimum tie-break, same membership partition.
- Both split loops (`_finalize_clusters` dict/columnar path + the `build_cluster_frames` frames-out loop) now call it **once per top-level oversized cluster**. No re-enqueue, so the old cascading-split-dup and next_cid-reuse hazards cannot occur.

### #726 (symptom + DX): budget exhaustion silently dropped true-match clusters
A denser edge set (e.g. probabilistic matchkeys, now selectable after #491) made bigger oversized clusters blow the hard-coded 5M budget, leaving clusters oversized and excluded from golden downstream with only a vague warning.

- Budget is now `max(5_000_000, n_rows * 5)`, precedence **`GoldenRulesConfig.split_edge_budget` > env `GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET` > auto-scaled**. Threaded through the full dispatch chain.
- On genuine exhaustion: loud `WARNING` naming the exact knob + the count, and the oversized clusters stay in the output **flagged** (excluded-from-golden behavior unchanged, but now visible/actionable, not silent).

## Invariant & tests

The binding invariant is the **membership partition** (cycle-property proof) + **cross-path label consistency** (dict path == frames-out path) + run-to-run determinism. Cluster-id label equality vs the prior release is NOT claimed and not needed (entity_ids are content-based fingerprints, not the integer cluster_id).

- New `test_cluster_split_to_size.py`: membership-equivalence vs a reference driving the unchanged single-edge `split_oversized_cluster` (native 0/1), single-MST-build count, one-batch-call-per-cluster, budget precedence (autoscale / env / config-override / invalid-env fall-through / clamp), and exhaustion-warns-and-keeps.
- Extended the byte-identical parity gate AND the frames-out parity gate with a 3-component split + a second splittable oversized cluster, plus a **budget-break cross-path parity** test.
- Local targeted regression: cluster + 5 parity/native files = **97 passed**; frames-out file = **8 passed**.

## Notes
- Tie-break: the new path cuts in full-MST edge order; the old per-pass path re-sorted each induced sub-MST. The proof says the tree-edge set + relative order are identical, and the tie-scored fixtures (the 0.99 clique) pass parity, so it is consistent on covered cases.
- Out of scope (per design): min-cut quality upgrade; EM non-convergence (parked follow-up on #726).