### PR TITLE
chore: download/usage badges for the 4 missing PyPI packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 [![DBLP-ACM F1](https://img.shields.io/badge/DBLP--ACM%20F1-97.2%25-d4a017)](packages/python/goldenmatch/README.md#benchmarks)
 
 <!-- Reach -->
-[![PyPI downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fpypi-downloads.json)](https://pepy.tech/projects?q=goldenmatch+goldencheck+goldenpipe+goldenflow+infermap+goldencheck-types)
+[![PyPI downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fpypi-downloads.json)](https://pepy.tech/projects?q=goldenmatch+goldencheck+goldenpipe+goldenflow+infermap+goldencheck-types+goldensuite-mcp+goldenmatch-duckdb+goldenmatch-native+goldenmatch-embed)
 [![npm downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fnpm-downloads.json)](https://www.npmjs.com/~benzsevern)
 [![GitHub stars](https://img.shields.io/github/stars/benseverndev-oss/goldenmatch?style=flat&color=d4a017&logo=github)](https://github.com/benseverndev-oss/goldenmatch/stargazers)
 

--- a/docs-site/extensions/sql.mdx
+++ b/docs-site/extensions/sql.mdx
@@ -6,6 +6,11 @@ keywords: ["postgres", "duckdb", "sql", "extension", "pgrx", "udf"]
 
 The `goldenmatch-extensions` package runs GoldenMatch directly from SQL, without leaving the database. It ships a pgrx-based PostgreSQL extension and a DuckDB UDF package.
 
+[![goldenmatch-duckdb on PyPI](https://img.shields.io/pypi/v/goldenmatch-duckdb?label=pypi%3A%20goldenmatch-duckdb&color=d4a017&logo=pypi&logoColor=white)](https://pypi.org/project/goldenmatch-duckdb/)
+[![goldenmatch-duckdb downloads](https://img.shields.io/pypi/dm/goldenmatch-duckdb?label=downloads/mo&color=2ea44f)](https://pypi.org/project/goldenmatch-duckdb/)
+[![goldenmatch-embed on PyPI](https://img.shields.io/pypi/v/goldenmatch-embed?label=pypi%3A%20goldenmatch-embed&color=d4a017&logo=pypi&logoColor=white)](https://pypi.org/project/goldenmatch-embed/)
+[![goldenmatch_pg release](https://img.shields.io/github/v/release/benseverndev-oss/goldenmatch?filter=goldenmatch-pg-v*&label=release%3A%20goldenmatch_pg&color=336791&logo=postgresql&logoColor=white)](https://github.com/benseverndev-oss/goldenmatch/releases?q=goldenmatch-pg)
+
 ## PostgreSQL
 
 ### Install

--- a/packages/rust/extensions/duckdb/README.md
+++ b/packages/rust/extensions/duckdb/README.md
@@ -1,5 +1,9 @@
 # goldenmatch-duckdb
 
+[![PyPI](https://img.shields.io/pypi/v/goldenmatch-duckdb?color=d4a017&logo=pypi&logoColor=white)](https://pypi.org/project/goldenmatch-duckdb/)
+[![Downloads](https://img.shields.io/pypi/dm/goldenmatch-duckdb?color=2ea44f)](https://pypi.org/project/goldenmatch-duckdb/)
+[![Python](https://img.shields.io/pypi/pyversions/goldenmatch-duckdb?logo=python&logoColor=white)](https://pypi.org/project/goldenmatch-duckdb/)
+
 GoldenMatch entity resolution functions for DuckDB.
 
 ```bash

--- a/packages/rust/extensions/embed-py/README.md
+++ b/packages/rust/extensions/embed-py/README.md
@@ -1,5 +1,9 @@
 # goldenmatch-embed
 
+[![PyPI](https://img.shields.io/pypi/v/goldenmatch-embed?color=d4a017&logo=pypi&logoColor=white)](https://pypi.org/project/goldenmatch-embed/)
+[![Downloads](https://img.shields.io/pypi/dm/goldenmatch-embed?color=2ea44f)](https://pypi.org/project/goldenmatch-embed/)
+[![Python](https://img.shields.io/pypi/pyversions/goldenmatch-embed?logo=python&logoColor=white)](https://pypi.org/project/goldenmatch-embed/)
+
 Local ONNX embedder for [GoldenMatch](https://github.com/benseverndev-oss/goldenmatch)
 SQL UDFs, shipped as a standalone abi3 wheel.
 

--- a/scripts/suite_download_badges.py
+++ b/scripts/suite_download_badges.py
@@ -25,6 +25,14 @@ PYPI_PACKAGES = [
     "goldenflow",
     "infermap",
     "goldencheck-types",
+    "goldensuite-mcp",
+    # SQL extensions + the optional compiled/embed runtimes. `goldenmatch-native`
+    # (goldenmatch[native]) and `goldenmatch-embed` (goldenmatch-duckdb[embed]) are
+    # extras, so their downloads partially overlap their parent packages -- counted
+    # here because they are distinct distributions in the suite, same as the rest.
+    "goldenmatch-duckdb",
+    "goldenmatch-native",
+    "goldenmatch-embed",
 ]
 NPM_PACKAGES = [
     "goldenmatch",


### PR DESCRIPTION
The suite download-badge system tracked only 6 packages; an audit of every publishing `pyproject.toml` found **four** PyPI packages missing from it:

- `goldensuite-mcp`, `goldenmatch-native` — pre-existing gaps
- `goldenmatch-duckdb`, `goldenmatch-embed` — new from #509

## Changes
- **`scripts/suite_download_badges.py`** — add the four to `PYPI_PACKAGES` so the daily suite-total downloads badge reflects them (with a note that native/embed are extras that partially overlap their parents). The `update-download-badges.yml` workflow picks this up on its next run.
- **Per-package badges** — version + downloads (+ pyversions) on the DuckDB and embed package READMEs, and a badge row on the Mintlify `extensions/sql` page (PyPI version/downloads for duckdb + embed, and a GitHub-release badge for the non-PyPI `goldenmatch_pg` Postgres extension).
- **Root README** — extend the suite-downloads badge link to list the four new packages.

Correctly excluded: `goldenmatch-datafusion-udf` (`publish = false`), `goldenmatch-monorepo` (workspace root), `infermap-bench` (internal), `dbt-goldensuite` (no publish workflow).

Note: the new badges render empty until the packages are published (embed/duckdb publishing now) and pypistats/pepy index them (~1-2 day lag). `mint validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)