### PR TITLE
feat(security): sanitize user-supplied values in log output

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/_logging.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_logging.py
@@ -1,0 +1,24 @@
+"""Log-output sanitization (CodeQL py/log-injection mitigation).
+
+User-supplied values (file paths, run ids, config strings) flow into
+log lines. Strip control characters so a crafted value can't forge
+log records or smuggle ANSI escapes into terminals tailing the log.
+"""
+
+from __future__ import annotations
+
+import re
+
+_CONTROL_CHARS = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+_MAX_LEN = 1000
+
+
+def sanitize_for_log(value: object, max_length: int = _MAX_LEN) -> str:
+    """Return a log-safe string: newlines collapsed, ANSI/control chars
+    stripped, truncated to *max_length*."""
+    s = str(value)
+    s = s.replace("\r", " ").replace("\n", " ")
+    s = _CONTROL_CHARS.sub("", s)
+    if len(s) > max_length:
+        s = s[: max_length - 3] + "..."
+    return s

--- a/packages/python/goldenmatch/goldenmatch/core/_logging.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_logging.py
@@ -20,5 +20,5 @@ def sanitize_for_log(value: object, max_length: int = _MAX_LEN) -> str:
     s = s.replace("\r", " ").replace("\n", " ")
     s = _CONTROL_CHARS.sub("", s)
     if len(s) > max_length:
-        s = s[: max_length - 3] + "..."
+        s = s[: max(0, max_length - 3)] + "..."
     return s

--- a/packages/python/goldenmatch/goldenmatch/core/domain_registry.py
+++ b/packages/python/goldenmatch/goldenmatch/core/domain_registry.py
@@ -34,6 +34,8 @@ from pathlib import Path
 
 import yaml
 
+from goldenmatch.core._logging import sanitize_for_log
+
 logger = logging.getLogger(__name__)
 
 # Default search paths for domain YAML files
@@ -179,7 +181,7 @@ def save_rulebook(rulebook: DomainRulebook, path: str | Path) -> Path:
     with open(path, "w", encoding="utf-8") as f:
         yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
-    logger.info("Saved domain rulebook '%s' to %s", rulebook.name, path)
+    logger.info("Saved domain rulebook '%s' to %s", sanitize_for_log(rulebook.name), sanitize_for_log(path))
     return path
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/lineage.py
+++ b/packages/python/goldenmatch/goldenmatch/core/lineage.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import polars as pl
 
 from goldenmatch.config.schemas import MatchkeyConfig
+from goldenmatch.core._logging import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ def save_lineage(
     if golden_provenance:
         data["golden_records"] = _serialize_provenance(golden_provenance)
     path.write_text(json.dumps(data, default=str, indent=2), encoding="utf-8")
-    logger.info("Saved lineage for %d pairs to %s", len(lineage), path)
+    logger.info("Saved lineage for %d pairs to %s", len(lineage), sanitize_for_log(path))
     return path
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/match_one.py
+++ b/packages/python/goldenmatch/goldenmatch/core/match_one.py
@@ -98,7 +98,7 @@ def _match_one_ann(
 
     logger.info(
         "match_one: %d ANN candidates, %d above threshold %.2f",
-        len(candidates), len(results), mk.threshold,
+        len(candidates), len(results), float(mk.threshold),
     )
     return results
 
@@ -128,6 +128,6 @@ def _match_one_brute(
 
     logger.info(
         "match_one (brute): %d records scanned, %d above threshold %.2f",
-        df.height, len(results), mk.threshold,
+        df.height, len(results), float(mk.threshold),
     )
     return results

--- a/packages/python/goldenmatch/goldenmatch/core/rollback.py
+++ b/packages/python/goldenmatch/goldenmatch/core/rollback.py
@@ -11,6 +11,8 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
+from goldenmatch.core._logging import sanitize_for_log
+
 logger = logging.getLogger(__name__)
 
 RUN_LOG_FILE = ".goldenmatch_runs.json"
@@ -103,7 +105,7 @@ def rollback_run(
     target["rolled_back_at"] = datetime.now().isoformat()
     log_path.write_text(json.dumps(runs, indent=2, default=str), encoding="utf-8")
 
-    logger.info("Rolled back run %s: deleted %d files", run_id, len(deleted))
+    logger.info("Rolled back run %s: deleted %d files", sanitize_for_log(run_id), len(deleted))
 
     return {
         "run_id": run_id,

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any
 
 from mcp.types import TextContent, Tool
 
+from goldenmatch.core._logging import sanitize_for_log
+
 from goldenmatch._exclusions_schema import (
     EXCLUDE_COLUMNS_SCHEMA as _EXCLUDE_COLUMNS_SCHEMA,
 )
@@ -622,7 +624,7 @@ def _dispatch(
         except Exception as exc:
             return {"error": f"Could not read CSV '{file_path}': {exc}"}
 
-        logger.info("scan_quality: scanning %s (%d records)", file_path, df.height)
+        logger.info("scan_quality: scanning %s (%d records)", sanitize_for_log(file_path), df.height)
         qc = QualityConfig(mode="silent", fix_mode="none", domain=args.get("domain"))
         _, issues = run_quality_check(df, qc)
         logger.info("scan_quality: found %d issues", len(issues))
@@ -658,7 +660,7 @@ def _dispatch(
 
         fix_mode = args.get("fix_mode", "safe")
         domain = args.get("domain")
-        logger.info("fix_quality: fixing %s (mode=%s)", file_path, fix_mode)
+        logger.info("fix_quality: fixing %s (mode=%s)", sanitize_for_log(file_path), sanitize_for_log(fix_mode))
         qc = QualityConfig(mode="silent", fix_mode=fix_mode, domain=domain)
         fixed_df, fixes = run_quality_check(df, qc)
         logger.info("fix_quality: %d fixes applied", len(fixes))
@@ -706,7 +708,7 @@ def _dispatch(
         except Exception as exc:
             return {"error": f"Could not read CSV '{file_path}': {exc}"}
 
-        logger.info("run_transforms: transforming %s (%d records)", file_path, df.height)
+        logger.info("run_transforms: transforming %s (%d records)", sanitize_for_log(file_path), df.height)
         tc = TransformConfig(mode="silent")
         transformed_df, fixes = run_transform(df, tc, strict=True)
         logger.info("run_transforms: %d transforms applied", len(fixes))

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -13,11 +13,10 @@ from typing import TYPE_CHECKING, Any
 
 from mcp.types import TextContent, Tool
 
-from goldenmatch.core._logging import sanitize_for_log
-
 from goldenmatch._exclusions_schema import (
     EXCLUDE_COLUMNS_SCHEMA as _EXCLUDE_COLUMNS_SCHEMA,
 )
+from goldenmatch.core._logging import sanitize_for_log
 
 if TYPE_CHECKING:
     from goldenmatch.core.memory.store import MemoryStore

--- a/packages/python/goldenmatch/tests/unit/test_log_sanitize.py
+++ b/packages/python/goldenmatch/tests/unit/test_log_sanitize.py
@@ -1,0 +1,27 @@
+"""Tests for goldenmatch.core._logging.sanitize_for_log."""
+
+from goldenmatch.core._logging import sanitize_for_log
+
+
+def test_strips_newlines_and_carriage_returns():
+    assert sanitize_for_log("a\nb\rc") == "a b c"
+
+
+def test_strips_ansi_and_control_chars():
+    assert sanitize_for_log("ok\x1b[31mred\x07") == "okred"
+
+
+def test_truncates_long_values():
+    out = sanitize_for_log("x" * 5000)
+    assert len(out) <= 1000
+    assert out.endswith("...")
+
+
+def test_non_string_values_coerced():
+    assert sanitize_for_log(0.85) == "0.85"
+    from pathlib import Path
+    assert sanitize_for_log(Path("a/b")) in ("a/b", "a\\b")
+
+
+def test_plain_string_unchanged():
+    assert sanitize_for_log("normal_file.csv") == "normal_file.csv"

--- a/packages/python/goldenmatch/tests/unit/test_log_sanitize.py
+++ b/packages/python/goldenmatch/tests/unit/test_log_sanitize.py
@@ -25,3 +25,7 @@ def test_non_string_values_coerced():
 
 def test_plain_string_unchanged():
     assert sanitize_for_log("normal_file.csv") == "normal_file.csv"
+
+
+def test_strips_osc_sequences():
+    assert sanitize_for_log("\x1b]0;evil\x07x") == "]0;evilx"


### PR DESCRIPTION
Closes 9 CodeQL `py/log-injection` alerts (396-404).

- New `goldenmatch/core/_logging.py`: `sanitize_for_log()` — CR/LF collapsed, ANSI/CSI/OSC escapes + C0/C1 control chars stripped, truncated at 1000 chars. 6 unit tests incl. an OSC-bypass pin.
- Applied at the 9 tainted args across 8 logger calls: `agent_tools._dispatch` (scan_quality / fix_quality / run_transforms `file_path`+`fix_mode`), `rollback_run` (`run_id`), `save_lineage` (`path`), `save_rulebook` (`rulebook.name`+`path`).
- `match_one` / `_match_one_brute` use `float(mk.threshold)` coercion instead (the tainted value is a config float; `float()` is the honest sanitizer). Safe eagerly: both paths compare `>= mk.threshold` before the log line, so it's provably non-None there.

Verified: 6/6 new tests; existing test files for all touched modules green (test_diff_preview_rollback 10/10, test_domain_registry 9/9, test_explain 12/12, test_agent 37/37); ruff clean.

Part 4/5 of the security-alerts remediation plan (docs/superpowers/plans/2026-06-05-security-alerts-remediation.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)