### PR TITLE
feat: native-direct SQL graph UDFs (DuckDB + Postgres), part of #509

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1028,7 +1028,8 @@ jobs:
           # handwritten one into PG's extension dir so `CREATE EXTENSION`
           # finds it. The schema file is the canonical declaration of
           # public function signatures.
-          cp sql/goldenmatch_pg--0.5.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
+          cp sql/goldenmatch_pg--0.6.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
+          cp sql/goldenmatch_pg--0.5.0--0.6.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
 
       - name: Expose goldenmatch to Postgres' Python interpreter
         # Postgres runs as user `postgres` under a different Python than the

--- a/.github/workflows/publish-goldenmatch-pg.yml
+++ b/.github/workflows/publish-goldenmatch-pg.yml
@@ -101,7 +101,8 @@ jobs:
           # canonical SQL file there. Path layout: <PKG_DIR>/usr/share/postgresql/<N>/extension/
           EXT_DIR="${PKG_DIR}/usr/share/postgresql/${PG_VERSION}/extension"
           mkdir -p "${EXT_DIR}"
-          cp sql/goldenmatch_pg--0.5.0.sql "${EXT_DIR}/"
+          cp sql/goldenmatch_pg--0.6.0.sql "${EXT_DIR}/"
+          cp sql/goldenmatch_pg--0.5.0--0.6.0.sql "${EXT_DIR}/"
           echo "PKG_DIR=${PKG_DIR}" >> "$GITHUB_ENV"
 
       - name: Tar artifact

--- a/docs/superpowers/plans/2026-06-04-sql-native-graph-embed-udfs.md
+++ b/docs/superpowers/plans/2026-06-04-sql-native-graph-embed-udfs.md
@@ -1,0 +1,489 @@
+# SQL-native graph + embedding UDFs (native-direct) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the #503 JSON/CPython-bridge placeholder UDFs with native-direct graph + embedding SQL primitives: a pyo3-free `graph-core` kernel shared across DuckDB (Arrow), Postgres (native arrays), and DataFusion (Arrow), plus a `goldenmatch-embed` pyo3 wheel over `goldenembed-rs`.
+
+**Architecture:** Extract the graph kernels (`connected_components`, `dedup_pairs_max_score`) into a new pyo3-free `graph-core` crate (mirrors `score-core`); `native` keeps thin `#[pyfunction]` shims delegating to it. DuckDB/DataFusion feed Arrow columns straight into `graph-core`; Postgres feeds native PG arrays. String record IDs are dictionary-mapped (first-seen order) to i64 around the kernel; int64 IDs pass through. `goldenmatch_embed_local` runs the same `goldenembed-rs` ONNX kernel everywhere — a new pyo3 wheel for DuckDB, direct crate calls for Postgres/DataFusion.
+
+**Tech Stack:** Rust (pyo3/abi3, pgrx 0.12.9, arrow 55, datafusion FFI, maturin), Python (DuckDB UDFs), `goldenembed`/`ort` ONNX runtime.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-sql-native-graph-embed-udfs-design.md`
+
+---
+
+## Environment preamble (every cargo command)
+
+```bash
+export PATH="/c/Users/bsevern/.cargo/bin:$PATH" && export RUSTUP_HOME="C:/Users/bsevern/.rustup" && export CARGO_HOME="C:/Users/bsevern/.cargo"
+```
+
+## Local vs CI test matrix (read before executing)
+
+| Component | Local (Windows) | CI |
+|---|---|---|
+| `graph-core` unit tests | ✅ `cargo test -p goldenmatch-graph-core` | ✅ |
+| `native` shim parity | ⚠️ needs goldenmatch Python installed | ✅ |
+| DuckDB graph UDFs | ✅ pytest (no ONNX) | ✅ |
+| DuckDB embed UDF | ❌ `ort` won't link locally — `cargo check` + CI only | ✅ |
+| Postgres (all) | ❌ pgrx needs libclang/Linux — CI only | ✅ PG 15/16/17 |
+| DataFusion graph | ✅ `cargo test` | ✅ |
+| DataFusion embed | ❌ `ort` — `cargo check` only | ✅ |
+
+When a step is CI-only locally, the "run" action is `cargo check`/`cargo fmt`/`cargo clippy` locally; the actual test assertion runs in CI. Note this in the commit and push to let CI verify. Never claim a CI-only test passed without CI evidence (per `feedback_verify_perf_not_just_ship`).
+
+## File structure
+
+**New:**
+- `packages/rust/extensions/graph-core/Cargo.toml` — pyo3-free crate manifest
+- `packages/rust/extensions/graph-core/src/lib.rs` — graph kernels + Arrow columnar helpers
+- `packages/rust/extensions/graph-core/src/dict.rs` — str↔i64 dictionary (first-seen)
+- `packages/rust/extensions/embed-py/Cargo.toml` — pyo3 wrapper crate over `goldenembed`
+- `packages/rust/extensions/embed-py/src/lib.rs` — `_embed` pymodule (`load`/`embed`)
+- `packages/rust/extensions/embed-py/pyproject.toml` — maturin packaging (`goldenmatch-embed`)
+- `packages/rust/extensions/embed-py/python/goldenmatch_embed/__init__.py`
+- `.github/workflows/publish-goldenmatch-embed.yml` — wheel publish (tag `goldenmatch-embed-v*`)
+- `packages/rust/extensions/postgres/sql/goldenmatch_pg--0.6.0.sql` — new SQL surface
+- `packages/rust/extensions/postgres/sql/goldenmatch_pg--0.5.0--0.6.0.sql` — upgrade script
+- `packages/rust/extensions/duckdb/tests/test_graph_arrow.py` — DuckDB Arrow graph tests
+- `packages/rust/extensions/duckdb/tests/test_parity_graph.py` — cross-backend parity
+
+**Modify:**
+- `native/src/cluster.rs`, `native/src/pairs.rs` — delegate to `graph-core`
+- `native/Cargo.toml` — add `goldenmatch-graph-core` path dep
+- `duckdb/goldenmatch_duckdb/core_kernels.py` — Arrow graph UDFs + embed via wheel
+- `postgres/src/kernels.rs` — native-direct graph + embed (drop bridge)
+- `postgres/Cargo.toml` — add `goldenmatch-graph-core`, `goldenembed` deps
+- `postgres/goldenmatch_pg.control` — `default_version = '0.6.0'`
+- `postgres/Cargo.toml` version → `0.6.0`; `duckdb/pyproject.toml` → `0.6.0`
+- `datafusion-udf/src/` — graph UDFs + 2-arg `goldenmatch_embed_local`
+- `bridge/src/api.rs` — remove the now-unused `connected_components`/`pair_dedup`/`embed_local` (or leave; decide in Task 13)
+
+---
+
+# PHASE A — Graph UDFs (graph-first)
+
+## Task 1: Create pyo3-free `graph-core` crate with `dedup_pairs_max_score`
+
+**Files:**
+- Create: `packages/rust/extensions/graph-core/Cargo.toml`
+- Create: `packages/rust/extensions/graph-core/src/lib.rs`
+- Test: inline `#[cfg(test)]` in `lib.rs`
+
+- [ ] **Step 1: Write `Cargo.toml`** (mirrors `score-core` — empty `[workspace]`, no rust-toolchain)
+
+```toml
+# Standalone workspace so this pyo3-free graph core can be a path dependency of
+# the `native` (extension-module), `postgres` (pgrx), and `datafusion-udf` (FFI)
+# crates without any of their workspaces claiming it. Same isolation rationale as
+# the sibling `score-core` / `fingerprint-core` crates.
+[workspace]
+
+[package]
+name = "goldenmatch-graph-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "Connected-components + pair-dedup graph kernels (no pyo3) shared across the native ext, the pgrx Postgres ext, and the DataFusion FFI UDFs"
+
+[lib]
+name = "goldenmatch_graph_core"
+
+[dependencies]
+# Arrow columnar helpers for the DuckDB/DataFusion zero-copy path. No pyarrow/pyo3
+# here — callers pass `arrow::array::ArrayData`; the pyo3 bridge lives in `native`.
+arrow = { version = "55", default-features = false }
+```
+
+- [ ] **Step 2: Write the failing test** in `src/lib.rs`
+
+```rust
+//! Pyo3-free graph kernels. Behavior-exact extraction of the loops that lived in
+//! `native/src/{cluster,pairs}.rs`; the `native` crate keeps thin `#[pyfunction]`
+//! shims delegating here (one source of truth, like `score-core`).
+use std::collections::BTreeMap;
+
+/// Canonicalize each pair as `(min,max)` and keep the max score per pair.
+/// Behavior-exact port of `native::pairs::dedup_pairs_max_score`.
+pub fn dedup_pairs_max_score(pairs: &[(i64, i64, f64)]) -> Vec<(i64, i64, f64)> {
+    let mut best: BTreeMap<(i64, i64), f64> = BTreeMap::new();
+    for &(a, b, s) in pairs {
+        let key = if a <= b { (a, b) } else { (b, a) };
+        match best.get(&key) {
+            Some(&cur) if s <= cur => {}
+            _ => {
+                best.insert(key, s);
+            }
+        }
+    }
+    best.into_iter().map(|((a, b), s)| (a, b, s)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_keeps_max_and_canonicalizes() {
+        let got = dedup_pairs_max_score(&[(2, 1, 0.5), (1, 2, 0.9), (3, 3, 0.1)]);
+        assert_eq!(got, vec![(1, 2, 0.9), (3, 3, 0.1)]);
+    }
+}
+```
+
+- [ ] **Step 3: Run test, verify it passes**
+
+Run: `cargo test -p goldenmatch-graph-core` (with preamble; run from `packages/rust/extensions/graph-core`)
+Expected: `test tests::dedup_keeps_max_and_canonicalizes ... ok`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/rust/extensions/graph-core
+git commit -m "feat(509): graph-core crate with dedup_pairs_max_score"
+```
+
+## Task 2: Add `connected_components` to `graph-core`
+
+**Files:**
+- Modify: `packages/rust/extensions/graph-core/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test** (append to `tests` mod)
+
+```rust
+#[test]
+fn cc_groups_transitive_and_includes_singletons() {
+    let comps = connected_components(&[(1, 2, 0.9), (2, 3, 0.8)], &[1, 2, 3, 4]);
+    let mut sorted: Vec<Vec<i64>> = comps.iter().map(|c| { let mut v = c.clone(); v.sort(); v }).collect();
+    sorted.sort();
+    assert_eq!(sorted, vec![vec![1, 2, 3], vec![4]]);
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL** — `cargo test -p goldenmatch-graph-core` → "cannot find function `connected_components`"
+
+- [ ] **Step 3: Implement** — copy the union-find verbatim from `native/src/cluster.rs:14-75` (the `find` helper + `connected_components` body), changing the signature to borrow:
+
+```rust
+use std::collections::HashMap;
+
+fn find(parent: &mut HashMap<i64, i64>, x: i64) -> i64 { /* verbatim from cluster.rs */ }
+
+/// Connected components over `all_ids` ∪ edge endpoints. Behavior-exact port of
+/// `native::cluster::connected_components`. Component membership is independent
+/// of union strategy.
+pub fn connected_components(edges: &[(i64, i64, f64)], all_ids: &[i64]) -> Vec<Vec<i64>> {
+    /* verbatim body, iterating &edges / &all_ids */
+}
+```
+
+- [ ] **Step 4: Run, verify PASS** — `cargo test -p goldenmatch-graph-core` (both tests ok)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/rust/extensions/graph-core/src/lib.rs
+git commit -m "feat(509): graph-core connected_components"
+```
+
+## Task 3: Add first-seen str↔i64 dictionary to `graph-core`
+
+**Files:**
+- Create: `packages/rust/extensions/graph-core/src/dict.rs`
+- Modify: `packages/rust/extensions/graph-core/src/lib.rs` (`mod dict; pub use dict::*;`)
+
+- [ ] **Step 1: Write the failing test** in `dict.rs`
+
+```rust
+//! Deterministic first-seen string→i64 dictionary, identical across the DuckDB,
+//! Postgres, and DataFusion wrappers so string-id grouping + round-trip agree.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_seen_order_is_deterministic() {
+        let mut d = Dict::new();
+        assert_eq!(d.intern("b"), 0);
+        assert_eq!(d.intern("a"), 1);
+        assert_eq!(d.intern("b"), 0); // stable
+        assert_eq!(d.resolve(1), Some("a"));
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL** — `cargo test -p goldenmatch-graph-core dict`
+
+- [ ] **Step 3: Implement**
+
+```rust
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct Dict {
+    to_id: HashMap<String, i64>,
+    to_str: Vec<String>,
+}
+
+impl Dict {
+    pub fn new() -> Self { Self::default() }
+    /// Return the i64 for `s`, assigning the next id on first sight.
+    pub fn intern(&mut self, s: &str) -> i64 {
+        if let Some(&id) = self.to_id.get(s) { return id; }
+        let id = self.to_str.len() as i64;
+        self.to_id.insert(s.to_string(), id);
+        self.to_str.push(s.to_string());
+        id
+    }
+    pub fn resolve(&self, id: i64) -> Option<&str> {
+        self.to_str.get(id as usize).map(|s| s.as_str())
+    }
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**; **Step 5: Commit** `feat(509): graph-core first-seen str↔i64 dict`
+
+## Task 4: Add Arrow columnar entry points to `graph-core`
+
+**Files:**
+- Modify: `packages/rust/extensions/graph-core/src/lib.rs`
+
+These take `arrow::array::ArrayData` (NOT `PyArrowType` — that stays in `native`) so DataFusion (pure arrow) and `native` (via pyarrow→ArrayData) both reuse them.
+
+- [ ] **Step 1: Write failing test** — build `Int64Array` id_a/id_b, `Float64Array` score, call `dedup_pairs_arrow_data` + `connected_components_arrow_data`, assert results match the `&[(i64,i64,f64)]` path. (Reference type-validation from `native/src/pairs.rs:80-100`.)
+
+- [ ] **Step 2: Run, verify FAIL**
+
+- [ ] **Step 3: Implement** `pub fn dedup_pairs_arrow_data(id_a, id_b, score: ArrayData) -> Result<(ArrayData,ArrayData,ArrayData), String>` and `connected_components_arrow_data(...)`. Validate `DataType::Int64`/`Float64`; build `&[(i64,i64,f64)]`; call the slice kernels; rebuild output `ArrayData`. Add a Utf8 overload pair (`*_arrow_data_utf8`) that interns via `Dict` then maps back to a `StringArray`.
+
+- [ ] **Step 4: Run, verify PASS**; **Step 5: Commit** `feat(509): graph-core arrow columnar entry points`
+
+## Task 5: Rewire `native` shims to delegate to `graph-core`
+
+**Files:**
+- Modify: `packages/rust/extensions/native/Cargo.toml` (add dep)
+- Modify: `packages/rust/extensions/native/src/pairs.rs`, `native/src/cluster.rs`
+
+- [ ] **Step 1:** Add to `native/Cargo.toml` `[dependencies]`:
+```toml
+goldenmatch-graph-core = { path = "../graph-core" }
+```
+
+- [ ] **Step 2:** In `pairs.rs`, replace the body of `dedup_pairs_max_score` with a delegation: keep the `#[pyfunction]` signature, call `goldenmatch_graph_core::dedup_pairs_max_score(&pairs)`. Same for `cluster.rs::connected_components`. For the `*_arrow` pyfunctions, unwrap `PyArrowType` to `ArrayData`, call the `graph-core` `*_arrow_data` fn, rewrap. Leave `build_clusters_arrow`/`build_clusters_native` as-is (out of #509 scope) unless they call the moved helpers — if so, point them at `graph-core`.
+
+- [ ] **Step 3: Verify behavior-exact** — Run `cargo check -p goldenmatch-native` locally (preamble). Full `cargo test -p goldenmatch-native` is CI (needs goldenmatch Python). Expected local: compiles clean.
+
+- [ ] **Step 4: Commit** `refactor(509): native graph kernels delegate to graph-core`. Note in body: native parity tests verified in CI.
+
+## Task 6: DuckDB graph UDFs → Arrow columnar (replace JSON)
+
+**Files:**
+- Modify: `packages/rust/extensions/duckdb/goldenmatch_duckdb/core_kernels.py`
+- Test: `packages/rust/extensions/duckdb/tests/test_graph_arrow.py`
+
+DuckDB Python UDFs registered with `type='arrow'` receive pyarrow arrays. The kernel lives in `goldenmatch.native` (Python) — but for the Arrow path the UDF calls the native Arrow entry (`goldenmatch.native.dedup_pairs_arrow` / `connected_components_arrow`) with pyarrow arrays, falling back to the pure-Python kernel when the ext isn't built.
+
+- [ ] **Step 1: Write the failing test** `test_graph_arrow.py`
+
+```python
+import duckdb
+import pytest
+from goldenmatch_duckdb.functions import register_functions
+
+
+@pytest.fixture
+def con():
+    c = duckdb.connect()
+    register_functions(c)
+    return c
+
+
+def test_pair_dedup_int64_arrow(con):
+    con.execute("CREATE TABLE p(a BIGINT, b BIGINT, s DOUBLE)")
+    con.execute("INSERT INTO p VALUES (2,1,0.5),(1,2,0.9)")
+    rows = con.execute(
+        "SELECT * FROM goldenmatch_pair_dedup((SELECT list(a) FROM p),"
+        " (SELECT list(b) FROM p), (SELECT list(s) FROM p))"
+    ).fetchall()
+    # canonical (1,2) kept at max score 0.9
+    assert (1, 2, 0.9) in [tuple(r) for r in rows]
+
+
+def test_connected_components_string_ids(con):
+    # string ids dictionary-mapped, components returned with original ids
+    res = con.execute(
+        "SELECT goldenmatch_connected_components(['x','y'], ['y','z'], [0.9,0.8], ['x','y','z','w'])"
+    ).fetchone()[0]
+    comps = [sorted(c) for c in res]
+    assert sorted(comps) == [["w"], ["x", "y", "z"]]
+```
+
+- [ ] **Step 2: Run, verify FAIL** — `cd packages/rust/extensions/duckdb && python -m pytest tests/test_graph_arrow.py -v` (set `POLARS_SKIP_CPU_CHECK=1`). Expected: fails (signatures are still JSON `VARCHAR`).
+
+- [ ] **Step 3: Rewrite `core_kernels.py` graph UDFs.** Replace `_connected_components(pairs_json)` / `_pair_dedup(pairs_json)` and their `con.create_function` registrations. Register the new signatures with list/arrow types; accept int64 lists (fast path) and Utf8 lists (build a Python dict, call kernel, map back). Decide the exact final SQL shape (table-returning vs list-return) to match the test above; keep `connected_components` returning `list<list<id>>` and `pair_dedup` table-returning `(a,b,s)`. Delegate to `goldenmatch.native.*_arrow` when available, else the pure-Python `connected_components`/`dedup_pairs_max_score`.
+
+- [ ] **Step 4: Run, verify PASS** — same pytest command, both tests pass.
+
+- [ ] **Step 5: Commit** `feat(509): DuckDB graph UDFs native-direct over Arrow columns`
+
+## Task 7: Postgres graph UDFs → native-direct (replace bridge)
+
+**Files:**
+- Modify: `packages/rust/extensions/postgres/Cargo.toml` (add `goldenmatch-graph-core`)
+- Modify: `packages/rust/extensions/postgres/src/kernels.rs`
+
+- [ ] **Step 1:** Add dep to `postgres/Cargo.toml`:
+```toml
+goldenmatch-graph-core = { path = "../graph-core" }
+```
+
+- [ ] **Step 2: Write the failing pg_test** in `kernels.rs` `mod tests`:
+
+```rust
+#[pg_test]
+fn pair_dedup_int_arrays_native() {
+    // canonical (1,2) max score 0.9, no CPython
+    let got = crate::kernels::goldenmatch_pair_dedup(vec![2, 1], vec![1, 2], vec![0.5, 0.9]);
+    // returns Vec<(i64,i64,f64)> composite; assert via SPI or direct call
+    assert_eq!(got, vec![(1, 2, 0.9)]);
+}
+```
+
+- [ ] **Step 3: Rewrite the three graph `#[pg_extern]`s** to native-direct. New signatures take PG arrays and call `graph-core`:
+
+```rust
+use pgrx::prelude::*;
+use goldenmatch_graph_core as gc;
+
+/// Native-direct (no CPython). Canonical max-score pairs over int64 id arrays.
+#[pg_extern]
+fn goldenmatch_pair_dedup(
+    id_a: Vec<i64>, id_b: Vec<i64>, score: Vec<f64>,
+) -> TableIterator<'static, (name!(a, i64), name!(b, i64), name!(s, f64))> {
+    let pairs: Vec<(i64,i64,f64)> = id_a.into_iter().zip(id_b).zip(score)
+        .map(|((a,b),s)| (a,b,s)).collect();
+    TableIterator::new(gc::dedup_pairs_max_score(&pairs).into_iter())
+}
+```
+
+Add a `text[]` overload (`goldenmatch_pair_dedup_text`) that interns via `gc::Dict`. Same pattern for `goldenmatch_connected_components` (returns `TableIterator<(name!(component, i64), name!(member, i64))>` or `Vec<Vec<i64>>` → SETOF). Drop the old `String`-JSON bodies + `goldenmatch_bridge::api` calls for these three.
+
+- [ ] **Step 4: Verify** — `cargo check -p goldenmatch_pg --no-default-features --features pg16` locally (preamble; may fail on libclang — if so, `cargo fmt --check` + push to CI). Real `pg_test` runs in CI.
+
+- [ ] **Step 5: Commit** `feat(509): Postgres graph UDFs native-direct (drop CPython bridge)`. Body: pg_test verified in CI.
+
+## Task 8: DataFusion graph UDFs (Arrow) over `graph-core`
+
+**Files:**
+- Create: `packages/rust/extensions/datafusion-udf/src/graph_udf.rs`
+- Modify: `packages/rust/extensions/datafusion-udf/src/lib.rs`, `datafusion-udf/Cargo.toml`
+
+- [ ] **Step 1:** Add `goldenmatch-graph-core` path dep to `datafusion-udf/Cargo.toml`.
+- [ ] **Step 2: Write failing test** — a `#[tokio::test]` (or unit) registering the UDFs on a `SessionContext`, running `SELECT goldenmatch_pair_dedup(...)` over an Arrow batch, asserting output. Follow the existing `embed_udf.rs`/`scalar_udf.rs` registration + test pattern.
+- [ ] **Step 3: Run, verify FAIL** — `cargo test -p <datafusion-udf-crate>`.
+- [ ] **Step 4: Implement** graph UDFs calling `graph-core::*_arrow_data`. Wire registration in `lib.rs`.
+- [ ] **Step 5: Run, verify PASS**; **Step 6: Commit** `feat(509): DataFusion graph UDFs over graph-core`
+
+## Task 9: Cross-backend graph parity test
+
+**Files:**
+- Test: `packages/rust/extensions/duckdb/tests/test_parity_graph.py`
+
+- [ ] **Step 1: Write the test** — same edge set fed to (a) the DuckDB UDF, (b) the pure-Python `goldenmatch.native` kernel, assert identical grouping. (PG/DataFusion parity asserted in their own CI lanes against the same pinned vectors; document the shared fixture.)
+- [ ] **Step 2: Run, verify PASS** locally — `python -m pytest tests/test_parity_graph.py -v`.
+- [ ] **Step 3: Commit** `test(509): cross-backend graph parity`
+
+---
+
+# PHASE B — Embedding UDF
+
+## Task 10: `goldenmatch-embed` pyo3 wheel over `goldenembed`
+
+**Files:**
+- Create: `packages/rust/extensions/embed-py/{Cargo.toml,pyproject.toml,src/lib.rs}`
+- Create: `packages/rust/extensions/embed-py/python/goldenmatch_embed/__init__.py`
+
+Mirrors the `goldenmatch-native` maturin/abi3 layout. Keeps `goldenembed` pyo3-free; this wheel is the only place `ort` meets Python.
+
+- [ ] **Step 1: Cargo.toml** — `[lib] name="_embed" crate-type=["cdylib"]`; deps `pyo3 = {features=["extension-module","abi3-py311"]}`, `goldenembed = { path = "../goldenembed" }`.
+- [ ] **Step 2: src/lib.rs** — `#[pymodule] _embed` exposing `PyGoldenEmbed { load(dir) -> Self; embed(texts: Vec<String>) -> Vec<Vec<f32>> }` over `goldenembed::GoldenEmbed`. Hold the model behind a `Mutex` (embed is `&mut self`, like `embed_udf.rs`).
+- [ ] **Step 3: pyproject.toml** — maturin backend, `[project] name="goldenmatch-embed" version="0.1.0"`, module path `python/goldenmatch_embed`. Mirror `native/pyproject.toml` (keep Cargo + pyproject versions in lockstep per CLAUDE.md gotcha).
+- [ ] **Step 4: `__init__.py`** — loader discovering `goldenmatch_embed._embed`.
+- [ ] **Step 5: Verify** — `cargo check -p goldenmatch-embed` (preamble). `ort` won't link locally on Windows → expect this is CI-only; if check fails on link, confirm it's the known `ort` LNK and proceed (push to CI). `cargo fmt --check`.
+- [ ] **Step 6: Commit** `feat(509): goldenmatch-embed pyo3 wheel over goldenembed-rs`
+
+## Task 11: Publish workflow for `goldenmatch-embed`
+
+**Files:**
+- Create: `.github/workflows/publish-goldenmatch-embed.yml`
+
+- [ ] **Step 1:** Copy `publish-goldenmatch-native.yml`, retarget tag `goldenmatch-embed-v*`, crate path `packages/rust/extensions/embed-py`, build both macOS arches on `macos-14` (per CLAUDE.md), `workflow_dispatch` `publish` toggle for dry-run. Ensure the ONNX runtime is available to the build (reuse goldenembed CI's `ort` setup).
+- [ ] **Step 2: Verify** — `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/publish-goldenmatch-embed.yml'))"`. (Workflow itself only fires on tag — verify via `workflow_dispatch` dry-run after merge, per CLAUDE.md trigger-ordering note.)
+- [ ] **Step 3: Commit** `ci(509): publish workflow for goldenmatch-embed wheel`
+
+## Task 12: DuckDB + Postgres + DataFusion embed UDFs → goldenembed-rs
+
+**Files:**
+- Modify: `duckdb/goldenmatch_duckdb/core_kernels.py` (`_embed_local`)
+- Modify: `postgres/src/kernels.rs` (`goldenmatch_embed_local`), `postgres/Cargo.toml` (add `goldenembed`)
+- Modify: `datafusion-udf/src/embed_udf.rs` (+ 2-arg `goldenmatch_embed_local`)
+
+- [ ] **Step 1 (DuckDB):** repoint `_embed_local(text, model_path)` to `from goldenmatch_embed import GoldenEmbed; GoldenEmbed.load(model_path).embed([text])[0]`. Fail-soft only if `goldenmatch_embed` unimportable → clear error. Add `goldenmatch-embed` to the duckdb package's optional deps/extras.
+- [ ] **Step 2 (Postgres):** add `goldenembed = { path = "../goldenembed" }` to `postgres/Cargo.toml`; rewrite `goldenmatch_embed_local` to call `goldenembed::GoldenEmbed::load(&model_path)?.embed(&[&text])?` directly (no `goldenmatch_bridge`). Return `Vec<f64>`/`float8[]`.
+- [ ] **Step 3 (DataFusion):** per the spec divergence note — add a 2-arg `goldenmatch_embed_local(text, model_path)` UDF alongside the existing env-var `goldenmatch_embed`; register in `lib.rs`.
+- [ ] **Step 4: Verify** — DuckDB embed test is CI-only (ONNX). `cargo check` the PG + DataFusion crates locally (expect `ort` link → CI). `cargo fmt --check`.
+- [ ] **Step 5: Commit** `feat(509): embed UDFs backed by goldenembed-rs on all surfaces`
+
+## Task 13: Embed parity test (vs Python in-house within tolerance)
+
+**Files:**
+- Test: `packages/rust/extensions/duckdb/tests/test_parity_embed.py` (CI-gated marker)
+- Modify (decision): `bridge/src/api.rs` — remove now-dead `connected_components`/`pair_dedup`/`embed_local`
+
+- [ ] **Step 1:** Write a CI-only parity test (skip locally via marker when `goldenmatch_embed` import fails): embed a fixed string via the wheel and via `goldenmatch.embeddings.inhouse`, assert cosine ≥ 0.999 (or L2 within tolerance). Pin the model fixture.
+- [ ] **Step 2:** Remove the three dead bridge API fns + their bridge tests (graph + embed now native-direct everywhere). Confirm nothing else imports them: `grep -rn "api::connected_components\|api::pair_dedup\|api::embed_local" packages/rust/extensions`.
+- [ ] **Step 3: Verify** — `cargo check -p goldenmatch-bridge` (preamble); parity test runs in CI.
+- [ ] **Step 4: Commit** `test(509): embed parity vs in-house + drop dead bridge fns`
+
+---
+
+# PHASE C — Versioning, SQL surface, CI
+
+## Task 14: Bump versions + Postgres SQL surface 0.6.0
+
+**Files:**
+- Modify: `postgres/Cargo.toml` → `0.6.0`, `postgres/goldenmatch_pg.control` → `default_version = '0.6.0'`
+- Create: `postgres/sql/goldenmatch_pg--0.6.0.sql`, `postgres/sql/goldenmatch_pg--0.5.0--0.6.0.sql`
+- Modify: `duckdb/pyproject.toml` → `0.6.0`
+
+- [ ] **Step 1:** Bump the three versions.
+- [ ] **Step 2:** Write the handwritten `--0.6.0.sql` (full surface — copy 0.5.0, replace the three graph/embed function signatures with the native-direct ones, drop the JSON variants). Write `--0.5.0--0.6.0.sql` upgrade: `DROP FUNCTION` old signatures + `CREATE FUNCTION` new (pgrx doesn't auto-generate; see CLAUDE.md).
+- [ ] **Step 3: Verify** — SQL is handwritten; sanity-check `CREATE FUNCTION` names match `#[pg_extern]` symbols (the wrapper names). CI postgres-build is the real gate.
+- [ ] **Step 4: Commit** `feat(509): goldenmatch_pg 0.6.0 SQL surface + upgrade script; bump duckdb 0.6.0`
+
+## Task 15: Update CLAUDE.md + docs; open PR
+
+**Files:**
+- Modify: `packages/rust/extensions/CLAUDE.md` (document `graph-core`, `goldenmatch-embed`, native-direct graph/embed UDFs, the dropped JSON variants)
+- Modify: root `CLAUDE.md` if a cross-cutting gotcha emerged
+
+- [ ] **Step 1:** Update the extensions CLAUDE.md SQL-surface section + add a `graph-core`/`goldenmatch-embed` subsection.
+- [ ] **Step 2:** Run the full local-testable suite: `cargo test -p goldenmatch-graph-core`; `cd duckdb && python -m pytest tests/test_graph_arrow.py tests/test_parity_graph.py -v` (POLARS_SKIP_CPU_CHECK=1).
+- [ ] **Step 3:** Push branch, open PR `feat: SQL-native graph + embedding UDFs (native-direct) — closes #509`. Use the `gh auth switch --user benzsevern` dance (per CLAUDE.md + memory `feedback_github_auth_switch`), switch back after. PR body: summary bullets + the local-vs-CI test matrix + "Closes #509".
+- [ ] **Step 4:** Poll CI per the CLAUDE.md poll-loop pattern; fix red lanes (especially postgres-build PG 15/16/17 and the embed ONNX lanes) until green.
+- [ ] **Step 5:** Use superpowers:finishing-a-development-branch for merge.
+
+---
+
+## Verification checklist (before claiming done)
+
+- [ ] `cargo test -p goldenmatch-graph-core` green locally
+- [ ] DuckDB graph + parity pytest green locally
+- [ ] CI: native parity, postgres-build (15/16/17), datafusion, duckdb, embed lanes all green
+- [ ] Embed parity (cosine ≥ tolerance) green in CI
+- [ ] No remaining `goldenmatch_bridge::api::{connected_components,pair_dedup,embed_local}` references
+- [ ] `goldenmatch-embed` wheel `workflow_dispatch` dry-run succeeds post-merge
+- [ ] Versions bumped: graph-core 0.1.0, embed-py 0.1.0, goldenmatch_pg 0.6.0, duckdb 0.6.0
+- [ ] #509 acceptance criteria all satisfied

--- a/docs/superpowers/plans/2026-06-04-sql-native-graph-embed-udfs.md
+++ b/docs/superpowers/plans/2026-06-04-sql-native-graph-embed-udfs.md
@@ -271,7 +271,9 @@ These take `arrow::array::ArrayData` (NOT `PyArrowType` — that stays in `nativ
 goldenmatch-graph-core = { path = "../graph-core" }
 ```
 
-- [ ] **Step 2:** In `pairs.rs`, replace the body of `dedup_pairs_max_score` with a delegation: keep the `#[pyfunction]` signature, call `goldenmatch_graph_core::dedup_pairs_max_score(&pairs)`. Same for `cluster.rs::connected_components`. For the `*_arrow` pyfunctions, unwrap `PyArrowType` to `ArrayData`, call the `graph-core` `*_arrow_data` fn, rewrap. Leave `build_clusters_arrow`/`build_clusters_native` as-is (out of #509 scope) unless they call the moved helpers — if so, point them at `graph-core`.
+- [ ] **Step 2:** In `pairs.rs`, replace the body of `dedup_pairs_max_score` with a delegation: keep the `#[pyfunction]` signature, call `goldenmatch_graph_core::dedup_pairs_max_score(&pairs)`. Same for `cluster.rs::connected_components`. For the existing `dedup_pairs_arrow` pyfunction (`pairs.rs:80`), unwrap `PyArrowType` to `ArrayData`, call `graph_core::dedup_pairs_arrow_data`, rewrap as `PyArrowType`.
+
+- [ ] **Step 2b: Add the missing `connected_components_arrow` pyfunction.** There is currently NO `connected_components_arrow` in `native` (only `dedup_pairs_arrow` is registered at `lib.rs:27`; `build_clusters_arrow` exists but has a different, cluster-building contract). Task 6's DuckDB "delegate to `goldenmatch.native.connected_components_arrow` when available" path requires it. Add a new `#[pyfunction] connected_components_arrow(id_a, id_b, score, all_ids: PyArrowType<ArrayData>) -> PyResult<PyArrowType<ArrayData>>` in `cluster.rs` (returns the components as an Arrow `List<Int64>`), delegating to `graph_core::connected_components_arrow_data`. **Register it in `lib.rs`** by adding `m.add_function(wrap_pyfunction!(cluster::connected_components_arrow, m)?)?;` to the `#[pymodule]` block (alongside the existing `connected_components` / `dedup_pairs_arrow` registrations at `lib.rs:19,27`). Leave `build_clusters_arrow`/`build_clusters_native` as-is (out of #509 scope) unless they call the moved helpers — if so, point them at `graph-core`.
 
 - [ ] **Step 3: Verify behavior-exact** — Run `cargo check -p goldenmatch-native` locally (preamble). Full `cargo test -p goldenmatch-native` is CI (needs goldenmatch Python). Expected local: compiles clean.
 
@@ -290,13 +292,13 @@ DuckDB Python UDFs registered with `type='arrow'` receive pyarrow arrays. The ke
 ```python
 import duckdb
 import pytest
-from goldenmatch_duckdb.functions import register_functions
+from goldenmatch_duckdb.functions import register  # public entrypoint (see functions.py:19; __init__.py calls register())
 
 
 @pytest.fixture
 def con():
     c = duckdb.connect()
-    register_functions(c)
+    register(c)
     return c
 
 
@@ -320,7 +322,9 @@ def test_connected_components_string_ids(con):
     assert sorted(comps) == [["w"], ["x", "y", "z"]]
 ```
 
-- [ ] **Step 2: Run, verify FAIL** — `cd packages/rust/extensions/duckdb && python -m pytest tests/test_graph_arrow.py -v` (set `POLARS_SKIP_CPU_CHECK=1`). Expected: fails (signatures are still JSON `VARCHAR`).
+- [ ] **Step 2: Run, verify FAIL** — `cd packages/rust/extensions/duckdb && python -m pytest tests/test_graph_arrow.py -v` (set `POLARS_SKIP_CPU_CHECK=1`). Expected: fails (signatures are still JSON `VARCHAR`). **Validate the new registration shape here:** no existing UDF in this codebase uses `con.create_function` with native `LIST`/list-of-list args or returns — confirm DuckDB accepts the list arg/return types in this FAIL run (a registration-time `TypeError` means the shape needs adjusting, e.g. fall back to a table-returning UDF) before writing Step 3.
+
+- [ ] **Step 2b: Update the pre-existing `test_core_kernels.py` for the clean break.** `duckdb/tests/test_core_kernels.py` tests the OLD JSON signatures (`goldenmatch_connected_components('[[1,2,0.9]]')`, `goldenmatch_pair_dedup('[[...]]')`) and the fail-soft `{"error": ...}` convention — all of which the clean break removes. Rewrite the graph-UDF cases in this file to the new Arrow/list signatures (the embed case is handled in Task 12), or move them into `test_graph_arrow.py` and delete the dead graph cases. Run `python -m pytest tests/test_core_kernels.py -v` and confirm no stale JSON-signature assertions remain. This file must not be left red.
 
 - [ ] **Step 3: Rewrite `core_kernels.py` graph UDFs.** Replace `_connected_components(pairs_json)` / `_pair_dedup(pairs_json)` and their `con.create_function` registrations. Register the new signatures with list/arrow types; accept int64 lists (fast path) and Utf8 lists (build a Python dict, call kernel, map back). Decide the exact final SQL shape (table-returning vs list-return) to match the test above; keep `connected_components` returning `list<list<id>>` and `pair_dedup` table-returning `(a,b,s)`. Delegate to `goldenmatch.native.*_arrow` when available, else the pure-Python `connected_components`/`dedup_pairs_max_score`.
 

--- a/docs/superpowers/specs/2026-06-04-sql-native-graph-embed-udfs-design.md
+++ b/docs/superpowers/specs/2026-06-04-sql-native-graph-embed-udfs-design.md
@@ -122,8 +122,11 @@ Same per-engine encoding as above.
 
 - **int64 columns/arrays** → straight into the kernel (zero mapping).
 - **Utf8/dictionary (DuckDB/DataFusion) or `text[]` (Postgres)** → wrapper builds
-  a deterministic str↔i64 dictionary, runs the i64 kernel, maps results back to
-  the original string ids. Dictionary build is parity-tested.
+  a deterministic str↔i64 dictionary (**first-seen insertion order**: scan
+  `id_a` then `id_b`, assign the next i64 to each unseen string), runs the i64
+  kernel, maps results back to the original string ids. Build order is identical
+  across all three wrappers so grouping + round-trip agree. Dictionary build is
+  parity-tested.
 
 ### `goldenmatch_embed_local(text, model_path)`
 
@@ -133,9 +136,20 @@ Same per-engine encoding as above.
 |---|---|
 | DuckDB | new `goldenmatch-embed` wheel (goldenembed-rs ONNX) |
 | Postgres | `goldenembed` crate **directly** (pure Rust, no CPython bridge) |
-| DataFusion | existing `goldenmatch_embed` UDF (`embed_udf.rs`) already does this |
+| DataFusion | extend existing `embed_udf.rs` — **see divergence note** |
 
 Returns the embedding vector (float array / `FixedSizeList<Float32>` on Arrow).
+
+**DataFusion divergence (must resolve in the plan):** the existing UDF is named
+`goldenmatch_embed` (not `goldenmatch_embed_local`), takes a **single** `text`
+arg, and reads the model dir from the `GOLDENEMBED_MODEL_DIR` env var at
+construction — it has **no per-call `model_path`**. So the DataFusion surface is
+**not** a no-op. The plan must choose one:
+- **(a)** add a 2-arg `goldenmatch_embed_local(text, model_path)` alongside the
+  existing env-var `goldenmatch_embed` (lockstep name parity, keeps back-compat), or
+- **(b)** rename/repoint to the 2-arg form and document the env-var contract drop.
+Recommended: **(a)** — adds the lockstep name without breaking the existing
+env-var UDF.
 
 ## Data flow (graph UDF, DuckDB, string ids)
 
@@ -183,7 +197,8 @@ DuckDB + `graph-core`.
 - `goldenmatch-duckdb`: `0.5.0 → 0.6.0` (Arrow graph UDFs, embed via wheel).
 - `goldenmatch_pg`: `0.5.0 → 0.6.0` — new handwritten `sql/goldenmatch_pg--0.6.0.sql`
   + `--0.5.0--0.6.0.sql` upgrade script (drops old JSON signatures, creates new).
-- `datafusion-udf`: graph UDFs added (version bump per its own scheme).
+- `datafusion-udf`: graph UDFs + 2-arg `goldenmatch_embed_local` added; bump its
+  crate version one minor (pin the exact target during planning).
 
 ## Build sequence (graph-first)
 

--- a/docs/superpowers/specs/2026-06-04-sql-native-graph-embed-udfs-design.md
+++ b/docs/superpowers/specs/2026-06-04-sql-native-graph-embed-udfs-design.md
@@ -1,0 +1,220 @@
+# SQL-native graph + embedding UDFs — native-direct (DuckDB / Postgres / DataFusion)
+
+- **Issue:** #509 (part of #504 Phase 5, SQL-native expansion)
+- **Date:** 2026-06-04
+- **Status:** Design approved (brainstorming); pending spec review + plan
+- **Depends on:** #508 (`goldenembed-rs`, landed — PR #734); #504 native kernels (landed)
+
+## Problem
+
+#509 asks for warehouse-first ER primitives exposed directly in SQL:
+
+- `goldenmatch_connected_components(...)` / `goldenmatch_pair_dedup(...)` backed by
+  the native graph kernels — **not** the JSON-bridge round-trip.
+- `goldenmatch_embed_local(text, model_path)` backed by `goldenembed-rs` — no
+  Vertex/OpenAI network dependency inside the warehouse.
+- Both backends kept in lockstep (DuckDB UDF + pgrx wrapper + handwritten SQL),
+  tested on both, identical SQL outputs.
+
+### The reframe: this is a rework, not greenfield
+
+PR #503 (epic #504) **already shipped a first implementation** of all three UDFs
+on both backends — but as exactly the anti-pattern #509 says to replace:
+
+- **DuckDB** (`duckdb/goldenmatch_duckdb/core_kernels.py`): JSON-in/JSON-out
+  scalar UDFs; `goldenmatch_embed_local` wraps the **Python in-house** embedder
+  (`provider="inhouse"`), not `goldenembed-rs`.
+- **Postgres** (`postgres/src/kernels.rs`): `#[pg_extern]` functions that wrap
+  `goldenmatch_bridge::api::{connected_components, pair_dedup, embed_local}` —
+  i.e. the **CPython JSON-bridge round-trip** (`pgrx → pyo3 → goldenmatch.native`).
+
+The existing `goldenmatch_record_fingerprint` (pure-Rust, bridge-free — "the
+decoupling lever" per its own doc comment) is the proven template for what these
+UDFs should become.
+
+**This worktree replaces the #503 placeholder with the native-direct contract.**
+
+## Goals
+
+- Graph UDFs call the native kernels **directly** (no embedded CPython on the
+  Postgres/DataFusion path; no JSON round-trip on DuckDB).
+- Columnar **Arrow** I/O on the Arrow-native engines (DuckDB, DataFusion);
+  native PG arrays on Postgres. Same kernel logic, identical values.
+- Accept **both** int64 record IDs (zero-mapping fast path) and **string** IDs
+  (dictionary-mapped str↔i64 around the i64 kernel).
+- `goldenmatch_embed_local` runs the **same `goldenembed-rs` ONNX kernel** on all
+  surfaces (new pyo3 wheel for DuckDB; direct crate call for Postgres/DataFusion),
+  matching the Python in-house path within tolerance.
+
+## Non-goals
+
+- No network embedding providers (Vertex/OpenAI) in SQL — out of scope by design.
+- No streaming / stateful surfaces.
+- No change to the existing `goldenmatch_record_fingerprint` contract.
+- Backward compatibility with the #503 JSON-string UDF signatures — **clean break**
+  (the placeholder just landed; same names are repointed to native-direct shapes).
+
+## Scope decisions (from brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Scope | All three UDFs, **graph-first** build order |
+| DuckDB embed backend | **New pyo3 binding** to `goldenembed-rs` (single-kernel lockstep) |
+| Graph I/O encoding | **Arrow on DuckDB/DataFusion, native arrays on Postgres** |
+| Record-ID handling | **Accept both** — int64 fast path + string dictionary mapping |
+| Embed binding packaging | **New thin wrapper wheel** (`goldenmatch-embed`), keeps `goldenembed` pyo3-free |
+| #503 JSON UDFs | **Replace in place** (clean break) |
+| DataFusion surface | **Include** — third Arrow-native surface sharing `graph-core` |
+
+## Architecture
+
+### New component: `graph-core` (pyo3-free crate)
+
+Mirrors the existing `score-core` precedent ("intentionally pyo3-free; the
+`native` crate keeps thin `#[pyfunction]` shims that delegate here; the FFI UDFs
+call these `pub fn`s").
+
+Today the graph kernels live in the **pyo3-coupled** `native` crate
+(`cluster.rs`, `pairs.rs` — `use pyo3`, `#[pyfunction]`, `PyArrowType`). To let
+pgrx and DataFusion call them without CPython, extract the pure logic:
+
+- `graph-core::connected_components(edges: &[(i64,i64,f64)], all_ids: &[i64]) -> Vec<Vec<i64>>`
+- `graph-core::dedup_pairs_max_score(pairs: &[(i64,i64,f64)]) -> Vec<(i64,i64,f64)>`
+- Columnar helpers over Arrow `Int64Array`/`Float64Array` (pure `arrow`, no
+  `pyarrow`/pyo3) for the Arrow-native callers.
+
+The `native` crate's `cluster.rs`/`pairs.rs` keep their `#[pyfunction]` +
+`PyArrowType` shims but delegate to `graph-core` (behavior-exact; existing
+native parity tests must still pass).
+
+### New component: `goldenmatch-embed` (pyo3 wheel)
+
+Thin pyo3/abi3 wrapper crate over `goldenembed`, packaged with maturin — mirrors
+the `goldenmatch-native` split. Keeps `goldenembed` itself pyo3-free and confines
+the heavy `ort`/ONNX runtime to this one wheel.
+
+- Python API: `GoldenEmbed.load(dir) -> model`; `model.embed(texts: list[str]) -> list[list[float]]`.
+- Loader/discovery parallel to `goldenmatch-native` (`goldenmatch_embed._embed`).
+- New publish workflow (tag `goldenmatch-embed-v*`), versioned independently.
+
+## Surface-by-surface contract
+
+All three engines expose the same function names and produce **identical values**;
+wire encoding is idiomatic per engine.
+
+### `goldenmatch_connected_components`
+
+Input: a candidate-pair set `(id_a, id_b, score)` + optional universe of ids.
+Output: components (each a sorted list of member ids).
+
+| Engine | Signature | Kernel path |
+|---|---|---|
+| DuckDB | Arrow columns `(id_a, id_b, score [, all_ids])`; returns list-of-lists | pyarrow → `graph-core` columnar |
+| Postgres | `(id_a bigint[]/text[], id_b ..., score float8[] [, all_ids ...])` | PG arrays → `graph-core` (pure Rust) |
+| DataFusion | Arrow UDF over `(id_a, id_b, score)` | `arrow` arrays → `graph-core` |
+
+### `goldenmatch_pair_dedup`
+
+Input: `(id_a, id_b, score)`. Output: canonical pairs, max score per `{a,b}`.
+Same per-engine encoding as above.
+
+### ID handling (accept both)
+
+- **int64 columns/arrays** → straight into the kernel (zero mapping).
+- **Utf8/dictionary (DuckDB/DataFusion) or `text[]` (Postgres)** → wrapper builds
+  a deterministic str↔i64 dictionary, runs the i64 kernel, maps results back to
+  the original string ids. Dictionary build is parity-tested.
+
+### `goldenmatch_embed_local(text, model_path)`
+
+`model_path` = a saved in-house model directory (ONNX + featurizer config).
+
+| Engine | Backend |
+|---|---|
+| DuckDB | new `goldenmatch-embed` wheel (goldenembed-rs ONNX) |
+| Postgres | `goldenembed` crate **directly** (pure Rust, no CPython bridge) |
+| DataFusion | existing `goldenmatch_embed` UDF (`embed_udf.rs`) already does this |
+
+Returns the embedding vector (float array / `FixedSizeList<Float32>` on Arrow).
+
+## Data flow (graph UDF, DuckDB, string ids)
+
+```
+SQL: SELECT goldenmatch_connected_components(id_a, id_b, score) ...
+  → DuckDB hands Arrow Utf8/Int64 columns to the Python UDF (zero-copy via pyarrow)
+  → wrapper: if Utf8/dict → build str↔i64 dict; else pass int64 through
+  → graph-core columnar kernel (pure Rust) computes components on i64
+  → wrapper maps i64 components back to original ids
+  → return Arrow list<list<id>>
+```
+
+No JSON parse, no per-row Python, no CPython interpreter spin-up on the kernel.
+
+## Error handling
+
+- **Type errors** (wrong Arrow type, malformed array): raise a clear engine-native
+  error (DuckDB exception / `pgrx::error!` / DataFusion `Execution`), naming the
+  function + offending column — mirrors the existing kernel `PyValueError` messages.
+- **Embed errors** (missing model dir, bad ONNX): surfaced as the engine-native
+  error; the embed model lock-poison path already handled in `embed_udf.rs`.
+- The #503 fail-soft `{"error": ...}` JSON convention is **dropped** for these
+  functions (clean break to typed columnar I/O; errors become real SQL errors).
+
+## Testing strategy
+
+| Layer | Where | Notes |
+|---|---|---|
+| `graph-core` units | local `cargo test` | pyo3-free; int64 + edge cases + dict mapping |
+| `native` shims still parity | CI (needs goldenmatch Python) | existing tests must stay green after delegation |
+| DuckDB graph UDFs | **local** pytest | Arrow int64 + string-dict cases; no ONNX needed |
+| DuckDB embed UDF | **CI-only** | `ort` won't link locally on Windows; `cargo check` locally |
+| Postgres (all) | **CI-only** | pgrx needs libclang/Linux; PG 15/16/17 lanes |
+| DataFusion UDFs | CI (`cargo test`) | Arrow end-to-end |
+| Cross-backend parity | CI | DuckDB value == PG value == DataFusion value == kernel; embed == Python in-house within tolerance |
+
+Local-build constraint: the embed half is CI-validated on Windows (per
+`feedback_ort_onnxruntime_no_local_link`). Graph half is fully local-testable on
+DuckDB + `graph-core`.
+
+## Versioning / packaging
+
+- `graph-core`: new internal crate (path dep of `native`, `postgres`, `datafusion-udf`).
+- `goldenmatch-embed`: new pyo3 wheel `0.1.0` + publish workflow (`goldenmatch-embed-v*`).
+- `goldenmatch-duckdb`: `0.5.0 → 0.6.0` (Arrow graph UDFs, embed via wheel).
+- `goldenmatch_pg`: `0.5.0 → 0.6.0` — new handwritten `sql/goldenmatch_pg--0.6.0.sql`
+  + `--0.5.0--0.6.0.sql` upgrade script (drops old JSON signatures, creates new).
+- `datafusion-udf`: graph UDFs added (version bump per its own scheme).
+
+## Build sequence (graph-first)
+
+1. Extract `graph-core` (pyo3-free) + rewire `native` `#[pyfunction]` shims; native parity green.
+2. DuckDB graph UDFs → Arrow columnar (accept-both ids).
+3. Postgres graph UDFs → native-direct over PG arrays (replace bridge `kernels.rs`).
+4. DataFusion graph UDFs (Arrow) over `graph-core`.
+5. Cross-backend graph parity tests.
+6. `goldenmatch-embed` wheel + publish workflow.
+7. DuckDB embed UDF → wheel; Postgres embed UDF → direct `goldenembed` crate.
+8. Embed parity tests (vs Python in-house within tolerance).
+
+## Acceptance (from #509)
+
+- `goldenmatch_connected_components` / `goldenmatch_pair_dedup` available + tested
+  on DuckDB and Postgres (and DataFusion), native-direct (no JSON-bridge).
+- `goldenmatch_embed_local` produces vectors matching the Python in-house path
+  within tolerance on every surface, backed by `goldenembed-rs`.
+- Identical SQL outputs across backends; both-backend tests green in CI.
+
+## Risks / open items
+
+- **`graph-core` extraction must be behavior-exact** — the union strategy is
+  irrelevant to component membership (documented in `cluster.rs`), but the
+  `build_clusters_arrow` path has more surface; keep delegation thin and rerun all
+  native parity tests.
+- **`goldenmatch-embed` wheel packaging** — bundling the ONNX runtime in a maturin
+  wheel across platforms is the same multi-platform-publish work `goldenmatch-native`
+  faced; reuse that workflow shape. CI-only validation on Windows.
+- **str↔i64 dictionary determinism** — must be stable so DuckDB and PG agree on
+  component grouping when ids are strings (grouping is order-independent, but the
+  returned ids must round-trip exactly).
+- **PG `text[]` ergonomics** — large pair sets as PG arrays; confirm acceptable vs
+  a table-reading variant (deferred; arrays match the lockstep contract).

--- a/packages/rust/extensions/CLAUDE.md
+++ b/packages/rust/extensions/CLAUDE.md
@@ -41,7 +41,8 @@ Native SQL extensions for [GoldenMatch](https://github.com/benseverndev-oss/gold
 - `pipeline.rs` -- 5 job management functions: gm_configure, gm_run, gm_jobs, gm_golden, gm_drop
 - `spi.rs` -- reads PG tables via `row_to_json()` SPI queries
 - `correction.rs` -- Learning Memory CRUD + tuning: `correction_add`, `correction_list`, plus `memory_learn` (force a MemoryLearner pass) and `memory_stats` (counts + learned adjustments). All wrap the bridge `goldenmatch_bridge::api::*`. `memory_learn` is REVOKEd from PUBLIC like `correction_add`; `memory_stats` is read-only status, left for PUBLIC.
-- SQL file at `sql/goldenmatch_pg--0.5.0.sql` -- handwritten (pgrx doesn't auto-generate)
+- SQL file at `sql/goldenmatch_pg--0.6.0.sql` -- handwritten (pgrx doesn't auto-generate); `sql/goldenmatch_pg--0.5.0--0.6.0.sql` is the upgrade script
+- `kernels.rs` -- native-direct graph + fingerprint functions (#509). `goldenmatch_pair_dedup`/`_str` + `goldenmatch_connected_components`/`_str` call the pyo3-free `goldenmatch-graph-core` crate in PURE RUST (no embedded CPython); `goldenmatch_record_fingerprint` uses `fingerprint-core`. `goldenmatch_embed_local` still uses the CPython bridge (goldenembed-rs cutover is the #509 embed follow-up)
 - .control file: `schema = goldenmatch` -- all functions in goldenmatch schema
 
 ### duckdb/ (goldenmatch-duckdb)
@@ -127,7 +128,7 @@ lockstep (bridge fn + pgrx wrapper + handwritten SQL on the Postgres side;
 `functions.py` UDF on the DuckDB side) so the two stay interchangeable.
 
 ## Gotchas
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.5.0.sql` manually
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.6.0.sql` manually (+ the `--0.5.0--0.6.0.sql` upgrade script). Bumping the PG version means renaming the SQL file AND updating the hardcoded `cp sql/goldenmatch_pg--X.Y.Z.sql` lines in root `.github/workflows/ci.yml` + `publish-goldenmatch-pg.yml` (the orphaned `packages/.../.github` copies are ignored)
 - pgrx extension functions are in `goldenmatch` schema -- use `goldenmatch.function_name()` in psql, or explicit `::TEXT` casts
 - `cargo` defaults CARGO_HOME to drive root on Windows when CWD is D: -- always set explicitly
 - DuckDB UDFs cannot query same connection (deadlock) -- use `con.cursor()` for table reads

--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/core_kernels.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/core_kernels.py
@@ -1,18 +1,33 @@
-"""DuckDB UDFs for the Native Core kernels + the local in-house embedder.
+"""DuckDB UDFs for the Native Core graph kernels + the local in-house embedder.
 
-Exposes in SQL:
-- ``goldenmatch_connected_components(pairs_json)`` -> JSON list of components.
-- ``goldenmatch_pair_dedup(pairs_json)`` -> JSON list of canonical max-score pairs.
-- ``goldenmatch_embed_local(text, model_path)`` -> JSON float array.
+The graph UDFs are **native-direct, columnar**: callers pass the WHOLE
+candidate-pair / edge columns as DuckDB ``LIST`` arguments (aggregate with
+``list(col)``) and get a ``LIST`` back. No JSON wire. Each UDF calls the native
+kernel (``goldenmatch.native.dedup_pairs_max_score`` /
+``connected_components``) directly -- the Rust kernel when the ``_native`` ext
+is built, else the pure-Python reference (identical values either way).
 
-The graph UDFs wrap ``goldenmatch.native`` (the Rust kernels when the ext is
-built, else the pure-Python reference). The embedding UDF wraps the local
-in-house embedder (``provider="inhouse"``) — no cloud, no network. ``model_path``
-is a directory saved by ``goldenmatch.embeddings.inhouse.GoldenEmbedModel.save``.
+Both int64 ids (fast path) and string ids are supported. DuckDB does NOT allow
+overloading one function name across arg signatures, so the string variants are
+registered under ``*_str`` names; the int variants keep the bare name.
 
-JSON in / JSON out, fail-soft to ``{"error": ...}`` (matches the other UDF
-modules). ``pairs_json`` is a JSON array of ``[id_a, id_b, score]`` triples;
-ids are coerced to int, score to float.
+Exposed in SQL:
+- ``goldenmatch_pair_dedup(id_a BIGINT[], id_b BIGINT[], score DOUBLE[])``
+  -> ``STRUCT(a BIGINT, b BIGINT, s DOUBLE)[]`` -- canonical max-score pairs.
+- ``goldenmatch_pair_dedup_str(id_a VARCHAR[], id_b VARCHAR[], score DOUBLE[])``
+  -> ``STRUCT(a VARCHAR, b VARCHAR, s DOUBLE)[]``.
+- ``goldenmatch_connected_components(id_a BIGINT[], id_b BIGINT[],
+  score DOUBLE[], all_ids BIGINT[])`` -> ``BIGINT[][]`` -- one inner list per
+  component; the universe (``all_ids``) makes singletons appear.
+- ``goldenmatch_connected_components_str(...VARCHAR variants...)``
+  -> ``VARCHAR[][]``.
+- ``goldenmatch_embed_local(text, model_path)`` -> JSON float array (unchanged;
+  owned by the embed task).
+
+The string variants build a first-seen ``str -> int`` dict, run the int kernel,
+then map results back to the original string ids. Bad input fails the query
+(no fail-soft JSON envelope) since the columnar shape has no string slot for an
+error sentinel -- a malformed list is a binder/type error at call time anyway.
 
 Registered via ``register_core_kernel_functions(con)`` from ``functions.register``.
 """
@@ -24,14 +39,24 @@ import duckdb
 
 
 def register_core_kernel_functions(con: duckdb.DuckDBPyConnection) -> None:
-    """Register the native-kernel + local-embedding UDFs on a connection."""
+    """Register the native-kernel graph UDFs + local-embedding UDF."""
     con.create_function(
-        "goldenmatch_connected_components", _connected_components,
-        ["VARCHAR"], "VARCHAR",
+        "goldenmatch_pair_dedup", _pair_dedup_int,
+        ["BIGINT[]", "BIGINT[]", "DOUBLE[]"],
+        "STRUCT(a BIGINT, b BIGINT, s DOUBLE)[]",
     )
     con.create_function(
-        "goldenmatch_pair_dedup", _pair_dedup,
-        ["VARCHAR"], "VARCHAR",
+        "goldenmatch_pair_dedup_str", _pair_dedup_str,
+        ["VARCHAR[]", "VARCHAR[]", "DOUBLE[]"],
+        "STRUCT(a VARCHAR, b VARCHAR, s DOUBLE)[]",
+    )
+    con.create_function(
+        "goldenmatch_connected_components", _connected_components_int,
+        ["BIGINT[]", "BIGINT[]", "DOUBLE[]", "BIGINT[]"], "BIGINT[][]",
+    )
+    con.create_function(
+        "goldenmatch_connected_components_str", _connected_components_str,
+        ["VARCHAR[]", "VARCHAR[]", "DOUBLE[]", "VARCHAR[]"], "VARCHAR[][]",
     )
     con.create_function(
         "goldenmatch_embed_local", _embed_local,
@@ -39,29 +64,76 @@ def register_core_kernel_functions(con: duckdb.DuckDBPyConnection) -> None:
     )
 
 
-def _parse_pairs(pairs_json: str) -> list[tuple[int, int, float]]:
-    raw = json.loads(pairs_json)
-    return [(int(p[0]), int(p[1]), float(p[2]) if len(p) > 2 else 1.0) for p in raw]
+def _zip_pairs(
+    id_a: list, id_b: list, score: list,
+) -> list[tuple[int, int, float]]:
+    return [(int(a), int(b), float(s)) for a, b, s in zip(id_a, id_b, score)]
 
 
-def _connected_components(pairs_json: str) -> str:
-    try:
-        from goldenmatch.native import connected_components
+def _str_dict(*cols: list) -> tuple[dict, list]:
+    """First-seen ``str -> int`` dict over one or more id columns.
 
-        comps = connected_components(_parse_pairs(pairs_json))
-        return json.dumps([sorted(c) for c in comps])
-    except Exception as e:  # noqa: BLE001 - fail-soft per module contract
-        return json.dumps({"error": str(e)})
+    Returns ``(to_int, to_str)`` where ``to_str[i]`` is the original string for
+    int code ``i``. Order is first-seen across the columns in argument order.
+    """
+    to_int: dict = {}
+    to_str: list = []
+    for col in cols:
+        for v in col:
+            if v not in to_int:
+                to_int[v] = len(to_str)
+                to_str.append(v)
+    return to_int, to_str
 
 
-def _pair_dedup(pairs_json: str) -> str:
-    try:
-        from goldenmatch.native import dedup_pairs_max_score
+# ── pair_dedup ───────────────────────────────────────────────────────────
 
-        out = dedup_pairs_max_score(_parse_pairs(pairs_json))
-        return json.dumps([[a, b, s] for a, b, s in out])
-    except Exception as e:  # noqa: BLE001 - fail-soft per module contract
-        return json.dumps({"error": str(e)})
+
+def _pair_dedup_int(id_a: list, id_b: list, score: list) -> list[dict]:
+    from goldenmatch.native import dedup_pairs_max_score
+
+    out = dedup_pairs_max_score(_zip_pairs(id_a, id_b, score))
+    return [{"a": a, "b": b, "s": s} for a, b, s in out]
+
+
+def _pair_dedup_str(id_a: list, id_b: list, score: list) -> list[dict]:
+    from goldenmatch.native import dedup_pairs_max_score
+
+    to_int, to_str = _str_dict(id_a, id_b)
+    pairs = [
+        (to_int[a], to_int[b], float(s))
+        for a, b, s in zip(id_a, id_b, score)
+    ]
+    out = dedup_pairs_max_score(pairs)
+    return [{"a": to_str[a], "b": to_str[b], "s": s} for a, b, s in out]
+
+
+# ── connected_components ─────────────────────────────────────────────────
+
+
+def _connected_components_int(
+    id_a: list, id_b: list, score: list, all_ids: list,
+) -> list[list[int]]:
+    from goldenmatch.native import connected_components
+
+    universe = [int(x) for x in all_ids]
+    comps = connected_components(_zip_pairs(id_a, id_b, score), universe)
+    return [sorted(c) for c in comps]
+
+
+def _connected_components_str(
+    id_a: list, id_b: list, score: list, all_ids: list,
+) -> list[list[str]]:
+    from goldenmatch.native import connected_components
+
+    to_int, to_str = _str_dict(all_ids, id_a, id_b)
+    pairs = [
+        (to_int[a], to_int[b], float(s))
+        for a, b, s in zip(id_a, id_b, score)
+    ]
+    universe = [to_int[x] for x in all_ids]
+    comps = connected_components(pairs, universe)
+    return [sorted(to_str[i] for i in c) for c in comps]
 
 
 def _embed_local(text: str, model_path: str) -> str:

--- a/packages/rust/extensions/duckdb/pyproject.toml
+++ b/packages/rust/extensions/duckdb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenmatch-duckdb"
-version = "0.5.0"
+version = "0.6.0"
 description = "GoldenMatch entity resolution functions for DuckDB"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/duckdb/tests/test_core_kernels.py
+++ b/packages/rust/extensions/duckdb/tests/test_core_kernels.py
@@ -1,7 +1,8 @@
-"""Tests for the Native Core + local-embedding UDFs in ``core_kernels.py``.
+"""Tests for the local-embedding UDF in ``core_kernels.py``.
 
-Registers the UDFs on a DuckDB connection and asserts the JSON results against
-what the underlying goldenmatch functions return — real parity, not a tautology.
+The graph UDFs moved to a native-direct columnar shape -- their tests live in
+``test_graph_arrow.py``. This module covers the JSON ``goldenmatch_embed_local``
+UDF (owned by the embed task), which stays JSON in / JSON out.
 """
 from __future__ import annotations
 
@@ -21,38 +22,6 @@ def con():
 
 def _scalar(con, sql: str) -> str:
     return con.sql(sql).fetchone()[0]
-
-
-class TestConnectedComponents:
-    def test_groups_and_singleton(self, con):
-        out = _scalar(
-            con,
-            "SELECT goldenmatch_connected_components('[[1,2,0.9],[2,3,0.8],[10,11,0.7]]')",
-        )
-        comps = {frozenset(c) for c in json.loads(out)}
-        assert comps == {frozenset({1, 2, 3}), frozenset({10, 11})}
-
-    def test_bad_json_is_fail_soft(self, con):
-        out = _scalar(con, "SELECT goldenmatch_connected_components('not json')")
-        assert "error" in json.loads(out)
-
-
-class TestPairDedup:
-    def test_canonicalizes_and_keeps_max(self, con):
-        out = _scalar(
-            con,
-            "SELECT goldenmatch_pair_dedup('[[2,1,0.5],[1,2,0.9],[3,4,0.2],[4,3,0.7]]')",
-        )
-        assert json.loads(out) == [[1, 2, 0.9], [3, 4, 0.7]]
-
-    def test_matches_native_reference(self, con):
-        from goldenmatch.native import dedup_pairs_max_score
-
-        pairs = [[5, 1, 0.3], [1, 5, 0.8], [2, 2, 1.0]]
-        out = json.loads(_scalar(con, f"SELECT goldenmatch_pair_dedup('{json.dumps(pairs)}')"))
-        ref = [[a, b, s] for a, b, s in dedup_pairs_max_score(
-            [(int(a), int(b), float(s)) for a, b, s in pairs])]
-        assert out == ref
 
 
 class TestEmbedLocal:

--- a/packages/rust/extensions/duckdb/tests/test_graph_arrow.py
+++ b/packages/rust/extensions/duckdb/tests/test_graph_arrow.py
@@ -1,0 +1,76 @@
+"""Value-level tests for the native-direct columnar graph UDFs.
+
+``goldenmatch_pair_dedup`` / ``goldenmatch_connected_components`` (int64 ids)
+and their ``_str`` siblings (string ids) take the WHOLE candidate-pair / edge
+columns as DuckDB ``LIST`` arguments (callers aggregate with ``list(col)``) and
+return ``LIST`` results -- a list of ``STRUCT`` for pair_dedup, a list of lists
+for connected_components. No JSON wire. They call the native kernel directly.
+"""
+from __future__ import annotations
+
+import duckdb
+import pytest
+from goldenmatch_duckdb.functions import register
+
+
+@pytest.fixture()
+def con():
+    c = duckdb.connect()
+    register(c)
+    return c
+
+
+class TestPairDedupColumnar:
+    def test_canonicalizes_and_keeps_max_int(self, con):
+        # pairs (2,1,0.5),(1,2,0.9) -> canonical (1,2) with max 0.9, not (2,1)/0.5
+        rows = con.execute(
+            "SELECT goldenmatch_pair_dedup([2, 1], [1, 2], [0.5, 0.9])"
+        ).fetchone()[0]
+        # list of STRUCT(a,b,s)
+        pairs = {(r["a"], r["b"], r["s"]) for r in rows}
+        assert (1, 2, 0.9) in pairs
+        assert (2, 1, 0.5) not in pairs
+        assert all(r["s"] != 0.5 for r in rows)
+
+    def test_str_ids(self, con):
+        rows = con.execute(
+            "SELECT goldenmatch_pair_dedup_str(['b', 'a'], ['a', 'b'], [0.5, 0.9])"
+        ).fetchone()[0]
+        # canonical order preserved on the string ids (first-seen -> 'b','a')
+        pairs = {(r["a"], r["b"], r["s"]) for r in rows}
+        assert len(rows) == 1
+        (a, b, s), = pairs
+        assert {a, b} == {"a", "b"}
+        assert s == 0.9
+
+
+class TestConnectedComponentsColumnar:
+    def test_groups_and_singleton_int(self, con):
+        # edges (1,2,0.9),(2,3,0.8) ; universe {1,2,3,4} -> {{1,2,3},{4}}
+        comps = con.execute(
+            "SELECT goldenmatch_connected_components("
+            "[1, 2], [2, 3], [0.9, 0.8], [1, 2, 3, 4])"
+        ).fetchone()[0]
+        got = {frozenset(c) for c in comps}
+        assert got == {frozenset({1, 2, 3}), frozenset({4})}
+
+    def test_groups_and_singleton_str(self, con):
+        # edges (x,y,0.9),(y,z,0.8) ; universe {x,y,z,w} -> {{x,y,z},{w}}
+        comps = con.execute(
+            "SELECT goldenmatch_connected_components_str("
+            "['x', 'y'], ['y', 'z'], [0.9, 0.8], ['x', 'y', 'z', 'w'])"
+        ).fetchone()[0]
+        got = {frozenset(c) for c in comps}
+        assert got == {frozenset({"x", "y", "z"}), frozenset({"w"})}
+
+    def test_matches_native_reference_int(self, con):
+        from goldenmatch.native import connected_components
+
+        comps = con.execute(
+            "SELECT goldenmatch_connected_components("
+            "[10, 11], [11, 12], [0.9, 0.8], [10, 11, 12, 99])"
+        ).fetchone()[0]
+        ref = connected_components(
+            [(10, 11, 0.9), (11, 12, 0.8)], [10, 11, 12, 99]
+        )
+        assert {frozenset(c) for c in comps} == {frozenset(c) for c in ref}

--- a/packages/rust/extensions/duckdb/tests/test_parity_graph.py
+++ b/packages/rust/extensions/duckdb/tests/test_parity_graph.py
@@ -1,0 +1,97 @@
+"""Cross-backend graph parity: the DuckDB graph UDFs must return the SAME values
+as the underlying ``goldenmatch.native`` kernel for the same input.
+
+The DuckDB UDFs add a columnar wrapper (struct/list shaping, accept-both int/str
+dictionary mapping) around the native kernels ``dedup_pairs_max_score`` /
+``connected_components``. This test pins that the wrapper is value-transparent:
+DuckDB output == native kernel output. The Postgres + DataFusion surfaces assert
+the same kernel contract in their own CI lanes (same pinned fixtures), so kernel
+parity here transitively covers all three backends.
+
+Runs locally against the pure-Python reference kernel (the ``_native`` ext need
+not be built); the native module dispatches to Rust when the ext is present and
+the values are identical either way.
+"""
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from goldenmatch_duckdb.functions import register
+
+
+@pytest.fixture
+def con() -> duckdb.DuckDBPyConnection:
+    c = duckdb.connect()
+    register(c)
+    return c
+
+
+# A fixed candidate-pair set with a tie, a reversed pair, and a singleton.
+EDGES = [(2, 1, 0.5), (1, 2, 0.9), (2, 3, 0.8), (5, 5, 0.4)]
+ALL_IDS = [1, 2, 3, 4, 5]
+
+
+def _cols(edges: list[tuple[int, int, float]]) -> tuple[list, list, list]:
+    return ([a for a, _, _ in edges], [b for _, b, _ in edges], [s for _, _, s in edges])
+
+
+def test_pair_dedup_matches_native_kernel(con: duckdb.DuckDBPyConnection) -> None:
+    from goldenmatch.native import dedup_pairs_max_score
+
+    a, b, s = _cols(EDGES)
+    duck = con.execute(
+        "SELECT goldenmatch_pair_dedup(?, ?, ?)", [a, b, s]
+    ).fetchone()[0]
+    duck_tuples = sorted((r["a"], r["b"], r["s"]) for r in duck)
+
+    kernel = sorted(dedup_pairs_max_score([(int(x), int(y), float(z)) for x, y, z in EDGES]))
+    assert duck_tuples == kernel
+
+
+def test_connected_components_matches_native_kernel(
+    con: duckdb.DuckDBPyConnection,
+) -> None:
+    from goldenmatch.native import connected_components
+
+    a, b, s = _cols(EDGES)
+    duck = con.execute(
+        "SELECT goldenmatch_connected_components(?, ?, ?, ?)", [a, b, s, ALL_IDS]
+    ).fetchone()[0]
+    duck_groups = sorted(sorted(c) for c in duck)
+
+    kernel = connected_components(
+        [(int(x), int(y), float(z)) for x, y, z in EDGES], ALL_IDS
+    )
+    kernel_groups = sorted(sorted(c) for c in kernel)
+    assert duck_groups == kernel_groups
+
+
+def test_str_variant_matches_int_under_mapping(
+    con: duckdb.DuckDBPyConnection,
+) -> None:
+    """The _str UDFs must produce the same grouping as the int UDFs when the
+    string ids are a relabeling of the int ids (validates the dict round-trip)."""
+    label = {1: "a", 2: "b", 3: "c", 4: "d", 5: "e"}
+    a = [label[x] for x, _, _ in EDGES]
+    b = [label[y] for _, y, _ in EDGES]
+    s = [z for _, _, z in EDGES]
+    all_str = [label[x] for x in ALL_IDS]
+
+    duck_str = con.execute(
+        "SELECT goldenmatch_connected_components_str(?, ?, ?, ?)", [a, b, s, all_str]
+    ).fetchone()[0]
+    str_groups = sorted(sorted(c) for c in duck_str)
+
+    inv = {v: k for k, v in label.items()}
+    int_groups = sorted(sorted(inv[m] for m in c) for c in duck_str)
+
+    ai, bi, si = _cols(EDGES)
+    duck_int = con.execute(
+        "SELECT goldenmatch_connected_components(?, ?, ?, ?)", [ai, bi, si, ALL_IDS]
+    ).fetchone()[0]
+    int_groups_direct = sorted(sorted(c) for c in duck_int)
+
+    assert int_groups == int_groups_direct
+    # and the string labels round-trip exactly
+    assert str_groups == sorted(sorted(label[m] for m in c) for c in duck_int)

--- a/packages/rust/extensions/graph-core/Cargo.toml
+++ b/packages/rust/extensions/graph-core/Cargo.toml
@@ -1,0 +1,21 @@
+# Standalone workspace so this pyo3-free graph core can be a path dependency of
+# the `native` (extension-module), `postgres` (pgrx), and `datafusion-udf` (FFI)
+# crates without any of their workspaces claiming it. Same isolation rationale as
+# the sibling `score-core` / `fingerprint-core` crates.
+[workspace]
+
+[package]
+name = "goldenmatch-graph-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "Connected-components + pair-dedup graph kernels (no pyo3) shared across the native ext, the pgrx Postgres ext, and the DataFusion FFI UDFs"
+
+[lib]
+name = "goldenmatch_graph_core"
+
+[dependencies]
+# Arrow columnar helpers for the DuckDB/DataFusion zero-copy path. No pyarrow/pyo3
+# here — callers pass `arrow::array::ArrayData`; the pyo3 bridge lives in `native`.
+arrow = { version = "55", default-features = false }

--- a/packages/rust/extensions/graph-core/src/dict.rs
+++ b/packages/rust/extensions/graph-core/src/dict.rs
@@ -1,0 +1,39 @@
+//! Deterministic first-seen string→i64 dictionary, identical across the DuckDB,
+//! Postgres, and DataFusion wrappers so string-id grouping + round-trip agree.
+
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct Dict {
+    to_id: HashMap<String, i64>,
+    to_str: Vec<String>,
+}
+
+impl Dict {
+    pub fn new() -> Self { Self::default() }
+    /// Return the i64 for `s`, assigning the next id on first sight.
+    pub fn intern(&mut self, s: &str) -> i64 {
+        if let Some(&id) = self.to_id.get(s) { return id; }
+        let id = self.to_str.len() as i64;
+        self.to_id.insert(s.to_string(), id);
+        self.to_str.push(s.to_string());
+        id
+    }
+    pub fn resolve(&self, id: i64) -> Option<&str> {
+        self.to_str.get(id as usize).map(|s| s.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_seen_order_is_deterministic() {
+        let mut d = Dict::new();
+        assert_eq!(d.intern("b"), 0);
+        assert_eq!(d.intern("a"), 1);
+        assert_eq!(d.intern("b"), 0); // stable
+        assert_eq!(d.resolve(1), Some("a"));
+    }
+}

--- a/packages/rust/extensions/graph-core/src/lib.rs
+++ b/packages/rust/extensions/graph-core/src/lib.rs
@@ -1,0 +1,31 @@
+//! Pyo3-free graph kernels. Behavior-exact extraction of the loops that lived in
+//! `native/src/{cluster,pairs}.rs`; the `native` crate keeps thin `#[pyfunction]`
+//! shims delegating here (one source of truth, like `score-core`).
+use std::collections::BTreeMap;
+
+/// Canonicalize each pair as `(min,max)` and keep the max score per pair.
+/// Behavior-exact port of `native::pairs::dedup_pairs_max_score`.
+pub fn dedup_pairs_max_score(pairs: &[(i64, i64, f64)]) -> Vec<(i64, i64, f64)> {
+    let mut best: BTreeMap<(i64, i64), f64> = BTreeMap::new();
+    for &(a, b, s) in pairs {
+        let key = if a <= b { (a, b) } else { (b, a) };
+        match best.get(&key) {
+            Some(&cur) if s <= cur => {}
+            _ => {
+                best.insert(key, s);
+            }
+        }
+    }
+    best.into_iter().map(|((a, b), s)| (a, b, s)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_keeps_max_and_canonicalizes() {
+        let got = dedup_pairs_max_score(&[(2, 1, 0.5), (1, 2, 0.9), (3, 3, 0.1)]);
+        assert_eq!(got, vec![(1, 2, 0.9), (3, 3, 0.1)]);
+    }
+}

--- a/packages/rust/extensions/graph-core/src/lib.rs
+++ b/packages/rust/extensions/graph-core/src/lib.rs
@@ -1,6 +1,9 @@
 //! Pyo3-free graph kernels. Behavior-exact extraction of the loops that lived in
 //! `native/src/{cluster,pairs}.rs`; the `native` crate keeps thin `#[pyfunction]`
 //! shims delegating here (one source of truth, like `score-core`).
+mod dict;
+pub use dict::*;
+
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 

--- a/packages/rust/extensions/graph-core/src/lib.rs
+++ b/packages/rust/extensions/graph-core/src/lib.rs
@@ -7,6 +7,10 @@ pub use dict::*;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
+use arrow::array::builder::{Int64Builder, ListBuilder, StringBuilder};
+use arrow::array::{Array, ArrayData, Float64Array, Int64Array, ListArray, StringArray};
+use arrow::datatypes::DataType;
+
 /// Canonicalize each pair as `(min,max)` and keep the max score per pair.
 /// Behavior-exact port of `native::pairs::dedup_pairs_max_score`.
 pub fn dedup_pairs_max_score(pairs: &[(i64, i64, f64)]) -> Vec<(i64, i64, f64)> {
@@ -73,6 +77,289 @@ pub fn connected_components(edges: &[(i64, i64, f64)], all_ids: &[i64]) -> Vec<V
     groups.into_values().collect()
 }
 
+/// Arrow columnar dedup over int64 id columns + float64 score. Validates types,
+/// reads the columns, runs `dedup_pairs_max_score`, returns three Arrow arrays.
+pub fn dedup_pairs_arrow_data(
+    id_a: ArrayData,
+    id_b: ArrayData,
+    score: ArrayData,
+) -> Result<(ArrayData, ArrayData, ArrayData), String> {
+    if id_a.data_type() != &DataType::Int64 {
+        return Err(format!(
+            "dedup_pairs_arrow_data: id_a column must be Int64, got {:?}",
+            id_a.data_type()
+        ));
+    }
+    if id_b.data_type() != &DataType::Int64 {
+        return Err(format!(
+            "dedup_pairs_arrow_data: id_b column must be Int64, got {:?}",
+            id_b.data_type()
+        ));
+    }
+    if score.data_type() != &DataType::Float64 {
+        return Err(format!(
+            "dedup_pairs_arrow_data: score column must be Float64, got {:?}",
+            score.data_type()
+        ));
+    }
+    if id_a.len() != id_b.len() || id_a.len() != score.len() {
+        return Err(format!(
+            "dedup_pairs_arrow_data: column length mismatch (id_a={}, id_b={}, score={})",
+            id_a.len(),
+            id_b.len(),
+            score.len()
+        ));
+    }
+    let id_a = Int64Array::from(id_a);
+    let id_b = Int64Array::from(id_b);
+    let score = Float64Array::from(score);
+    let mut pairs: Vec<(i64, i64, f64)> = Vec::with_capacity(id_a.len());
+    for i in 0..id_a.len() {
+        if id_a.is_null(i) || id_b.is_null(i) || score.is_null(i) {
+            continue;
+        }
+        pairs.push((id_a.value(i), id_b.value(i), score.value(i)));
+    }
+    let deduped = dedup_pairs_max_score(&pairs);
+    let mut out_a = Vec::with_capacity(deduped.len());
+    let mut out_b = Vec::with_capacity(deduped.len());
+    let mut out_s = Vec::with_capacity(deduped.len());
+    for (a, b, s) in deduped {
+        out_a.push(a);
+        out_b.push(b);
+        out_s.push(s);
+    }
+    Ok((
+        Int64Array::from(out_a).to_data(),
+        Int64Array::from(out_b).to_data(),
+        Float64Array::from(out_s).to_data(),
+    ))
+}
+
+/// String-id dedup: id columns are Utf8 (StringArray). Builds a first-seen Dict,
+/// runs the i64 kernel, maps the deduped pairs back to the original strings.
+pub fn dedup_pairs_arrow_data_utf8(
+    id_a: ArrayData,
+    id_b: ArrayData,
+    score: ArrayData,
+) -> Result<(ArrayData, ArrayData, ArrayData), String> {
+    if id_a.data_type() != &DataType::Utf8 {
+        return Err(format!(
+            "dedup_pairs_arrow_data_utf8: id_a column must be Utf8, got {:?}",
+            id_a.data_type()
+        ));
+    }
+    if id_b.data_type() != &DataType::Utf8 {
+        return Err(format!(
+            "dedup_pairs_arrow_data_utf8: id_b column must be Utf8, got {:?}",
+            id_b.data_type()
+        ));
+    }
+    if score.data_type() != &DataType::Float64 {
+        return Err(format!(
+            "dedup_pairs_arrow_data_utf8: score column must be Float64, got {:?}",
+            score.data_type()
+        ));
+    }
+    if id_a.len() != id_b.len() || id_a.len() != score.len() {
+        return Err(format!(
+            "dedup_pairs_arrow_data_utf8: column length mismatch (id_a={}, id_b={}, score={})",
+            id_a.len(),
+            id_b.len(),
+            score.len()
+        ));
+    }
+    let id_a = StringArray::from(id_a);
+    let id_b = StringArray::from(id_b);
+    let score = Float64Array::from(score);
+    let mut dict = Dict::new();
+    let mut pairs: Vec<(i64, i64, f64)> = Vec::with_capacity(id_a.len());
+    for i in 0..id_a.len() {
+        if id_a.is_null(i) || id_b.is_null(i) || score.is_null(i) {
+            continue;
+        }
+        let a = dict.intern(id_a.value(i));
+        let b = dict.intern(id_b.value(i));
+        pairs.push((a, b, score.value(i)));
+    }
+    let deduped = dedup_pairs_max_score(&pairs);
+    let mut out_a: Vec<&str> = Vec::with_capacity(deduped.len());
+    let mut out_b: Vec<&str> = Vec::with_capacity(deduped.len());
+    let mut out_s: Vec<f64> = Vec::with_capacity(deduped.len());
+    for (a, b, s) in &deduped {
+        let sa = dict.resolve(*a).ok_or_else(|| {
+            format!("dedup_pairs_arrow_data_utf8: unresolved interned id {a}")
+        })?;
+        let sb = dict.resolve(*b).ok_or_else(|| {
+            format!("dedup_pairs_arrow_data_utf8: unresolved interned id {b}")
+        })?;
+        out_a.push(sa);
+        out_b.push(sb);
+        out_s.push(*s);
+    }
+    Ok((
+        StringArray::from(out_a).to_data(),
+        StringArray::from(out_b).to_data(),
+        Float64Array::from(out_s).to_data(),
+    ))
+}
+
+/// Arrow columnar connected components. Edge columns int64/int64/float64 + an
+/// int64 `all_ids` universe column. Returns ONE Arrow `List<Int64>` array: one
+/// list element per component, each a sorted list of member ids.
+pub fn connected_components_arrow_data(
+    id_a: ArrayData,
+    id_b: ArrayData,
+    score: ArrayData,
+    all_ids: ArrayData,
+) -> Result<ArrayData, String> {
+    if id_a.data_type() != &DataType::Int64 {
+        return Err(format!(
+            "connected_components_arrow_data: id_a column must be Int64, got {:?}",
+            id_a.data_type()
+        ));
+    }
+    if id_b.data_type() != &DataType::Int64 {
+        return Err(format!(
+            "connected_components_arrow_data: id_b column must be Int64, got {:?}",
+            id_b.data_type()
+        ));
+    }
+    if score.data_type() != &DataType::Float64 {
+        return Err(format!(
+            "connected_components_arrow_data: score column must be Float64, got {:?}",
+            score.data_type()
+        ));
+    }
+    if all_ids.data_type() != &DataType::Int64 {
+        return Err(format!(
+            "connected_components_arrow_data: all_ids column must be Int64, got {:?}",
+            all_ids.data_type()
+        ));
+    }
+    if id_a.len() != id_b.len() || id_a.len() != score.len() {
+        return Err(format!(
+            "connected_components_arrow_data: edge column length mismatch (id_a={}, id_b={}, score={})",
+            id_a.len(),
+            id_b.len(),
+            score.len()
+        ));
+    }
+    let id_a = Int64Array::from(id_a);
+    let id_b = Int64Array::from(id_b);
+    let score = Float64Array::from(score);
+    let all_ids = Int64Array::from(all_ids);
+    let mut edges: Vec<(i64, i64, f64)> = Vec::with_capacity(id_a.len());
+    for i in 0..id_a.len() {
+        if id_a.is_null(i) || id_b.is_null(i) || score.is_null(i) {
+            continue;
+        }
+        edges.push((id_a.value(i), id_b.value(i), score.value(i)));
+    }
+    let mut ids: Vec<i64> = Vec::with_capacity(all_ids.len());
+    for i in 0..all_ids.len() {
+        if all_ids.is_null(i) {
+            continue;
+        }
+        ids.push(all_ids.value(i));
+    }
+    let mut comps = connected_components(&edges, &ids);
+    for c in comps.iter_mut() {
+        c.sort_unstable();
+    }
+    let mut builder = ListBuilder::new(Int64Builder::new());
+    for comp in &comps {
+        for &member in comp {
+            builder.values().append_value(member);
+        }
+        builder.append(true);
+    }
+    let list: ListArray = builder.finish();
+    Ok(list.to_data())
+}
+
+/// String-id connected components. Edge + universe columns are Utf8. Interns via
+/// a first-seen Dict, runs the i64 kernel, maps members back to strings, sorts
+/// each component by the original string ascending, returns a `List<Utf8>`.
+pub fn connected_components_arrow_data_utf8(
+    id_a: ArrayData,
+    id_b: ArrayData,
+    score: ArrayData,
+    all_ids: ArrayData,
+) -> Result<ArrayData, String> {
+    if id_a.data_type() != &DataType::Utf8 {
+        return Err(format!(
+            "connected_components_arrow_data_utf8: id_a column must be Utf8, got {:?}",
+            id_a.data_type()
+        ));
+    }
+    if id_b.data_type() != &DataType::Utf8 {
+        return Err(format!(
+            "connected_components_arrow_data_utf8: id_b column must be Utf8, got {:?}",
+            id_b.data_type()
+        ));
+    }
+    if score.data_type() != &DataType::Float64 {
+        return Err(format!(
+            "connected_components_arrow_data_utf8: score column must be Float64, got {:?}",
+            score.data_type()
+        ));
+    }
+    if all_ids.data_type() != &DataType::Utf8 {
+        return Err(format!(
+            "connected_components_arrow_data_utf8: all_ids column must be Utf8, got {:?}",
+            all_ids.data_type()
+        ));
+    }
+    if id_a.len() != id_b.len() || id_a.len() != score.len() {
+        return Err(format!(
+            "connected_components_arrow_data_utf8: edge column length mismatch (id_a={}, id_b={}, score={})",
+            id_a.len(),
+            id_b.len(),
+            score.len()
+        ));
+    }
+    let id_a = StringArray::from(id_a);
+    let id_b = StringArray::from(id_b);
+    let score = Float64Array::from(score);
+    let all_ids = StringArray::from(all_ids);
+    let mut dict = Dict::new();
+    let mut edges: Vec<(i64, i64, f64)> = Vec::with_capacity(id_a.len());
+    for i in 0..id_a.len() {
+        if id_a.is_null(i) || id_b.is_null(i) || score.is_null(i) {
+            continue;
+        }
+        let a = dict.intern(id_a.value(i));
+        let b = dict.intern(id_b.value(i));
+        edges.push((a, b, score.value(i)));
+    }
+    let mut ids: Vec<i64> = Vec::with_capacity(all_ids.len());
+    for i in 0..all_ids.len() {
+        if all_ids.is_null(i) {
+            continue;
+        }
+        ids.push(dict.intern(all_ids.value(i)));
+    }
+    let comps = connected_components(&edges, &ids);
+    let mut builder = ListBuilder::new(StringBuilder::new());
+    for comp in &comps {
+        let mut members: Vec<&str> = Vec::with_capacity(comp.len());
+        for &id in comp {
+            let s = dict.resolve(id).ok_or_else(|| {
+                format!("connected_components_arrow_data_utf8: unresolved interned id {id}")
+            })?;
+            members.push(s);
+        }
+        members.sort_unstable();
+        for m in members {
+            builder.values().append_value(m);
+        }
+        builder.append(true);
+    }
+    let list: ListArray = builder.finish();
+    Ok(list.to_data())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -89,5 +376,90 @@ mod tests {
         let mut sorted: Vec<Vec<i64>> = comps.iter().map(|c| { let mut v = c.clone(); v.sort(); v }).collect();
         sorted.sort();
         assert_eq!(sorted, vec![vec![1, 2, 3], vec![4]]);
+    }
+
+    use arrow::array::{Array, Float64Array, Int64Array, ListArray, StringArray};
+
+    #[test]
+    fn dedup_arrow_int64_canonicalizes_and_keeps_max() {
+        let id_a = Int64Array::from(vec![2_i64, 1]).to_data();
+        let id_b = Int64Array::from(vec![1_i64, 2]).to_data();
+        let score = Float64Array::from(vec![0.5_f64, 0.9]).to_data();
+        let (out_a, out_b, out_s) = dedup_pairs_arrow_data(id_a, id_b, score).unwrap();
+        let a = Int64Array::from(out_a);
+        let b = Int64Array::from(out_b);
+        let s = Float64Array::from(out_s);
+        assert_eq!(a.len(), 1);
+        assert_eq!(a.value(0), 1);
+        assert_eq!(b.value(0), 2);
+        assert!((s.value(0) - 0.9).abs() < 1e-12);
+    }
+
+    #[test]
+    fn dedup_arrow_utf8_maps_back_to_strings() {
+        let id_a = StringArray::from(vec!["b", "a"]).to_data();
+        let id_b = StringArray::from(vec!["a", "b"]).to_data();
+        let score = Float64Array::from(vec![0.5_f64, 0.9]).to_data();
+        let (out_a, out_b, out_s) = dedup_pairs_arrow_data_utf8(id_a, id_b, score).unwrap();
+        let a = StringArray::from(out_a);
+        let b = StringArray::from(out_b);
+        let s = Float64Array::from(out_s);
+        assert_eq!(a.len(), 1);
+        // first-seen intern: "b"=0, "a"=1; canonical (min,max) i64 => (0,1) => ("b","a")
+        let pair = (a.value(0), b.value(0));
+        assert_eq!(pair, ("b", "a"));
+        assert!((s.value(0) - 0.9).abs() < 1e-12);
+    }
+
+    fn read_list_int64(out: arrow::array::ArrayData) -> Vec<Vec<i64>> {
+        let list = ListArray::from(out);
+        let mut comps = Vec::new();
+        for i in 0..list.len() {
+            let vals = list.value(i);
+            let int = vals.as_any().downcast_ref::<Int64Array>().unwrap();
+            comps.push((0..int.len()).map(|j| int.value(j)).collect());
+        }
+        comps
+    }
+
+    fn read_list_utf8(out: arrow::array::ArrayData) -> Vec<Vec<String>> {
+        let list = ListArray::from(out);
+        let mut comps = Vec::new();
+        for i in 0..list.len() {
+            let vals = list.value(i);
+            let strs = vals.as_any().downcast_ref::<StringArray>().unwrap();
+            comps.push((0..strs.len()).map(|j| strs.value(j).to_string()).collect());
+        }
+        comps
+    }
+
+    #[test]
+    fn cc_arrow_int64_returns_sorted_list() {
+        let id_a = Int64Array::from(vec![1_i64, 2]).to_data();
+        let id_b = Int64Array::from(vec![2_i64, 3]).to_data();
+        let score = Float64Array::from(vec![0.9_f64, 0.8]).to_data();
+        let all_ids = Int64Array::from(vec![1_i64, 2, 3, 4]).to_data();
+        let out = connected_components_arrow_data(id_a, id_b, score, all_ids).unwrap();
+        let mut comps = read_list_int64(out);
+        comps.sort();
+        assert_eq!(comps, vec![vec![1, 2, 3], vec![4]]);
+    }
+
+    #[test]
+    fn cc_arrow_utf8_returns_sorted_list() {
+        let id_a = StringArray::from(vec!["x", "y"]).to_data();
+        let id_b = StringArray::from(vec!["y", "z"]).to_data();
+        let score = Float64Array::from(vec![0.9_f64, 0.8]).to_data();
+        let all_ids = StringArray::from(vec!["x", "y", "z", "w"]).to_data();
+        let out = connected_components_arrow_data_utf8(id_a, id_b, score, all_ids).unwrap();
+        let mut comps = read_list_utf8(out);
+        comps.sort();
+        assert_eq!(
+            comps,
+            vec![
+                vec!["w".to_string()],
+                vec!["x".to_string(), "y".to_string(), "z".to_string()],
+            ]
+        );
     }
 }

--- a/packages/rust/extensions/graph-core/src/lib.rs
+++ b/packages/rust/extensions/graph-core/src/lib.rs
@@ -2,6 +2,7 @@
 //! `native/src/{cluster,pairs}.rs`; the `native` crate keeps thin `#[pyfunction]`
 //! shims delegating here (one source of truth, like `score-core`).
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 /// Canonicalize each pair as `(min,max)` and keep the max score per pair.
 /// Behavior-exact port of `native::pairs::dedup_pairs_max_score`.
@@ -19,6 +20,56 @@ pub fn dedup_pairs_max_score(pairs: &[(i64, i64, f64)]) -> Vec<(i64, i64, f64)> 
     best.into_iter().map(|((a, b), s)| (a, b, s)).collect()
 }
 
+/// Iterative find with path compression over a `HashMap` parent table.
+fn find(parent: &mut HashMap<i64, i64>, x: i64) -> i64 {
+    let mut root = x;
+    while let Some(&p) = parent.get(&root) {
+        if p == root {
+            break;
+        }
+        root = p;
+    }
+    // Path-compress x..root.
+    let mut cur = x;
+    while let Some(&p) = parent.get(&cur) {
+        if p == root {
+            break;
+        }
+        parent.insert(cur, root);
+        cur = p;
+    }
+    root
+}
+
+/// Connected components over `all_ids` ∪ edge endpoints. Behavior-exact port of
+/// `native::cluster::connected_components`. Component membership is independent
+/// of union strategy, so naive union yields the identical grouping the Python
+/// union-by-rank produces. Component and member order is irrelevant.
+pub fn connected_components(edges: &[(i64, i64, f64)], all_ids: &[i64]) -> Vec<Vec<i64>> {
+    let mut parent: HashMap<i64, i64> = HashMap::with_capacity(all_ids.len());
+    for &id in all_ids {
+        parent.entry(id).or_insert(id);
+    }
+    for (a, b, _s) in edges {
+        parent.entry(*a).or_insert(*a);
+        parent.entry(*b).or_insert(*b);
+    }
+    for (a, b, _s) in edges {
+        let ra = find(&mut parent, *a);
+        let rb = find(&mut parent, *b);
+        if ra != rb {
+            parent.insert(ra, rb);
+        }
+    }
+    let keys: Vec<i64> = parent.keys().copied().collect();
+    let mut groups: HashMap<i64, Vec<i64>> = HashMap::new();
+    for k in keys {
+        let r = find(&mut parent, k);
+        groups.entry(r).or_default().push(k);
+    }
+    groups.into_values().collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -27,5 +78,13 @@ mod tests {
     fn dedup_keeps_max_and_canonicalizes() {
         let got = dedup_pairs_max_score(&[(2, 1, 0.5), (1, 2, 0.9), (3, 3, 0.1)]);
         assert_eq!(got, vec![(1, 2, 0.9), (3, 3, 0.1)]);
+    }
+
+    #[test]
+    fn cc_groups_transitive_and_includes_singletons() {
+        let comps = connected_components(&[(1, 2, 0.9), (2, 3, 0.8)], &[1, 2, 3, 4]);
+        let mut sorted: Vec<Vec<i64>> = comps.iter().map(|c| { let mut v = c.clone(); v.sort(); v }).collect();
+        sorted.sort();
+        assert_eq!(sorted, vec![vec![1, 2, 3], vec![4]]);
     }
 }

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -33,6 +33,10 @@ goldenmatch-fingerprint-core = { path = "../fingerprint-core" }
 # identically by construction. The #[pyfunction] scorers below are thin shims
 # over this crate; score_one is re-imported verbatim.
 goldenmatch-score-core = { path = "../score-core" }
+# Pyo3-free graph kernels (dedup + connected components, columnar + scalar).
+# The #[pyfunction] graph shims below delegate here so DuckDB/DataFusion and
+# this extension module share one behavior-exact path.
+goldenmatch-graph-core = { path = "../graph-core" }
 rayon = "1.12.0"
 # Arrow C Data Interface for zero-copy kernel input (see score.rs
 # score_block_pairs_arrow). `pyarrow` brings the PyArrowType FFI bridge;

--- a/packages/rust/extensions/native/src/cluster.rs
+++ b/packages/rust/extensions/native/src/cluster.rs
@@ -44,28 +44,7 @@ pub fn connected_components(
     edges: Vec<(i64, i64, f64)>,
     all_ids: Vec<i64>,
 ) -> Vec<Vec<i64>> {
-    let mut parent: HashMap<i64, i64> = HashMap::with_capacity(all_ids.len());
-    for id in all_ids {
-        parent.entry(id).or_insert(id);
-    }
-    for (a, b, _s) in &edges {
-        parent.entry(*a).or_insert(*a);
-        parent.entry(*b).or_insert(*b);
-    }
-    for (a, b, _s) in &edges {
-        let ra = find(&mut parent, *a);
-        let rb = find(&mut parent, *b);
-        if ra != rb {
-            parent.insert(ra, rb);
-        }
-    }
-    let keys: Vec<i64> = parent.keys().copied().collect();
-    let mut groups: HashMap<i64, Vec<i64>> = HashMap::new();
-    for k in keys {
-        let r = find(&mut parent, k);
-        groups.entry(r).or_default().push(k);
-    }
-    groups.into_values().collect()
+    goldenmatch_graph_core::connected_components(&edges, &all_ids)
 }
 
 /// Max-weight spanning tree (Kruskal), then drop the single weakest MST edge
@@ -574,4 +553,22 @@ pub fn build_clusters_arrow(
         PyArrowType(metadata_min.to_data()),
         PyArrowType(metadata_avg.to_data()),
     ))
+}
+
+/// Arrow columnar connected components. Edge columns int64/int64/float64 + an
+/// int64 `all_ids` universe column. Returns one Arrow `List<Int64>` array (one
+/// list per component, members sorted ascending). Delegates to the pyo3-free
+/// `graph-core` kernel so DuckDB (via this shim) and DataFusion share one path.
+#[pyfunction]
+pub fn connected_components_arrow(
+    id_a: PyArrowType<ArrayData>,
+    id_b: PyArrowType<ArrayData>,
+    score: PyArrowType<ArrayData>,
+    all_ids: PyArrowType<ArrayData>,
+) -> PyResult<PyArrowType<ArrayData>> {
+    let out = goldenmatch_graph_core::connected_components_arrow_data(
+        id_a.0, id_b.0, score.0, all_ids.0,
+    )
+    .map_err(PyValueError::new_err)?;
+    Ok(PyArrowType(out))
 }

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -22,6 +22,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cluster::cluster_confidence, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::build_clusters_native, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::build_clusters_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(cluster::connected_components_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::canonicalize_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::dedup_pairs_max_score, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::dedup_pairs_arrow, m)?)?;

--- a/packages/rust/extensions/native/src/pairs.rs
+++ b/packages/rust/extensions/native/src/pairs.rs
@@ -6,10 +6,7 @@
 //! is bit-exact with its Python reference (integer arithmetic + a strict-`>`
 //! max reduction — no float tolerance), so the `pairs` component is gated on by
 //! default once the parity test passes.
-use std::collections::BTreeMap;
-
-use arrow::array::{Array, ArrayData, Float64Array, Int64Array};
-use arrow::datatypes::DataType;
+use arrow::array::ArrayData;
 use arrow::pyarrow::PyArrowType;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -30,17 +27,7 @@ pub fn canonicalize_pairs(pairs: Vec<(i64, i64, f64)>) -> Vec<(i64, i64, f64)> {
 /// occurrence wins on ties — identical to the Python `if s > best[key]` guard.
 #[pyfunction]
 pub fn dedup_pairs_max_score(pairs: Vec<(i64, i64, f64)>) -> Vec<(i64, i64, f64)> {
-    let mut best: BTreeMap<(i64, i64), f64> = BTreeMap::new();
-    for (a, b, s) in pairs {
-        let key = if a <= b { (a, b) } else { (b, a) };
-        match best.get(&key) {
-            Some(&cur) if s <= cur => {}
-            _ => {
-                best.insert(key, s);
-            }
-        }
-    }
-    best.into_iter().map(|((a, b), s)| (a, b, s)).collect()
+    goldenmatch_graph_core::dedup_pairs_max_score(&pairs)
 }
 
 /// Total candidate comparisons across blocks: `sum(n*(n-1)/2)`. Accumulates in
@@ -82,82 +69,9 @@ pub fn dedup_pairs_arrow(
     id_b: PyArrowType<ArrayData>,
     score: PyArrowType<ArrayData>,
 ) -> PyResult<(PyArrowType<ArrayData>, PyArrowType<ArrayData>, PyArrowType<ArrayData>)> {
-    let id_a_data = id_a.0;
-    let id_b_data = id_b.0;
-    let score_data = score.0;
-
-    if id_a_data.data_type() != &DataType::Int64 {
-        return Err(PyValueError::new_err(format!(
-            "dedup_pairs_arrow: id_a must be int64, got {:?}",
-            id_a_data.data_type()
-        )));
-    }
-    if id_b_data.data_type() != &DataType::Int64 {
-        return Err(PyValueError::new_err(format!(
-            "dedup_pairs_arrow: id_b must be int64, got {:?}",
-            id_b_data.data_type()
-        )));
-    }
-    if score_data.data_type() != &DataType::Float64 {
-        return Err(PyValueError::new_err(format!(
-            "dedup_pairs_arrow: score must be float64, got {:?}",
-            score_data.data_type()
-        )));
-    }
-
-    let id_a = Int64Array::from(id_a_data);
-    let id_b = Int64Array::from(id_b_data);
-    let score = Float64Array::from(score_data);
-
-    let n = id_a.len();
-    if id_b.len() != n || score.len() != n {
-        return Err(PyValueError::new_err(format!(
-            "dedup_pairs_arrow: array lengths differ -- id_a={}, id_b={}, score={}",
-            n, id_b.len(), score.len(),
-        )));
-    }
-
-    // Reduce: same algorithm as dedup_pairs_max_score. Strict `>`
-    // first-occurrence-wins on ties keeps it bit-identical with the
-    // dict-shaped kernel at the output value layer.
-    let mut best: BTreeMap<(i64, i64), f64> = BTreeMap::new();
-    for i in 0..n {
-        if id_a.is_null(i) || id_b.is_null(i) || score.is_null(i) {
-            continue;
-        }
-        let a = id_a.value(i);
-        let b = id_b.value(i);
-        let s = score.value(i);
-        let key = if a <= b { (a, b) } else { (b, a) };
-        match best.get(&key) {
-            Some(&cur) if s <= cur => {}
-            _ => {
-                best.insert(key, s);
-            }
-        }
-    }
-
-    // Emit sorted output as three Arrow arrays. BTreeMap iter yields
-    // ascending key order, so the result is already sorted by (a, b).
-    let n_out = best.len();
-    let mut out_a: Vec<i64> = Vec::with_capacity(n_out);
-    let mut out_b: Vec<i64> = Vec::with_capacity(n_out);
-    let mut out_s: Vec<f64> = Vec::with_capacity(n_out);
-    for ((a, b), s) in best {
-        out_a.push(a);
-        out_b.push(b);
-        out_s.push(s);
-    }
-
-    let a_array = Int64Array::from(out_a);
-    let b_array = Int64Array::from(out_b);
-    let s_array = Float64Array::from(out_s);
-
-    Ok((
-        PyArrowType(a_array.to_data()),
-        PyArrowType(b_array.to_data()),
-        PyArrowType(s_array.to_data()),
-    ))
+    let (a, b, s) = goldenmatch_graph_core::dedup_pairs_arrow_data(id_a.0, id_b.0, score.0)
+        .map_err(PyValueError::new_err)?;
+    Ok((PyArrowType(a), PyArrowType(b), PyArrowType(s)))
 }
 
 /// `(count, total_records, max, p50, p95, p99)` over the block-size

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -24,6 +24,9 @@ goldenmatch-bridge = { path = "../bridge" }
 # Pure-Rust canonical fingerprint — computed in-process, NOT through the
 # embedded-CPython bridge (the decoupling lever; see kernels.rs).
 goldenmatch-fingerprint-core = { path = "../fingerprint-core" }
+# Pure-Rust connected-components + pair-dedup graph kernels (no pyo3) — the graph
+# UDFs call these native-direct, NOT through the embedded-CPython bridge.
+goldenmatch-graph-core = { path = "../graph-core" }
 serde_json = "1"
 
 [[bin]]

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goldenmatch_pg"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/postgres/goldenmatch_pg.control
+++ b/packages/rust/extensions/postgres/goldenmatch_pg.control
@@ -1,5 +1,5 @@
 comment = 'Entity resolution toolkit -- deduplicate, match, and maintain golden records'
-default_version = '0.5.0'
+default_version = '0.6.0'
 module_pathname = '$libdir/goldenmatch_pg'
 relocatable = false
 schema = goldenmatch

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.5.0--0.6.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.5.0--0.6.0.sql
@@ -1,0 +1,51 @@
+-- goldenmatch_pg 0.5.0 -> 0.6.0 upgrade.
+--
+-- #509: the graph kernels move from the CPython JSON-bridge (JSON in / JSON out)
+-- to native-direct (pure-Rust goldenmatch-graph-core, no embedded CPython) with
+-- columnar array I/O + accept-both int64/string ids. The two old TEXT-signature
+-- functions are dropped and replaced by four array-signature, table-returning
+-- functions. The embedder + record-fingerprint functions are unchanged in 0.6.0.
+
+-- Drop the old JSON-bridge graph functions (TEXT in / TEXT out).
+DROP FUNCTION IF EXISTS "goldenmatch_connected_components"(TEXT);
+DROP FUNCTION IF EXISTS "goldenmatch_pair_dedup"(TEXT);
+
+-- Native-direct replacements (mirror sql/goldenmatch_pg--0.6.0.sql).
+
+CREATE FUNCTION "goldenmatch_pair_dedup"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_wrapper';
+
+CREATE FUNCTION "goldenmatch_pair_dedup_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" TEXT, "b" TEXT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_str_wrapper';
+
+CREATE FUNCTION "goldenmatch_connected_components"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" BIGINT[]
+) RETURNS TABLE ("component" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_wrapper';
+
+CREATE FUNCTION "goldenmatch_connected_components_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" TEXT[]
+) RETURNS TABLE ("component" BIGINT, "member" TEXT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_str_wrapper';

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.6.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.6.0.sql
@@ -1,0 +1,681 @@
+-- goldenmatch_pg SQL extension schema v0.5.0
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline tables (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS goldenmatch._jobs (
+    name TEXT PRIMARY KEY,
+    config_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    last_run_at TIMESTAMPTZ,
+    status TEXT DEFAULT 'configured',
+    -- v1.7-v1.12: most-recent run's AutoConfigController telemetry. NULL when
+    -- the job used an explicit config (controller didn't fire) or hasn't run.
+    last_telemetry_json JSONB
+);
+-- ALTER for upgrades from extension installs that pre-date the telemetry column.
+ALTER TABLE goldenmatch._jobs ADD COLUMN IF NOT EXISTS last_telemetry_json JSONB;
+
+CREATE TABLE IF NOT EXISTS goldenmatch._pairs (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    id_a BIGINT,
+    id_b BIGINT,
+    score DOUBLE PRECISION,
+    matchkey TEXT,
+    field_scores JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_pairs_job ON goldenmatch._pairs(job_name, id_a, id_b);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._clusters (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_id BIGINT,
+    is_golden BOOLEAN DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS idx_clusters_job ON goldenmatch._clusters(job_name, cluster_id);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._golden (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_data JSONB
+);
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-based functions (primary interface)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_table"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_table_wrapper';
+
+CREATE FUNCTION "goldenmatch_match_tables"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_tables_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline functions (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "gm_configure"(
+    "job_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_configure_wrapper';
+
+CREATE FUNCTION "gm_run"(
+    "job_name" TEXT,
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_run_wrapper';
+
+CREATE FUNCTION "gm_jobs"() RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_jobs_wrapper';
+
+CREATE FUNCTION "gm_golden"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_golden_wrapper';
+
+CREATE FUNCTION "gm_drop"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_drop_wrapper';
+
+CREATE FUNCTION "gm_pairs"(
+    "job_name" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_pairs_wrapper';
+
+CREATE FUNCTION "gm_clusters"(
+    "job_name" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_clusters_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-returning functions (structured results)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_pairs"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_pairs_wrapper';
+
+CREATE FUNCTION "goldenmatch_dedupe_clusters"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT, "cluster_size" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_clusters_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Scalar functions
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_score"(
+    "value_a" TEXT,
+    "value_b" TEXT,
+    "scorer" TEXT DEFAULT 'jaro_winkler'
+) RETURNS DOUBLE PRECISION
+STRICT PARALLEL RESTRICTED
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_wrapper';
+
+CREATE FUNCTION "goldenmatch_score_pair"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_pair_wrapper';
+
+CREATE FUNCTION "goldenmatch_explain"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_explain_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- JSON-based functions (programmatic use)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe"(
+    "rows_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_wrapper';
+
+CREATE FUNCTION "goldenmatch_match"(
+    "target_json" TEXT,
+    "reference_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- AutoConfig + controller telemetry (v1.7-v1.12)
+-- ══════════════════════════════════════════════════════════════════════
+
+-- Run AutoConfigController on a table and return the committed GoldenMatchConfig
+-- as JSON. Pipe the output into goldenmatch_dedupe_full to apply it.
+CREATE FUNCTION "goldenmatch_autoconfig"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_wrapper';
+
+-- Same as above but returns the controller telemetry blob (stop_reason,
+-- decisions, health, indicator priors, committed NE).
+CREATE FUNCTION "goldenmatch_autoconfig_telemetry"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_telemetry_wrapper';
+
+-- Deduplicate a table with a *full* GoldenMatchConfig JSON (supports
+-- negative_evidence / Path Y, per-matchkey scorers, standardization, etc.).
+CREATE FUNCTION "goldenmatch_dedupe_full"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_wrapper';
+
+-- Same as above but returns the controller telemetry from that run.
+CREATE FUNCTION "goldenmatch_dedupe_full_telemetry"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_telemetry_wrapper';
+
+-- Retrieve the telemetry from the most recent gm_run of a named job.
+-- Returns '{"available":false}' for jobs that haven't run or used an
+-- explicit config.
+CREATE FUNCTION "gm_telemetry"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_telemetry_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Identity Graph (v2.0)
+-- ══════════════════════════════════════════════════════════════════════
+-- Contract: docs/superpowers/specs/2026-05-12-identity-graph-duckdb-contract.md
+-- All identity functions accept the path to the identity store as an explicit
+-- second arg. For SQLite pass the filesystem path; for Postgres pass the libpq
+-- DSN. Empty-string filters mean "no filter on that dimension".
+
+-- Resolve a `{source}:{source_pk}` record id to its identity view JSON.
+-- Returns {"found": false} when the record has no identity.
+CREATE FUNCTION "goldenmatch_identity_resolve"(
+    "record_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_resolve_wrapper';
+
+-- Return the full identity view JSON for a given entity_id.
+CREATE FUNCTION "goldenmatch_identity_view"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_view_wrapper';
+
+-- Return the temporal event log for an identity as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_history"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_history_wrapper';
+
+-- List `conflicts_with` evidence edges as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_conflicts"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_conflicts_wrapper';
+
+-- List identities filtered by dataset and status (empty = no filter).
+CREATE FUNCTION "goldenmatch_identity_list"(
+    "dataset" TEXT,
+    "status" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_list_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Core-API parity (mirrors duckdb/core_apis.py -- 13 UDFs)
+-- ══════════════════════════════════════════════════════════════════════
+-- Wrappers over goldenmatch's function-shaped core APIs. IDENTICAL JSON
+-- in / JSON out contract to the DuckDB `goldenmatch_*` core-API UDFs so the
+-- two backends are interchangeable. Table-input functions read the table via
+-- SPI (`row_to_json`, like goldenmatch_dedupe_table); JSON-in functions take
+-- the payloads directly. All read-only -- no REVOKE.
+
+-- Profile a table (column stats, types, quality signals) as JSON.
+CREATE FUNCTION "goldenmatch_profile_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_profile_table_wrapper';
+
+-- Otsu threshold over a JSON array of scores. Returns SQL NULL when the
+-- distribution is unimodal / too few scores.
+CREATE FUNCTION "goldenmatch_suggest_threshold"(
+    "scores_json" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_suggest_threshold_wrapper';
+
+-- Domain profile for a JSON array of column names, as JSON.
+CREATE FUNCTION "goldenmatch_detect_domain"(
+    "columns_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_domain_wrapper';
+
+-- Extract structured features from text. kind: product/electronics (default),
+-- software, biblio/bibliographic. Returns the features as JSON.
+CREATE FUNCTION "goldenmatch_extract_features"(
+    "text" TEXT,
+    "kind" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_extract_features_wrapper';
+
+-- Evaluate predicted pairs (JSON array) or clusters (JSON object) against a
+-- ground-truth JSON array of [a, b] pairs. Returns EvalResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_evaluate"(
+    "pairs_json" TEXT,
+    "ground_truth_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_evaluate_wrapper';
+
+-- CCMS comparison of two clusterings (JSON objects). Returns
+-- CompareResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_compare_clusters"(
+    "a_json" TEXT,
+    "b_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_compare_clusters_wrapper';
+
+-- Run validation rules (JSON array of ValidationRule) over a table. Returns
+-- {report, valid_rows, quarantine_rows, quarantine} JSON.
+CREATE FUNCTION "goldenmatch_validate_table"(
+    "table_name" TEXT,
+    "rules_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_validate_table_wrapper';
+
+-- Apply auto-fixes to a table. Returns {fixes, fixed_rows, rows} JSON.
+CREATE FUNCTION "goldenmatch_autofix_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autofix_table_wrapper';
+
+-- Flag suspicious records in a table. sensitivity: low/medium/high. Returns
+-- a JSON array of anomaly dicts.
+CREATE FUNCTION "goldenmatch_detect_anomalies"(
+    "table_name" TEXT,
+    "sensitivity" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_anomalies_wrapper';
+
+-- Validate (table, full GoldenMatchConfig JSON) before a run. Returns
+-- {has_errors, config_was_modified, findings} JSON.
+CREATE FUNCTION "goldenmatch_preflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_preflight_wrapper';
+
+-- Post-run signal report for (table, config). Derives pair_scores by running
+-- dedupe_df on the table. Returns {signals, adjustments, advisories} JSON.
+CREATE FUNCTION "goldenmatch_postflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_postflight_wrapper';
+
+-- Train Fellegi-Sunter m/u probabilities via EM. Returns the EMResult JSON;
+-- pass it straight to goldenmatch_score_probabilistic.
+CREATE FUNCTION "goldenmatch_train_em"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "params_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_train_em_wrapper';
+
+-- Score record pairs with trained Fellegi-Sunter probabilities. Returns a
+-- JSON array of [a, b, score] triples above the link threshold.
+CREATE FUNCTION "goldenmatch_score_probabilistic"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "em_result_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_probabilistic_wrapper';
+
+-- ─── Correction CRUD (v0.5.0, Phase 6A of #437 surface sync) ──────────
+--
+-- File pair-level / field-level / cluster-decision corrections into
+-- the goldenmatch MemoryStore. Read with `correction_list` or via
+-- the `goldenmatch.corrections` view (no auth required for reads).
+--
+-- Permissions: `correction_add` is REVOKEd from PUBLIC at the bottom
+-- of this file and granted to `goldenmatch_correction_writer`. Roles
+-- needing write access must be GRANTed that role.
+
+CREATE FUNCTION "correction_add"(
+    "decision" TEXT,
+    "dataset" TEXT,
+    "id_a" BIGINT DEFAULT NULL,
+    "id_b" BIGINT DEFAULT NULL,
+    "cluster_id" BIGINT DEFAULT NULL,
+    "field_name" TEXT DEFAULT NULL,
+    "original_value" TEXT DEFAULT NULL,
+    "corrected_value" TEXT DEFAULT NULL,
+    "cluster_score" DOUBLE PRECISION DEFAULT NULL,
+    "cluster_outcome" TEXT DEFAULT NULL,
+    "reason" TEXT DEFAULT NULL,
+    "matchkey_name" TEXT DEFAULT NULL,
+    "source" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_add_wrapper';
+
+CREATE FUNCTION "correction_list"(
+    "dataset" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_list_wrapper';
+
+-- Learning Memory: force a MemoryLearner pass; returns JSON
+-- { "count": N, "adjustments": [...] }. Needs >= 10 corrections per matchkey.
+CREATE FUNCTION "memory_learn"(
+    "matchkey_name" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_learn_wrapper';
+
+-- Learning Memory status: JSON
+-- { "total_corrections": N, "last_learn_time": ISO|null, "adjustments": [...] }.
+CREATE FUNCTION "memory_stats"(
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_stats_wrapper';
+
+-- Read-only view over the correction store. Wraps `correction_list`
+-- with `json_array_elements` so callers can write SQL like
+-- `SELECT * FROM goldenmatch.corrections WHERE dataset = 'customers'`.
+-- View access uses the default GRANT chain; no special role required.
+CREATE OR REPLACE VIEW goldenmatch.corrections AS
+SELECT
+    (entry->>'id')::TEXT              AS id,
+    (entry->>'id_a')::BIGINT          AS id_a,
+    (entry->>'id_b')::BIGINT          AS id_b,
+    (entry->>'decision')::TEXT        AS decision,
+    (entry->>'source')::TEXT          AS source,
+    (entry->>'trust')::DOUBLE PRECISION AS trust,
+    (entry->>'reason')::TEXT          AS reason,
+    (entry->>'dataset')::TEXT         AS dataset,
+    (entry->>'matchkey_name')::TEXT   AS matchkey_name,
+    (entry->>'field_name')::TEXT      AS field_name,
+    (entry->>'original_value')::TEXT  AS original_value,
+    (entry->>'corrected_value')::TEXT AS corrected_value,
+    (entry->>'cluster_score')::DOUBLE PRECISION AS cluster_score,
+    (entry->>'cluster_outcome')::TEXT AS cluster_outcome,
+    (entry->>'created_at')::TIMESTAMPTZ AS created_at
+FROM jsonb_array_elements(
+    goldenmatch.correction_list(NULL, NULL)::jsonb
+) AS entry;
+
+-- ─── Permissions ──────────────────────────────────────────────────────
+--
+-- `correction_add` writes into the Learning Memory store; default
+-- REVOKE from PUBLIC so accidental SELECT-from-anywhere can't file
+-- correctness signals. Grant `goldenmatch_correction_writer` to any
+-- role that needs to file corrections.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'goldenmatch_correction_writer') THEN
+        CREATE ROLE goldenmatch_correction_writer NOLOGIN;
+    END IF;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) TO goldenmatch_correction_writer;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) TO goldenmatch_correction_writer;
+
+-- memory_learn mutates the store (writes learned adjustments); gate it like
+-- correction_add. memory_stats is read-only status (counts + thresholds, no
+-- correction contents) and stays available to PUBLIC.
+REVOKE EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) TO goldenmatch_correction_writer;
+GRANT SELECT ON goldenmatch.corrections TO goldenmatch_correction_writer;
+
+-- ─── GoldenFlow transforms (src/goldenflow.rs) ────────────────────────────
+--
+-- 8 scalar text -> text wrappers over goldenflow's transform registry,
+-- mirroring the DuckDB goldenflow_* UDFs (goldenmatch_duckdb/goldenflow.py).
+-- Closes the last DuckDB <-> Postgres parity gap. All STRICT (NULL in -> NULL
+-- out); the bridge fails open (passes the input through unchanged when
+-- goldenflow isn't installed / the transform errors), so these are read-only
+-- and safe for PUBLIC -- no REVOKE.
+
+-- Normalize an email address. Wraps goldenflow `email_normalize`.
+CREATE FUNCTION "goldenflow_normalize_email"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_email_wrapper';
+
+-- Normalize a phone number to E.164. Wraps goldenflow `phone_e164`.
+CREATE FUNCTION "goldenflow_normalize_phone"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_phone_wrapper';
+
+-- Normalize a date to ISO-8601. Wraps goldenflow `date_iso8601`.
+CREATE FUNCTION "goldenflow_normalize_date"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_date_wrapper';
+
+-- Proper-case a personal name. Wraps goldenflow `name_proper`.
+CREATE FUNCTION "goldenflow_normalize_name_proper"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_name_proper_wrapper';
+
+-- Canonicalize a URL. Wraps goldenflow `url_normalize`.
+CREATE FUNCTION "goldenflow_canonicalize_url"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_url_wrapper';
+
+-- Standardize a postal address. Wraps goldenflow `address_standardize`.
+CREATE FUNCTION "goldenflow_canonicalize_address"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_address_wrapper';
+
+-- Strip leading/trailing whitespace. Wraps goldenflow `strip`.
+CREATE FUNCTION "goldenflow_strip"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_strip_wrapper';
+
+-- Collapse internal whitespace runs. Wraps goldenflow `collapse_whitespace`.
+CREATE FUNCTION "goldenflow_whitespace_normalize"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_whitespace_normalize_wrapper';
+
+-- ── Native Core graph kernels (#509) ──────────────────────────────────────
+-- Native-direct: these call the pyo3-free goldenmatch-graph-core crate in pure
+-- Rust (NO embedded CPython). DuckDB<->Postgres lockstep with core_kernels.py.
+-- Accept-both: int64 ids on the bare name, string ids on the _str sibling
+-- (a first-seen str<->i64 dictionary wraps the i64 kernel).
+
+-- Canonical max-score pairs over int64 id arrays. Returns (a, b, s) rows.
+CREATE FUNCTION "goldenmatch_pair_dedup"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_wrapper';
+
+-- String-id variant: same kernel via a first-seen str<->i64 dictionary.
+CREATE FUNCTION "goldenmatch_pair_dedup_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" TEXT, "b" TEXT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_str_wrapper';
+
+-- Connected components over int64 edge arrays + an int64 id universe.
+-- Returns (component_index, member) rows.
+CREATE FUNCTION "goldenmatch_connected_components"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" BIGINT[]
+) RETURNS TABLE ("component" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_wrapper';
+
+-- String-id variant of connected components.
+CREATE FUNCTION "goldenmatch_connected_components_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" TEXT[]
+) RETURNS TABLE ("component" BIGINT, "member" TEXT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_str_wrapper';
+
+-- Embed one text with a local in-house model (a saved GoldenEmbedModel dir).
+CREATE FUNCTION "goldenmatch_embed_local"(
+    "text" TEXT,
+    "model_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_embed_local_wrapper';
+
+-- Canonical record fingerprint (64 hex) of a JSON record object. The
+-- cross-surface stable record-id hash; matches the DuckDB
+-- goldenmatch_record_fingerprint UDF + the Python identity path.
+CREATE FUNCTION "goldenmatch_record_fingerprint"(
+    "record_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_record_fingerprint_wrapper';

--- a/packages/rust/extensions/postgres/src/kernels.rs
+++ b/packages/rust/extensions/postgres/src/kernels.rs
@@ -1,38 +1,126 @@
 //! Native Core kernel + local-embedding SQL functions for the goldenmatch
 //! Postgres extension (#509 — DuckDB<->Postgres lockstep with `core_kernels.py`).
 //!
-//! Wraps `goldenmatch_bridge::api::{connected_components, pair_dedup, embed_local}`
-//! as pgrx `#[pg_extern]` functions. The bridge handles pyo3 dispatch into
-//! `goldenmatch.native` (Rust kernels when built, else pure-Python) and the
-//! local in-house embedder; this module is the SQL surface.
+//! The graph functions (`goldenmatch_pair_dedup`, `goldenmatch_connected_components`,
+//! and their `_str` siblings) call the pyo3-free `goldenmatch-graph-core` crate
+//! **native-direct** — no embedded CPython, same shape as `goldenmatch_record_fingerprint`
+//! over `goldenmatch-fingerprint-core`. They take id/score arrays (not JSON) and
+//! return relational `TableIterator` rows. `goldenmatch_embed_local` still routes
+//! through the bridge until the goldenembed-direct rewrite lands.
 //!
 //! ```sql
-//! SELECT goldenmatch.goldenmatch_connected_components('[[1,2,0.9],[2,3,0.8]]');
-//! SELECT goldenmatch.goldenmatch_pair_dedup('[[2,1,0.5],[1,2,0.9]]');
+//! SELECT * FROM goldenmatch.goldenmatch_pair_dedup(ARRAY[2,1], ARRAY[1,2], ARRAY[0.5,0.9]);
+//! SELECT * FROM goldenmatch.goldenmatch_connected_components(
+//!     ARRAY[1,2], ARRAY[2,3], ARRAY[0.9,0.8], ARRAY[1,2,3,4]);
 //! SELECT goldenmatch.goldenmatch_embed_local('John Smith', '/path/to/model');
 //! ```
-//!
-//! JSON in / JSON out; the bridge functions are fail-soft (`{"error": ...}`),
-//! so a malformed call returns an error JSON rather than aborting the query.
+use goldenmatch_graph_core as gc;
 use pgrx::prelude::*;
 
-/// Connected components over JSON `[[a, b, score], ...]` pairs. Returns a JSON
-/// array of components.
+/// Native-direct (no CPython): canonical max-score pairs over int64 id arrays.
+/// Each pair is canonicalized to `(min, max)` keeping the maximum score.
 #[pg_extern]
-pub fn goldenmatch_connected_components(pairs_json: String) -> String {
-    match goldenmatch_bridge::api::connected_components(&pairs_json) {
-        Ok(json) => json,
-        Err(e) => pgrx::error!("goldenmatch_connected_components: {}", e),
-    }
+pub fn goldenmatch_pair_dedup(
+    id_a: Vec<i64>,
+    id_b: Vec<i64>,
+    score: Vec<f64>,
+) -> TableIterator<'static, (name!(a, i64), name!(b, i64), name!(s, f64))> {
+    let n = id_a.len().min(id_b.len()).min(score.len());
+    let pairs: Vec<(i64, i64, f64)> = (0..n).map(|i| (id_a[i], id_b[i], score[i])).collect();
+    let out: Vec<(i64, i64, f64)> = gc::dedup_pairs_max_score(&pairs);
+    TableIterator::new(out)
 }
 
-/// Canonicalize + keep max score per pair. Returns a JSON array of `[a, b, score]`.
+/// String-id variant of [`goldenmatch_pair_dedup`]: first-seen dict -> int64
+/// kernel -> map deduped pairs back to text.
 #[pg_extern]
-pub fn goldenmatch_pair_dedup(pairs_json: String) -> String {
-    match goldenmatch_bridge::api::pair_dedup(&pairs_json) {
-        Ok(json) => json,
-        Err(e) => pgrx::error!("goldenmatch_pair_dedup: {}", e),
+pub fn goldenmatch_pair_dedup_str(
+    id_a: Vec<String>,
+    id_b: Vec<String>,
+    score: Vec<f64>,
+) -> TableIterator<'static, (name!(a, String), name!(b, String), name!(s, f64))> {
+    let n = id_a.len().min(id_b.len()).min(score.len());
+    let mut dict = gc::Dict::new();
+    let pairs: Vec<(i64, i64, f64)> = (0..n)
+        .map(|i| (dict.intern(&id_a[i]), dict.intern(&id_b[i]), score[i]))
+        .collect();
+    let out: Vec<(String, String, f64)> = gc::dedup_pairs_max_score(&pairs)
+        .into_iter()
+        .map(|(a, b, s)| {
+            (
+                dict.resolve(a).unwrap_or_default().to_string(),
+                dict.resolve(b).unwrap_or_default().to_string(),
+                s,
+            )
+        })
+        .collect();
+    TableIterator::new(out)
+}
+
+/// Native-direct connected components over int64 ids. `all_ids` seeds the universe
+/// so singletons (ids with no edge) get their own component. Returns one
+/// `(component_idx, member)` row per member; components are ordered by their
+/// minimum member and members within a component are sorted ascending.
+#[pg_extern]
+pub fn goldenmatch_connected_components(
+    id_a: Vec<i64>,
+    id_b: Vec<i64>,
+    score: Vec<f64>,
+    all_ids: Vec<i64>,
+) -> TableIterator<'static, (name!(component, i64), name!(member, i64))> {
+    let n = id_a.len().min(id_b.len()).min(score.len());
+    let edges: Vec<(i64, i64, f64)> = (0..n).map(|i| (id_a[i], id_b[i], score[i])).collect();
+    let mut comps = gc::connected_components(&edges, &all_ids);
+    for c in comps.iter_mut() {
+        c.sort();
     }
+    comps.sort(); // deterministic component order by min member
+    let rows: Vec<(i64, i64)> = comps
+        .into_iter()
+        .enumerate()
+        .flat_map(|(ci, members)| members.into_iter().map(move |m| (ci as i64, m)))
+        .collect();
+    TableIterator::new(rows)
+}
+
+/// String-id variant of [`goldenmatch_connected_components`]. `all_ids` is folded
+/// into the dict FIRST (stable codes), then edges. Members map back to strings and
+/// each component is sorted by the original string ascending before component
+/// indices are assigned (so component order is deterministic by min string).
+#[pg_extern]
+pub fn goldenmatch_connected_components_str(
+    id_a: Vec<String>,
+    id_b: Vec<String>,
+    score: Vec<f64>,
+    all_ids: Vec<String>,
+) -> TableIterator<'static, (name!(component, i64), name!(member, String))> {
+    let n = id_a.len().min(id_b.len()).min(score.len());
+    let mut dict = gc::Dict::new();
+    // Fold the universe first so its codes are stable, then the edge endpoints.
+    let ids: Vec<i64> = all_ids.iter().map(|s| dict.intern(s)).collect();
+    let edges: Vec<(i64, i64, f64)> = (0..n)
+        .map(|i| (dict.intern(&id_a[i]), dict.intern(&id_b[i]), score[i]))
+        .collect();
+    let comps = gc::connected_components(&edges, &ids);
+    // Map each component to its sorted string members.
+    let mut str_comps: Vec<Vec<String>> = comps
+        .into_iter()
+        .map(|members| {
+            let mut s: Vec<String> = members
+                .into_iter()
+                .map(|m| dict.resolve(m).unwrap_or_default().to_string())
+                .collect();
+            s.sort();
+            s
+        })
+        .collect();
+    str_comps.sort(); // deterministic component order by min string
+    let rows: Vec<(i64, String)> = str_comps
+        .into_iter()
+        .enumerate()
+        .flat_map(|(ci, members)| members.into_iter().map(move |m| (ci as i64, m)))
+        .collect();
+    TableIterator::new(rows)
 }
 
 /// Embed one text with the local in-house embedder. `model_path` is a saved
@@ -79,5 +167,68 @@ mod tests {
             got,
             "7381d5ba2dac5be0af49232a3209ab8d0dc2e4ed804a60ce533fdfe5254307e3"
         );
+    }
+
+    /// Native-direct int64 pair dedup: canonicalizes `(2,1)`/`(1,2)` to `(1,2)`
+    /// and keeps the max score.
+    #[pg_test]
+    fn pair_dedup_int_native() {
+        let rows: Vec<(i64, i64, f64)> =
+            crate::kernels::goldenmatch_pair_dedup(vec![2, 1], vec![1, 2], vec![0.5, 0.9])
+                .collect();
+        assert_eq!(rows, vec![(1, 2, 0.9)]);
+    }
+
+    /// String-id pair dedup round-trips through the first-seen dict.
+    #[pg_test]
+    fn pair_dedup_str_native() {
+        let rows: Vec<(String, String, f64)> = crate::kernels::goldenmatch_pair_dedup_str(
+            vec!["b".to_string(), "a".to_string()],
+            vec!["a".to_string(), "b".to_string()],
+            vec![0.5, 0.9],
+        )
+        .collect();
+        // first-seen intern: "b"=0, "a"=1; canonical (min,max)=(0,1)=("b","a").
+        assert_eq!(rows, vec![("b".to_string(), "a".to_string(), 0.9)]);
+    }
+
+    /// Connected components seeds singletons from `all_ids`: {1,2,3} and {4}.
+    #[pg_test]
+    fn connected_components_int_includes_singleton() {
+        let rows: Vec<(i64, i64)> = crate::kernels::goldenmatch_connected_components(
+            vec![1, 2],
+            vec![2, 3],
+            vec![0.9, 0.8],
+            vec![1, 2, 3, 4],
+        )
+        .collect();
+        let comp_of = |m: i64| rows.iter().find(|(_, x)| *x == m).unwrap().0;
+        assert_eq!(comp_of(1), comp_of(2));
+        assert_eq!(comp_of(2), comp_of(3));
+        assert_ne!(comp_of(1), comp_of(4));
+    }
+
+    /// String connected components: deterministic component order by min string,
+    /// members sorted ascending within a component.
+    #[pg_test]
+    fn connected_components_str_includes_singleton() {
+        let rows: Vec<(i64, String)> = crate::kernels::goldenmatch_connected_components_str(
+            vec!["x".to_string(), "y".to_string()],
+            vec!["y".to_string(), "z".to_string()],
+            vec![0.9, 0.8],
+            vec![
+                "x".to_string(),
+                "y".to_string(),
+                "z".to_string(),
+                "w".to_string(),
+            ],
+        )
+        .collect();
+        // component 0 = {w} (min string "w"), component 1 = {x,y,z}.
+        assert_eq!(rows[0], (0, "w".to_string()));
+        let comp_of = |m: &str| rows.iter().find(|(_, x)| x == m).unwrap().0;
+        assert_eq!(comp_of("x"), comp_of("y"));
+        assert_eq!(comp_of("y"), comp_of("z"));
+        assert_ne!(comp_of("x"), comp_of("w"));
     }
 }


### PR DESCRIPTION
Part of #509 (the graph half). Replaces the #503 JSON/CPython-bridge placeholder graph UDFs with the native-direct contract #509 asks for. The embedding UDF (`goldenmatch_embed_local` over `goldenembed-rs`) + the DataFusion surface are a tracked follow-up; #509 stays open.

## What changed

- **New pyo3-free `graph-core` crate** (mirrors `score-core`/`fingerprint-core`): `connected_components`, `dedup_pairs_max_score`, a first-seen str<->i64 `Dict`, and Arrow columnar entry points. One source of truth shared across `native`, `postgres`, and (later) `datafusion-udf`.
- **`native` delegates** its graph `#[pyfunction]`s to `graph-core` (behavior-exact) and adds `connected_components_arrow`.
- **DuckDB graph UDFs native-direct** (`core_kernels.py`): JSON-string scalars replaced by columnar list UDFs over the native kernel. Accept-both: int64 ids on the bare name, string ids on the `_str` sibling (first-seen dictionary). No CPython JSON round-trip.
- **Postgres graph UDFs native-direct** (`kernels.rs`): the CPython JSON-bridge calls replaced by direct `graph-core` calls over PG arrays, table-returning, with `_str` siblings. Mirrors how `goldenmatch_record_fingerprint` already escaped the bridge.
- **Versioning**: `goldenmatch_pg` 0.5.0 -> 0.6.0 (new handwritten `--0.6.0.sql` + `--0.5.0--0.6.0.sql` upgrade script; old TEXT graph signatures dropped); `goldenmatch-duckdb` 0.5.0 -> 0.6.0. CI + publish workflows copy the 0.6.0 SQL.

`goldenmatch_embed_local` is untouched on both backends in this PR (still the in-house / bridge path) and keeps working; the `goldenembed-rs` cutover is wave 2.

## Test plan

Locally verified (Windows):
- `graph-core`: `cargo test` 7/7 green + clippy clean.
- `native`: `cargo check` clean (zero warnings); full parity tests run in CI.
- DuckDB: `test_graph_arrow.py` + `test_parity_graph.py` + `test_core_kernels.py` 10/10 green (parity asserts DuckDB == native kernel for int + string ids).

CI-gated (not buildable on this Windows box, libclang):
- Postgres PG 15/16/17: `cargo pgrx` build + `CREATE EXTENSION goldenmatch_pg` against the new 0.6.0 SQL surface + the four `#[pg_test]` cases.

## Design + plan
- `docs/superpowers/specs/2026-06-04-sql-native-graph-embed-udfs-design.md`
- `docs/superpowers/plans/2026-06-04-sql-native-graph-embed-udfs.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)