### PR TITLE
chore(deps): bump bridge pyo3 to >=0.24.1 (GHSA-pph8-gcv7-4qj5)

### DIFF
--- a/packages/rust/extensions/bridge/Cargo.toml
+++ b/packages/rust/extensions/bridge/Cargo.toml
@@ -7,9 +7,8 @@ authors.workspace = true
 description = "Python bridge for GoldenMatch SQL extensions"
 
 [dependencies]
-# Pinned to >=0.23.3 to exclude the vulnerable range
-# (GHSA: >= 0.23.0, < 0.23.3). Bumping to 0.24+ is a separate task — pyo3
-# 0.24 has API breaks that need migration; tracked in the Rust extensions
-# workstream.
-pyo3 = { version = ">=0.23.3, <0.24", features = ["auto-initialize"] }
+# Pinned to >=0.24.1 for the GHSA buffer-overflow fix in PyString::from_object
+# (affected range: >=0.23.0, <0.24.1). Upper bound <0.25 keeps us on the same
+# API line as the native crate.
+pyo3 = { version = ">=0.24.1, <0.25", features = ["auto-initialize"] }
 thiserror = "2"


### PR DESCRIPTION
Clears Dependabot alert 6: buffer overflow in `PyString::from_object` (GHSA-pph8-gcv7-4qj5, affected `>=0.23.0, <0.24.1`).

- `packages/rust/extensions/bridge/Cargo.toml`: `>=0.23.3, <0.24` -> `>=0.24.1, <0.25` (resolves to 0.24.2). Ceiling matches the native crate's range so the two crates track the same pyo3 minor.
- No src changes needed -- `cargo check` clean on 0.24.2 (two runs).
- `native/Cargo.lock` already resolves pyo3 0.24.1 -- untouched.
- No bridge lockfile in the diff because the extensions workspace `Cargo.lock` is intentionally gitignored (only `native/` and `goldenembed/` locks are carved out); the alert drives off the manifest range.

Verified locally with `cargo check` only (repo rule: no local cargo build/test); CI is the functional verifier.

Part 3/5 of the security-alerts remediation plan (docs/superpowers/plans/2026-06-05-security-alerts-remediation.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)