### PR TITLE
docs: #509 native-direct UDFs — Mintlify site + context network

### DIFF
--- a/context-network/architecture/sql-native-extensions.md
+++ b/context-network/architecture/sql-native-extensions.md
@@ -1,0 +1,81 @@
+# SQL-Native Extensions (graph + embedding UDFs, native-direct)
+
+The warehouse-first SQL surface: GoldenMatch's graph kernels and the local embedder
+exposed as UDFs on **DuckDB, Postgres, and DataFusion**, computed **native-direct** —
+pure Rust, no embedded-CPython JSON bridge. The SQL sibling of the Python toolkit:
+the same entity-resolution primitives, callable from the warehouse.
+
+**Status:** SHIPPED — issue #509 fully delivered across three PRs (#740 graph half,
+#743 embed half, #745 DataFusion). **Spec:**
+`docs/superpowers/specs/2026-06-04-sql-native-graph-embed-udfs-design.md`. **Plan:**
+`docs/superpowers/plans/2026-06-04-sql-native-graph-embed-udfs.md`. **Decision:**
+[../decisions/0005-sql-native-direct-udfs.md](../decisions/0005-sql-native-direct-udfs.md).
+**Code-level notes:** `packages/rust/extensions/CLAUDE.md`.
+
+## The reframe (why #509 was a rework, not greenfield)
+PR #503 had already shipped all three UDFs — but as exactly the anti-pattern #509
+names: **JSON-in/JSON-out through the embedded-CPython bridge** (`pgrx → pyo3 →
+goldenmatch.native`) and `embed_local` over the Python in-house path. #509 replaced
+that placeholder with the native-direct contract. The pre-existing
+`goldenmatch_record_fingerprint` (pure-Rust, bridge-free) was the proven template.
+
+## The shared kernel: `graph-core`
+A new **pyo3-free** crate `packages/rust/extensions/graph-core` (mirrors the
+`score-core` / `fingerprint-core` precedent): `connected_components`,
+`dedup_pairs_max_score`, a first-seen `str↔i64` `Dict`, and Arrow columnar entry
+points. ONE source of truth consumed by all three surfaces:
+- the `native` pyo3 ext keeps thin `#[pyfunction]` shims delegating to it (+ a new
+  `connected_components_arrow`);
+- the pgrx `postgres` ext calls it directly in pure Rust;
+- the `datafusion-udf` FFI crate calls its **arrow-free slice kernels** (it is
+  arrow-58 while graph-core is arrow-55 — passing only `Vec`s sidesteps the mismatch).
+
+## The embedding kernel: `goldenmatch-embed` wheel
+`goldenmatch_embed_local` runs `goldenembed-rs` (the pyo3-free ONNX embed runtime,
+#508 — no network, no torch). A new maturin/abi3 wheel
+`packages/rust/extensions/embed-py` wraps it for Python (DuckDB), confining `ort`/ONNX
+to that one wheel and keeping `goldenembed` pyo3-free. Postgres + DataFusion call the
+`goldenembed` crate directly.
+
+## Per-surface contract (identical values, idiomatic encoding)
+
+| Function | DuckDB | Postgres | DataFusion |
+|---|---|---|---|
+| `goldenmatch_connected_components` | Arrow list cols → `BIGINT[][]` (+ `_str`) | `bigint[]`→`TABLE(component,member)` (+ `_str`) | FFI `List` cols → `List<List<Int64>>` |
+| `goldenmatch_pair_dedup` | list cols → `STRUCT(a,b,s)[]` (+ `_str`) | `bigint[]`→`TABLE(a,b,s)` (+ `_str`) | FFI → `List<Struct<a,b,s>>` |
+| `goldenmatch_embed_local` | `goldenmatch-embed` wheel → JSON array | `goldenembed` crate → `float8[]` | existing env-var `goldenmatch_embed` (see divergence) |
+
+- **Accept-both ids:** int64 on the bare name; strings on a `_str` sibling (first-seen
+  `Dict` maps `str↔i64` around the kernel). DuckDB rejects same-name overloading, so the
+  `_str` split is explicit on every surface for cross-backend name parity.
+- **Wire encoding is per-engine** (Arrow on DuckDB/DataFusion, native arrays/tables on
+  Postgres) — the *values* are identical, which is the lockstep contract (already true
+  for the older JSON-vs-table-returning functions).
+- **Versions:** `goldenmatch_pg` + `goldenmatch-duckdb` 0.5.0 → **0.6.0** (new handwritten
+  `sql/goldenmatch_pg--0.6.0.sql` + `--0.5.0--0.6.0.sql` upgrade; 0.5.0 was a released
+  tag so the bump was mandatory). `goldenmatch-embed` 0.1.0 + `goldenmatch-embed-v*`
+  publish workflow. `graph-core` is an internal path-dep crate.
+
+## Relationship to existing code
+- **Replaces** the #503 bridge graph/embed functions; the now-dead
+  `goldenmatch_bridge::api::{connected_components, pair_dedup, embed_local}` were removed.
+- **Parallels** `score-core` / `fingerprint-core` (the existing pyo3-free shared crates).
+- The graph kernels are the SQL-callable form of the Python `core/cluster.py` +
+  `core/pairs.py` primitives (behavior-exact ports, CI parity-gated).
+
+## Verification
+- **Local:** `graph-core` `cargo test` (pyo3-free, 7 tests); DuckDB graph + cross-backend
+  parity pytest (DuckDB value == native kernel).
+- **CI-only (Windows can't link `ort`/libclang):** Postgres PG 15/16/17 (`cargo pgrx` +
+  `CREATE EXTENSION` on the 0.6.0 surface + `pg_test`); `embed_wheel` lane (maturin build +
+  load/embed the `tiny_model` fixture + best-effort in-house cosine parity); the
+  datafusion FFI lane (`test_datafusion_ffi_udf.py`).
+
+## Known follow-ups (non-blocking, not part of #509 acceptance)
+- DataFusion `_str` (string-id) graph variants — int64-only this pass.
+- DataFusion embed name/arg lockstep: its `goldenmatch_embed` loads the model from
+  `GOLDENEMBED_MODEL_DIR` at construction, not a per-call `model_path` (doesn't fit a
+  construct-time-model ScalarUDF) — a documented divergence, not a gap.
+
+---
+**Classification:** architecture/shipped • **Last updated:** 2026-06-05

--- a/context-network/decisions/0005-sql-native-direct-udfs.md
+++ b/context-network/decisions/0005-sql-native-direct-udfs.md
@@ -1,0 +1,50 @@
+# 0005 — SQL graph + embedding UDFs go native-direct (replace the bridge)
+
+**Status:** accepted (2026-06-05, Ben) • **Spec:** `docs/superpowers/specs/2026-06-04-sql-native-graph-embed-udfs-design.md` • **Shipped:** PRs #740 / #743 / #745
+
+## Context
+Issue #509 asked for warehouse-first ER primitives in SQL: `connected_components` /
+`pair_dedup` over the native kernels (NOT the JSON-bridge round-trip) and
+`embed_local` over `goldenembed-rs` (no network). PR #503 had already shipped all
+three — but through the embedded-CPython JSON bridge, i.e. the exact thing the issue
+says to avoid. So #509 is a **rework of the placeholder into the native-direct
+contract**, with the existing pure-Rust `goldenmatch_record_fingerprint` as the
+proven template. Six scoping forks were put to Ben; he chose the ambitious option on
+each.
+
+## Decision
+1. **Native-direct, drop the bridge.** Graph fns call a new pyo3-free `graph-core`
+   crate; embed calls `goldenembed-rs` directly. No embedded CPython on the
+   Postgres/DataFusion path. The dead `bridge::api` fns are deleted.
+2. **One shared kernel (`graph-core`),** mirroring `score-core` — consumed by the
+   `native` pyo3 shims, the pgrx ext, and the DataFusion FFI crate.
+3. **Arrow where it's free, native arrays where it isn't.** Columnar Arrow I/O on
+   DuckDB + DataFusion; native PG arrays on Postgres. Same kernel, identical values.
+4. **Accept-both ids** — int64 fast path + string `_str` siblings (first-seen
+   `str↔i64` dictionary). Separate names because DuckDB rejects same-name overloading.
+5. **New `goldenmatch-embed` wheel** for the DuckDB embed path — a thin pyo3 wrapper
+   over `goldenembed`, keeping that crate pyo3-free and confining `ort`/ONNX to one wheel.
+6. **Clean break + DataFusion expansion** — the #503 JSON-string signatures are
+   replaced in place (0.5.0→0.6.0), and DataFusion is added as a third Arrow-native
+   surface beyond #509's named DuckDB+Postgres.
+
+## Consequences / honest flags
+- **CI-only verification** for most of it (Windows can't link `ort`/libclang) — the
+  graph half is locally testable, the embed + DataFusion halves are CI-gated.
+- **Per-engine wire shapes diverge** (Arrow vs PG arrays/tables; PG embed returns
+  `float8[]` while DuckDB returns JSON). Values are identical — that's the contract.
+- **DuckDB embed now needs the optional `goldenmatch-embed` wheel + `onnx`** (the
+  model's `model.onnx` export is onnx-gated); the happy-path test `importorskip`s both.
+- **DataFusion embed keeps its env-var construct-time model** (`goldenmatch_embed`),
+  not a per-call `model_path` — a documented divergence, not full lockstep.
+
+## Alternatives not taken
+- Keep the #503 JSON bridge (declined — it's the anti-pattern #509 names).
+- DuckDB embed via the Python in-house path instead of a goldenembed-rs wheel
+  (declined — chose true single-kernel lockstep across surfaces).
+- Uniform Arrow on both backends incl. a PG Arrow↔array bridge (declined — PG isn't
+  columnar; native arrays for zero real gain).
+- DuckDB + Postgres only (declined — added DataFusion as the third surface).
+
+---
+**Classification:** decision/accepted • **Last updated:** 2026-06-05

--- a/context-network/discovery.md
+++ b/context-network/discovery.md
@@ -10,12 +10,14 @@ links rather than reading everything.
 ## Architecture (active technical knowledge)
 - [architecture/datafusion-spine.md](architecture/datafusion-spine.md) — the embedded-DataFusion "scale mode" spine (Stages A-E); current status + entry points.
 - [architecture/sail-tier.md](architecture/sail-tier.md) — the distributed Sail-native tier (Spark Connect) that replaces Ray; specced, build not started.
+- [architecture/sql-native-extensions.md](architecture/sql-native-extensions.md) — graph + embedding UDFs on DuckDB/Postgres/DataFusion, native-direct (shared `graph-core` + `goldenembed-rs`); SHIPPED (#509).
 
 ## Decisions (records with no other home)
 - [decisions/0001-gate-reframe-engine-portability.md](decisions/0001-gate-reframe-engine-portability.md) — retire one-box RSS as the gate; engine portability is the destination.
 - [decisions/0002-scale-mode-contract.md](decisions/0002-scale-mode-contract.md) — `mode={standard,scale}`, opt-in, semantically-correct-not-bit-identical.
 - [decisions/0003-stage-e-spill-honest-null.md](decisions/0003-stage-e-spill-honest-null.md) — one-box spill-survival does not bind (the UF island); default stays opt-in.
 - [decisions/0004-sail-tier-scope.md](decisions/0004-sail-tier-scope.md) — Sail tier: full, buildable, Sail-native, replaces Ray; WCC-on-Sail is the gate.
+- [decisions/0005-sql-native-direct-udfs.md](decisions/0005-sql-native-direct-udfs.md) — SQL graph + embed UDFs go native-direct (drop the CPython bridge); shared `graph-core`, accept-both ids, embed wheel, 3 surfaces.
 
 ## Processes (how work is done here)
 - [processes/development-workflow.md](processes/development-workflow.md) — spec → plan → execute → review → CI → merge, plus the hard environment constraints.
@@ -28,4 +30,4 @@ links rather than reading everything.
 - [meta/maintenance.md](meta/maintenance.md) — how to keep nodes accurate and small.
 
 ---
-**Classification:** navigation • **Last updated:** 2026-06-03
+**Classification:** navigation • **Last updated:** 2026-06-05

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,21 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-06-05 — SQL-native graph + embedding UDFs shipped (#509, all 3 PRs)
+- #509 fully delivered across PRs #740 (graph half — DuckDB + Postgres), #743 (embed
+  half — `goldenmatch-embed` wheel + repoint + bridge cleanup), #745 (DataFusion FFI
+  graph UDFs). The graph + embed SQL surface is now **native-direct** (pure-Rust
+  `graph-core` + `goldenembed-rs`, no embedded-CPython JSON bridge) across all three
+  backends; the #503 bridge placeholder + its dead `bridge::api` fns are gone.
+- New nodes: [../architecture/sql-native-extensions.md](../architecture/sql-native-extensions.md),
+  [../decisions/0005-sql-native-direct-udfs.md](../decisions/0005-sql-native-direct-udfs.md).
+  Noted the adjacent SQL surface in [../planning/roadmap.md](../planning/roadmap.md).
+- New crates/packages: `graph-core` (pyo3-free shared kernel), `goldenmatch-embed`
+  (maturin wheel over goldenembed-rs). `goldenmatch_pg` + `goldenmatch-duckdb` bumped
+  0.5.0→0.6.0 (new handwritten SQL surface + upgrade script). Spec/plan:
+  `docs/superpowers/specs/2026-06-04-sql-native-graph-embed-udfs-design.md`,
+  `docs/superpowers/plans/2026-06-04-sql-native-graph-embed-udfs.md`.
+
 ## 2026-06-04 — Sail tier S4 harness shipped (buildable tier COMPLETE)
 - S4 harness merged (PR #717): chain-robust O(log n) WCC via pointer-jumping (the blind
   large-star/small-star attempt was wrong, caught by plan-review hand-trace + replaced),
@@ -50,4 +65,4 @@ Newest first. One entry per meaningful change to the network.
 - Committed to git on branch `chore/context-network`.
 
 ---
-**Classification:** meta/log • **Last updated:** 2026-06-03
+**Classification:** meta/log • **Last updated:** 2026-06-05

--- a/context-network/planning/roadmap.md
+++ b/context-network/planning/roadmap.md
@@ -47,10 +47,18 @@ Spec: `docs/superpowers/specs/2026-06-03-sail-tier-design.md`. Staged, each a ga
 - **Fix the pre-existing empty/all-singleton `run_spine` SchemaError** (frames-out tail,
   null vs i64 join key) — flagged during Stage D, out of scope there.
 
+## Adjacent — SQL-native extensions surface (SHIPPED 2026-06-05)
+Not part of the scale arc, but the same Arrow-native theme: the graph + embedding
+UDFs went **native-direct** (no CPython bridge) across DuckDB, Postgres, and DataFusion
+via a shared pyo3-free `graph-core` kernel + a `goldenmatch-embed` wheel over
+`goldenembed-rs` (#509; PRs #740/#743/#745). See
+[../architecture/sql-native-extensions.md](../architecture/sql-native-extensions.md) +
+[../decisions/0005-sql-native-direct-udfs.md](../decisions/0005-sql-native-direct-udfs.md).
+
 ## Related larger arcs (in `packages/python/goldenmatch/CLAUDE.md`)
 - The Splink-Spark parity roadmap (Ray Phases 1-6) — distributed loader → controller →
   clustering → golden → multi-node → identity. Mostly plumbing-complete, gated behind
   `GOLDENMATCH_ENABLE_DISTRIBUTED_RAY=1`.
 
 ---
-**Classification:** planning/active • **Last updated:** 2026-06-03
+**Classification:** planning/active • **Last updated:** 2026-06-05

--- a/docs-site/extensions/sql.mdx
+++ b/docs-site/extensions/sql.mdx
@@ -85,6 +85,75 @@ Registered UDFs:
 | `goldenmatch_match_tables(target, ref, config)` | Match two tables. |
 | `goldenmatch_dedupe(json, config)` | Deduplicate JSON records directly. |
 | `goldenmatch_match(target_json, ref_json, config)` | Match two JSON record sets. |
+| `goldenmatch_connected_components(...)` | Group a candidate-pair graph into entities. |
+| `goldenmatch_pair_dedup(...)` | Keep the best score per canonical pair. |
+| `goldenmatch_embed_local(text, model_path)` | Embed text with a local in-house model. |
+
+## Graph and embedding kernels
+
+These run native-direct in pure Rust, with no CPython round-trip. They expose GoldenMatch's clustering primitives and the local embedder directly in SQL, on both backends (and as DataFusion FFI UDFs). One shared kernel backs all surfaces, so results are identical across them.
+
+### Connected components and pair dedupe
+
+`goldenmatch_connected_components` groups a candidate-pair graph into entities, one component per entity, with singletons included. `goldenmatch_pair_dedup` canonicalizes a candidate-pair set and keeps the best score per pair. Both take the edge columns as lists. Pass integer record ids to the bare name, or string ids to the `_str` sibling.
+
+<CodeGroup>
+
+```sql DuckDB
+-- Components over an edge set plus the id universe
+SELECT goldenmatch_connected_components(
+  (SELECT list(id_a) FROM edges),
+  (SELECT list(id_b) FROM edges),
+  (SELECT list(score) FROM edges),
+  (SELECT list(id) FROM records)
+);  -- [[id, ...], ...]
+
+-- Canonical max-score pairs
+SELECT goldenmatch_pair_dedup(
+  (SELECT list(id_a) FROM pairs),
+  (SELECT list(id_b) FROM pairs),
+  (SELECT list(score) FROM pairs)
+);  -- [{a, b, s}, ...]
+
+-- String record ids use the _str variants
+SELECT goldenmatch_connected_components_str(
+  ['a', 'b'], ['b', 'c'], [0.9, 0.8], ['a', 'b', 'c', 'd']
+);
+```
+
+```sql PostgreSQL
+-- Components: returns (component, member) rows
+SELECT * FROM goldenmatch.goldenmatch_connected_components(
+  ARRAY[1, 2], ARRAY[2, 3], ARRAY[0.9, 0.8], ARRAY[1, 2, 3, 4]
+);
+
+-- Canonical max-score pairs: returns (a, b, s) rows
+SELECT * FROM goldenmatch.goldenmatch_pair_dedup(
+  ARRAY[2, 1], ARRAY[1, 2], ARRAY[0.5, 0.9]
+);
+```
+
+</CodeGroup>
+
+### Local embedding
+
+`goldenmatch_embed_local` embeds text with a saved in-house model through the `goldenembed` ONNX runtime. No network and no API key. `model_path` is a directory holding `config.json` and `model.onnx`.
+
+<CodeGroup>
+
+```sql DuckDB
+SELECT goldenmatch_embed_local('John Smith', '/path/to/model');  -- JSON float array
+```
+
+```sql PostgreSQL
+SELECT goldenmatch.goldenmatch_embed_local('John Smith', '/path/to/model');  -- double precision[]
+```
+
+</CodeGroup>
+
+<Note>
+  The DuckDB embedding UDF needs the optional embed runtime: `pip install goldenmatch-duckdb[embed]`.
+</Note>
 
 ## Requirements
 
@@ -94,5 +163,5 @@ Registered UDFs:
 - PostgreSQL 15, 16, or 17 (Postgres extension)
 
 <Note>
-  The extension embeds CPython through pyo3 and calls the GoldenMatch Python API, so the matching the extension performs is identical to the Python package.
+  The scoring and table operations embed CPython through pyo3 and call the GoldenMatch Python API, so they match the Python package exactly. The graph and embedding kernels run native-direct in pure Rust with no CPython, sharing one kernel across DuckDB, PostgreSQL, and DataFusion.
 </Note>

--- a/packages/python/goldenmatch/docs/sql-duckdb.md
+++ b/packages/python/goldenmatch/docs/sql-duckdb.md
@@ -164,6 +164,39 @@ SELECT * FROM goldenmatch_get_pairs('job_id');
 SELECT goldenmatch_job_status('job_id');
 ```
 
+### Native graph kernels + local embedding (v0.6.0)
+
+Native-direct UDFs over the Rust kernels — no Python round-trip. The graph UDFs take the
+candidate-pair / edge columns as lists (aggregate with `list(...)`) and accept either
+integer record ids (the bare name) or string ids (the `_str` sibling).
+
+```sql
+-- Canonical max-score pairs (dedupe a candidate-pair set, keep the best score per pair)
+SELECT goldenmatch_pair_dedup(
+  (SELECT list(id_a) FROM pairs),
+  (SELECT list(id_b) FROM pairs),
+  (SELECT list(score) FROM pairs)
+);  -- -> [{a, b, s}, ...]
+
+-- Connected components over an edge set + the id universe (singletons included)
+SELECT goldenmatch_connected_components(
+  (SELECT list(id_a) FROM edges),
+  (SELECT list(id_b) FROM edges),
+  (SELECT list(score) FROM edges),
+  (SELECT list(id) FROM records)
+);  -- -> [[id, ...], ...]   (one list per entity)
+
+-- String record ids: use the _str variants
+SELECT goldenmatch_connected_components_str([ 'a','b' ], [ 'b','c' ], [0.9, 0.8], [ 'a','b','c','d' ]);
+
+-- Local embedding via goldenembed-rs (no network). model_path is a saved in-house
+-- model dir (config.json + model.onnx). Requires `pip install goldenmatch-duckdb[embed]`.
+SELECT goldenmatch_embed_local('John Smith', '/path/to/model');  -- -> JSON float array
+```
+
+The same functions are available on Postgres (`goldenmatch.goldenmatch_*`, table-returning;
+embed returns `double precision[]`) and as DataFusion FFI UDFs — same kernels, identical values.
+
 ### Utility functions
 
 ```sql


### PR DESCRIPTION
Documents #509 (SQL-native graph + embedding UDFs, shipped #740/#743/#745) across the docs surfaces.

## Mintlify site (docs-site/)
- `extensions/sql.mdx` — new "Graph and embedding kernels" section: `goldenmatch_connected_components` / `goldenmatch_pair_dedup` / `goldenmatch_embed_local` (+ `_str` variants), with DuckDB + PostgreSQL `<CodeGroup>` examples and the `goldenmatch-duckdb[embed]` note. Extended the registered-UDFs table. Corrected the closing `<Note>` (graph + embed kernels are native-direct pure Rust, not the CPython bridge). `mint validate` passes.

## Context network (context-network/)
- New `architecture/sql-native-extensions.md` + `decisions/0005-sql-native-direct-udfs.md`; indexed in `discovery.md`; entry in `meta/updates.md`; adjacent note in `planning/roadmap.md`.

## Legacy Jekyll docs (docs/)
- `packages/python/goldenmatch/docs/sql-duckdb.md` also updated for parity (in case that tree is still published alongside Mintlify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)