### PR TITLE
fix(embed): cross-platform goldenmatch-embed wheel build

### DIFF
--- a/.github/workflows/publish-goldenmatch-embed.yml
+++ b/.github/workflows/publish-goldenmatch-embed.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: "2_28"
+          # vendored OpenSSL (Linux-only, see embed-py/Cargo.toml) compiles from
+          # source and needs perl in the manylinux container.
+          before-script-linux: "command -v perl >/dev/null || dnf install -y perl-core || yum install -y perl-core"
           args: --release --out dist -m ${{ env.MANIFEST }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         with:
@@ -79,14 +82,16 @@ jobs:
 
   macos:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'goldenmatch-embed-v')
-    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile
-    # (Apple ships the x86_64 SDK slice). macos-13 (Intel) runners queue
-    # indefinitely in this org, so we don't depend on them.
+    # Apple Silicon only. `ort` ships NO prebuilt ONNX Runtime for
+    # x86_64-apple-darwin (Intel Macs), so that cross-compile cannot link
+    # without building ONNX from source -- not worth it for an EOL arch; those
+    # users fall back to the pure-Python in-house embedder. macos-13 (Intel)
+    # runners also queue indefinitely in this org.
     runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64, aarch64]
+        target: [aarch64]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:

--- a/packages/rust/extensions/embed-py/Cargo.toml
+++ b/packages/rust/extensions/embed-py/Cargo.toml
@@ -33,6 +33,16 @@ pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py31
 # that dependency is confined to this wheel by construction.
 goldenembed = { path = "../goldenembed" }
 
+# `ort`'s binary downloader pulls `openssl-sys` on Linux, but the minimal
+# manylinux build container has no system OpenSSL (and the aarch64 leg has no
+# target OpenSSL). Vendoring OpenSSL from source -- Linux ONLY -- fixes both
+# Linux wheels without disturbing the Windows / macOS-arm builds, which don't
+# hit this path. Cargo feature unification makes every transitive `openssl-sys`
+# in the tree build vendored. (Needs `perl` in the build env; the publish
+# workflow installs perl-core in the manylinux container.)
+[target.'cfg(target_os = "linux")'.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
+
 [profile.release]
 opt-level = 3
 lto = "thin"


### PR DESCRIPTION
The `goldenmatch-embed` v0.1.0 publish run failed (publish job skipped, nothing hit PyPI). Two distinct `ort` build problems:

- **Linux (x86_64 + aarch64):** `ort`'s binary downloader pulls `openssl-sys`, which the minimal manylinux container has no system OpenSSL for. Fix: vendor OpenSSL from source, scoped to `cfg(target_os = "linux")` so it only affects the Linux legs (Windows/macOS-arm, which build fine, are untouched), plus install `perl-core` in the manylinux container for the vendored build.
- **macOS x86_64:** `ort` ships no prebuilt ONNX Runtime for `x86_64-apple-darwin`. Fix: drop the Intel-Mac leg (aarch64 only); Intel-Mac users fall back to the pure-Python in-house embedder.

Windows, macOS-arm, and the sdist already built green and are unchanged.

## Test plan
Not locally buildable (`ort` won't link on Windows). After merge I'll re-run `publish-goldenmatch-embed.yml` from main (workflow_dispatch) and confirm all legs go green before cutting `goldenmatch-duckdb` + `goldenmatch-pg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)