### PR TITLE
feat(a2a): add 12 skills for MCP parity (19 -> 31)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/a2a/server.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/server.py
@@ -164,6 +164,93 @@ _SKILLS = [
         "inputModes": ["application/json"],
         "outputModes": ["application/json"],
     },
+    # MCP tool-coverage parity pass: high-level capabilities that had no A2A
+    # skill. Most delegate to the matching MCP dispatch (same JSON contract,
+    # mirroring how the identity_* skills already reuse MCP).
+    {
+        "id": "evaluate",
+        "name": "Evaluate",
+        "description": "Score matching accuracy (precision/recall/F1) against a ground-truth pair CSV. Auto-configures if no config is supplied.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "analyze_blocking",
+        "name": "Analyze Blocking",
+        "description": "Rank blocking-key candidates for a file: block counts, max block size, candidate-pair totals, estimated recall.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "compare_clusters",
+        "name": "Compare Clusters",
+        "description": "Compare two ER clustering outcomes (CCMS): unchanged/merged/partitioned/overlapping + Talburt-Wang Index. Inputs are two cluster JSON files.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "schema_match",
+        "name": "Schema Match",
+        "description": "Auto-map columns between two files with different schemas (synonym + name similarity), with confidence scores.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "sensitivity",
+        "name": "Sensitivity",
+        "description": "Sweep config parameters across a range and report clustering stability (CCMS unchanged %) at each value.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "incremental",
+        "name": "Incremental Match",
+        "description": "Match a batch of new records against an existing base dataset; returns matched (new, base) pairs plus counts.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "identity_show",
+        "name": "Identity Show",
+        "description": "Fetch the full detail of one identity by entity_id (records, evidence edges, recent events).",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "list_runs",
+        "name": "List Runs",
+        "description": "List previous dedupe/match runs from the run log (for rollback).",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "rollback",
+        "name": "Rollback",
+        "description": "Undo a previous run by deleting its output files (looked up by run_id). Destructive.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "list_corrections",
+        "name": "List Corrections",
+        "description": "Page through stored Learning Memory corrections, optionally filtered by dataset.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "learn_thresholds",
+        "name": "Learn Thresholds",
+        "description": "Run the MemoryLearner over stored corrections and return the per-matchkey threshold adjustments.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "memory_stats",
+        "name": "Memory Stats",
+        "description": "Correction counts, last-learned timestamps, and current learned adjustments from the Learning Memory store.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
 ]
 
 

--- a/packages/python/goldenmatch/goldenmatch/a2a/skills.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/skills.py
@@ -248,6 +248,7 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
     if skill_id in {
         "identity_resolve", "identity_list", "identity_history",
         "identity_conflicts", "identity_merge", "identity_split",
+        "identity_show",
     }:
         from goldenmatch.mcp.identity_tools import _dispatch as _identity_dispatch
         # Reuse MCP dispatch since the contract is identical (JSON in/out).
@@ -349,6 +350,69 @@ def dispatch_skill(skill_id: str, params: dict) -> dict:
             result["id_a"] = correction.id_a
             result["id_b"] = correction.id_b
         return result
+
+    # ── MCP tool-coverage parity ──────────────────────────────────────────────
+    # Reuse the MCP dispatch where the JSON contract is identical (same pattern
+    # as the identity_* skills above). File-based analysis skills that depend on
+    # MCP's loaded-dataset state are implemented directly instead.
+    if skill_id in {"compare_clusters", "schema_match", "list_runs", "rollback"}:
+        from goldenmatch.mcp.server import _handle_tool
+        return _handle_tool(skill_id, params)
+
+    if skill_id in {"sensitivity", "incremental"}:
+        from goldenmatch.mcp.agent_tools import _dispatch as _agent_dispatch
+        return _agent_dispatch(skill_id, params, AgentSession)
+
+    if skill_id in {"list_corrections", "learn_thresholds", "memory_stats"}:
+        from goldenmatch.mcp.memory_tools import _dispatch as _memory_dispatch
+        return _memory_dispatch(skill_id, params)
+
+    if skill_id == "evaluate":
+        from goldenmatch._api import evaluate as _evaluate
+
+        fp = params["file_path"]
+        cfg = params.get("config")
+        if not cfg:
+            from pathlib import Path as _Path
+
+            from goldenmatch.core.autoconfig import auto_configure
+            cfg = auto_configure([(fp, _Path(fp).stem)])
+        return _evaluate(
+            fp,
+            config=cfg,
+            ground_truth=params["ground_truth"],
+            col_a=params.get("col_a", "id_a"),
+            col_b=params.get("col_b", "id_b"),
+        )
+
+    if skill_id == "analyze_blocking":
+        from dataclasses import asdict
+        from pathlib import Path as _Path
+
+        import polars as pl
+
+        from goldenmatch.core.block_analyzer import analyze_blocking
+
+        fp = params["file_path"]
+        cfg = params.get("config")
+        if cfg:
+            from goldenmatch.config.loader import load_config
+            cfg = load_config(cfg) if isinstance(cfg, str) else cfg
+        else:
+            from goldenmatch.core.autoconfig import auto_configure
+            cfg = auto_configure([(fp, _Path(fp).stem)])
+        df = pl.read_csv(fp, encoding="utf8-lossy", ignore_errors=True)
+        cols = sorted({f.field for mk in cfg.get_matchkeys() for f in mk.fields if f.field})
+        suggestions = analyze_blocking(
+            df, cols,
+            sample_size=int(params.get("sample_size", 1000)),
+            target_block_size=int(params.get("target_block_size", 5000)),
+        )
+        limit = int(params.get("limit", 10))
+        return {
+            "matchkey_columns": cols,
+            "suggestions": [asdict(s) for s in suggestions[:limit]],
+        }
 
     raise ValueError(f"Unknown skill: {skill_id}")
 

--- a/packages/python/goldenmatch/tests/test_a2a.py
+++ b/packages/python/goldenmatch/tests/test_a2a.py
@@ -33,14 +33,14 @@ def test_agent_card_has_required_fields():
     assert card["authentication"]["schemes"] == ["bearer"]
 
 
-def test_agent_card_has_19_skills():
+def test_agent_card_has_31_skills():
     """v1.7-v1.12 added autoconfig+controller_telemetry (10->12); v2.0 added
     six identity_* skills (12->18); v1.19.x Phase 3 added add_correction
-    (18->19)."""
+    (18->19); the MCP tool-coverage parity pass added 12 (19->31)."""
     from goldenmatch.a2a.server import build_agent_card
 
     card = build_agent_card("http://localhost:8080")
-    assert len(card["skills"]) == 19
+    assert len(card["skills"]) == 31
     ids = {s["id"] for s in card["skills"]}
     assert "autoconfig" in ids
     assert "controller_telemetry" in ids
@@ -48,6 +48,12 @@ def test_agent_card_has_19_skills():
     assert {
         "identity_resolve", "identity_list", "identity_history",
         "identity_conflicts", "identity_merge", "identity_split",
+    } <= ids
+    # MCP tool-coverage parity pass.
+    assert {
+        "evaluate", "analyze_blocking", "compare_clusters", "schema_match",
+        "sensitivity", "incremental", "identity_show", "list_runs", "rollback",
+        "list_corrections", "learn_thresholds", "memory_stats",
     } <= ids
 
 
@@ -152,6 +158,142 @@ def test_dispatch_unknown_skill():
 
     with pytest.raises(ValueError, match="Unknown skill"):
         dispatch_skill("nonexistent_skill", {})
+
+
+# ── MCP tool-coverage parity skills ───────────────────────────────────────────
+
+
+def _exact_email_cfg(tmp_path) -> str:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "matchkeys:\n"
+        "  - name: exact_email\n"
+        "    type: exact\n"
+        "    fields:\n"
+        "      - field: email\n"
+        "        transforms: [lowercase, strip]\n"
+    )
+    return str(cfg)
+
+
+def test_dispatch_compare_clusters(tmp_path):
+    import json
+
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    a.write_text(json.dumps({"0": {"members": [0, 1, 2]}}))
+    b.write_text(json.dumps({"0": {"members": [0, 1]}, "1": {"members": [2]}}))
+    result = dispatch_skill("compare_clusters", {
+        "clusters_a_path": str(a), "clusters_b_path": str(b),
+    })
+    assert "twi" in result
+    assert result["cc1"] == 1 and result["cc2"] == 2
+
+
+def test_dispatch_schema_match(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    fa = tmp_path / "a.csv"
+    fb = tmp_path / "b.csv"
+    fa.write_text("full_name,email\nJohn,j@x.com\n")
+    fb.write_text("contact_name,email_address\nJohn,j@x.com\n")
+    result = dispatch_skill("schema_match", {"file_a": str(fa), "file_b": str(fb)})
+    assert isinstance(result["mappings"], list)
+    assert len(result["mappings"]) >= 1
+
+
+def test_dispatch_list_runs_and_rollback(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    assert dispatch_skill("list_runs", {"output_dir": str(tmp_path)})["runs"] == []
+    assert "error" in dispatch_skill("rollback", {"run_id": "nope", "output_dir": str(tmp_path)})
+
+
+def test_dispatch_evaluate(tmp_path):
+    import csv
+
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    data = tmp_path / "data.csv"
+    with open(data, "w", newline="") as fp:
+        w = csv.writer(fp)
+        w.writerow(["name", "email"])
+        w.writerow(["John Smith", "john@x.com"])
+        w.writerow(["Jon Smith", "john@x.com"])
+    gt = tmp_path / "gt.csv"
+    with open(gt, "w", newline="") as fp:
+        w = csv.writer(fp)
+        w.writerow(["id_a", "id_b"])
+        w.writerow([0, 1])
+    result = dispatch_skill("evaluate", {
+        "file_path": str(data), "config": _exact_email_cfg(tmp_path), "ground_truth": str(gt),
+    })
+    assert "f1" in result and "precision" in result
+
+
+def test_dispatch_incremental(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    base = tmp_path / "base.csv"
+    new = tmp_path / "new.csv"
+    base.write_text("name,email\nJohn Smith,john@x.com\nJane Doe,jane@x.com\n")
+    new.write_text("name,email\nJohnny Smith,john@x.com\nBob New,bob@x.com\n")
+    result = dispatch_skill("incremental", {
+        "base_file": str(base), "new_records": str(new), "config": _exact_email_cfg(tmp_path),
+    })
+    assert result["matched_to_base"] == 1
+    assert result["new_entities"] == 1
+
+
+def test_dispatch_analyze_blocking(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    data = tmp_path / "data.csv"
+    data.write_text("name,email\nA,a@x.com\nB,b@x.com\n")
+    result = dispatch_skill("analyze_blocking", {
+        "file_path": str(data), "config": _exact_email_cfg(tmp_path),
+    })
+    assert "suggestions" in result
+    assert isinstance(result["suggestions"], list)
+
+
+def test_dispatch_sensitivity_requires_sweep(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    data = tmp_path / "data.csv"
+    data.write_text("name,email\nA,a@x.com\n")
+    result = dispatch_skill("sensitivity", {
+        "file_path": str(data), "sweep": [], "config": _exact_email_cfg(tmp_path),
+    })
+    assert "error" in result
+
+
+def test_dispatch_identity_show(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+    from goldenmatch.identity import IdentityNode, IdentityStore, SourceRecord, new_entity_id
+
+    path = str(tmp_path / "identity.db")
+    eid = new_entity_id()
+    with IdentityStore(path=path) as s:
+        s.upsert_identity(IdentityNode(entity_id=eid, dataset="d", confidence=0.9))
+        s.upsert_record(SourceRecord("src:1", "src", "1", "h1", entity_id=eid, dataset="d"))
+    result = dispatch_skill("identity_show", {"entity_id": eid, "path": path})
+    assert result.get("entity_id") == eid
+
+
+def test_dispatch_memory_loop(tmp_path):
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    path = str(tmp_path / "memory.db")
+    dispatch_skill("add_correction", {
+        "decision": "reject", "id_a": 1, "id_b": 2, "dataset": "ds1", "path": path,
+    })
+    listed = dispatch_skill("list_corrections", {"path": path, "dataset": "ds1"})
+    assert listed["count"] == 1
+    stats = dispatch_skill("memory_stats", {"path": path})
+    assert stats["total_corrections"] == 1
 
 
 def test_agent_card_has_quality_and_transform_skills():


### PR DESCRIPTION
## What

Mirrors the MCP tool-coverage pass (#746) on the **A2A** surface. A2A is coarser than MCP by design (task-level, not inspection-level), so this adds the high-level capabilities that had **no A2A skill at all** — reusing the MCP dispatch where the JSON contract is identical, exactly as the `identity_*` skills already do.

**12 new skills → 31:** `evaluate`, `analyze_blocking`, `compare_clusters`, `schema_match`, `sensitivity`, `incremental`, `identity_show`, `list_runs`, `rollback`, `list_corrections`, `learn_thresholds`, `memory_stats`.

| Wiring | Skills |
|---|---|
| → MCP `_handle_tool` | `compare_clusters`, `schema_match`, `list_runs`, `rollback` |
| → MCP agent `_dispatch` | `sensitivity`, `incremental` |
| → MCP memory `_dispatch` | `list_corrections`, `learn_thresholds`, `memory_stats` |
| → existing identity delegation set | `identity_show` |
| implemented directly (can't reuse MCP's loaded-dataset tools) | `evaluate` (`gm.evaluate`, auto-configs), `analyze_blocking` (`auto_configure` + `core.block_analyzer`) |

## Deferred (with reason)

- `lineage` — needs the pipeline's `scored_pairs`/frame, which A2A's serialized results don't carry. It's an inspection feature; MCP/CLI are the right home.
- `memory_export` / `memory_import` — bulk JSON transfer isn't an A2A fit (A2A already has `add_correction` for the write path).

## Tests

`test_agent_card_has_31_skills` (count + new ids) plus dispatch smoke tests per new skill. Explicit exact-email configs keep the pipeline-running ones (`evaluate`, `incremental`, `analyze_blocking`) hermetic for offline CI.

## ⚠️ Stacked on #746

10 of the 12 skills delegate to the MCP tools added in **#746**. This PR is based on `feat/mcp-tool-coverage`. **Merge #746 first**, then this. (If #746 is squash-merged with `--delete-branch`, this PR auto-closes per the known stacked-PR footgun — recover by rebasing onto `main` and reopening.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)