### PR TITLE
docs: add Mintlify documentation site for the Golden Suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ labels.jsonl
 # still be committed since only the worktrees subdir is ignored.
 .claude/worktrees/
 
+# Superpowers / manual git worktrees (isolated checkouts; never tracked)
+.worktrees/
+
 # Local profiling artifacts (per CLAUDE.md convention — cProfile dumps,
 # scale-audit JSON outputs, synthetic fixtures). Documented as gitignored
 # in CLAUDE.md; this entry makes that real.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/benseverndev-oss/goldenmatch?style=flat&color=d4a017&logo=github)](https://github.com/benseverndev-oss/goldenmatch/stargazers)
 
 <!-- Ecosystem -->
-[![Docs](https://img.shields.io/badge/docs-bensevern.dev-d4a017)](https://bensevern.dev/)
+[![Docs](https://img.shields.io/badge/docs-docs.bensevern.dev-d4a017)](https://docs.bensevern.dev/)
 [![Wiki](https://img.shields.io/badge/wiki-github-d4a017)](https://github.com/benseverndev-oss/goldenmatch/wiki)
 [![Web UI](https://img.shields.io/badge/web%20ui-FastAPI%20%2B%20React-d4a017?logo=react&logoColor=white)](https://github.com/benseverndev-oss/goldenmatch/wiki/Web-UI)
 [![Smithery MCP](https://img.shields.io/badge/MCP-smithery-6e40c9)](https://smithery.ai/servers/benseverndev-oss/goldenmatch)

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,0 +1,31 @@
+# Golden Suite docs
+
+Mintlify documentation site for the Golden Suite monorepo.
+
+## Preview locally
+
+```bash
+npm i -g mint        # one-time
+cd docs-site
+mint dev             # http://localhost:3000
+```
+
+## Validate before pushing
+
+```bash
+mint validate        # strict build check (fails on warnings)
+mint broken-links    # check internal links and anchors
+mint a11y            # alt-text and contrast checks
+```
+
+## Structure
+
+- `docs.json` — site config and navigation.
+- `index.mdx`, `quickstart.mdx` — landing and 30-second quickstart.
+- `concepts/` — architecture, entity resolution, scale envelope.
+- `goldenmatch/`, `goldencheck/`, `goldenflow/`, `goldenpipe/`, `infermap/` — per-package docs.
+- `extensions/` — Postgres and DuckDB SQL extensions.
+- `reference/` — vendor comparison and other reference material.
+
+Content is sourced from the package `README.md` files. When a package's public API
+or CLI changes, update both the README and the matching page here.

--- a/docs-site/concepts/architecture.mdx
+++ b/docs-site/concepts/architecture.mdx
@@ -1,0 +1,87 @@
+---
+title: "Architecture"
+description: "How the five Golden Suite tools compose into one pipeline across Python, TypeScript, Rust, dbt, and GitHub Actions."
+keywords: ["architecture", "pipeline", "composition", "polyglot"]
+---
+
+The Golden Suite is built so each tool stands alone but composes into a single pipeline. You can pick just the piece you need, or run the full chain end to end.
+
+## The pipeline flow
+
+```mermaid
+flowchart LR
+  A[Raw rows] --> B[InferMap]
+  B --> C[GoldenCheck]
+  C --> D[GoldenFlow]
+  D --> E[GoldenMatch]
+  E --> F[Golden records]
+```
+
+<Steps>
+  <Step title="InferMap aligns schemas">
+    Auto-maps messy source columns to a known target schema with confidence scores and human-readable reasoning.
+  </Step>
+  <Step title="GoldenCheck profiles and validates">
+    Discovers quality rules from the data itself: encoding, format, nullability, anomalies.
+  </Step>
+  <Step title="GoldenFlow standardizes">
+    Normalizes phone numbers, dates, addresses, and categorical spelling with 76 built-in transforms.
+  </Step>
+  <Step title="GoldenMatch deduplicates">
+    Blocks, scores, clusters, and synthesizes golden records using fuzzy, exact, probabilistic, and LLM scoring.
+  </Step>
+  <Step title="GoldenPipe orchestrates">
+    Runs the whole chain with adaptive logic. It skips transformation if no issues are found and explains every decision.
+  </Step>
+</Steps>
+
+## Polyglot by design
+
+The same engine is implemented across languages so you can run it wherever your data lives.
+
+| Surface | What it covers |
+|---------|----------------|
+| Python | Headline runtime. Full feature set, `pip install`, native Postgres and DuckDB support. |
+| TypeScript | Parity core. Edge-safe (Vercel Edge, Cloudflare Workers, Deno). Matches Python scorer outputs to four decimals. |
+| Rust | Postgres extension (pgrx) and DuckDB UDFs for SQL-native matching. |
+| dbt | `dbt-goldencheck` data-quality tests as a dbt package. |
+| GitHub Actions | `goldencheck-action` gates pull requests on data-quality regressions. |
+
+## AI-native surface
+
+Every package ships an MCP server, a REST API, and an agent surface. Across the suite there are 35+ MCP tools. The `AutoConfigController` is visible from every interface: the web `ControllerPanel`, the TUI (`Ctrl+A`), the CLI, REST endpoints, Postgres functions, DuckDB UDFs, and MCP/agent tools.
+
+Add the remote MCP server to Claude Desktop or Claude Code:
+
+```json
+{
+  "mcpServers": {
+    "goldenmatch": {
+      "url": "https://goldenmatch-mcp-production.up.railway.app/mcp/"
+    }
+  }
+}
+```
+
+## Repository layout
+
+The suite is a single monorepo:
+
+```text
+packages/
+├── python/       goldenmatch, goldencheck, goldenflow, goldenpipe, infermap, goldensuite-mcp
+├── typescript/   goldenmatch, goldencheck, goldenflow, infermap
+├── rust/         extensions (Postgres pgrx + DuckDB UDFs)
+├── dbt/          dbt-goldencheck
+└── actions/      goldencheck GitHub Action
+examples/         Python, TypeScript, and Airflow DAG demos
+```
+
+## Production paths
+
+- Postgres sync and daemon mode for continuous deduplication.
+- Review queues for human-in-the-loop correction.
+- dbt integration for warehouse-native pipelines.
+- GitHub Actions for pull-request data-quality gates.
+- Airflow DAGs (drop-in examples, TaskFlow API, Airflow 2.7+).
+- The Rust extension layer for matching directly inside Postgres or DuckDB.

--- a/docs-site/concepts/entity-resolution.mdx
+++ b/docs-site/concepts/entity-resolution.mdx
@@ -1,0 +1,57 @@
+---
+title: "Entity resolution"
+description: "The core concepts behind deduplication and record linkage: blocking, scoring, clustering, and survivorship."
+keywords: ["entity resolution", "blocking", "scoring", "clustering", "survivorship", "matchkey"]
+---
+
+Entity resolution (ER) is the process of finding records that refer to the same real-world entity, whether within one dataset (deduplication) or across two (record linkage). GoldenMatch breaks this into four stages.
+
+## Blocking
+
+Comparing every pair of records is quadratic and infeasible at scale. Blocking reduces candidate pairs by grouping records that share a key (for example, the same ZIP or the same soundex of a surname) and only comparing within blocks.
+
+The blocking key is the single biggest performance lever. For `N` rows split into blocks of sizes `n1, n2, ...`:
+
+```text
+candidate_pairs = sum_i (ni choose 2)
+```
+
+A good key produces many small blocks. A poor key (for example, blocking on a low-cardinality city field) produces a few huge blocks and an explosion of pairs. See [scale envelope](/concepts/scale-envelope) for the guard rails.
+
+GoldenMatch ships 8+ blocking strategies: `static`, `adaptive`, `sorted_neighborhood`, `multi_pass`, `ann`, `ann_pairs`, `canopy`, and `learned` (data-driven predicate selection).
+
+## Scoring
+
+Within each block, candidate pairs are scored. A **matchkey** is a named rule that combines one or more fields, each with a scorer and a weight, and a threshold above which a pair is a match.
+
+GoldenMatch provides 12+ scoring methods, including:
+
+- **String similarity**: `exact`, `jaro_winkler`, `levenshtein`, `token_sort`, `soundex_match`, `dice`, `jaccard`.
+- **Name-aware**: `name_freq_weighted_jw` (surname IDF-weighted), `given_name_aliased_jw` (alias-aware).
+- **Embedding**: `embedding`, `record_embedding`.
+- **Probabilistic**: Fellegi-Sunter EM-trained m/u probabilities with automatic threshold estimation.
+- **LLM**: GPT-4o-mini or Claude scores borderline pairs, with budget caps and graceful degradation.
+
+## Clustering
+
+Pairwise matches are transitively closed into clusters: if A matches B and B matches C, then A, B, and C form one cluster. Clusters are labeled `strong`, `weak`, or `split`. Oversized clusters are automatically split on their weakest edge using a minimum spanning tree, which prevents a single shared value (a common `info@` email, say) from collapsing unrelated records into one giant cluster.
+
+## Survivorship
+
+A **golden record** is the canonical record synthesized from a cluster. GoldenMatch offers five merge strategies:
+
+- `most_complete`
+- `majority_vote`
+- `source_priority`
+- `most_recent`
+- `first_non_null`
+
+Fields can be weighted by source quality (from GoldenCheck), and field-level provenance tracks which source row contributed each value.
+
+## Privacy-preserving linkage
+
+When you cannot share raw data across organizations, [PPRL](/goldenmatch/pprl) matches records using Bloom-filter encodings instead of plaintext, reaching F1 0.924 on the FEBRL4 benchmark.
+
+<Card title="Auto-config" icon="robot" href="/goldenmatch/auto-config">
+  GoldenMatch can choose all of the above for you and iterate until it converges.
+</Card>

--- a/docs-site/concepts/scale-envelope.mdx
+++ b/docs-site/concepts/scale-envelope.mdx
@@ -1,0 +1,67 @@
+---
+title: "Scale envelope"
+description: "Pick the right backend for your row count, and avoid the block-size failure modes that dominate ER performance."
+keywords: ["scale", "backend", "polars", "duckdb", "ray", "blocking", "performance"]
+---
+
+The right backend depends mostly on your row count. The single biggest performance lever, though, is the blocking key, not the backend.
+
+## Backend by row count
+
+| Rows | Backend | Notes |
+|------|---------|-------|
+| < 500K | `polars` (default) | In-memory. Fastest per record. OOM ceiling near 500K on fuzzy runs. |
+| 500K – 50M | `duckdb` | Out-of-core, single machine. Spills to disk, so RAM stops being the ceiling. |
+| ≥ 50M, or many large blocks | `ray` | Distributed block scoring. Needs ≥ 4 large blocks to pay back overhead. |
+
+<Note>
+  GoldenMatch also has a `chunked` backend used for very large single-machine dedupe (streaming CSV reader plus a Polars cross-chunk join plus a block-keyed index). See [backends and scale](/goldenmatch/backends-and-scale).
+</Note>
+
+## Measured numbers
+
+These are quoted from the repository and were measured on the versions noted. Re-measure for your own hardware.
+
+| Records | Backend | Wall | Peak RSS | Notes |
+|---------|---------|------|----------|-------|
+| 1M exact dedupe | polars | ~7.8s | — | In-memory self-join |
+| 100K fuzzy (name + zip) | polars | ~12.8s | 544 MB | Full pipeline, ~8,200 rec/s |
+| 1M fuzzy | polars | — | — | OOMs in-memory |
+| 5M | chunked | ~50 min | 11.9 GB | 4c/16GB runner, 618,817 multi-member clusters, no OOM |
+
+## Block-size failure modes
+
+Most ER blow-ups come from a blocking key that produces a few huge blocks. GoldenMatch enforces guard rails:
+
+- `max_block_size: 5000` in hand-written `BlockingConfig`.
+- `max_safe_block = 1000` in auto-config (blocks over 1000 can OOM ensemble scorers).
+- `skip_oversized: false` by default. When true, oversized blocks are ANN-sub-blocked or skipped.
+
+### Cardinality guards (v1.2.7)
+
+| Guard | Threshold | Prevents |
+|-------|-----------|----------|
+| Blocking exclusion | `cardinality_ratio >= 0.95` | Near-unique columns producing single-record blocks. |
+| Matchkey exclusion | `cardinality_ratio < 0.01` | Too few distinct values to be useful. |
+| Null-rate exclusion | `null_rate > 0.2` | Sparse columns creating huge null-block sinks. |
+
+### The common-email trap
+
+Using `exact=["email"]` as the only matchkey creates oversized clusters around shared values like `info@`, `noreply@`, or null. Symptoms: one giant cluster, stalled scoring, memory pressure. Fix it by standardizing or stripping common patterns, or by adding a second blocking pass.
+
+## Checklist before scaling
+
+<Steps>
+  <Step title="Profile your blocking key">
+    Check its `cardinality_ratio`. Auto-config prints this in its postflight health report.
+  </Step>
+  <Step title="Respect the block-size cap">
+    Stay under `max_block_size=1000` for auto-config, or `5000` for hand-written configs.
+  </Step>
+  <Step title="Pick the backend from row count">
+    < 500K → Polars; 500K – 50M → DuckDB; ≥ 50M or many large blocks → Ray.
+  </Step>
+  <Step title="Re-measure if exact numbers matter">
+    The published figures are baselines on specific versions and hardware.
+  </Step>
+</Steps>

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "Golden Suite",
+  "description": "A polyglot data-quality and entity-resolution toolkit. Zero-config, AI-native, MIT-licensed.",
+  "colors": {
+    "primary": "#8a6d0f",
+    "light": "#e8b923",
+    "dark": "#b8860b"
+  },
+  "favicon": "/favicon.svg",
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "Documentation",
+        "groups": [
+          {
+            "group": "Get started",
+            "pages": [
+              "index",
+              "quickstart"
+            ]
+          },
+          {
+            "group": "Concepts",
+            "pages": [
+              "concepts/architecture",
+              "concepts/entity-resolution",
+              "concepts/scale-envelope"
+            ]
+          },
+          {
+            "group": "GoldenMatch",
+            "pages": [
+              "goldenmatch/overview",
+              "goldenmatch/quickstart",
+              "goldenmatch/auto-config",
+              "goldenmatch/backends-and-scale",
+              "goldenmatch/pprl",
+              "goldenmatch/cli"
+            ]
+          },
+          {
+            "group": "GoldenCheck",
+            "pages": [
+              "goldencheck/overview",
+              "goldencheck/cli",
+              "goldencheck/integrations"
+            ]
+          },
+          {
+            "group": "GoldenFlow",
+            "pages": [
+              "goldenflow/overview",
+              "goldenflow/cli"
+            ]
+          },
+          {
+            "group": "GoldenPipe",
+            "pages": [
+              "goldenpipe/overview"
+            ]
+          },
+          {
+            "group": "InferMap",
+            "pages": [
+              "infermap/overview"
+            ]
+          },
+          {
+            "group": "SQL extensions",
+            "pages": [
+              "extensions/sql"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "reference/vendor-comparison"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "navbar": {
+    "links": [
+      {
+        "label": "GitHub",
+        "href": "https://github.com/benseverndev-oss/goldenmatch"
+      }
+    ],
+    "primary": {
+      "type": "button",
+      "label": "PyPI",
+      "href": "https://pypi.org/project/goldenmatch/"
+    }
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/benseverndev-oss/goldenmatch"
+    }
+  },
+  "seo": {
+    "metatags": {
+      "canonical": "https://docs.bensevern.dev"
+    }
+  }
+}

--- a/docs-site/extensions/sql.mdx
+++ b/docs-site/extensions/sql.mdx
@@ -1,0 +1,98 @@
+---
+title: "SQL extensions"
+description: "Run GoldenMatch fuzzy matching directly inside PostgreSQL and DuckDB."
+keywords: ["postgres", "duckdb", "sql", "extension", "pgrx", "udf"]
+---
+
+The `goldenmatch-extensions` package runs GoldenMatch directly from SQL, without leaving the database. It ships a pgrx-based PostgreSQL extension and a DuckDB UDF package.
+
+## PostgreSQL
+
+### Install
+
+The fastest path is the prebuilt Docker image with the extension preinstalled:
+
+```bash
+docker run -p 5432:5432 -e POSTGRES_PASSWORD=postgres \
+  ghcr.io/benseverndev-oss/goldenmatch-extensions:latest
+
+psql -h localhost -U postgres \
+  -c "SELECT goldenmatch.goldenmatch_score('John', 'Jon', 'jaro_winkler');"
+```
+
+Package installs are also available:
+
+```bash
+# Debian / Ubuntu
+curl -LO https://github.com/benseverndev-oss/goldenmatch-extensions/releases/latest/download/postgresql-16-goldenmatch_0.2.0_amd64.deb
+sudo dpkg -i postgresql-16-goldenmatch_0.2.0_amd64.deb
+pip install goldenmatch>=1.1.0
+```
+
+Then enable it:
+
+```sql
+CREATE EXTENSION goldenmatch_pg;
+SELECT goldenmatch.goldenmatch_score('John Smith', 'Jon Smyth', 'jaro_winkler');
+```
+
+### Functions
+
+```sql
+-- Score two strings
+SELECT goldenmatch_score('John Smith', 'Jon Smyth', 'jaro_winkler');  -- 0.91
+
+-- Score two JSON records against a config
+SELECT goldenmatch_score_pair(
+    '{"name": "John Smith", "email": "j@x.com"}',
+    '{"name": "Jon Smyth", "email": "j@x.com"}',
+    '{"fuzzy": {"name": 0.85}, "exact": ["email"]}'
+);  -- 0.95
+
+-- Explain a match
+SELECT goldenmatch_explain(rec_a, rec_b, config);
+
+-- Whole-table operations
+SELECT goldenmatch_dedupe_table('customers', '{"exact": ["email"]}');
+SELECT goldenmatch_match_tables('prospects', 'customers', '{"fuzzy": {"name": 0.85}}');
+```
+
+## DuckDB
+
+```bash
+pip install goldenmatch-duckdb
+```
+
+```python
+import duckdb
+import goldenmatch_duckdb
+
+con = duckdb.connect()
+goldenmatch_duckdb.register(con)
+
+con.sql("SELECT goldenmatch_score('John Smith', 'Jon Smyth', 'jaro_winkler')").show()
+con.sql("SELECT goldenmatch_dedupe_table('customers', '{\"exact\": [\"email\"]}')").show()
+```
+
+Registered UDFs:
+
+| Function | Purpose |
+|----------|---------|
+| `goldenmatch_score(a, b, scorer)` | Score two strings. |
+| `goldenmatch_score_pair(rec_a, rec_b, config)` | Score two JSON records. |
+| `goldenmatch_explain(rec_a, rec_b, config)` | Explain a match. |
+| `goldenmatch_dedupe_table(table, config)` | Deduplicate a table. |
+| `goldenmatch_match_tables(target, ref, config)` | Match two tables. |
+| `goldenmatch_dedupe(json, config)` | Deduplicate JSON records directly. |
+| `goldenmatch_match(target_json, ref_json, config)` | Match two JSON record sets. |
+
+## Requirements
+
+- Python 3.11+
+- `goldenmatch >= 1.1.0`
+- DuckDB 1.0+ (DuckDB extension)
+- PostgreSQL 15, 16, or 17 (Postgres extension)
+
+<Note>
+  The extension embeds CPython through pyo3 and calls the GoldenMatch Python API, so the matching the extension performs is identical to the Python package.
+</Note>

--- a/docs-site/favicon.svg
+++ b/docs-site/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Golden Suite">
+  <circle cx="16" cy="16" r="14" fill="#d4a017"/>
+  <circle cx="16" cy="16" r="6" fill="#fff8e1"/>
+</svg>

--- a/docs-site/goldencheck/cli.mdx
+++ b/docs-site/goldencheck/cli.mdx
@@ -1,0 +1,87 @@
+---
+title: "GoldenCheck CLI"
+description: "Commands, key flags, domain packs, and the goldencheck.yml config format."
+keywords: ["goldencheck", "cli", "commands", "domains", "config"]
+---
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `goldencheck <file>` | Scan and launch the interactive TUI. |
+| `goldencheck scan <file>` | Explicit scan (`--smart`, `--guided`). |
+| `goldencheck validate <file>` | Validate against `goldencheck.yml` rules. |
+| `goldencheck review <file>` | Scan plus validate, then launch the TUI. |
+| `goldencheck init <file>` | Interactive setup wizard (scan → config → CI). |
+| `goldencheck diff <file> [file2]` | Compare two files, or against git HEAD (`--ref main`). |
+| `goldencheck watch <dir>` | Poll a directory and re-scan on change (`--interval 30`). |
+| `goldencheck fix <file>` | Auto-fix issues (`--mode safe\|moderate\|aggressive`, `--dry-run`). |
+| `goldencheck baseline <file>` | Deep-profile and save a statistical baseline to YAML. |
+| `goldencheck learn <file>` | Generate LLM validation rules. |
+| `goldencheck history` | Show scan history and trends. |
+| `goldencheck serve` | Start the REST API server (`--port 8000`). |
+| `goldencheck scan-db <conn>` | Scan a database table directly. |
+| `goldencheck schedule <files>` | Run scans on a cron schedule (`--interval`, `--webhook`). |
+| `goldencheck mcp-serve` | Start the MCP server (19 tools). |
+
+The TypeScript CLI mirrors the core commands under `goldencheck-js` (`scan`, `validate`, `profile`, `health-score`, `baseline`, `fix`, `diff`, `demo`).
+
+## Key flags
+
+| Flag | Values | Effect |
+|------|--------|--------|
+| `--no-tui` | — | Print results to the console. |
+| `--json` | — | JSON output. |
+| `--fail-on` | `error`, `warning` | Exit non-zero at this severity. |
+| `--domain` | `healthcare`, `finance`, `ecommerce`, `real_estate`, `people_hr` | Apply a domain pack. |
+| `--llm-boost` | — | Enable LLM enhancement. |
+| `--llm-provider` | `anthropic` (default), `openai` | Choose the LLM provider. |
+| `--mode` | `safe`, `moderate`, `aggressive` | Fix mode (for `fix`). |
+| `--smart` | — | Auto-triage: pin high-confidence, dismiss low. |
+| `--webhook` | URL | POST findings to Slack, PagerDuty, or a custom endpoint. |
+| `--baseline` | path | Baseline YAML for drift detection. |
+
+## Config
+
+A `goldencheck.yml` pins explicit rules for CI:
+
+```yaml
+version: 1
+
+settings:
+  sample_size: 100000
+  fail_on: error
+
+columns:
+  email:
+    type: string
+    required: true
+    format: email
+    unique: true
+  age:
+    type: integer
+    range: [0, 120]
+  status:
+    type: string
+    enum: [active, inactive, pending, closed]
+
+relations:
+  - type: temporal_order
+    columns: [start_date, end_date]
+
+ignore:
+  - column: notes
+    check: nullability
+```
+
+Relation types: `temporal_order`, `null_correlation`, `numeric_cross_column`, and `age_vs_dob`.
+
+## Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `ANTHROPIC_API_KEY` | LLM boost (default provider). |
+| `OPENAI_API_KEY` | LLM boost (alternative provider). |
+| `GOLDENCHECK_LLM_BUDGET` | Max spend per scan, in USD. |
+| `GOLDENCHECK_SAMPLE_SIZE` | Override the default sample size (100K rows). |
+| `GOLDENCHECK_DOMAIN` | Default domain pack. |

--- a/docs-site/goldencheck/integrations.mdx
+++ b/docs-site/goldencheck/integrations.mdx
@@ -1,0 +1,80 @@
+---
+title: "GoldenCheck integrations"
+description: "Run GoldenCheck as dbt tests and as a GitHub Action that gates pull requests on data-quality regressions."
+keywords: ["dbt", "github actions", "ci", "data quality", "integration"]
+---
+
+GoldenCheck plugs into the two places data-quality regressions usually slip through: warehouse models and pull requests.
+
+## dbt
+
+Add the package to `packages.yml`:
+
+```yaml
+packages:
+  - git: "https://github.com/benseverndev-oss/goldenmatch.git"
+    subdirectory: "packages/dbt/goldencheck"
+    revision: main
+```
+
+Then run `dbt deps`. The package offers a SQL-native test macro and a Python runner.
+
+Use the test macro in a schema file:
+
+```yaml
+models:
+  - name: orders
+    tests:
+      - goldencheck_not_empty
+```
+
+Run a full scan against a model's output:
+
+```bash
+python scripts/run_goldencheck.py orders --fail-on error
+python scripts/run_goldencheck.py patients --fail-on warning --domain healthcare
+```
+
+The runner connects through `profiles.yml`, queries the model via `dbt show`, writes a temp CSV, runs the full profiler, and exits non-zero on findings at or above `--fail-on`.
+
+<Note>
+  Requires dbt-core 1.7+, goldencheck 0.5.0+, and Python 3.11+.
+</Note>
+
+## GitHub Actions
+
+Scan CSV files in CI and post a findings summary on the pull request:
+
+```yaml
+- uses: benseverndev-oss/goldencheck-action@v1
+  with:
+    files: "data/*.csv"
+    fail-on: error
+    config: goldencheck.yml
+    llm-boost: true
+    llm-provider: openai
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+### Inputs
+
+| Input | Required | Default | Values |
+|-------|----------|---------|--------|
+| `files` | Yes | — | Glob pattern (for example `data/*.csv`). |
+| `fail-on` | No | `error` | `error`, `warning`. |
+| `config` | No | — | Path to `goldencheck.yml`. |
+| `llm-boost` | No | `false` | `true`, `false`. |
+| `llm-provider` | No | `anthropic` | `anthropic`, `openai`. |
+| `python-version` | No | `3.12` | Python version string. |
+| `version` | No | `latest` | GoldenCheck version. |
+
+### Outputs
+
+| Output | Type | Description |
+|--------|------|-------------|
+| `errors` | number | Total error count. |
+| `warnings` | number | Total warning count. |
+| `health-grade` | string | Worst health grade (A–F). |
+
+The action posts a summary table on the pull request and sets a pass/fail status check from the exit code.

--- a/docs-site/goldencheck/overview.mdx
+++ b/docs-site/goldencheck/overview.mdx
@@ -1,0 +1,109 @@
+---
+title: "GoldenCheck overview"
+description: "Zero-config data-quality scanning that discovers rules from your data instead of making you write them."
+keywords: ["goldencheck", "data quality", "validation", "profiling", "drift detection"]
+---
+
+GoldenCheck is a zero-config data-validation platform that discovers quality rules automatically from your data. It combines fast statistical profilers with optional LLM enhancement to catch type mismatches, missing values, format violations, outliers, and cross-column constraints. It runs as a CLI, a Python and TypeScript library, a dbt package, and a GitHub Action.
+
+<CardGroup cols={2}>
+  <Card title="CLI reference" icon="terminal" href="/goldencheck/cli">
+    Commands, flags, and domain packs.
+  </Card>
+  <Card title="Integrations" icon="plug" href="/goldencheck/integrations">
+    dbt tests and the GitHub Action.
+  </Card>
+</CardGroup>
+
+## Install
+
+<CodeGroup>
+
+```bash pip
+pip install goldencheck
+```
+
+```bash npm
+npm install goldencheck
+```
+
+</CodeGroup>
+
+Extras:
+
+```bash
+pip install goldencheck[llm]                # LLM boost (Anthropic / OpenAI)
+pip install goldencheck[baseline]           # deep profiling and drift detection
+pip install goldencheck[baseline,semantic]  # + semantic type inference
+pip install goldencheck[db]                  # database scanning
+pip install goldencheck[mcp]                 # MCP server
+```
+
+## Quickstart
+
+```bash
+# Scan a file: discover issues and launch the TUI
+goldencheck data.csv
+
+# CI-friendly: no TUI, JSON output, fail on errors
+goldencheck data.csv --no-tui --json
+goldencheck validate data.csv
+```
+
+In Python:
+
+```python
+import goldencheck
+
+findings = goldencheck.scan_file("data.csv")
+for f in findings:
+    print(f"[{f.severity}] {f.column}: {f.check} — {f.message}")
+
+score = goldencheck.health_score("data.csv")
+print(score)  # e.g. "B (78/100)"
+```
+
+The edge-safe TypeScript core:
+
+```typescript
+import { scanData, TabularData, Severity } from "goldencheck";
+
+const data = new TabularData([
+  { id: 1, email: "alice@example.com", age: 30, status: "active" },
+  { id: 2, email: "bob@test.com", age: -5, status: "inactive" },
+  { id: 3, email: "not-an-email", age: 25, status: "active" },
+]);
+
+const { findings, profile } = scanData(data);
+for (const f of findings) {
+  console.log(`[${f.severity === Severity.ERROR ? "ERROR" : "WARNING"}] ${f.column}: ${f.message}`);
+}
+```
+
+## Key features
+
+- **Profiling**: type inference, nullability, uniqueness, format detection, range and distribution, cardinality, and pattern consistency.
+- **Cross-column checks**: temporal ordering, null correlation, numeric constraints, and age-versus-DOB.
+- **Baseline and drift detection**: 13 check types including distribution drift, entropy drift, Benford drift, functional-dependency violation, and type drift.
+- **Domain packs**: healthcare, finance, ecommerce, real estate, and people/HR.
+- **Auto-fix**: safe repairs such as trim, normalize case, fix encoding, and coerce types.
+- **LLM boost**: optional semantic understanding at roughly $0.01 per scan.
+- **Confidence scoring**: every finding carries a 0.0–1.0 confidence.
+
+## Baseline and drift
+
+Create a statistical baseline once, then check new data against it cheaply:
+
+```python
+import goldencheck
+
+baseline = goldencheck.create_baseline("reference.csv")
+baseline.save("goldencheck_baseline.yaml")
+
+findings, profile = goldencheck.scan_file("production.csv", baseline="goldencheck_baseline.yaml")
+drift = [f for f in findings if f.source == "baseline_drift"]
+```
+
+## Benchmark
+
+GoldenCheck scores 88.40 on DQBench (versus Pandera 32.51, Great Expectations 21.68, Soda 22.36), at roughly 482K rows/sec.

--- a/docs-site/goldenflow/cli.mdx
+++ b/docs-site/goldenflow/cli.mdx
@@ -1,0 +1,74 @@
+---
+title: "GoldenFlow CLI"
+description: "Commands, flags, and the goldenflow.yaml config format."
+keywords: ["goldenflow", "cli", "commands", "config", "transforms"]
+---
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `goldenflow transform <file>` | Zero-config auto-detect and fix. |
+| `goldenflow <file>` | Shorthand that routes to `transform`. |
+| `goldenflow -` | Read from stdin, write to stdout. |
+| `goldenflow map --source a.csv --target b.csv` | Auto-map schemas between files. |
+| `goldenflow profile <file>` | Show column profiles. |
+| `goldenflow learn <file> -o config.yaml` | Generate a config from data patterns. |
+| `goldenflow validate <file>` | Dry-run: show what would change. |
+| `goldenflow diff before.csv after.csv` | Compare pre/post transform. |
+| `goldenflow watch ./data/` | Auto-transform new or changed files. |
+| `goldenflow schedule <file> --every 1h` | Run on a schedule (`5m`, `1h`, `30s`...). |
+| `goldenflow stream large_file.csv --chunk-size 50000` | Stream-process in batches. |
+| `goldenflow init <file>` | Interactive setup wizard. |
+| `goldenflow demo` | Generate sample data to try. |
+| `goldenflow history [-n 50]` | Show recent transform runs. |
+| `goldenflow interactive <file>` | Launch the TUI. |
+| `goldenflow serve` | REST API for real-time transforms. |
+| `goldenflow mcp-serve` | MCP server for Claude Desktop. |
+
+## Key flags
+
+| Flag | Effect |
+|------|--------|
+| `--domain healthcare\|people_hr\|finance\|ecommerce\|real_estate` | Apply a domain pack. |
+| `--strict` | Fail on the first transform error (exit 1). |
+| `--llm` | Enable LLM-enhanced corrections. |
+| `-c <config.yaml>` | Load an explicit config. |
+| `-o <output_path>` | Output directory or file. |
+| `--every <interval>` | Scheduling interval. |
+| `--chunk-size <N>` | Streaming batch size. |
+
+## Config
+
+```yaml
+source: customers.csv
+output: customers_clean.csv
+
+transforms:
+  - column: name
+    ops: [strip, title_case]
+  - column: email
+    ops: [lowercase, strip]
+  - column: phone
+    ops: [phone_e164]
+
+renames:
+  email_address: email
+  phone_number: phone
+
+drop: [internal_id, temp_notes]
+
+dedup:
+  columns: [email]
+  keep: first
+```
+
+## Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `OPENAI_API_KEY` | LLM-enhanced categorical corrections (with `--llm`). |
+| `ANTHROPIC_API_KEY` | Alternative LLM provider. |
+| `GOLDENFLOW_LLM=1` | Enable LLM mode programmatically. |
+
+Transform runs are saved to `~/.goldenflow/history/` as JSON.

--- a/docs-site/goldenflow/overview.mdx
+++ b/docs-site/goldenflow/overview.mdx
@@ -1,0 +1,111 @@
+---
+title: "GoldenFlow overview"
+description: "Standardize, reshape, and normalize messy data with 76 built-in transforms across 11 categories."
+keywords: ["goldenflow", "transforms", "standardization", "normalization", "data cleaning"]
+---
+
+GoldenFlow standardizes, reshapes, and normalizes messy data before it enters a pipeline. In zero-config mode it auto-detects quality issues and applies safe transforms. It ships 76 built-in transforms across 11 categories (text, phone, name, address, date, categorical, numeric, email, identifiers, and URLs), plus domain packs for healthcare, finance, ecommerce, people/HR, and real estate. It scores 100/100 on the DQBench transform benchmarks.
+
+<Card title="CLI reference" icon="terminal" href="/goldenflow/cli">
+  Commands, flags, and the config format.
+</Card>
+
+## Install
+
+<CodeGroup>
+
+```bash pip
+pip install goldenflow
+```
+
+```bash npm
+npm install goldenflow
+```
+
+</CodeGroup>
+
+Extras: `goldenflow[check]` adds GoldenCheck integration, `goldenflow[mcp]` adds the MCP server, and `goldenflow[all]` brings everything.
+
+## Quickstart
+
+Zero-config auto-detect:
+
+```bash
+goldenflow transform messy_data.csv
+goldenflow demo
+```
+
+In Python:
+
+```python
+import goldenflow
+
+result = goldenflow.transform_file("messy_data.csv")
+print(result.df)        # clean Polars DataFrame
+print(result.manifest)  # audit trail
+```
+
+In TypeScript:
+
+```typescript
+import { TransformEngine } from "goldenflow";
+
+const result = new TransformEngine().transformDf([
+  { name: "  JOHN  ", phone: "(555) 123-4567", email: "John@Example.COM" },
+]);
+console.log(result.rows[0]);
+// { name: "JOHN", phone: "+15551234567", email: "john@example.com" }
+```
+
+## Key features
+
+- **Zero-config mode**: auto-detects column types and applies safe transforms.
+- **76 transforms** across 11 categories.
+- **5 domain packs**: healthcare, finance, ecommerce, people/HR, real estate.
+- **Audit trail**: a JSON manifest of every transform, which rows changed, and before/after samples.
+- **Schema mapping**: auto-map columns between systems by name similarity and data profiling.
+- **Streaming**: process large files in chunks via `StreamProcessor`.
+- **Cloud connectors**: transparent `s3://` and `gs://` paths.
+- **Watch and schedule**: auto-transform new files, or run on an interval.
+- **LLM-enhanced mode**: optional categorical corrections via `--llm`.
+- **Polars-native**, with Jupyter-friendly rich rendering.
+
+## Configured transforms
+
+```python
+import goldenflow
+from goldenflow import GoldenFlowConfig, TransformSpec
+
+config = GoldenFlowConfig(transforms=[
+    TransformSpec(column="first_name", ops=["strip", "title_case"]),
+    TransformSpec(column="last_name", ops=["strip", "title_case"]),
+    TransformSpec(column="email", ops=["strip", "lowercase"]),
+    TransformSpec(column="phone", ops=["strip", "phone_national"]),
+])
+result = goldenflow.transform_df(df, config=config)
+```
+
+## Schema mapping
+
+```python
+from goldenflow import SchemaMapper
+import polars as pl
+
+source = pl.DataFrame({"fname": ["John"], "lname": ["Smith"]})
+target = pl.DataFrame({"first_name": [""], "last_name": [""]})
+
+mapper = SchemaMapper()
+for m in mapper.map(source, target):
+    print(f"{m.source} → {m.target} ({m.confidence:.0%})")
+```
+
+## Streaming
+
+```python
+from goldenflow.streaming import StreamProcessor
+
+processor = StreamProcessor(config=config)
+for result in processor.stream_file("large_data.csv", chunk_size=10_000):
+    write_to_output(result.df)
+print(f"Processed {processor.batches_processed} batches")
+```

--- a/docs-site/goldenmatch/auto-config.mdx
+++ b/docs-site/goldenmatch/auto-config.mdx
@@ -1,0 +1,66 @@
+---
+title: "Auto-config"
+description: "How the introspective AutoConfig controller detects column types, picks scorers and blocking, and iterates until it converges."
+keywords: ["auto-config", "controller", "zero-config", "complexity profile", "convergence"]
+---
+
+The introspective AutoConfig controller is what lets GoldenMatch beat hand-tuned baselines with no input. It detects column types, selects scorers, picks a blocking strategy, then iterates on signals the pipeline emits until it converges on a defensible config.
+
+## What it does
+
+Given a file, the controller:
+
+1. Detects column types (name, email, phone, zip, address, description).
+2. Selects appropriate scorers per column.
+3. Picks a blocking strategy.
+4. Runs the pipeline and reads back complexity signals.
+5. Applies refinement rules and repeats until health stops improving.
+
+## Signals it watches
+
+The controller iterates on a `ComplexityProfile`:
+
+- Block-size distribution (p50 / p95 / p99).
+- Score histogram (bimodality detection).
+- Transitivity rate.
+- Borderline mass (pairs near the threshold).
+- Negative-evidence collision rate (v1.11+).
+
+## Refinement rules
+
+The `HeuristicRefitPolicy` applies rules such as:
+
+| Rule | Effect |
+|------|--------|
+| `rule_no_matches` | Raises the threshold if no pairs are found. |
+| `rule_blocking_key_swap` | Switches to an orthogonal blocking key on low recall. |
+| `rule_corruption_normalize` | Adds normalization for corrupted identity columns. |
+| `rule_sparse_match_expand` | Lowers the threshold and adds side-channel blocking for sparse matches. |
+| `rule_demote_clustered_identity` | Demotes exact matchkeys with a collision rate above 0.75 (v1.11). |
+| `promote_negative_evidence` | Adds negative-evidence penalties for identity-discriminating columns (v1.11). |
+| `rule_negative_evidence_exact_filter` | Applies negative-evidence penalties to exact matchkeys via a post-filter (Path Y, v1.12). |
+
+Configs are ranked by a health metric: GREEN > YELLOW > RED, with the initial config as a virtual fallback.
+
+<Warning>
+  At 100,000+ rows, auto-config raises `ControllerNotConfidentError` rather than silently committing a low-confidence (RED) config. Handle this explicitly instead of adding a silent fallback path.
+</Warning>
+
+## Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `GOLDENMATCH_AUTOCONFIG_MEMORY=0` | Disable cross-run memory (default on; stored at `~/.goldenmatch/autoconfig_memory.db`). |
+| `GOLDENMATCH_AUTOCONFIG_MEMORY_PATH=<path>` | Custom path for the cross-run memory store. |
+| `GOLDENMATCH_AUTOCONFIG_LLM=1` | Enable the LLM fallback policy (requires `OPENAI_API_KEY`). |
+| `GOLDENMATCH_AUTOCONFIG_BACKEND=duckdb\|ray\|0` | Force a backend, or `0` to auto-select. |
+| `GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD=<int>` | Row-count cutoff for DuckDB auto-selection (default 1,000,000). |
+| `GOLDENMATCH_AUTOCONFIG_INDICATOR_BUDGET=fast\|full` | Run the cheap or the full indicator set (default `fast`). |
+
+## Cross-run memory
+
+By default the controller remembers what worked on prior runs and seeds future runs from it. Disable it with `GOLDENMATCH_AUTOCONFIG_MEMORY=0`, or point it elsewhere with `GOLDENMATCH_AUTOCONFIG_MEMORY_PATH`.
+
+<Card title="Scale envelope" icon="gauge-high" href="/concepts/scale-envelope">
+  The block-size guards the controller respects, and how it picks a backend.
+</Card>

--- a/docs-site/goldenmatch/backends-and-scale.mdx
+++ b/docs-site/goldenmatch/backends-and-scale.mdx
@@ -1,0 +1,69 @@
+---
+title: "Backends and scale"
+description: "The Polars, chunked, DuckDB, and Ray backends, and the measured scale numbers for each."
+keywords: ["backend", "polars", "duckdb", "chunked", "ray", "scale", "performance"]
+---
+
+GoldenMatch runs the same pipeline across four backends. The default is in-memory Polars; the others trade per-record speed for the ability to handle larger datasets without running out of memory.
+
+## Backends
+
+| Backend | Range | How it works |
+|---------|-------|--------------|
+| `polars` (default) | < 500K rows | In-memory Polars DataFrames. Fastest per record. |
+| `chunked` | 5M+ rows, single machine | Streaming CSV reader plus a vectorized Polars cross-chunk join plus a block-keyed bucketed index. |
+| `duckdb` | 500K – 50M rows | Out-of-core pair store via DuckDB. Spills to disk, so RAM is not the ceiling. |
+| `ray` | ≥ 50M rows, distributed | Per-block remote tasks; matchkey config and exclude-pairs set shared zero-copy via the Ray object store. |
+
+## Measured scale
+
+Quoted from the repository. Re-measure for your own hardware.
+
+| Records | Backend | Wall | Peak RSS | Clusters |
+|---------|---------|------|----------|----------|
+| 1,000 | polars | 0.2s | 101 MB | 210 multi-member |
+| 10,000 | polars | 1.4s | 123 MB | 7,000 multi-member |
+| 100,000 | polars | 12s | 544 MB | ~8,200 rec/s |
+| 1M (exact) | polars | ~7.8s | — | — |
+| 1M (fuzzy) | polars | ~43 min | ~10 GB | 836K |
+| 5M | chunked | ~50 min | 11.9 GB | 618,817 multi-member, no OOM |
+
+## Selecting a backend
+
+You can force a backend in config or on the CLI:
+
+```python
+config = gm.GoldenMatchConfig(backend="duckdb")
+```
+
+```bash
+goldenmatch dedupe big.csv --backend ray
+goldenmatch dedupe big.csv --chunked
+```
+
+Or let auto-config pick. By default it chooses `duckdb` at 1M+ rows and `chunked` for 5M+. Tune the cutoff with `GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD`.
+
+## DuckDB spill path
+
+The DuckDB backend stores candidate pairs in an on-disk store. Point it somewhere with room:
+
+```bash
+export GOLDENMATCH_DUCKDB_SCORE_DB=/scratch/goldenmatch_pairs.duckdb
+```
+
+## Ray distributed
+
+```bash
+pip install goldenmatch[ray]
+goldenmatch dedupe big.csv --backend ray
+```
+
+The Ray path short-circuits back to local parallel scoring below four large blocks, since the distribution overhead does not pay off for small workloads.
+
+<Note>
+  Debug the prep-versus-kernel split for the bucket backend with `GOLDENMATCH_BUCKET_DEBUG=1`. It prints a per-bucket prep / kernel / post-filter timing breakdown. It is off by default, costs nothing, and does not change output.
+</Note>
+
+<Card title="Scale envelope" icon="gauge-high" href="/concepts/scale-envelope">
+  The block-size failure modes that matter more than the backend choice.
+</Card>

--- a/docs-site/goldenmatch/cli.mdx
+++ b/docs-site/goldenmatch/cli.mdx
@@ -1,0 +1,58 @@
+---
+title: "GoldenMatch CLI"
+description: "Every GoldenMatch command and the key flags for the dedupe pipeline."
+keywords: ["cli", "commands", "dedupe", "flags"]
+---
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `goldenmatch dedupe FILE [...]` | Deduplicate one or more CSV / Parquet / Excel files. |
+| `goldenmatch match TARGET --against REF` | Match a target against a reference file. |
+| `goldenmatch sync --table TABLE --connection-string "$DB"` | Incremental Postgres database sync. |
+| `goldenmatch watch --table TABLE` | Live stream mode (`--daemon` for service mode). |
+| `goldenmatch serve FILE [...]` | Start the REST API server (default `localhost:8000`). |
+| `goldenmatch mcp-serve FILE [...]` | Start the MCP server (stdio or HTTP transport). |
+| `goldenmatch interactive FILE [...]` | Launch the interactive TUI. |
+| `goldenmatch serve-ui [--project DIR]` | Start the web UI workbench. |
+| `goldenmatch setup` | Interactive setup wizard (GPU, API keys, database). |
+| `goldenmatch demo` | Run the built-in demo with sample data. |
+| `goldenmatch init` | Interactive config wizard. |
+| `goldenmatch profile FILE` | Profile data quality. |
+| `goldenmatch evaluate FILE --gt GT.csv` | Evaluate matching accuracy against ground truth. |
+| `goldenmatch incremental BASE --new NEW` | Match new records against an existing base. |
+| `goldenmatch analyze-blocking FILE` | Analyze data and suggest blocking strategies. |
+| `goldenmatch label FILE --config --gt` | Interactively label pairs to build ground truth. |
+| `goldenmatch rollback RUN_ID` | Undo a previous merge run. |
+| `goldenmatch unmerge RECORD_ID` | Remove a record from its cluster. |
+| `goldenmatch runs` | List previous runs for rollback. |
+| `goldenmatch memory stats\|learn\|export\|import\|show` | Manage the Learning Memory store. |
+| `goldenmatch config save\|load\|list\|show` | Manage config presets. |
+| `goldenmatch compare-clusters A B` | Cluster comparison (unchanged / merged / partitioned / overlapping). |
+| `goldenmatch sensitivity FILE` | Parameter sweep over threshold, blocking, and matchkey. |
+| `goldenmatch pprl link FILE_A FILE_B` | Privacy-preserving record linkage. |
+
+## Key dedupe flags
+
+| Flag | Effect |
+|------|--------|
+| `--anomalies` | Detect fake emails, placeholder data, and suspicious records. |
+| `--preview` | Show what will change before writing. |
+| `--diff` / `--diff-html` | Generate a before/after change report. |
+| `--dashboard` | Before/after data-quality dashboard (HTML). |
+| `--html-report` | Detailed match report with charts. |
+| `--chunked` | Large-dataset mode (process in chunks). |
+| `--backend ray` | Force a backend. |
+| `--llm-boost` | Improve accuracy with LLM-labeled training. |
+| `--daemon` | Run watch mode as a background service with a health endpoint. |
+
+## Cloud storage
+
+Read directly from cloud storage by passing a URI:
+
+```bash
+goldenmatch dedupe s3://bucket/customers.csv
+goldenmatch dedupe gs://bucket/customers.csv
+goldenmatch dedupe az://container/customers.csv
+```

--- a/docs-site/goldenmatch/overview.mdx
+++ b/docs-site/goldenmatch/overview.mdx
@@ -1,0 +1,86 @@
+---
+title: "GoldenMatch overview"
+description: "Zero-config entity resolution for Python and TypeScript: fuzzy, exact, probabilistic, and LLM scoring with golden-record synthesis."
+keywords: ["goldenmatch", "entity resolution", "deduplication", "record linkage", "fuzzy matching"]
+---
+
+GoldenMatch is the headline package of the Golden Suite. It finds duplicate records in seconds with no rules to write and no model to train. It combines fuzzy matching, probabilistic Fellegi-Sunter EM, LLM scoring, privacy-preserving record linkage, golden-record synthesis, and an introspective auto-configuration controller that beats hand-tuned baselines on standard benchmarks.
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/goldenmatch/quickstart">
+    Dedupe, match, and write golden records.
+  </Card>
+  <Card title="Auto-config" icon="robot" href="/goldenmatch/auto-config">
+    How zero-config converges on a defensible config.
+  </Card>
+  <Card title="Backends and scale" icon="gauge-high" href="/goldenmatch/backends-and-scale">
+    Polars, DuckDB, chunked, and Ray.
+  </Card>
+  <Card title="CLI reference" icon="terminal" href="/goldenmatch/cli">
+    Every command and the key flags.
+  </Card>
+</CardGroup>
+
+## Install
+
+<CodeGroup>
+
+```bash pip
+pip install goldenmatch
+```
+
+```bash npm
+npm install goldenmatch
+```
+
+</CodeGroup>
+
+Common extras:
+
+```bash
+pip install goldenmatch[embeddings]   # sentence-transformers, FAISS
+pip install goldenmatch[llm]          # Claude / OpenAI borderline scoring
+pip install goldenmatch[duckdb]       # out-of-core backend
+pip install goldenmatch[ray]          # distributed backend (50M+ rows)
+pip install goldenmatch[postgres]     # Postgres sync
+pip install goldenmatch[quality]      # GoldenCheck integration
+pip install goldenmatch[transform]    # GoldenFlow integration
+pip install goldenmatch[web]          # localhost browser workbench
+pip install goldenmatch[mcp]          # MCP server for Claude Desktop
+```
+
+## Key features
+
+- **12+ scoring methods**: exact, Jaro-Winkler, Levenshtein, token-sort, soundex, ensemble, embedding, record-embedding, dice, jaccard, surname IDF-weighted, and alias-aware.
+- **Probabilistic matching**: Fellegi-Sunter EM-trained m/u probabilities with automatic threshold estimation.
+- **LLM scorer**: scores borderline pairs with budget caps and graceful degradation.
+- **8+ blocking strategies**: static, adaptive, sorted-neighborhood, multi-pass, ANN, canopy, and learned.
+- **Golden records**: five merge strategies with field-level provenance and quality-weighted survivorship.
+- **PPRL**: privacy-preserving record linkage across organizations (F1 0.924 on FEBRL4).
+- **Learning Memory**: persists steward corrections, unmerges, and LLM votes across runs.
+- **Interactive TUI**, REST API, MCP server (35 tools), A2A agent, and a localhost web workbench.
+
+## Benchmarks
+
+Zero-config accuracy, quoted from the package README:
+
+| Dataset | F1 | Note |
+|---------|----|----|
+| DBLP-ACM (bibliographic) | 0.964 | Hand-tuned ceiling 0.918 |
+| Febrl3 (PII) | 0.944 | Zero-config |
+| NCVR (voter records) | 0.972 | Zero-config |
+| Febrl4 (PII, PPRL) | 0.924 | Bloom-filter PPRL |
+| DQBench ER composite | 91.04 | No LLM (v1.12.0) |
+
+## A minimal example
+
+```python
+import goldenmatch as gm
+
+result = gm.dedupe("customers.csv", exact=["email"], fuzzy={"name": 0.85, "zip": 0.95})
+result.golden.write_csv("deduped.csv")
+```
+
+<Tip>
+  Leave out `exact` and `fuzzy` entirely to let [auto-config](/goldenmatch/auto-config) choose them.
+</Tip>

--- a/docs-site/goldenmatch/pprl.mdx
+++ b/docs-site/goldenmatch/pprl.mdx
@@ -1,0 +1,39 @@
+---
+title: "Privacy-preserving linkage"
+description: "Match records across organizations without sharing raw data, using Bloom-filter PPRL."
+keywords: ["pprl", "privacy", "record linkage", "bloom filter", "federated"]
+---
+
+Privacy-preserving record linkage (PPRL) lets two parties find shared entities without exchanging plaintext identifiers. GoldenMatch encodes fields into Bloom filters and matches on those, reaching F1 0.924 on the FEBRL4 benchmark.
+
+## Auto-configured
+
+```python
+import goldenmatch as gm
+
+result = gm.pprl_link("hospital_a.csv", "hospital_b.csv")
+print(f"Found {result['match_count']} matches")
+```
+
+## Manual config
+
+```python
+import goldenmatch as gm
+
+result = gm.pprl_link(
+    "party_a.csv", "party_b.csv",
+    fields=["first_name", "last_name", "dob", "zip"],
+    threshold=0.85,
+    security_level="high",
+)
+```
+
+## CLI
+
+```bash
+goldenmatch pprl link file_a.csv file_b.csv
+```
+
+<Warning>
+  PPRL reduces but does not eliminate disclosure risk. Choose `security_level` and field sets with your privacy and compliance requirements in mind.
+</Warning>

--- a/docs-site/goldenmatch/quickstart.mdx
+++ b/docs-site/goldenmatch/quickstart.mdx
@@ -1,0 +1,145 @@
+---
+title: "GoldenMatch quickstart"
+description: "Dedupe a file, match two files, write golden records, and configure matchkeys in Python and TypeScript."
+keywords: ["goldenmatch", "quickstart", "dedupe", "match", "config", "matchkey"]
+---
+
+## Zero-config dedupe
+
+```bash
+goldenmatch dedupe customers.csv
+```
+
+This auto-detects column types, assigns scorers, picks a blocking strategy, and launches a review TUI. The same in Python:
+
+```python
+import goldenmatch as gm
+
+result = gm.dedupe("customers.csv")
+print(result)  # DedupeResult(records=5000, clusters=847, match_rate=12.0%)
+result.golden.write_csv("deduped.csv")
+```
+
+## Match two files
+
+Match a target file against a reference file:
+
+```bash
+goldenmatch match prospects.csv --against customers.csv
+```
+
+## TypeScript
+
+The TypeScript core is edge-safe and zero-dependency:
+
+```typescript
+import { dedupe } from "goldenmatch";
+
+const rows = [
+  { id: 1, name: "John Smith", email: "john@example.com", zip: "12345" },
+  { id: 2, name: "Jon Smith",  email: "john@example.com", zip: "12345" },
+  { id: 3, name: "Jane Doe",   email: "jane@example.com", zip: "54321" },
+];
+
+const result = dedupe(rows, {
+  fuzzy: { name: 0.85 },
+  blocking: ["zip"],
+  threshold: 0.85,
+});
+
+console.log(result.stats);
+for (const record of result.goldenRecords) {
+  console.log(record);
+}
+```
+
+## Explicit configuration
+
+For full control, build a `GoldenMatchConfig` with named matchkeys:
+
+```python
+import goldenmatch as gm
+
+config = gm.GoldenMatchConfig(
+    matchkeys=[
+        gm.MatchkeyConfig(
+            name="exact_email",
+            type="exact",
+            fields=[gm.MatchkeyField(field="email", transforms=["lowercase"])],
+        ),
+        gm.MatchkeyConfig(
+            name="fuzzy_name",
+            type="weighted",
+            threshold=0.85,
+            fields=[
+                gm.MatchkeyField(field="name", scorer="jaro_winkler", weight=0.7),
+                gm.MatchkeyField(field="zip", scorer="exact", weight=0.3),
+            ],
+        ),
+    ],
+    blocking=gm.BlockingConfig(strategy="learned"),
+    llm_scorer=gm.LLMScorerConfig(enabled=True, mode="cluster"),
+    backend="ray",
+)
+
+result = gm.dedupe_df(df, config=config)
+```
+
+## YAML config
+
+The same config in `goldenmatch.yml`:
+
+```yaml
+matchkeys:
+  - name: exact_email
+    type: exact
+    fields:
+      - field: email
+        transforms: [lowercase]
+  - name: fuzzy_name
+    type: weighted
+    threshold: 0.85
+    fields:
+      - field: name
+        scorer: jaro_winkler
+        weight: 0.7
+      - field: zip
+        scorer: exact
+        weight: 0.3
+
+blocking:
+  strategy: learned
+
+golden_rules:
+  default_strategy: most_complete
+  auto_split: true
+```
+
+## Learning Memory
+
+Record steward corrections so future runs improve:
+
+```python
+import goldenmatch
+
+goldenmatch.add_correction(
+    id_a=42, id_b=87,
+    decision="reject",
+    source="steward",
+    reason="Different EIN despite name match",
+    dataset="customers",
+)
+
+adjustments = goldenmatch.learn()
+print(f"Adjusted {len(adjustments)} matchkey thresholds")
+print(goldenmatch.memory_stats())
+```
+
+## Evaluate against ground truth
+
+```python
+import goldenmatch as gm
+
+metrics = gm.evaluate("data.csv", config="config.yaml", ground_truth="gt.csv")
+print(f"F1: {metrics['f1']:.1%}, Precision: {metrics['precision']:.1%}")
+```

--- a/docs-site/goldenpipe/overview.mdx
+++ b/docs-site/goldenpipe/overview.mdx
@@ -1,0 +1,91 @@
+---
+title: "GoldenPipe overview"
+description: "The orchestrator that chains data-quality checking, transformation, and deduplication into a single adaptive pipeline."
+keywords: ["goldenpipe", "orchestration", "pipeline", "check", "flow", "match"]
+---
+
+GoldenPipe chains GoldenCheck, GoldenFlow, and GoldenMatch into one pipeline. It profiles your data, conditionally routes it through transformation, deduplicates it (or routes sensitive fields to privacy-preserving matching), and emits golden records. Its logic is adaptive: it skips transformation when no issues are found, and it explains the reasoning behind every decision.
+
+## Install
+
+```bash
+pip install goldenpipe
+pip install goldenpipe[mcp]   # MCP server mode
+```
+
+## Quickstart
+
+```python
+import goldenpipe as gp
+
+result = gp.run("customers.csv")
+
+print(result.status)     # "success"
+print(result.check)      # quality findings
+print(result.transform)  # what was fixed
+print(result.match)      # deduplicated clusters
+print(result.reasoning)  # why each decision was made
+```
+
+On the CLI:
+
+```bash
+goldenpipe run customers.csv                 # full pipeline
+goldenpipe run customers.csv --verbose       # show reasoning
+goldenpipe run customers.csv --skip-flow     # check + match only
+goldenpipe run customers.csv --strategy pprl # force privacy mode
+goldenpipe run customers.csv -o golden.csv   # save golden records
+```
+
+## Key features
+
+- **Orchestrates the full pipeline** (Check → Flow → Match) in one call.
+- **Adaptive logic** that skips transformation when there are no quality issues.
+- **Privacy-preserving routing** that detects sensitive fields and routes to PPRL.
+- **Reasoning transparency** that reports why each stage ran or was skipped.
+- **Column-context enrichment** that builds targeted dedupe config from GoldenCheck profiles and column-name heuristics.
+- **Remote and local MCP server** (`goldenpipe mcp-serve`).
+
+GoldenPipe scores 88.07 on the DQBench Pipeline category.
+
+## Selective stages
+
+Run only part of the pipeline by specifying stages:
+
+```python
+from goldenpipe import Pipeline, PipelineConfig, StageSpec
+
+config = PipelineConfig(
+    pipeline="check-and-flow-only",
+    stages=[
+        StageSpec(use="goldencheck.scan"),
+        StageSpec(use="goldenflow.transform"),
+        # omit goldenmatch.dedupe to skip dedup
+    ],
+)
+result = Pipeline(config=config).run(source="data.csv")
+```
+
+## The PipeResult
+
+`Pipeline.run()` returns a `PipeResult`, not the output DataFrame:
+
+```python
+result.status      # PipeStatus enum: SUCCESS, PARTIAL, FAILED
+result.input_rows  # int
+result.stages      # dict[str, StageResult]
+result.artifacts   # dict[str, Any], e.g. {"manifest": Manifest}
+result.errors      # list[str]
+result.reasoning   # dict[str, str], why each stage ran or was skipped
+result.timing      # dict[str, float]
+result.skipped     # list[str]
+```
+
+<Warning>
+  A few sharp edges from the package docs: `PipeResult` does not expose the output DataFrame directly. Use `gp.run(path)` (file-based) rather than `gp.run_df(df)`, since GoldenCheck needs a file extension. And cast mixed-type columns (for example a `birth_year` that is sometimes an int and sometimes a string) to a single type before dedup, or GoldenMatch will raise.
+</Warning>
+
+## MCP endpoints
+
+- Remote: `https://goldenpipe-mcp-production.up.railway.app/mcp/`
+- Local: `goldenpipe mcp-serve --transport http --port 8250`

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -1,0 +1,78 @@
+---
+title: "Golden Suite"
+description: "A polyglot data-quality and entity-resolution toolkit. Zero-config, AI-native, MIT-licensed."
+keywords: ["entity resolution", "deduplication", "data quality", "record linkage", "golden records"]
+---
+
+The Golden Suite is a polyglot data-quality and entity-resolution toolkit. Each tool stands alone, but together they form a single pipeline: profile your data, standardize it, deduplicate it, and emit golden records. Every package ships zero-config defaults, a CLI, a Python and (mostly) a TypeScript library, and an AI-native surface (MCP server, REST API, agent skills).
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Deduplicate a CSV in 30 seconds.
+  </Card>
+  <Card title="Architecture" icon="diagram-project" href="/concepts/architecture">
+    How the five tools compose into one pipeline.
+  </Card>
+  <Card title="GoldenMatch" icon="object-group" href="/goldenmatch/overview">
+    The headline package: zero-config entity resolution.
+  </Card>
+  <Card title="Scale envelope" icon="gauge-high" href="/concepts/scale-envelope">
+    Pick the right backend for your row count.
+  </Card>
+</CardGroup>
+
+## The pipeline
+
+Raw, messy records enter on the left and leave as clean golden records on the right. You can run the whole chain through GoldenPipe or use any single tool on its own.
+
+```mermaid
+flowchart LR
+  A[Raw rows] --> B[InferMap]
+  B --> C[GoldenCheck]
+  C --> D[GoldenFlow]
+  D --> E[GoldenMatch]
+  E --> F[Golden records]
+  G[GoldenPipe] -.orchestrates.-> B & C & D & E
+```
+
+| Tool | Role |
+|------|------|
+| [InferMap](/infermap/overview) | Schema mapping. Auto-aligns columns across heterogeneous sources. |
+| [GoldenCheck](/goldencheck/overview) | Profile and validate. Encoding, format, anomaly detection. |
+| [GoldenFlow](/goldenflow/overview) | Standardize and transform. Phone, date, address, categorical normalization. |
+| [GoldenMatch](/goldenmatch/overview) | Dedupe, cluster, and survivorship. Fuzzy, exact, probabilistic, and LLM scoring. |
+| [GoldenPipe](/goldenpipe/overview) | Orchestrator. Wires the tools into one adaptive pipeline. |
+
+## Packages
+
+<CardGroup cols={2}>
+  <Card title="GoldenMatch" icon="object-group" href="/goldenmatch/overview">
+    Zero-config entity resolution for Python and TypeScript.
+  </Card>
+  <Card title="GoldenCheck" icon="magnifying-glass-chart" href="/goldencheck/overview">
+    Data-quality scanning that discovers rules automatically.
+  </Card>
+  <Card title="GoldenFlow" icon="wand-magic-sparkles" href="/goldenflow/overview">
+    76 transforms across 11 categories for cleaning messy data.
+  </Card>
+  <Card title="GoldenPipe" icon="diagram-project" href="/goldenpipe/overview">
+    One call to chain Check, Flow, and Match.
+  </Card>
+  <Card title="InferMap" icon="arrows-left-right" href="/infermap/overview">
+    Inference-driven schema mapping with confidence scores.
+  </Card>
+  <Card title="SQL extensions" icon="database" href="/extensions/sql">
+    Native Postgres and DuckDB fuzzy matching in SQL.
+  </Card>
+</CardGroup>
+
+## Why Golden Suite
+
+- **Zero-config that beats hand-tuned.** GoldenMatch's introspective auto-config controller reaches F1 0.964 on DBLP-ACM out of the box, above the hand-tuned ceiling of 0.918.
+- **Polyglot.** Python is the headline runtime; TypeScript runs the same scorers on edge runtimes (Vercel Edge, Cloudflare Workers, Deno); Rust powers the Postgres and DuckDB extensions.
+- **AI-native.** Every package ships an MCP server (35+ tools across the suite), a REST API, and agent skills.
+- **MIT-licensed.** Every package in the suite.
+
+<Note>
+  Benchmark and scale numbers throughout these docs are quoted from the package READMEs and `docs/` in the repository. Re-measure for your own hardware and data before relying on exact figures.
+</Note>

--- a/docs-site/infermap/overview.mdx
+++ b/docs-site/infermap/overview.mdx
@@ -1,0 +1,126 @@
+---
+title: "InferMap overview"
+description: "An inference-driven schema mapping engine that aligns messy source columns to a target schema with confidence scores and reasoning."
+keywords: ["infermap", "schema mapping", "column matching", "confidence", "hungarian algorithm"]
+---
+
+InferMap maps messy source columns to a known target schema, with a confidence score and a human-readable reason for each mapping. It runs in Python and TypeScript, and the two implementations are verified bit-for-bit against a shared golden-test suite.
+
+## Install
+
+<CodeGroup>
+
+```bash pip
+pip install infermap
+```
+
+```bash npm
+npm install infermap
+```
+
+</CodeGroup>
+
+Python database extras: `infermap[postgres]`, `infermap[mysql]`, `infermap[duckdb]`, `infermap[all]`. The TypeScript package requires Node 20+ and is edge-runtime compatible.
+
+## Quickstart
+
+```python
+import infermap
+
+result = infermap.map("crm_export.csv", "canonical_customers.csv")
+for m in result.mappings:
+    print(f"{m.source} -> {m.target}  ({m.confidence:.0%})")
+
+# Apply the mapping to a DataFrame
+import polars as pl
+df = pl.read_csv("crm_export.csv")
+renamed = result.apply(df)
+
+# Save and reload
+result.to_config("my_mapping.yaml")
+saved = infermap.from_config("my_mapping.yaml")
+```
+
+In TypeScript:
+
+```typescript
+import { map } from "infermap";
+
+const result = map(
+  { records: [{ fname: "John", lname: "Doe", email_addr: "j@d.co" }] },
+  { records: [{ first_name: "", last_name: "", email: "" }] },
+);
+
+for (const m of result.mappings) {
+  console.log(`${m.source} → ${m.target}  (${m.confidence.toFixed(2)})`);
+}
+```
+
+## Key features
+
+- **7 built-in scorers**: exact, alias, initialism, pattern-type, profile, fuzzy-name, and LLM (pluggable).
+- **Optimal 1:1 assignment** via the Hungarian algorithm.
+- **Common-prefix canonicalization** that strips schema-wide prefixes (for example `prospect_City` versus `City`).
+- **Confidence calibration** (identity, isotonic, or Platt) into probabilities.
+- **Domain dictionaries** for healthcare, finance, and ecommerce.
+- **Custom scorers** via the `@infermap.scorer` decorator (Python) or `defineScorer()` (TypeScript).
+- **Many input formats**: CSV, JSON, in-memory records, database tables, and schema definition files.
+- **Edge-runtime compatible** and zero-dependency in the TypeScript core.
+- Accuracy benchmark: 162 test cases, F1 0.84 (Python); TypeScript parity within 0.0005.
+
+## CLI
+
+| Command | Purpose |
+|---------|---------|
+| `infermap map <source> <target>` | Map two files or schemas and print a report. |
+| `infermap apply <source> --config <mapping> --output <file>` | Apply a saved mapping to rename columns. |
+| `infermap inspect <source>` | Extract and display a schema from a file or DB table. |
+| `infermap validate <source> --config <mapping> --required <fields> --strict` | Validate a saved config against a source. |
+
+```bash
+infermap map crm_export.csv canonical_customers.csv -o mapping.json
+infermap apply crm_export.csv --config mapping.json --output renamed.csv
+infermap inspect "sqlite:///mydb.db" --table customers
+```
+
+## Custom scorer
+
+```python
+import infermap
+from infermap.types import FieldInfo, ScorerResult
+
+@infermap.scorer("prefix_scorer", weight=0.8)
+def prefix_scorer(source: FieldInfo, target: FieldInfo) -> ScorerResult | None:
+    if source.name[:3].lower() != target.name[:3].lower():
+        return None
+    return ScorerResult(score=0.85, reasoning=f"Shared prefix '{source.name[:3]}'")
+```
+
+## Default scorer weights
+
+| Scorer | Weight |
+|--------|--------|
+| ExactScorer | 1.0 |
+| AliasScorer | 0.95 |
+| LLMScorer | 0.8 (pluggable, stubbed by default) |
+| InitialismScorer | 0.75 |
+| PatternTypeScorer | 0.7 |
+| ProfileScorer | 0.5 |
+| FuzzyNameScorer | 0.4 |
+
+## Config
+
+```yaml
+domains:
+  - healthcare
+  - finance
+scorers:
+  LLMScorer:
+    enabled: false
+  FuzzyNameScorer:
+    weight: 0.3
+aliases:
+  order_id:
+    - order_num
+    - ord_no
+```

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -1,0 +1,103 @@
+---
+title: "Quickstart"
+description: "Deduplicate a CSV in 30 seconds, then run the full pipeline."
+keywords: ["quickstart", "install", "dedupe", "getting started"]
+---
+
+This page gets you from install to a deduplicated file in a couple of minutes. For a deeper tour of the headline package, see the [GoldenMatch quickstart](/goldenmatch/quickstart).
+
+## Install
+
+<CodeGroup>
+
+```bash pip
+pip install goldenmatch
+```
+
+```bash npm
+npm install goldenmatch
+```
+
+</CodeGroup>
+
+## Deduplicate a file
+
+The fastest path is zero-config. GoldenMatch detects column types, assigns scorers, picks a blocking strategy, and writes golden records.
+
+```bash CLI
+goldenmatch dedupe customers.csv
+```
+
+The same in Python:
+
+```python
+import goldenmatch as gm
+
+result = gm.dedupe("customers.csv")
+print(result)  # DedupeResult(records=5000, clusters=847, match_rate=12.0%)
+result.golden.write_csv("deduped.csv")
+```
+
+And in TypeScript:
+
+```typescript
+import { dedupe } from "goldenmatch";
+
+const rows = [
+  { id: 1, name: "John Smith", email: "john@example.com", zip: "12345" },
+  { id: 2, name: "Jon Smith",  email: "john@example.com", zip: "12345" },
+  { id: 3, name: "Jane Doe",   email: "jane@example.com", zip: "54321" },
+];
+
+const result = dedupe(rows, { fuzzy: { name: 0.85 }, blocking: ["zip"], threshold: 0.85 });
+console.log(result.stats);
+```
+
+## Run the whole pipeline
+
+To profile, standardize, and deduplicate in one call, use GoldenPipe. It runs GoldenCheck, conditionally routes through GoldenFlow, then deduplicates with GoldenMatch.
+
+```bash
+pip install goldenpipe
+```
+
+```python
+import goldenpipe as gp
+
+result = gp.run("customers.csv")
+print(result.status)     # "success"
+print(result.reasoning)  # why each stage ran or was skipped
+```
+
+## Optional extras
+
+GoldenMatch ships a single core install plus opt-in extras:
+
+```bash
+pip install goldenmatch[llm]          # Claude / OpenAI borderline scoring
+pip install goldenmatch[duckdb]       # out-of-core backend
+pip install goldenmatch[ray]          # distributed backend (50M+ rows)
+pip install goldenmatch[web]          # localhost browser workbench
+pip install goldenmatch[mcp]          # MCP server for Claude Desktop
+```
+
+Run the interactive setup wizard to configure GPU, API keys, and database connections:
+
+```bash
+goldenmatch setup
+```
+
+<Tip>
+  Try it on bundled sample data first with `goldenmatch demo`.
+</Tip>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Auto-config" icon="robot" href="/goldenmatch/auto-config">
+    How zero-config converges on a defensible config.
+  </Card>
+  <Card title="Backends and scale" icon="gauge-high" href="/goldenmatch/backends-and-scale">
+    Polars, DuckDB, chunked, and Ray.
+  </Card>
+</CardGroup>

--- a/docs-site/reference/vendor-comparison.mdx
+++ b/docs-site/reference/vendor-comparison.mdx
@@ -1,0 +1,58 @@
+---
+title: "ER vendor comparison"
+description: "How GoldenMatch compares to other entity-resolution engines across OSS, identity-graph, cloud-managed, and enterprise MDM tiers."
+keywords: ["comparison", "splink", "dedupe", "senzing", "zingg", "entity resolution vendors"]
+---
+
+This page summarizes the entity-resolution landscape as recorded in the repository's vendor comparison. The intent is honest positioning: where GoldenMatch leads, and where other engines lead.
+
+<Note>
+  Pricing is indicative, vendor surfaces change quickly, and academic F1 numbers are not enterprise outcomes on your real data. GoldenMatch numbers are reproducible from `docs/reproducing-benchmarks.md` in the repository.
+</Note>
+
+## GoldenMatch baseline
+
+| Axis | GoldenMatch |
+|------|-------------|
+| License | MIT (every package). |
+| Languages | Python (headline) + TypeScript (parity) + Rust (Postgres/DuckDB). |
+| Runtimes | Polars (≤500K), DuckDB (500K–50M), Ray (≥50M); Postgres via pgrx; DuckDB UDFs; edge JS. |
+| Throughput | 1M dedupe in ~12.3 min on 4-core / 16 GB; 100K fuzzy ~39s. |
+| Accuracy (DBLP-ACM) | F1 0.964 zero-config (hand-tuned ceiling 0.918). |
+| Accuracy (NCVR) | F1 0.972 zero-config. |
+| Zero-config | Introspective auto-config controller with cross-run memory and LLM fallback. |
+| PPRL | Bloom-filter PPRL, F1 0.924 on FEBRL4. |
+| AI-native surface | 35+ MCP tools, agent skills, REST API. |
+
+## OSS engines
+
+| Engine | License | Where it beats GoldenMatch | Where GoldenMatch beats it |
+|--------|---------|----------------------------|----------------------------|
+| Splink (UK MoJ) | MIT | Throughput (1B+ rows); PII F1 on Febrl (0.998). | Non-PII accuracy (DBLP-ACM 0.964 vs 0.728); zero-config; polyglot; AI-native; PPRL. |
+| dedupe.io | BSD | Cleanest active-learning UX in OSS. | Accuracy without labels; throughput at scale; polyglot; AI-native; PPRL. |
+| RecordLinkage Toolkit | BSD | DBLP-ACM F1 0.923 (narrowly). | Throughput, scale, PPRL, AI-native, zero-config, polyglot. |
+| Zingg | AGPL + commercial | Native Spark scale. | MIT license; polyglot; AI-native; zero-config; PPRL. |
+| Senzing G2 CE | Apache wrapper + closed core | Native identity graph; bundled reference data; real-time latency. | OSS license; zero-config; AI-native; bibliographic/product matching; PPRL. |
+
+## Identity-graph and cloud-managed
+
+| Engine | Where it beats GoldenMatch | Where GoldenMatch beats it |
+|--------|----------------------------|----------------------------|
+| Quantexa | Graph-native output; decisioning layer; enterprise governance. | OSS and composable; time-to-value; AI-native; cost. |
+| Tilores | Identity-graph engine; GraphQL API; hosted by default. | OSS; edge runtimes; zero-config; AI-native; PPRL. |
+| AWS Entity Resolution | Scale is AWS's problem; Glue/Lake Formation integration. | Portability (laptop, Postgres, edge worker); zero-config; AI-native; multi-cloud. |
+| Snowflake Cortex Match | Runs in-warehouse, no data movement. | Full engine (blocking, clustering, golden records); portable; published F1. |
+
+## Research SOTA
+
+| Engine | Where it beats GoldenMatch | Where GoldenMatch beats it |
+|--------|----------------------------|----------------------------|
+| Ditto (Megagon) | Abt-Buy F1 0.893 (product-matching SOTA) vs GoldenMatch 0.722 (+LLM) / 0.817 (+Vertex). | No training labels; non-product domains; throughput; AI-native; cheaper than fine-tuning. |
+
+## Cross-cutting observations
+
+- **Zero-config is uncontested.** No other vendor publishes zero-config benchmark numbers.
+- **Identity graph is the next frontier.** Mainstream OSS engines emit clusters; Senzing, Quantexa, and Tilores emit a graph.
+- **AI-native is uncontested but unproven.** Nobody else ships MCP, agent skills, or LLM-budget-controlled borderline scoring.
+- **License matters.** MIT and BSD engines have outgrown AGPL and closed-core peers partly on embedding permissions.
+- **Portability is the wedge** against warehouse-native managed services: the same engine runs in app code, an edge worker, or a Postgres trigger.


### PR DESCRIPTION
Adds a full Mintlify documentation site under `docs-site/` for the whole Golden Suite, branched cleanly off current `main`.

> Supersedes #735, which was accidentally branched from a stale local `main` with unrelated history (no common ancestor with `origin/main`) and could not be merged safely. This PR replaces it.

## What's here
- **Get started:** landing page + 30-second quickstart
- **Concepts:** architecture, entity resolution, scale envelope
- **Per-package docs:** goldenmatch (overview, quickstart, auto-config, backends/scale, PPRL, CLI), goldencheck, goldenflow, goldenpipe, infermap
- **SQL extensions** (Postgres pgrx + DuckDB) and a **vendor comparison** reference
- `docs.json` navigation, gold theme, canonical URL, `docs-site/README.md` with preview instructions
- README "Docs" badge now points at `docs.bensevern.dev` (custom domain); `.worktrees/` ignored

Content is sourced from the package `README.md` files. Benchmark/scale figures are quoted from the repo and flagged "re-measure for your own hardware."

## Validation (mint 4.2.595)
- `mint validate` — build validation passed
- `mint broken-links --check-anchors` — no broken links
- `mint a11y` — all images have alt text; primary color set to `#8a6d0f` (4.91:1) to pass WCAG AA

## Deploy note
Mintlify Git settings must use the monorepo toggle with directory `docs-site` (config lives at `docs-site/docs.json`, not repo root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)