### PR TITLE
fix(embed): apt fallback for OpenSSL on aarch64 cross image

### DIFF
--- a/.github/workflows/publish-goldenmatch-embed.yml
+++ b/.github/workflows/publish-goldenmatch-embed.yml
@@ -52,10 +52,15 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: "2_28"
           # ort-sys's build script downloads ONNX Runtime via a TLS client that
-          # needs system OpenSSL; the minimal manylinux_2_28 (AlmaLinux 8)
-          # container ships none. Install it (host arch in the emulated container,
-          # so it covers both x86_64 and the aarch64 leg).
-          before-script-linux: "dnf install -y openssl-devel || yum install -y openssl-devel"
+          # needs system OpenSSL (a host/build-dep). The x86_64 leg uses the
+          # AlmaLinux manylinux image (dnf/yum -> openssl-devel); the aarch64 leg
+          # uses the Debian-based rust-cross image (apt -> libssl-dev). Try each
+          # package manager so both containers are covered.
+          before-script-linux: |
+            if command -v dnf >/dev/null 2>&1; then dnf install -y openssl-devel pkgconfig
+            elif command -v yum >/dev/null 2>&1; then yum install -y openssl-devel pkgconfig
+            elif command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y libssl-dev pkg-config
+            fi
           args: --release --out dist -m ${{ env.MANIFEST }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         with:


### PR DESCRIPTION
Iteration 3. linux x86_64 builds green now; the aarch64 leg uses the Debian-based `rust-cross/manylinux_2_28-cross:aarch64` image where `dnf`/`yum` don't exist (exit 127). Make `before-script-linux` try dnf/yum/apt so both the AlmaLinux (x86_64) and Debian (aarch64) containers get system OpenSSL for ort-sys's downloader. Windows/macOS-arm/sdist/linux-x86_64 already green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)