### PR TITLE
fix(embed): install openssl-devel in manylinux for ort-sys build-dep

### DIFF
--- a/.github/workflows/publish-goldenmatch-embed.yml
+++ b/.github/workflows/publish-goldenmatch-embed.yml
@@ -51,9 +51,11 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: "2_28"
-          # vendored OpenSSL (Linux-only, see embed-py/Cargo.toml) compiles from
-          # source and needs perl in the manylinux container.
-          before-script-linux: "command -v perl >/dev/null || dnf install -y perl-core || yum install -y perl-core"
+          # ort-sys's build script downloads ONNX Runtime via a TLS client that
+          # needs system OpenSSL; the minimal manylinux_2_28 (AlmaLinux 8)
+          # container ships none. Install it (host arch in the emulated container,
+          # so it covers both x86_64 and the aarch64 leg).
+          before-script-linux: "dnf install -y openssl-devel || yum install -y openssl-devel"
           args: --release --out dist -m ${{ env.MANIFEST }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         with:

--- a/packages/rust/extensions/embed-py/Cargo.toml
+++ b/packages/rust/extensions/embed-py/Cargo.toml
@@ -33,15 +33,11 @@ pyo3 = { version = ">=0.23.3, <0.25", features = ["extension-module", "abi3-py31
 # that dependency is confined to this wheel by construction.
 goldenembed = { path = "../goldenembed" }
 
-# `ort`'s binary downloader pulls `openssl-sys` on Linux, but the minimal
-# manylinux build container has no system OpenSSL (and the aarch64 leg has no
-# target OpenSSL). Vendoring OpenSSL from source -- Linux ONLY -- fixes both
-# Linux wheels without disturbing the Windows / macOS-arm builds, which don't
-# hit this path. Cargo feature unification makes every transitive `openssl-sys`
-# in the tree build vendored. (Needs `perl` in the build env; the publish
-# workflow installs perl-core in the manylinux container.)
-[target.'cfg(target_os = "linux")'.dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
+# NOTE: `ort-sys`'s build script downloads the ONNX Runtime via a TLS client
+# that pulls `openssl-sys` as a BUILD-dependency. Resolver v2 does NOT propagate
+# a normal-dependency `openssl/vendored` feature into build-deps, so vendoring
+# from here does nothing -- the fix lives in the publish workflow, which installs
+# system `openssl-devel` into the manylinux build container.
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
Follow-up to #752. The vendored-OpenSSL approach was a no-op: `ort-sys`'s build script downloads ONNX Runtime via a TLS client that pulls `openssl-sys` as a **build-dependency**, and Cargo resolver v2 does not propagate a normal-dependency `vendored` feature into build-deps. So both linux legs still failed looking for system OpenSSL.

Fix: install system `openssl-devel` into the manylinux_2_28 (AlmaLinux 8) container via `before-script-linux` (covers x86_64 and the emulated aarch64 leg). Revert the ineffective vendored dep.

CI-only validation; after merge I re-run `publish-goldenmatch-embed.yml` from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)