### PR TITLE
feat(mcp): add 11 tools to close the CLI/core coverage gap (43 -> 54)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/a2a/server.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/server.py
@@ -164,6 +164,93 @@ _SKILLS = [
         "inputModes": ["application/json"],
         "outputModes": ["application/json"],
     },
+    # MCP tool-coverage parity pass: high-level capabilities that had no A2A
+    # skill. Most delegate to the matching MCP dispatch (same JSON contract,
+    # mirroring how the identity_* skills already reuse MCP).
+    {
+        "id": "evaluate",
+        "name": "Evaluate",
+        "description": "Score matching accuracy (precision/recall/F1) against a ground-truth pair CSV. Auto-configures if no config is supplied.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "analyze_blocking",
+        "name": "Analyze Blocking",
+        "description": "Rank blocking-key candidates for a file: block counts, max block size, candidate-pair totals, estimated recall.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "compare_clusters",
+        "name": "Compare Clusters",
+        "description": "Compare two ER clustering outcomes (CCMS): unchanged/merged/partitioned/overlapping + Talburt-Wang Index. Inputs are two cluster JSON files.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "schema_match",
+        "name": "Schema Match",
+        "description": "Auto-map columns between two files with different schemas (synonym + name similarity), with confidence scores.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "sensitivity",
+        "name": "Sensitivity",
+        "description": "Sweep config parameters across a range and report clustering stability (CCMS unchanged %) at each value.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "incremental",
+        "name": "Incremental Match",
+        "description": "Match a batch of new records against an existing base dataset; returns matched (new, base) pairs plus counts.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "identity_show",
+        "name": "Identity Show",
+        "description": "Fetch the full detail of one identity by entity_id (records, evidence edges, recent events).",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "list_runs",
+        "name": "List Runs",
+        "description": "List previous dedupe/match runs from the run log (for rollback).",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "rollback",
+        "name": "Rollback",
+        "description": "Undo a previous run by deleting its output files (looked up by run_id). Destructive.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "list_corrections",
+        "name": "List Corrections",
+        "description": "Page through stored Learning Memory corrections, optionally filtered by dataset.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "learn_thresholds",
+        "name": "Learn Thresholds",
+        "description": "Run the MemoryLearner over stored corrections and return the per-matchkey threshold adjustments.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "memory_stats",
+        "name": "Memory Stats",
+        "description": "Correction counts, last-learned timestamps, and current learned adjustments from the Learning Memory store.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
 ]
 
 

--- a/packages/python/goldenmatch/goldenmatch/a2a/skills.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/skills.py
@@ -248,6 +248,7 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
     if skill_id in {
         "identity_resolve", "identity_list", "identity_history",
         "identity_conflicts", "identity_merge", "identity_split",
+        "identity_show",
     }:
         from goldenmatch.mcp.identity_tools import _dispatch as _identity_dispatch
         # Reuse MCP dispatch since the contract is identical (JSON in/out).
@@ -349,6 +350,69 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
             result["id_a"] = correction.id_a
             result["id_b"] = correction.id_b
         return result
+
+    # ── MCP tool-coverage parity ──────────────────────────────────────────────
+    # Reuse the MCP dispatch where the JSON contract is identical (same pattern
+    # as the identity_* skills above). File-based analysis skills that depend on
+    # MCP's loaded-dataset state are implemented directly instead.
+    if skill_id in {"compare_clusters", "schema_match", "list_runs", "rollback"}:
+        from goldenmatch.mcp.server import _handle_tool
+        return _handle_tool(skill_id, params)
+
+    if skill_id in {"sensitivity", "incremental"}:
+        from goldenmatch.mcp.agent_tools import _dispatch as _agent_dispatch
+        return _agent_dispatch(skill_id, params, AgentSession)
+
+    if skill_id in {"list_corrections", "learn_thresholds", "memory_stats"}:
+        from goldenmatch.mcp.memory_tools import _dispatch as _memory_dispatch
+        return _memory_dispatch(skill_id, params)
+
+    if skill_id == "evaluate":
+        from goldenmatch._api import evaluate as _evaluate
+
+        fp = params["file_path"]
+        cfg = params.get("config")
+        if not cfg:
+            from pathlib import Path as _Path
+
+            from goldenmatch.core.autoconfig import auto_configure
+            cfg = auto_configure([(fp, _Path(fp).stem)])
+        return _evaluate(
+            fp,
+            config=cfg,
+            ground_truth=params["ground_truth"],
+            col_a=params.get("col_a", "id_a"),
+            col_b=params.get("col_b", "id_b"),
+        )
+
+    if skill_id == "analyze_blocking":
+        from dataclasses import asdict
+        from pathlib import Path as _Path
+
+        import polars as pl
+
+        from goldenmatch.core.block_analyzer import analyze_blocking
+
+        fp = params["file_path"]
+        cfg = params.get("config")
+        if cfg:
+            from goldenmatch.config.loader import load_config
+            cfg = load_config(cfg) if isinstance(cfg, str) else cfg
+        else:
+            from goldenmatch.core.autoconfig import auto_configure
+            cfg = auto_configure([(fp, _Path(fp).stem)])
+        df = pl.read_csv(fp, encoding="utf8-lossy", ignore_errors=True)
+        cols = sorted({f.field for mk in cfg.get_matchkeys() for f in mk.fields if f.field})
+        suggestions = analyze_blocking(
+            df, cols,
+            sample_size=int(params.get("sample_size", 1000)),
+            target_block_size=int(params.get("target_block_size", 5000)),
+        )
+        limit = int(params.get("limit", 10))
+        return {
+            "matchkey_columns": cols,
+            "suggestions": [asdict(s) for s in suggestions[:limit]],
+        }
 
     raise ValueError(f"Unknown skill: {skill_id}")
 

--- a/packages/python/goldenmatch/goldenmatch/cli/incremental.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/incremental.py
@@ -33,19 +33,13 @@ def incremental_cmd(
     import polars as pl
 
     from goldenmatch._exclusions_schema import merge_exclude_columns_into_config
-    from goldenmatch.core.autofix import auto_fix_dataframe
-    from goldenmatch.core.ingest import load_file
-    from goldenmatch.core.match_one import match_one
-    from goldenmatch.core.matchkey import compute_matchkeys
-    from goldenmatch.core.scorer import find_exact_matches
-    from goldenmatch.core.standardize import apply_standardization
+    from goldenmatch.core.incremental import run_incremental
 
     if not new_records.exists():
         err_console.print(f"[red]New records file not found: {new_records}[/red]")
         raise typer.Exit(1)
 
     cfg = load_config(str(config))
-    matchkeys = cfg.get_matchkeys()
 
     _resolved_excludes = merge_exclude_columns_into_config(cfg, exclude_columns)
     if _resolved_excludes:
@@ -54,115 +48,23 @@ def incremental_cmd(
             f"{', '.join(_resolved_excludes)}[/dim]",
         )
 
-    if threshold is not None:
-        for mk in matchkeys:
-            if mk.threshold is not None:
-                mk.threshold = threshold
-
-    # Load base dataset
-    console.print("[bold]Loading base dataset...[/bold]")
-    base_lf = load_file(base_file)
-    base_df = base_lf.collect()
-    base_df = base_df.with_row_index("__row_id__").with_columns(
-        pl.col("__row_id__").cast(pl.Int64),
-        pl.lit("base").alias("__source__"),
-    )
-    base_df, _ = auto_fix_dataframe(base_df)
-
-    # Load new records
-    console.print("[bold]Loading new records...[/bold]")
-    new_lf = load_file(str(new_records))
-    new_df = new_lf.collect()
-    base_max_id = base_df["__row_id__"].max() + 1 if base_df.height > 0 else 0
-    new_df = new_df.with_row_index("__row_id__").with_columns(
-        (pl.col("__row_id__").cast(pl.Int64) + base_max_id).alias("__row_id__"),
-        pl.lit("new").alias("__source__"),
-    )
-    new_df, _ = auto_fix_dataframe(new_df)
-
-    # Standardize and compute matchkeys on combined data
-    combined = pl.concat([base_df, new_df], how="diagonal")
-    lf = combined.lazy()
-    if cfg.standardization:
-        lf = apply_standardization(lf, cfg.standardization)
-    for mk in matchkeys:
-        lf = compute_matchkeys(lf, [mk])
-    combined = lf.collect()
-
-    # Match each new record against the base
-    console.print(f"[bold]Matching {new_df.height} new records against {base_df.height} base records...[/bold]")
+    console.print("[bold]Matching new records against the base dataset...[/bold]")
     t0 = time.perf_counter()
-
-    all_matches = []
-    new_ids = set(range(base_max_id, base_max_id + new_df.height))
-
-    # Handle exact matchkeys via Polars join (match_one doesn't support exact)
-    exact_mks = [mk for mk in matchkeys if mk.type == "exact"]
-    fuzzy_mks = [mk for mk in matchkeys if mk.type != "exact"]
-
-    for mk in exact_mks:
-        mk_col = f"__mk_{mk.name}__"
-        if mk_col not in combined.columns:
-            continue
-        pairs = find_exact_matches(combined.lazy(), mk)
-        for a, b, score in pairs:
-            # Keep only cross-source pairs (one new, one base)
-            if (a in new_ids) != (b in new_ids):
-                new_id = a if a in new_ids else b
-                base_id = b if a in new_ids else a
-                all_matches.append((new_id, base_id, score))
-
-    # Handle fuzzy matchkeys via match_one
-    if fuzzy_mks:
-        row_index = {}
-        for row in combined.to_dicts():
-            row_index[row["__row_id__"]] = row
-
-        for new_id in sorted(new_ids):
-            row = row_index.get(new_id)
-            if not row:
-                continue
-            for mk in fuzzy_mks:
-                matches = match_one(row, combined, mk)
-                for rid, score in matches:
-                    if rid not in new_ids:
-                        all_matches.append((new_id, rid, score))
-
-    # Deduplicate: keep best score per (new_id, base_id) pair
-    best = {}
-    for new_id, base_id, score in all_matches:
-        key = (new_id, base_id)
-        if key not in best or score > best[key]:
-            best[key] = score
-    all_matches = [(n, b, s) for (n, b), s in best.items()]
-
-    matched_new_ids = {n for n, _, _ in all_matches}
-    matched_count = len(matched_new_ids)
-    new_entity_count = len(new_ids) - matched_count
-
+    summary = run_incremental(base_file, str(new_records), cfg, threshold=threshold)
     elapsed = time.perf_counter() - t0
 
-    # Build results
     table = Table(title="Incremental Match Results")
     table.add_column("Metric", style="bold cyan")
     table.add_column("Value", justify="right")
-    table.add_row("New records processed", str(new_df.height))
-    table.add_row("Matched to base", str(matched_count))
-    table.add_row("New entities", str(new_entity_count))
-    table.add_row("Total match pairs", str(len(all_matches)))
+    table.add_row("New records processed", str(summary["new_records"]))
+    table.add_row("Matched to base", str(summary["matched_to_base"]))
+    table.add_row("New entities", str(summary["new_entities"]))
+    table.add_row("Total match pairs", str(summary["total_pairs"]))
     table.add_row("Time", f"{elapsed:.2f}s")
     console.print(table)
 
-    if output and all_matches:
-        rows = []
-        for new_id, base_id, score in all_matches:
-            rows.append({
-                "new_row_id": new_id,
-                "base_row_id": base_id,
-                "score": round(score, 4),
-            })
-        result_df = pl.DataFrame(rows)
-        result_df.write_csv(output)
+    if output and summary["matches"]:
+        pl.DataFrame(summary["matches"]).write_csv(output)
         console.print(f"\n[green]Results saved to {output}[/green]")
     elif output:
         console.print("\n[yellow]No matches found - no output written[/yellow]")

--- a/packages/python/goldenmatch/goldenmatch/core/incremental.py
+++ b/packages/python/goldenmatch/goldenmatch/core/incremental.py
@@ -1,0 +1,121 @@
+"""Incremental matching: match new records against an existing base dataset.
+
+Shared core used by BOTH the CLI ``incremental`` command and the MCP
+``incremental`` tool so the two never drift. Exact matchkeys run via a
+Polars self-join (``find_exact_matches``); fuzzy matchkeys run via
+per-record ``match_one``. New records get ``__row_id__`` offset above the
+base max so the two populations never collide.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+
+def run_incremental(
+    base_file: str,
+    new_file: str,
+    config: GoldenMatchConfig,
+    threshold: float | None = None,
+) -> dict:
+    """Match records in ``new_file`` against the existing ``base_file``.
+
+    Returns a dict with the matched ``(new_row_id, base_row_id, score)``
+    pairs plus summary counts. Only cross-source pairs (one new, one base)
+    are returned; new-vs-new pairs are dropped.
+    """
+    import polars as pl
+
+    from goldenmatch.core.autofix import auto_fix_dataframe
+    from goldenmatch.core.ingest import load_file
+    from goldenmatch.core.match_one import match_one
+    from goldenmatch.core.matchkey import compute_matchkeys
+    from goldenmatch.core.scorer import find_exact_matches
+    from goldenmatch.core.standardize import apply_standardization
+
+    matchkeys = config.get_matchkeys()
+    if threshold is not None:
+        for mk in matchkeys:
+            if mk.threshold is not None:
+                mk.threshold = threshold
+
+    # Load base dataset, stamp row ids + source.
+    base_df = load_file(base_file).collect()
+    base_df = base_df.with_row_index("__row_id__").with_columns(
+        pl.col("__row_id__").cast(pl.Int64),
+        pl.lit("base").alias("__source__"),
+    )
+    base_df, _ = auto_fix_dataframe(base_df)
+
+    # Load new records, offsetting row ids above the base max. with_row_index
+    # numbers base rows 0..height-1, so the next free id is exactly height.
+    new_df = load_file(new_file).collect()
+    base_max_id = base_df.height
+    new_df = new_df.with_row_index("__row_id__").with_columns(
+        (pl.col("__row_id__").cast(pl.Int64) + base_max_id).alias("__row_id__"),
+        pl.lit("new").alias("__source__"),
+    )
+    new_df, _ = auto_fix_dataframe(new_df)
+
+    # Standardize + compute matchkeys on the combined frame.
+    combined = pl.concat([base_df, new_df], how="diagonal")
+    lf = combined.lazy()
+    if config.standardization:
+        lf = apply_standardization(lf, config.standardization)  # type: ignore[arg-type]
+    for mk in matchkeys:
+        lf = compute_matchkeys(lf, [mk])
+    combined = lf.collect()
+
+    all_matches: list[tuple[int, int, float]] = []
+    new_ids = set(range(base_max_id, base_max_id + new_df.height))
+
+    exact_mks = [mk for mk in matchkeys if mk.type == "exact"]
+    fuzzy_mks = [mk for mk in matchkeys if mk.type != "exact"]
+
+    # Exact matchkeys via Polars join (match_one doesn't support exact).
+    for mk in exact_mks:
+        mk_col = f"__mk_{mk.name}__"
+        if mk_col not in combined.columns:
+            continue
+        for a, b, score in find_exact_matches(combined.lazy(), mk):
+            # Keep only cross-source pairs (one new, one base).
+            if (a in new_ids) != (b in new_ids):
+                new_id = a if a in new_ids else b
+                base_id = b if a in new_ids else a
+                all_matches.append((new_id, base_id, score))
+
+    # Fuzzy matchkeys via match_one, per new record.
+    if fuzzy_mks:
+        row_index = {row["__row_id__"]: row for row in combined.to_dicts()}
+        for new_id in sorted(new_ids):
+            row = row_index.get(new_id)
+            if not row:
+                continue
+            for mk in fuzzy_mks:
+                for rid, score in match_one(row, combined, mk):
+                    if rid not in new_ids:
+                        all_matches.append((new_id, rid, score))
+
+    # Deduplicate: keep best score per (new_id, base_id) pair.
+    best: dict[tuple[int, int], float] = {}
+    for new_id, base_id, score in all_matches:
+        key = (new_id, base_id)
+        if key not in best or score > best[key]:
+            best[key] = score
+
+    matches = [
+        {"new_row_id": n, "base_row_id": b, "score": round(s, 4)}
+        for (n, b), s in best.items()
+    ]
+    matched_new_ids = {m["new_row_id"] for m in matches}
+
+    return {
+        "base_records": base_df.height,
+        "new_records": new_df.height,
+        "matched_to_base": len(matched_new_ids),
+        "new_entities": len(new_ids) - len(matched_new_ids),
+        "total_pairs": len(matches),
+        "matches": matches,
+    }

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -312,6 +312,54 @@ AGENT_TOOLS = [
             "required": ["file_path"],
         },
     ),
+    Tool(
+        name="sensitivity",
+        description=(
+            "Parameter-sensitivity analysis: sweep one or more config "
+            "parameters across a range and report how stable the clustering "
+            "is at each value (CCMS unchanged %). Use it to find robust "
+            "thresholds. Auto-configures the file if no config is given."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "file_path": {"type": "string", "description": "CSV/Parquet to analyze"},
+                "sweep": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Sweep specs as 'field:start:stop:step', e.g. "
+                        "'threshold:0.70:0.95:0.05'. One or more."
+                    ),
+                },
+                "config": {"type": "string", "description": "Optional config YAML path"},
+                "sample_size": {
+                    "type": "integer",
+                    "description": "Optional: randomly sample N records before sweeping",
+                },
+            },
+            "required": ["file_path", "sweep"],
+        },
+    ),
+    Tool(
+        name="incremental",
+        description=(
+            "Match a batch of new records against an existing base dataset "
+            "(without re-running the whole base). Returns matched "
+            "(new_row_id, base_row_id, score) pairs plus counts. "
+            "Auto-configures from the base file if no config is given."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "base_file": {"type": "string", "description": "Existing base dataset path"},
+                "new_records": {"type": "string", "description": "New records file to match in"},
+                "config": {"type": "string", "description": "Optional config YAML path"},
+                "threshold": {"type": "number", "description": "Optional threshold override"},
+            },
+            "required": ["base_file", "new_records"],
+        },
+    ),
 ]
 
 _AGENT_TOOL_NAMES = frozenset(t.name for t in AGENT_TOOLS)
@@ -682,5 +730,58 @@ def _dispatch(
         if write_error:
             result["write_error"] = write_error
         return result
+
+    if name == "sensitivity":
+        from pathlib import Path as _Path
+
+        from goldenmatch.core.sensitivity import SweepParam, run_sensitivity
+
+        file_path = args["file_path"]
+        specs = [(file_path, _Path(file_path).stem)]
+        cfg_path = args.get("config")
+        if cfg_path:
+            from goldenmatch.config.loader import load_config
+            cfg = load_config(cfg_path)
+        else:
+            from goldenmatch.core.autoconfig import auto_configure
+            cfg = auto_configure(specs)
+
+        sweeps = []
+        for spec in args.get("sweep", []):
+            parts = str(spec).split(":")
+            if len(parts) != 4:
+                return {"error": f"Bad sweep spec '{spec}'; expected 'field:start:stop:step'"}
+            sweeps.append(SweepParam(
+                field=parts[0],
+                start=float(parts[1]),
+                stop=float(parts[2]),
+                step=float(parts[3]),
+            ))
+        if not sweeps:
+            return {"error": "Provide at least one sweep spec, e.g. 'threshold:0.70:0.95:0.05'"}
+
+        results = run_sensitivity(specs, cfg, sweeps, sample_size=args.get("sample_size"))
+        return {"results": [r.stability_report() for r in results]}
+
+    if name == "incremental":
+        from pathlib import Path as _Path
+
+        from goldenmatch.core.incremental import run_incremental
+
+        base_file = args["base_file"]
+        cfg_path = args.get("config")
+        if cfg_path:
+            from goldenmatch.config.loader import load_config
+            cfg = load_config(cfg_path)
+        else:
+            from goldenmatch.core.autoconfig import auto_configure
+            cfg = auto_configure([(base_file, _Path(base_file).stem)])
+
+        return run_incremental(
+            base_file,
+            args["new_records"],
+            cfg,
+            threshold=args.get("threshold"),
+        )
 
     return {"error": f"Unknown agent tool: {name}"}

--- a/packages/python/goldenmatch/goldenmatch/mcp/identity_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/identity_tools.py
@@ -20,6 +20,7 @@ from goldenmatch.identity import (
     IdentityStore,
     find_by_record,
     find_conflicts,
+    get_entity,
     history,
     list_entities,
     manual_merge,
@@ -123,6 +124,23 @@ IDENTITY_TOOLS: list[Tool] = [
             "required": ["entity_id", "record_ids"],
         },
     ),
+    Tool(
+        name="identity_show",
+        description=(
+            "Fetch the full detail of one identity by entity_id: its member "
+            "records, evidence edges, and recent event log. Returns "
+            "{found: false} when no such entity exists."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string"},
+                "event_limit": {"type": "integer", "default": 100},
+                "path": {"type": "string", "description": "Identity DB path"},
+            },
+            "required": ["entity_id"],
+        },
+    ),
 ]
 
 
@@ -179,6 +197,11 @@ def _dispatch(name: str, args: dict) -> dict[str, Any]:
                 reason=args.get("reason"),
                 run_name="mcp",
             )
+
+    if name == "identity_show":
+        with _open(args) as s:
+            view = get_entity(s, args["entity_id"], event_limit=int(args.get("event_limit", 100)))
+        return view.to_dict() if view else {"found": False}
 
     raise ValueError(f"unknown identity tool: {name}")
 

--- a/packages/python/goldenmatch/goldenmatch/mcp/memory_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/memory_tools.py
@@ -171,6 +171,29 @@ MEMORY_TOOLS: list[Tool] = [
             },
         },
     ),
+    Tool(
+        name="memory_import",
+        description=(
+            "Import corrections from a list of dicts (the exact shape "
+            "memory_export returns). Upserts into the store: higher trust "
+            "wins, same trust = latest wins. Returns the count imported."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "corrections": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": "Correction dicts, as returned by memory_export.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "SQLite memory DB path. Default: .goldenmatch/memory.db",
+                },
+            },
+            "required": ["corrections"],
+        },
+    ),
 ]
 
 
@@ -408,5 +431,31 @@ def _dispatch(name: str, args: dict) -> dict:
             "count": len(corrections),
             "corrections": [_correction_to_dict(c) for c in corrections],
         }
+
+    if name == "memory_import":
+        from goldenmatch.core.memory.store import Correction
+
+        rows = args.get("corrections") or []
+        imported = 0
+        with MemoryStore(backend="sqlite", path=path) as store:
+            for r in rows:
+                created = r.get("created_at")
+                store.add_correction(Correction(
+                    id=r.get("id") or str(uuid.uuid4()),
+                    id_a=int(r.get("id_a", 0)),
+                    id_b=int(r.get("id_b", 0)),
+                    decision=r["decision"],
+                    source=r.get("source", "api"),
+                    trust=float(r.get("trust", 0.5)),
+                    field_hash=r.get("field_hash", ""),
+                    record_hash=r.get("record_hash", ""),
+                    original_score=float(r.get("original_score", 0.0)),
+                    matchkey_name=r.get("matchkey_name"),
+                    reason=r.get("reason"),
+                    dataset=r.get("dataset"),
+                    created_at=datetime.fromisoformat(created) if created else datetime.now(),
+                ))
+                imported += 1
+        return {"imported": imported}
 
     return {"error": f"Unknown memory tool: {name}"}

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -417,6 +417,124 @@ _BASE_TOOLS = [
             "required": ["file_a", "file_b", "fields"],
         },
     ),
+    Tool(
+        name="evaluate",
+        description=(
+            "Score the loaded run against ground-truth pairs. Loads a "
+            "ground-truth CSV (id_a,id_b columns) and returns precision, "
+            "recall, and F1 for the current clustering."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "ground_truth_path": {
+                    "type": "string",
+                    "description": "CSV of true match pairs (columns id_a,id_b or idA,idB).",
+                },
+                "col_a": {"type": "string", "default": "id_a"},
+                "col_b": {"type": "string", "default": "id_b"},
+            },
+            "required": ["ground_truth_path"],
+        },
+    ),
+    Tool(
+        name="analyze_blocking",
+        description=(
+            "Diagnose blocking on the loaded dataset: returns ranked blocking "
+            "key candidates with block counts, max block size, total candidate "
+            "comparisons, and estimated recall. Use it to explain why matching "
+            "is slow or produces too many candidate pairs."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "sample_size": {"type": "integer", "default": 1000},
+                "target_block_size": {"type": "integer", "default": 5000},
+                "limit": {"type": "integer", "default": 10, "description": "Top N suggestions"},
+            },
+        },
+    ),
+    Tool(
+        name="compare_clusters",
+        description=(
+            "Compare two ER clustering outcomes on the same dataset without "
+            "ground truth (CCMS): classifies each cluster as unchanged / "
+            "merged / partitioned / overlapping and returns the Talburt-Wang "
+            "Index. Both inputs are JSON cluster files (as written by "
+            "export-style output)."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "clusters_a_path": {"type": "string", "description": "Baseline clusters JSON"},
+                "clusters_b_path": {"type": "string", "description": "Comparison clusters JSON"},
+            },
+            "required": ["clusters_a_path", "clusters_b_path"],
+        },
+    ),
+    Tool(
+        name="schema_match",
+        description=(
+            "Auto-map columns between two files with different schemas. "
+            "Returns proposed (col_a, col_b) mappings with a confidence score "
+            "and method (synonym / name_sim / composite). Useful before "
+            "matching two sources."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "file_a": {"type": "string"},
+                "file_b": {"type": "string"},
+                "min_score": {"type": "number", "default": 0.5},
+            },
+            "required": ["file_a", "file_b"],
+        },
+    ),
+    Tool(
+        name="lineage",
+        description=(
+            "Field-level provenance for the loaded run: for each scored pair, "
+            "the per-field scores that produced the match, plus cluster id. "
+            "Optionally write a lineage JSON to a directory."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "max_pairs": {"type": "integer", "default": 100},
+                "natural_language": {"type": "boolean", "default": False},
+                "output_dir": {
+                    "type": "string",
+                    "description": "If set, write lineage JSON here and return the path instead of inline records.",
+                },
+            },
+        },
+    ),
+    Tool(
+        name="list_runs",
+        description="List previous dedupe/match runs (for rollback) from the run log.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "output_dir": {"type": "string", "default": "."},
+            },
+        },
+    ),
+    Tool(
+        name="rollback",
+        description=(
+            "Undo a previous run by DELETING its output files (looked up by "
+            "run_id in the run log). Destructive: removes the files that run "
+            "wrote. Use list_runs first to find the run_id."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string"},
+                "output_dir": {"type": "string", "default": "."},
+            },
+            "required": ["run_id"],
+        },
+    ),
 ]
 
 # TOOLS is the union of agent tools + memory tools + base tools, in the same order list_tools returns.
@@ -748,6 +866,32 @@ def _handle_tool(name: str, args: dict) -> dict:
         return _tool_pprl_auto_config(args.get("security_level", "high"), args.get("use_llm", False))
     elif name == "pprl_link":
         return _tool_pprl_link(args)
+    elif name == "evaluate":
+        return _tool_evaluate(
+            args["ground_truth_path"],
+            args.get("col_a", "id_a"),
+            args.get("col_b", "id_b"),
+        )
+    elif name == "analyze_blocking":
+        return _tool_analyze_blocking(
+            args.get("sample_size", 1000),
+            args.get("target_block_size", 5000),
+            args.get("limit", 10),
+        )
+    elif name == "compare_clusters":
+        return _tool_compare_clusters(args["clusters_a_path"], args["clusters_b_path"])
+    elif name == "schema_match":
+        return _tool_schema_match(args["file_a"], args["file_b"], args.get("min_score", 0.5))
+    elif name == "lineage":
+        return _tool_lineage(
+            args.get("max_pairs", 100),
+            args.get("natural_language", False),
+            args.get("output_dir"),
+        )
+    elif name == "list_runs":
+        return _tool_list_runs(args.get("output_dir", "."))
+    elif name == "rollback":
+        return _tool_rollback(args["run_id"], args.get("output_dir", "."))
     else:
         return {"error": f"Unknown tool: {name}"}
 
@@ -1261,6 +1405,93 @@ async def run_server(file_paths: list[str], config_path: str | None = None) -> N
         await server.run(read_stream, write_stream, server.create_initialization_options())
 
 
+def _load_clusters_json(path: str) -> dict[int, dict]:
+    """Load a clusters JSON file into the {cluster_id: {"members": [...]}} shape.
+
+    Accepts either a bare cluster mapping or a {"clusters": {...}} wrapper, and
+    cluster values that are either a dict with a "members" list or a bare list.
+    """
+    with open(path, encoding="utf-8") as fp:
+        data = json.load(fp)
+    raw = data.get("clusters", data) if isinstance(data, dict) else data
+    out: dict[int, dict] = {}
+    for k, v in raw.items():
+        members = v.get("members") if isinstance(v, dict) else v
+        out[int(k)] = {"members": [int(m) for m in members]}
+    return out
+
+
+def _tool_evaluate(ground_truth_path: str, col_a: str = "id_a", col_b: str = "id_b") -> dict:
+    from goldenmatch.core.evaluate import evaluate_clusters, load_ground_truth_csv
+    if _result is None:
+        return {"error": "No dataset loaded"}
+    gt = load_ground_truth_csv(ground_truth_path, col_a, col_b)
+    return evaluate_clusters(_result.clusters, gt).summary()
+
+
+def _tool_analyze_blocking(
+    sample_size: int = 1000, target_block_size: int = 5000, limit: int = 10
+) -> dict:
+    from dataclasses import asdict
+
+    from goldenmatch.core.block_analyzer import analyze_blocking
+    if _engine is None or _config is None:
+        return {"error": "No dataset loaded"}
+    cols = sorted({f.field for mk in _config.get_matchkeys() for f in mk.fields})
+    suggestions = analyze_blocking(
+        _engine.data, cols, sample_size=sample_size, target_block_size=target_block_size
+    )
+    return {
+        "matchkey_columns": cols,
+        "suggestions": [asdict(s) for s in suggestions[:limit]],
+    }
+
+
+def _tool_compare_clusters(clusters_a_path: str, clusters_b_path: str) -> dict:
+    from goldenmatch.core.compare_clusters import compare_clusters
+    a = _load_clusters_json(clusters_a_path)
+    b = _load_clusters_json(clusters_b_path)
+    return compare_clusters(a, b).summary()
+
+
+def _tool_schema_match(file_a: str, file_b: str, min_score: float = 0.5) -> dict:
+    from goldenmatch.core.ingest import load_file
+    from goldenmatch.core.schema_match import auto_map_columns
+    df_a = load_file(file_a).collect()
+    df_b = load_file(file_b).collect()
+    return {"mappings": auto_map_columns(df_a, df_b, min_score=min_score)}
+
+
+def _tool_lineage(
+    max_pairs: int = 100, natural_language: bool = False, output_dir: str | None = None
+) -> dict:
+    from goldenmatch.core.lineage import build_lineage, save_lineage
+    if _result is None or _engine is None or _config is None:
+        return {"error": "No dataset loaded"}
+    lineage = build_lineage(
+        _result.scored_pairs,
+        _engine.data,
+        _config.get_matchkeys(),
+        _result.clusters,
+        max_pairs=max_pairs,
+        natural_language=natural_language,
+    )
+    if output_dir:
+        path = save_lineage(lineage, output_dir, run_name="mcp")
+        return {"saved_to": str(path), "count": len(lineage)}
+    return {"count": len(lineage), "lineage": lineage}
+
+
+def _tool_list_runs(output_dir: str = ".") -> dict:
+    from goldenmatch.core.rollback import list_runs
+    return {"runs": list_runs(output_dir)}
+
+
+def _tool_rollback(run_id: str, output_dir: str = ".") -> dict:
+    from goldenmatch.core.rollback import rollback_run
+    return rollback_run(run_id, output_dir)
+
+
 async def run_server_http(
     host: str = "0.0.0.0",
     port: int = 8200,
@@ -1291,7 +1522,7 @@ async def run_server_http(
     async def server_card(request):
         return JSONResponse({
             "name": "GoldenMatch",
-            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 35 MCP tools for matching, explaining, reviewing, data quality, transforms, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
+            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 54 MCP tools for matching, explaining, reviewing, evaluating, blocking analysis, lineage, data quality, transforms, identity graph, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
             "homepage": "https://github.com/benseverndev-oss/goldenmatch",
             "iconUrl": "https://avatars.githubusercontent.com/u/192581748"
         })

--- a/packages/python/goldenmatch/tests/test_a2a.py
+++ b/packages/python/goldenmatch/tests/test_a2a.py
@@ -33,14 +33,14 @@ def test_agent_card_has_required_fields():
     assert card["authentication"]["schemes"] == ["bearer"]
 
 
-def test_agent_card_has_19_skills():
+def test_agent_card_has_31_skills():
     """v1.7-v1.12 added autoconfig+controller_telemetry (10->12); v2.0 added
     six identity_* skills (12->18); v1.19.x Phase 3 added add_correction
-    (18->19)."""
+    (18->19); the MCP tool-coverage parity pass added 12 (19->31)."""
     from goldenmatch.a2a.server import build_agent_card
 
     card = build_agent_card("http://localhost:8080")
-    assert len(card["skills"]) == 19
+    assert len(card["skills"]) == 31
     ids = {s["id"] for s in card["skills"]}
     assert "autoconfig" in ids
     assert "controller_telemetry" in ids
@@ -48,6 +48,12 @@ def test_agent_card_has_19_skills():
     assert {
         "identity_resolve", "identity_list", "identity_history",
         "identity_conflicts", "identity_merge", "identity_split",
+    } <= ids
+    # MCP tool-coverage parity pass.
+    assert {
+        "evaluate", "analyze_blocking", "compare_clusters", "schema_match",
+        "sensitivity", "incremental", "identity_show", "list_runs", "rollback",
+        "list_corrections", "learn_thresholds", "memory_stats",
     } <= ids
 
 
@@ -152,6 +158,142 @@ def test_dispatch_unknown_skill():
 
     with pytest.raises(ValueError, match="Unknown skill"):
         dispatch_skill("nonexistent_skill", {})
+
+
+# ── MCP tool-coverage parity skills ───────────────────────────────────────────
+
+
+def _exact_email_cfg(tmp_path) -> str:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "matchkeys:\n"
+        "  - name: exact_email\n"
+        "    type: exact\n"
+        "    fields:\n"
+        "      - field: email\n"
+        "        transforms: [lowercase, strip]\n"
+    )
+    return str(cfg)
+
+
+def test_dispatch_compare_clusters(tmp_path):
+    import json
+
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    a.write_text(json.dumps({"0": {"members": [0, 1, 2]}}))
+    b.write_text(json.dumps({"0": {"members": [0, 1]}, "1": {"members": [2]}}))
+    result = dispatch_skill("compare_clusters", {
+        "clusters_a_path": str(a), "clusters_b_path": str(b),
+    })
+    assert "twi" in result
+    assert result["cc1"] == 1 and result["cc2"] == 2
+
+
+def test_dispatch_schema_match(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    fa = tmp_path / "a.csv"
+    fb = tmp_path / "b.csv"
+    fa.write_text("full_name,email\nJohn,j@x.com\n")
+    fb.write_text("contact_name,email_address\nJohn,j@x.com\n")
+    result = dispatch_skill("schema_match", {"file_a": str(fa), "file_b": str(fb)})
+    assert isinstance(result["mappings"], list)
+    assert len(result["mappings"]) >= 1
+
+
+def test_dispatch_list_runs_and_rollback(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    assert dispatch_skill("list_runs", {"output_dir": str(tmp_path)})["runs"] == []
+    assert "error" in dispatch_skill("rollback", {"run_id": "nope", "output_dir": str(tmp_path)})
+
+
+def test_dispatch_evaluate(tmp_path):
+    import csv
+
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    data = tmp_path / "data.csv"
+    with open(data, "w", newline="") as fp:
+        w = csv.writer(fp)
+        w.writerow(["name", "email"])
+        w.writerow(["John Smith", "john@x.com"])
+        w.writerow(["Jon Smith", "john@x.com"])
+    gt = tmp_path / "gt.csv"
+    with open(gt, "w", newline="") as fp:
+        w = csv.writer(fp)
+        w.writerow(["id_a", "id_b"])
+        w.writerow([0, 1])
+    result = dispatch_skill("evaluate", {
+        "file_path": str(data), "config": _exact_email_cfg(tmp_path), "ground_truth": str(gt),
+    })
+    assert "f1" in result and "precision" in result
+
+
+def test_dispatch_incremental(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    base = tmp_path / "base.csv"
+    new = tmp_path / "new.csv"
+    base.write_text("name,email\nJohn Smith,john@x.com\nJane Doe,jane@x.com\n")
+    new.write_text("name,email\nJohnny Smith,john@x.com\nBob New,bob@x.com\n")
+    result = dispatch_skill("incremental", {
+        "base_file": str(base), "new_records": str(new), "config": _exact_email_cfg(tmp_path),
+    })
+    assert result["matched_to_base"] == 1
+    assert result["new_entities"] == 1
+
+
+def test_dispatch_analyze_blocking(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    data = tmp_path / "data.csv"
+    data.write_text("name,email\nA,a@x.com\nB,b@x.com\n")
+    result = dispatch_skill("analyze_blocking", {
+        "file_path": str(data), "config": _exact_email_cfg(tmp_path),
+    })
+    assert "suggestions" in result
+    assert isinstance(result["suggestions"], list)
+
+
+def test_dispatch_sensitivity_requires_sweep(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    data = tmp_path / "data.csv"
+    data.write_text("name,email\nA,a@x.com\n")
+    result = dispatch_skill("sensitivity", {
+        "file_path": str(data), "sweep": [], "config": _exact_email_cfg(tmp_path),
+    })
+    assert "error" in result
+
+
+def test_dispatch_identity_show(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+    from goldenmatch.identity import IdentityNode, IdentityStore, SourceRecord, new_entity_id
+
+    path = str(tmp_path / "identity.db")
+    eid = new_entity_id()
+    with IdentityStore(path=path) as s:
+        s.upsert_identity(IdentityNode(entity_id=eid, dataset="d", confidence=0.9))
+        s.upsert_record(SourceRecord("src:1", "src", "1", "h1", entity_id=eid, dataset="d"))
+    result = dispatch_skill("identity_show", {"entity_id": eid, "path": path})
+    assert result.get("entity_id") == eid
+
+
+def test_dispatch_memory_loop(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    path = str(tmp_path / "memory.db")
+    dispatch_skill("add_correction", {
+        "decision": "reject", "id_a": 1, "id_b": 2, "dataset": "ds1", "path": path,
+    })
+    listed = dispatch_skill("list_corrections", {"path": path, "dataset": "ds1"})
+    assert listed["count"] == 1
+    stats = dispatch_skill("memory_stats", {"path": path})
+    assert stats["total_corrections"] == 1
 
 
 def test_agent_card_has_quality_and_transform_skills():

--- a/packages/python/goldenmatch/tests/test_mcp_identity_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_identity_tools.py
@@ -19,10 +19,11 @@ from goldenmatch.mcp.identity_tools import (
 
 
 def test_identity_tool_count_and_names():
-    assert len(IDENTITY_TOOLS) == 6
+    assert len(IDENTITY_TOOLS) == 7
     assert IDENTITY_TOOL_NAMES == {
         "identity_resolve", "identity_list", "identity_history",
         "identity_conflicts", "identity_merge", "identity_split",
+        "identity_show",
     }
 
 

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -59,13 +59,32 @@ def demo_file(tmp_path):
     return str(f)
 
 
+@pytest.fixture
+def simple_config(tmp_path):
+    """Explicit exact-email config so create_server skips auto-config.
+
+    Auto-config on a 3-field shape can enable rerank (cross-encoder download),
+    which fails in offline CI. An explicit config keeps these tests hermetic.
+    """
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "matchkeys:\n"
+        "  - name: exact_email\n"
+        "    type: exact\n"
+        "    fields:\n"
+        "      - field: email\n"
+        "        transforms: [lowercase, strip]\n"
+    )
+    return str(cfg)
+
+
 # ── Base tools on a loaded dataset ────────────────────────────────────────────
 
 
-def test_evaluate(demo_file, tmp_path):
+def test_evaluate(demo_file, simple_config, tmp_path):
     from goldenmatch.mcp.server import _handle_tool, create_server
 
-    create_server([demo_file])
+    create_server([demo_file], simple_config)
     gt = tmp_path / "gt.csv"
     with open(gt, "w", newline="") as fp:
         w = csv.writer(fp)
@@ -75,29 +94,29 @@ def test_evaluate(demo_file, tmp_path):
     assert "f1" in result and "precision" in result and "recall" in result
 
 
-def test_analyze_blocking(demo_file):
+def test_analyze_blocking(demo_file, simple_config):
     from goldenmatch.mcp.server import _handle_tool, create_server
 
-    create_server([demo_file])
+    create_server([demo_file], simple_config)
     result = _handle_tool("analyze_blocking", {"limit": 5})
     assert "suggestions" in result
     assert isinstance(result["suggestions"], list)
     assert "matchkey_columns" in result
 
 
-def test_lineage(demo_file):
+def test_lineage(demo_file, simple_config):
     from goldenmatch.mcp.server import _handle_tool, create_server
 
-    create_server([demo_file])
+    create_server([demo_file], simple_config)
     result = _handle_tool("lineage", {"max_pairs": 10})
     assert "count" in result
     assert "lineage" in result
 
 
-def test_lineage_to_dir(demo_file, tmp_path):
+def test_lineage_to_dir(demo_file, simple_config, tmp_path):
     from goldenmatch.mcp.server import _handle_tool, create_server
 
-    create_server([demo_file])
+    create_server([demo_file], simple_config)
     out = tmp_path / "lineage_out"
     out.mkdir()
     result = _handle_tool("lineage", {"max_pairs": 10, "output_dir": str(out)})

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -1,0 +1,257 @@
+"""Coverage for the MCP tool-coverage pass: 11 new tools across the four groups.
+
+Base (server.py):  evaluate, analyze_blocking, compare_clusters, schema_match,
+                   lineage, list_runs, rollback
+Agent:             sensitivity, incremental
+Identity:          identity_show
+Memory:            memory_import
+"""
+from __future__ import annotations
+
+import csv
+import json
+
+import pytest
+
+# ── Registration ──────────────────────────────────────────────────────────────
+
+
+def test_total_tool_count_is_54():
+    from goldenmatch.mcp.agent_tools import AGENT_TOOLS
+    from goldenmatch.mcp.identity_tools import IDENTITY_TOOLS
+    from goldenmatch.mcp.memory_tools import MEMORY_TOOLS
+    from goldenmatch.mcp.server import _BASE_TOOLS, TOOLS
+
+    assert len(AGENT_TOOLS) == 16
+    assert len(MEMORY_TOOLS) == 7
+    assert len(IDENTITY_TOOLS) == 7
+    assert len(_BASE_TOOLS) == 24
+    assert len(TOOLS) == 54
+    # No duplicate tool names across the whole surface.
+    names = [t.name for t in TOOLS]
+    assert len(names) == len(set(names))
+
+
+def test_new_tool_names_registered():
+    from goldenmatch.mcp.server import TOOLS
+
+    names = {t.name for t in TOOLS}
+    for new in (
+        "evaluate", "analyze_blocking", "compare_clusters", "schema_match",
+        "lineage", "list_runs", "rollback", "sensitivity", "incremental",
+        "identity_show", "memory_import",
+    ):
+        assert new in names, f"{new} missing from TOOLS"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def demo_file(tmp_path):
+    f = tmp_path / "demo.csv"
+    with open(f, "w", newline="") as fp:
+        w = csv.writer(fp)
+        w.writerow(["name", "email", "zip"])
+        w.writerow(["John Smith", "john@test.com", "10001"])
+        w.writerow(["Jon Smith", "john@test.com", "10001"])
+        w.writerow(["Jane Doe", "jane@test.com", "90210"])
+    return str(f)
+
+
+# ── Base tools on a loaded dataset ────────────────────────────────────────────
+
+
+def test_evaluate(demo_file, tmp_path):
+    from goldenmatch.mcp.server import _handle_tool, create_server
+
+    create_server([demo_file])
+    gt = tmp_path / "gt.csv"
+    with open(gt, "w", newline="") as fp:
+        w = csv.writer(fp)
+        w.writerow(["id_a", "id_b"])
+        w.writerow([0, 1])
+    result = _handle_tool("evaluate", {"ground_truth_path": str(gt)})
+    assert "f1" in result and "precision" in result and "recall" in result
+
+
+def test_analyze_blocking(demo_file):
+    from goldenmatch.mcp.server import _handle_tool, create_server
+
+    create_server([demo_file])
+    result = _handle_tool("analyze_blocking", {"limit": 5})
+    assert "suggestions" in result
+    assert isinstance(result["suggestions"], list)
+    assert "matchkey_columns" in result
+
+
+def test_lineage(demo_file):
+    from goldenmatch.mcp.server import _handle_tool, create_server
+
+    create_server([demo_file])
+    result = _handle_tool("lineage", {"max_pairs": 10})
+    assert "count" in result
+    assert "lineage" in result
+
+
+def test_lineage_to_dir(demo_file, tmp_path):
+    from goldenmatch.mcp.server import _handle_tool, create_server
+
+    create_server([demo_file])
+    out = tmp_path / "lineage_out"
+    out.mkdir()
+    result = _handle_tool("lineage", {"max_pairs": 10, "output_dir": str(out)})
+    assert "saved_to" in result
+
+
+# ── Base tools that are file/store based (no loaded dataset needed) ────────────
+
+
+def test_compare_clusters(tmp_path):
+    from goldenmatch.mcp.server import _handle_tool
+
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    a.write_text(json.dumps({"0": {"members": [0, 1, 2]}}))
+    b.write_text(json.dumps({"0": {"members": [0, 1]}, "1": {"members": [2]}}))
+    result = _handle_tool("compare_clusters", {
+        "clusters_a_path": str(a), "clusters_b_path": str(b),
+    })
+    assert "twi" in result
+    assert result["cc1"] == 1
+    assert result["cc2"] == 2
+
+
+def test_schema_match(tmp_path):
+    from goldenmatch.mcp.server import _handle_tool
+
+    fa = tmp_path / "a.csv"
+    fb = tmp_path / "b.csv"
+    fa.write_text("full_name,email\nJohn,j@x.com\n")
+    fb.write_text("contact_name,email_address\nJohn,j@x.com\n")
+    result = _handle_tool("schema_match", {"file_a": str(fa), "file_b": str(fb)})
+    assert "mappings" in result
+    assert isinstance(result["mappings"], list)
+    assert len(result["mappings"]) >= 1
+
+
+def test_list_runs_empty(tmp_path):
+    from goldenmatch.mcp.server import _handle_tool
+
+    result = _handle_tool("list_runs", {"output_dir": str(tmp_path)})
+    assert result["runs"] == []
+
+
+def test_rollback_missing_run(tmp_path):
+    from goldenmatch.mcp.server import _handle_tool
+
+    result = _handle_tool("rollback", {"run_id": "nope", "output_dir": str(tmp_path)})
+    assert "error" in result
+
+
+# ── Agent tools ───────────────────────────────────────────────────────────────
+
+
+def test_incremental(tmp_path):
+    from goldenmatch.core.agent import AgentSession
+    from goldenmatch.mcp.agent_tools import _dispatch
+
+    base = tmp_path / "base.csv"
+    new = tmp_path / "new.csv"
+    base.write_text("name,email\nJohn Smith,john@x.com\nJane Doe,jane@x.com\n")
+    new.write_text("name,email\nJohnny Smith,john@x.com\nBob New,bob@x.com\n")
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "matchkeys:\n"
+        "  - name: exact_email\n"
+        "    type: exact\n"
+        "    fields:\n"
+        "      - field: email\n"
+        "        transforms: [lowercase, strip]\n"
+    )
+    result = _dispatch(
+        "incremental",
+        {"base_file": str(base), "new_records": str(new), "config": str(cfg)},
+        AgentSession,
+    )
+    assert result["matched_to_base"] == 1
+    assert result["new_entities"] == 1
+    assert any(m["base_row_id"] == 0 for m in result["matches"])
+
+
+def test_sensitivity_requires_sweep(tmp_path):
+    from goldenmatch.core.agent import AgentSession
+    from goldenmatch.mcp.agent_tools import _dispatch
+
+    f = tmp_path / "d.csv"
+    f.write_text("name,email\nA,a@x.com\n")
+    cfg = tmp_path / "c.yaml"
+    cfg.write_text(
+        "matchkeys:\n"
+        "  - name: exact_email\n"
+        "    type: exact\n"
+        "    fields:\n"
+        "      - field: email\n"
+    )
+    # Empty sweep -> structured error, not an exception.
+    result = _dispatch(
+        "sensitivity",
+        {"file_path": str(f), "sweep": [], "config": str(cfg)},
+        AgentSession,
+    )
+    assert "error" in result
+
+    # Malformed sweep spec -> structured error.
+    result2 = _dispatch(
+        "sensitivity",
+        {"file_path": str(f), "sweep": ["threshold:0.7"], "config": str(cfg)},
+        AgentSession,
+    )
+    assert "error" in result2
+
+
+# ── Identity ──────────────────────────────────────────────────────────────────
+
+
+def test_identity_show(tmp_path):
+    from goldenmatch.identity import IdentityNode, IdentityStore, SourceRecord, new_entity_id
+    from goldenmatch.mcp.identity_tools import _dispatch
+
+    path = str(tmp_path / "identity.db")
+    eid = new_entity_id()
+    with IdentityStore(path=path) as s:
+        s.upsert_identity(IdentityNode(entity_id=eid, dataset="d", confidence=0.9))
+        s.upsert_record(SourceRecord("src:1", "src", "1", "h1", entity_id=eid, dataset="d"))
+
+    result = _dispatch("identity_show", {"entity_id": eid, "path": path})
+    assert result.get("entity_id") == eid
+
+    missing = _dispatch("identity_show", {"entity_id": "does-not-exist", "path": path})
+    assert missing == {"found": False}
+
+
+# ── Memory ────────────────────────────────────────────────────────────────────
+
+
+def test_memory_import_round_trips_export(tmp_path):
+    from goldenmatch.mcp.memory_tools import _dispatch
+
+    path = str(tmp_path / "memory.db")
+    corrections = [
+        {
+            "id_a": 1, "id_b": 2, "decision": "reject", "source": "agent",
+            "trust": 0.5, "dataset": "ds1",
+        },
+        {
+            "id_a": 3, "id_b": 4, "decision": "approve", "source": "steward",
+            "trust": 1.0, "dataset": "ds1",
+        },
+    ]
+    imported = _dispatch("memory_import", {"corrections": corrections, "path": path})
+    assert imported["imported"] == 2
+
+    exported = _dispatch("memory_export", {"path": path})
+    assert exported["count"] == 2
+    decisions = {c["decision"] for c in exported["corrections"]}
+    assert decisions == {"reject", "approve"}

--- a/packages/python/goldenmatch/tests/test_memory_tools.py
+++ b/packages/python/goldenmatch/tests/test_memory_tools.py
@@ -26,12 +26,14 @@ EXPECTED_NAMES = {
     "memory_export",
     # v1.18.3 (#predefined-merge-plugins): plugin discovery via MCP.
     "list_plugins",
+    # MCP tool-coverage pass: round-trips memory_export.
+    "memory_import",
 }
 
 
 def test_memory_tools_registered():
-    """MEMORY_TOOLS exposes the six tool definitions; names match frozenset."""
-    assert len(MEMORY_TOOLS) == 6
+    """MEMORY_TOOLS exposes the seven tool definitions; names match frozenset."""
+    assert len(MEMORY_TOOLS) == 7
     names = {t.name for t in MEMORY_TOOLS}
     assert names == EXPECTED_NAMES
     assert _MEMORY_TOOL_NAMES == frozenset(EXPECTED_NAMES)
@@ -162,4 +164,4 @@ def test_server_card_description_count():
     text = server_path.read_text(encoding="utf-8")
     match = re.search(r"(\d+) MCP tools", text)
     assert match is not None
-    assert int(match.group(1)) == 35
+    assert int(match.group(1)) == 54


### PR DESCRIPTION
## What

The MCP tool surface had fallen behind the CLI/core as the repo grew. This adds **11 tools** (43 → 54 registered) that wrap existing, already-tested capabilities so an LLM driving GoldenMatch can reach them — no new algorithms, mostly thin wrappers.

| Tool | Group | Wraps |
|---|---|---|
| `evaluate` | base | `core.evaluate.evaluate_clusters` — F1/precision/recall vs a ground-truth CSV |
| `analyze_blocking` | base | `core.block_analyzer.analyze_blocking` — block sizes, candidate-pair counts, est. recall |
| `compare_clusters` | base | `core.compare_clusters` — CCMS + Talburt-Wang Index between two cluster sets |
| `schema_match` | base | `core.schema_match.auto_map_columns` — auto column mapping across two files |
| `lineage` | base | `core.lineage.build_lineage` — field-level provenance for the loaded run |
| `list_runs` | base | `core.rollback.list_runs` |
| `rollback` | base | `core.rollback.rollback_run` (destructive: deletes a run's outputs) |
| `sensitivity` | agent | `core.sensitivity.run_sensitivity` — parameter-sweep stability |
| `incremental` | agent | new `core.incremental.run_incremental` — match new records vs a base |
| `identity_show` | identity | `identity.get_entity` — full detail of one entity |
| `memory_import` | memory | round-trips `memory_export` |

## Notable

- **`incremental` was inline in the CLI.** Extracted the logic to `core/incremental.run_incremental`; the CLI command and the new MCP tool now call the same function (no drift). CLI behavior unchanged.
- **The real count was already 43, not the advertised 35.** The server card had drifted. This corrects it to **54** and a test now pins the card count to the true number.
- New base tools that need a loaded dataset (`evaluate`, `analyze_blocking`, `lineage`) guard on it and return a structured error if absent; the file/store-based ones (`compare_clusters`, `schema_match`, `list_runs`, `rollback`) work standalone.

## Deliberately not added (not MCP-shaped)

Server lifecycle (`serve`/`serve-ui`/`watch`/`agent-serve`/`mcp-serve`/`setup`/`init`/`interactive`/`demo`/`schedule`/`sync`), `graph_er` (multi-table, stateful), `config save/load`, `label` (interactive TUI).

## Tests

- New `tests/test_mcp_new_tools.py`: registration (counts per group + total 54, no dup names) and a smoke test per new tool (incremental runs a real exact-email match; sensitivity wiring via error paths; identity_show + memory_import round-trips).
- Updated count assertions: identity 6→7, memory 6→7, server-card 35→54.
- Verified locally with `ruff` (clean) and `py_compile` (clean); full suite runs in CI per repo convention.

## Follow-up

User-facing doc counts (README / llms.txt / mcp.md) are handled in #744 (badge fix) and want a `35 → 54` bump once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)