### PR TITLE
feat(datafusion-udf): SQL embed UDF over goldenembed (#508 c)

### DIFF
--- a/packages/python/goldenmatch/tests/test_embed_udf.py
+++ b/packages/python/goldenmatch/tests/test_embed_udf.py
@@ -39,7 +39,11 @@ def test_embed_udf_shape_and_parity(monkeypatch):
     assert len(out[0]) == 8  # model dim
     assert out[0] == out[1]  # determinism: identical input -> identical vector
 
-    py = GoldenEmbedModel.load(str(FIXTURE)).embed(["acme corp"], backend="onnx")[0]
+    # Reference via the numpy forward pass (the model's documented source of
+    # truth) -- the CI venv has no `onnxruntime` Python package, and numpy needs
+    # none. This is a genuine cross-impl parity check: the Rust UDF runs ONNX,
+    # the reference runs numpy; they must agree to high precision.
+    py = GoldenEmbedModel.load(str(FIXTURE)).embed(["acme corp"], backend="numpy")[0]
     v = np.asarray(out[0], dtype=np.float32)
     cos = float(np.dot(v, py) / (np.linalg.norm(v) * np.linalg.norm(py) + 1e-9))
     assert cos > 0.999, f"UDF vs python embed cosine {cos}"

--- a/packages/python/goldenmatch/tests/test_embed_udf.py
+++ b/packages/python/goldenmatch/tests/test_embed_udf.py
@@ -1,0 +1,45 @@
+"""goldenmatch_embed FFI UDF: shape + determinism + parity vs Python embed.
+
+Mirrors test_datafusion_ffi_udf.py: pyarrow/datafusion are soft deps; the crate
+is a HARD import (CI builds goldenmatch_datafusion_udf into .venv). The UDF reads
+GOLDENEMBED_MODEL_DIR at construction, so it is set (via monkeypatch) BEFORE
+EmbedUDF() is instantiated. The fixture is the tiny model committed alongside the
+goldenembed crate.
+"""
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+datafusion = pytest.importorskip("datafusion")  # noqa: F841  registered below
+import goldenmatch_datafusion_udf  # noqa: E402,F401  HARD import (loud guard)
+from goldenmatch.embeddings.inhouse.model import GoldenEmbedModel  # noqa: E402
+
+# tests -> goldenmatch -> python -> packages -> <repo root>
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURE = _REPO_ROOT / "packages/rust/extensions/goldenembed/tests/fixtures/tiny_model"
+
+
+def test_embed_udf_shape_and_parity(monkeypatch):
+    monkeypatch.setenv("GOLDENEMBED_MODEL_DIR", str(FIXTURE))
+    from datafusion import SessionContext, udf
+    from goldenmatch_datafusion_udf import EmbedUDF
+
+    ctx = SessionContext()
+    ctx.register_udf(udf(EmbedUDF()))
+    ctx.from_arrow(
+        pa.table({"t": pa.array(["acme corp", "acme corp"], pa.string())}),
+        name="rows",
+    )
+    batches = ctx.sql("SELECT goldenmatch_embed(t) AS e FROM rows").collect()
+    out = batches[0].column(0).to_pylist()
+
+    assert len(out) == 2
+    assert len(out[0]) == 8  # model dim
+    assert out[0] == out[1]  # determinism: identical input -> identical vector
+
+    py = GoldenEmbedModel.load(str(FIXTURE)).embed(["acme corp"], backend="onnx")[0]
+    v = np.asarray(out[0], dtype=np.float32)
+    cos = float(np.dot(v, py) / (np.linalg.norm(v) * np.linalg.norm(py) + 1e-9))
+    assert cos > 0.999, f"UDF vs python embed cosine {cos}"

--- a/packages/rust/extensions/datafusion-udf/Cargo.toml
+++ b/packages/rust/extensions/datafusion-udf/Cargo.toml
@@ -35,6 +35,10 @@ arrow-schema = "58"
 # UDFs score byte-identically to the per-pair native scorers (parity by
 # construction — one source of truth).
 goldenmatch-score-core = { path = "../score-core" }
+# Standalone local embedding runtime (featurize + ONNX). Lets goldenmatch_embed
+# run the in-house embed path with zero CPython inside the SQL engine. Pulls
+# `ort` (onnxruntime) into this cdylib — heavier build; validated in CI.
+goldenembed = { path = "../goldenembed" }
 # extension-module: don't link libpython (this .so is imported BY CPython).
 # abi3-py311: one stable-ABI artifact spans CPython 3.11-3.13 (matches the
 # sibling `native` crate; the example uses abi3-py310 but we floor at 3.11).

--- a/packages/rust/extensions/datafusion-udf/src/embed_udf.rs
+++ b/packages/rust/extensions/datafusion-udf/src/embed_udf.rs
@@ -101,8 +101,13 @@ impl ScalarUDFImpl for EmbedUDF {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        // Nullable item field to match what `FixedSizeListBuilder` produces in
+        // `invoke_with_args` (its inner field defaults to nullable). DataFusion
+        // validates the returned array's type against this exactly; a non-null
+        // declaration here mismatches the nullable builder output. The values
+        // are never actually null (we append a full row each time).
         Ok(DataType::FixedSizeList(
-            Arc::new(Field::new("item", DataType::Float32, false)),
+            Arc::new(Field::new("item", DataType::Float32, true)),
             self.dim,
         ))
     }

--- a/packages/rust/extensions/datafusion-udf/src/embed_udf.rs
+++ b/packages/rust/extensions/datafusion-udf/src/embed_udf.rs
@@ -1,0 +1,133 @@
+// goldenmatch_embed(text: Utf8) -> FixedSizeList<Float32, dim>. Loads a saved
+// GoldenEmbedModel from GOLDENEMBED_MODEL_DIR once at construction and runs the
+// pure-Rust featurize + ONNX projection per batch — a zero-CPython SQL embed
+// path. NULL Utf8 -> empty string -> the model's zero-ish vector (matches the
+// Python None convention used by the string-scorer UDFs).
+//
+// `ort` 2.x `Session::run` takes `&mut self` and `GoldenEmbed::embed` is `&mut`,
+// so the loaded model is wrapped in `Arc<Mutex<…>>`: correctness under
+// DataFusion's parallel batch execution over throughput. The Python caller
+// already parallelizes across queries, and embed batches are coarse, so the
+// per-batch lock is not the bottleneck.
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
+use arrow_array::builder::{FixedSizeListBuilder, Float32Builder};
+use arrow_array::cast::AsArray;
+use arrow_schema::{DataType, Field};
+use datafusion_common::error::{DataFusionError, Result as DataFusionResult};
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_ffi::udf::FFI_ScalarUDF;
+use goldenembed::GoldenEmbed;
+use pyo3::types::PyCapsule;
+use pyo3::{pyclass, pymethods, Bound, PyResult, Python};
+
+#[pyclass(
+    from_py_object,
+    name = "EmbedUDF",
+    module = "goldenmatch_datafusion_udf",
+    subclass
+)]
+#[derive(Clone)]
+pub(crate) struct EmbedUDF {
+    signature: Signature,
+    dim: i32,
+    model: Arc<Mutex<GoldenEmbed>>,
+}
+
+// ScalarUDFImpl requires Eq + Hash + PartialEq. The loaded model isn't
+// meaningfully comparable, so identity is the (single) output dim — there is
+// only ever one goldenmatch_embed UDF per session.
+impl PartialEq for EmbedUDF {
+    fn eq(&self, other: &Self) -> bool {
+        self.dim == other.dim
+    }
+}
+impl Eq for EmbedUDF {}
+impl std::hash::Hash for EmbedUDF {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.dim.hash(state);
+    }
+}
+impl std::fmt::Debug for EmbedUDF {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EmbedUDF{{dim:{}}}", self.dim)
+    }
+}
+
+#[pymethods]
+impl EmbedUDF {
+    #[new]
+    fn new() -> PyResult<Self> {
+        let dir = std::env::var("GOLDENEMBED_MODEL_DIR").map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err(
+                "GOLDENEMBED_MODEL_DIR not set (a saved GoldenEmbedModel directory)",
+            )
+        })?;
+        let model = GoldenEmbed::load(&dir)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        let dim = model.dim() as i32;
+        Ok(Self {
+            signature: Signature::exact(vec![DataType::Utf8], Volatility::Immutable),
+            dim,
+            model: Arc::new(Mutex::new(model)),
+        })
+    }
+
+    fn __datafusion_scalar_udf__<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyCapsule>> {
+        let name = cr"datafusion_scalar_udf".into();
+        let func = Arc::new(ScalarUDF::from(self.clone()));
+        let provider = FFI_ScalarUDF::from(func);
+        PyCapsule::new(py, provider, Some(name))
+    }
+}
+
+impl ScalarUDFImpl for EmbedUDF {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "goldenmatch_embed"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::Float32, false)),
+            self.dim,
+        ))
+    }
+
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> DataFusionResult<ColumnarValue> {
+        let arrs = ColumnarValue::values_to_arrays(&args.args)?;
+        let texts = arrs[0].as_string::<i32>();
+        // NULL -> "" (matches the native string-scorer NULL convention).
+        let owned: Vec<&str> = texts.iter().map(|o| o.unwrap_or("")).collect();
+        let vecs = {
+            let mut model = self.model.lock().map_err(|_| {
+                DataFusionError::Execution("goldenmatch_embed model lock poisoned".into())
+            })?;
+            model
+                .embed(&owned)
+                .map_err(|e| DataFusionError::Execution(e.to_string()))?
+        };
+        let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), self.dim);
+        for row in vecs {
+            builder.values().append_slice(&row);
+            builder.append(true);
+        }
+        Ok(ColumnarValue::Array(Arc::new(builder.finish())))
+    }
+}

--- a/packages/rust/extensions/datafusion-udf/src/lib.rs
+++ b/packages/rust/extensions/datafusion-udf/src/lib.rs
@@ -8,8 +8,10 @@
 
 use pyo3::prelude::*;
 
+use crate::embed_udf::EmbedUDF;
 use crate::scalar_udf::{JaroWinklerUDF, LevenshteinUDF, TokenSortUDF};
 
+pub(crate) mod embed_udf;
 pub(crate) mod scalar_udf;
 
 #[pymodule]
@@ -17,5 +19,6 @@ fn goldenmatch_datafusion_udf(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<JaroWinklerUDF>()?;
     m.add_class::<TokenSortUDF>()?;
     m.add_class::<LevenshteinUDF>()?;
+    m.add_class::<EmbedUDF>()?;
     Ok(())
 }


### PR DESCRIPTION
Stage C of #508 (goldenembed-rs finish-line). The first non-CPython caller of the goldenembed crate.

## What
- `datafusion-udf` now depends on `goldenembed` by Cargo path. New `goldenmatch_embed(text: Utf8) -> FixedSizeList<Float32, dim>` ScalarUDF (`src/embed_udf.rs`), registered alongside the string scorers. Loads a saved GoldenEmbedModel from `GOLDENEMBED_MODEL_DIR` once at construction; runs the pure-Rust featurize + ONNX projection per batch -- zero CPython inside the SQL engine.
- NULL Utf8 -> "" (matches the native string-scorer NULL convention).

## Spike verdict (the Stage C gate)
- **`ort` 2.x `Session::run` is `&mut self`** (confirmed from source: `ort-2.0.0-rc.12/src/session/mod.rs:212`), and `GoldenEmbed::embed` is `&mut`. So the UDF holds `Arc<Mutex<GoldenEmbed>>` -- correctness under DataFusion's parallel batch execution over throughput. No lock-free path exists.
- **onnxruntime-loads-inside-the-cdylib** (the real risk) is validated by this PR's CI: the goldenmatch lane builds the `datafusion-udf` wheel (now pulling `ort`) and runs `tests/test_embed_udf.py`, which HARD-imports the module and runs the UDF. Green CI = spike part 2 proven.

## Tests
`packages/python/goldenmatch/tests/test_embed_udf.py` (goldenmatch lane): registers the UDF via `register_udf(udf(EmbedUDF()))`, asserts output shape `(n, dim)`, determinism (identical input -> identical vector), and cosine parity vs the Python `GoldenEmbedModel.embed` on the committed tiny fixture.

## Cost flag
Every goldenmatch CI run now builds the `datafusion-udf` wheel with onnxruntime -- a heavier/slower build than before.

Refs #508. postgres `gm_embed` remains a tracked follow-up.