### PR TITLE
fix(security): bench traversal via enumeration + 3 missed workflow perms

### DIFF
--- a/.github/workflows/bench-goldenembed.yml
+++ b/.github/workflows/bench-goldenembed.yml
@@ -12,6 +12,10 @@ on:
       runner:
         description: "runner label"
         default: "large-new-64GB"
+
+permissions:
+  contents: read
+
 jobs:
   bench:
     runs-on: ${{ github.event.inputs.runner }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -40,6 +40,8 @@ permissions:
 
 jobs:
   benchmarks:
+    permissions:
+      contents: read
     # Datasets are gated behind repo VARS so a fork without dataset access
     # doesn't try to run and fail. Set vars.RUN_BENCHMARKS=true and provide
     # the dataset secrets/vars to enable; otherwise the workflow exits 0

--- a/.github/workflows/generate-bench-dataset.yml
+++ b/.github/workflows/generate-bench-dataset.yml
@@ -23,11 +23,13 @@ on:
         default: "bench-dataset-v1"
 
 permissions:
-  contents: write  # required to create / update releases
+  contents: read
 
 jobs:
   generate:
     name: "generate bench dataset"
+    permissions:
+      contents: write  # required to create / update releases
     runs-on: large-new-64GB
     timeout-minutes: 60
 

--- a/packages/python/goldenmatch/scripts/bench_data_gen_server.py
+++ b/packages/python/goldenmatch/scripts/bench_data_gen_server.py
@@ -241,16 +241,24 @@ def trigger_generate(
 
 @app.get("/download", dependencies=[Depends(_auth)])
 def download(file: str) -> FileResponse:
-    """Stream a file from ``DATA_DIR``. Path is a simple filename
-    (no `/`, no `..`) so the operator can only pull files we wrote."""
-    p = _safe_child(DATA_DIR, file)
-    if not p.is_file():
-        raise HTTPException(404, f"{file} not found")
-    return FileResponse(
-        str(p),
-        media_type="application/octet-stream",
-        filename=file,
-    )
+    """Stream a file from ``DATA_DIR`` by exact name.
+
+    The path handed to ``FileResponse`` comes from a directory listing, never
+    from the request value: we validate ``file`` is a simple name, then look
+    for a real entry whose ``.name`` matches. A traversal string therefore
+    can't reach the filesystem sink (the served path is `entry`, not a path
+    built from user input)."""
+    if not _SAFE_NAME_RE.fullmatch(file) or ".." in file:
+        raise HTTPException(400, "file must be a simple name (no path)")
+    listing = DATA_DIR.iterdir() if DATA_DIR.exists() else []
+    for entry in listing:
+        if entry.is_file() and entry.name == file:
+            return FileResponse(
+                str(entry),
+                media_type="application/octet-stream",
+                filename=entry.name,
+            )
+    raise HTTPException(404, f"{file} not found")
 
 
 @app.get("/list", dependencies=[Depends(_auth)])
@@ -273,8 +281,13 @@ def list_files() -> JSONResponse:
 
 @app.get("/logs", dependencies=[Depends(_auth)])
 def get_log(job_id: str) -> FileResponse:
-    """Stream a job's log file."""
-    p = _safe_child(LOGS_DIR, f"{job_id}.log")
-    if not p.is_file():
-        raise HTTPException(404, f"log for {job_id} not found")
-    return FileResponse(str(p), media_type="text/plain", filename=p.name)
+    """Stream a job's log file by exact name from a directory listing
+    (same no-user-derived-path-at-the-sink pattern as ``/download``)."""
+    if not _SAFE_NAME_RE.fullmatch(job_id) or ".." in job_id:
+        raise HTTPException(400, "job_id must be a simple identifier")
+    target = f"{job_id}.log"
+    listing = LOGS_DIR.iterdir() if LOGS_DIR.exists() else []
+    for entry in listing:
+        if entry.is_file() and entry.name == target:
+            return FileResponse(str(entry), media_type="text/plain", filename=entry.name)
+    raise HTTPException(404, f"log for {job_id} not found")

--- a/packages/python/goldenmatch/tests/test_bench_server_endpoints.py
+++ b/packages/python/goldenmatch/tests/test_bench_server_endpoints.py
@@ -1,0 +1,62 @@
+"""Endpoint-level traversal safety for /download and /logs (CodeQL #290-#293).
+
+These serve the response path from a directory listing rather than a path built
+from the request value, so the filesystem sink never sees user-derived input.
+The tests pin the security behavior: valid name -> 200, traversal -> 400,
+unknown name -> 404.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import bench_data_gen_server as srv
+import pytest
+from fastapi.testclient import TestClient
+
+_TRAVERSAL = ["../x", "..\\x", "sub/x", "/etc/passwd", ".hidden", "", "a/../b"]
+
+
+def _client(tmp_path: Path, monkeypatch) -> tuple[TestClient, dict[str, str]]:
+    monkeypatch.setenv("GOLDENMATCH_BENCH_JOB_TOKEN", "tok")
+    monkeypatch.setattr(srv, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(srv, "LOGS_DIR", tmp_path / "logs")
+    return TestClient(srv.app), {"Authorization": "Bearer tok"}
+
+
+def test_download_serves_existing_file(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "bench_1000.parquet").write_bytes(b"DATA")
+    client, h = _client(tmp_path, monkeypatch)
+    r = client.get("/download", params={"file": "bench_1000.parquet"}, headers=h)
+    assert r.status_code == 200
+    assert r.content == b"DATA"
+
+
+@pytest.mark.parametrize("bad", _TRAVERSAL)
+def test_download_rejects_traversal(tmp_path: Path, monkeypatch, bad: str) -> None:
+    client, h = _client(tmp_path, monkeypatch)
+    r = client.get("/download", params={"file": bad}, headers=h)
+    assert r.status_code == 400
+
+
+def test_download_missing_is_404(tmp_path: Path, monkeypatch) -> None:
+    client, h = _client(tmp_path, monkeypatch)
+    r = client.get("/download", params={"file": "nope.parquet"}, headers=h)
+    assert r.status_code == 404
+
+
+def test_logs_serves_existing_log(tmp_path: Path, monkeypatch) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "job-1.log").write_text("hello")
+    client, h = _client(tmp_path, monkeypatch)
+    r = client.get("/logs", params={"job_id": "job-1"}, headers=h)
+    assert r.status_code == 200
+    assert "hello" in r.text
+
+
+@pytest.mark.parametrize("bad", _TRAVERSAL)
+def test_logs_rejects_traversal(tmp_path: Path, monkeypatch, bad: str) -> None:
+    client, h = _client(tmp_path, monkeypatch)
+    r = client.get("/logs", params={"job_id": bad}, headers=h)
+    assert r.status_code == 400


### PR DESCRIPTION
Round-2 follow-up to #738. The first pass closed 63 alerts (51 action SHA-pins + 12 permissions blocks) but several code fixes used sanitization patterns CodeQL doesn't recognize, so the underlying alerts stayed open. This PR fixes the genuinely-fixable ones with CodeQL-recognized patterns.

## Fixes
- **bench path-traversal (#290-#293, high):** `/download` and `/logs` now serve the response path from a **directory listing** (validate name -> find matching `entry` -> `FileResponse(entry)`), so the filesystem sink never receives a path built from the request. CodeQL's helper-as-sanitizer blind spot is sidestepped, and it's stricter (only existing files are servable). Tests: `test_bench_server_endpoints.py`.
- **3 missed `TokenPermissionsID`:** `bench-goldenembed.yml` (+top-level read), `generate-bench-dataset.yml` (read at top, write at job for `gh release`), `benchmarks.yml` (+job-level read).

## Recommended dismissals (CodeQL false-positives / already-defensive)
These remain open and are best dismissed in the Security tab rather than contorted:
- `store.py:174` path-injection + `:188` log-injection — `path` is the caller's own DB config, not untrusted input.
- `scanner.py:431` log-injection — YAML filename already `%r`-quoted (newline-safe); CodeQL doesn't model `%r`.
- 3x `js/stack-trace-exposure` (goldenpipe/goldenflow servers) — handlers already return generic messages + log server-side; the flagged flow through `result.errors` is conservative.

## Out of scope (accepted)
58 `PinnedDependenciesID` are `pip install` / `docker` / `npm` calls in run-steps (not GitHub Actions) across internal bench workflows — impractical/noisy to hash-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)