### PR TITLE
chore(release): goldenmatch v1.27.0 + goldenmatch_pg 0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1096,9 +1096,12 @@ jobs:
         run: |
           cargo pgrx install "--pg-config=/usr/lib/postgresql/${PG_VERSION}/bin/pg_config" --release --features "pg${PG_VERSION}" --no-default-features
           # pgrx 0.12.9 doesn't auto-emit the SQL extension file — copy the
-          # handwritten one into PG's extension dir so `CREATE EXTENSION`
-          # finds it. The schema file is the canonical declaration of
-          # public function signatures.
+          # handwritten ones into PG's extension dir so `CREATE EXTENSION`
+          # (installs default_version, now 0.7.0) and `ALTER EXTENSION ... UPDATE`
+          # find them. The schema files are the canonical declaration of public
+          # function signatures.
+          cp sql/goldenmatch_pg--0.7.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
+          cp sql/goldenmatch_pg--0.6.0--0.7.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.6.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.5.0--0.6.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
 

--- a/.github/workflows/publish-goldenmatch-pg.yml
+++ b/.github/workflows/publish-goldenmatch-pg.yml
@@ -101,6 +101,8 @@ jobs:
           # canonical SQL file there. Path layout: <PKG_DIR>/usr/share/postgresql/<N>/extension/
           EXT_DIR="${PKG_DIR}/usr/share/postgresql/${PG_VERSION}/extension"
           mkdir -p "${EXT_DIR}"
+          cp sql/goldenmatch_pg--0.7.0.sql "${EXT_DIR}/"
+          cp sql/goldenmatch_pg--0.6.0--0.7.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.6.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.5.0--0.6.0.sql "${EXT_DIR}/"
           echo "PKG_DIR=${PKG_DIR}" >> "$GITHUB_ENV"

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [1.27.0] - 2026-06-05
+
+### Fixed
+- **Distributed Phase-5 pipeline now honors an explicit config (#739).** `run_dedupe_pipeline_distributed(..., config=my_config)` previously dropped the `config` kwarg and forced `auto_configure_df`, so a hand-built config was ignored and a RED auto-config commit could crash the run. `allow_red_config` was likewise dropped. Both are now respected (`allow_red_config=True` is the documented escape hatch at scale, per the post-#715 contract).
+
+### Changed
+- **Auto-config admits high-cardinality identifiers to probabilistic matchkeys (#721).** `build_probabilistic_matchkeys` no longer skips `col_type="identifier"`, matching the exact path (#715). Identifiers become Fellegi-Sunter comparison fields with no lower cardinality floor (F-S self-regulates a weak identifier via its u/EM weight); only perfectly-unique surrogate keys (`cardinality_ratio >= 1.0`) are excluded, now uniformly across all exact-scorer fields.
+
+### Notes
+- The Postgres extension gains `gm_embed(text) -> real[]` (#737), released separately as `goldenmatch-pg` 0.7.0 (a cached, `GOLDENEMBED_MODEL_DIR`-based convenience over the in-house embedder, mirroring the DataFusion `goldenmatch_embed` UDF). No change to the Python package surface.
+
 ## [1.26.0] - 2026-06-04
 
 <!-- README-callout

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "1.26.0"
+__version__ = "1.27.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "1.26.0"
+version = "1.27.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/CLAUDE.md
+++ b/packages/rust/extensions/CLAUDE.md
@@ -129,7 +129,7 @@ lockstep (bridge fn + pgrx wrapper + handwritten SQL on the Postgres side;
 `functions.py` UDF on the DuckDB side) so the two stay interchangeable.
 
 ## Gotchas
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.6.0.sql` manually (+ the `--0.5.0--0.6.0.sql` upgrade script). Bumping the PG version means renaming the SQL file AND updating the hardcoded `cp sql/goldenmatch_pg--X.Y.Z.sql` lines in root `.github/workflows/ci.yml` + `publish-goldenmatch-pg.yml` (the orphaned `packages/.../.github` copies are ignored)
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.7.0.sql` (the current `default_version` base) manually, plus the chained upgrade scripts (`--0.5.0--0.6.0.sql`, `--0.6.0--0.7.0.sql`). Bumping the extension version means adding a new `--X.Y.Z.sql` base + `--<prev>--X.Y.Z.sql` migration, bumping `default_version` in `goldenmatch_pg.control` AND `version` in `Cargo.toml`, and adding the hardcoded `cp sql/goldenmatch_pg--*.sql` lines in root `.github/workflows/ci.yml` + `publish-goldenmatch-pg.yml` (the orphaned `packages/.../.github` copies are ignored). A new function in an ALREADY-PUBLISHED version is wrong: published versions are immutable, so the function goes in the NEXT version's base + migration, NOT retro-added to the released base (bit gm_embed/#737 -- it shipped into 0.6.0 which was already released, fixed by moving it to 0.7.0).
 - pgrx extension functions are in `goldenmatch` schema -- use `goldenmatch.function_name()` in psql, or explicit `::TEXT` casts
 - `cargo` defaults CARGO_HOME to drive root on Windows when CWD is D: -- always set explicitly
 - DuckDB UDFs cannot query same connection (deadlock) -- use `con.cursor()` for table reads

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goldenmatch_pg"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/postgres/goldenmatch_pg.control
+++ b/packages/rust/extensions/postgres/goldenmatch_pg.control
@@ -1,5 +1,5 @@
 comment = 'Entity resolution toolkit -- deduplicate, match, and maintain golden records'
-default_version = '0.6.0'
+default_version = '0.7.0'
 module_pathname = '$libdir/goldenmatch_pg'
 relocatable = false
 schema = goldenmatch

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.5.0--0.6.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.5.0--0.6.0.sql
@@ -63,12 +63,3 @@ CREATE FUNCTION "goldenmatch_embed_local"(
 STRICT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'goldenmatch_embed_local_wrapper';
-
--- gm_embed: 1-arg convenience over the in-house model, dir from
--- GOLDENEMBED_MODEL_DIR, real[] (float4) for DataFusion parity. NULL -> ""
--- (NOT STRICT). #737.
-CREATE FUNCTION "gm_embed"(
-    "text" TEXT  /* nullable: NULL -> "" */
-) RETURNS real[]
-LANGUAGE c
-AS 'MODULE_PATHNAME', 'gm_embed_wrapper';

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.6.0--0.7.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.6.0--0.7.0.sql
@@ -1,0 +1,10 @@
+-- goldenmatch_pg 0.6.0 -> 0.7.0 upgrade.
+--
+-- Adds gm_embed(text) -> real[] (#737): a 1-arg convenience over the in-house
+-- embedder, model dir from GOLDENEMBED_MODEL_DIR, float4 output for parity with
+-- the DataFusion goldenmatch_embed UDF. NULL -> "" (so NOT STRICT).
+CREATE FUNCTION "gm_embed"(
+    "text" TEXT  /* nullable: NULL -> "" */
+) RETURNS real[]
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_embed_wrapper';

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.7.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.7.0.sql
@@ -672,6 +672,15 @@ STRICT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'goldenmatch_embed_local_wrapper';
 
+-- Embed one text with the in-house model, model dir from GOLDENEMBED_MODEL_DIR
+-- (loaded once per backend process). Returns real[] (float4) -- parity with the
+-- DataFusion goldenmatch_embed UDF, including NULL -> "" (so NOT STRICT). #737.
+CREATE FUNCTION "gm_embed"(
+    "text" TEXT  /* nullable: NULL -> "" */
+) RETURNS real[]
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_embed_wrapper';
+
 -- Canonical record fingerprint (64 hex) of a JSON record object. The
 -- cross-surface stable record-id hash; matches the DuckDB
 -- goldenmatch_record_fingerprint UDF + the Python identity path.


### PR DESCRIPTION
Release bump for the three issue fixes that just landed.

## goldenmatch (Python) 1.26.0 -> 1.27.0
- **#739** (PR #757): distributed Phase-5 pipeline honors explicit `config` + `allow_red_config`.
- **#721** (PR #758): auto-config admits high-cardinality identifiers to probabilistic matchkeys.
- Bumps `pyproject.toml`, `goldenmatch/__init__.py`, and adds a dated `CHANGELOG.md` entry (ASCII-only).

## goldenmatch_pg (Postgres extension) 0.6.0 -> 0.7.0
- **#737** (PR #759): `gm_embed(text) -> real[]`.
- `gm_embed` was merged into the **already-published** `goldenmatch-pg-v0.6.0` SQL files. Published versions are immutable, so this PR:
  - adds `sql/goldenmatch_pg--0.7.0.sql` (full base) + `sql/goldenmatch_pg--0.6.0--0.7.0.sql` (the `gm_embed` delta),
  - reverts `gm_embed` out of `--0.6.0.sql` and `--0.5.0--0.6.0.sql`,
  - bumps `Cargo.toml` + `goldenmatch_pg.control` `default_version` to 0.7.0,
  - updates the hardcoded `cp sql/...` lines in `ci.yml` + `publish-goldenmatch-pg.yml`.

## After merge
Tag both, together:
- `v1.27.0` -> `publish-goldenmatch.yml` -> PyPI.
- `goldenmatch-pg-v0.7.0` -> `publish-goldenmatch-pg.yml` -> .deb/.rpm/Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)