### PR TITLE
fix(ci): remove duplicate permissions key in benchmarks.yml

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -40,8 +40,6 @@ permissions:
 
 jobs:
   benchmarks:
-    permissions:
-      contents: read
     # Datasets are gated behind repo VARS so a fork without dataset access
     # doesn't try to run and fail. Set vars.RUN_BENCHMARKS=true and provide
     # the dataset secrets/vars to enable; otherwise the workflow exits 0


### PR DESCRIPTION
## What
`benchmarks.yml` is startup-failing on **every push, including main** -- "This run likely failed because of a workflow file issue."

## Root cause
#741 (`fix(security): ... + 3 missed perms`) added a job-level `permissions: contents: read` to the `benchmarks` job, but that job **already had** a `permissions:` block a few lines down (`contents: read` + `actions: write`). Two `permissions:` keys on the same mapping is a duplicate YAML key, which GitHub's workflow parser rejects -> the run fails before any step starts.

## Fix
Drop the redundant block #741 added. The pre-existing block already grants `contents: read` and adds the `actions: write` the job needs for artifact upload, so #741's security intent is preserved.

Validated locally: the file parses with a duplicate-key-strict YAML loader, and `jobs.benchmarks.permissions == {contents: read, actions: write}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)